### PR TITLE
Documentation checker

### DIFF
--- a/server/src/KRPCConfiguration.cs
+++ b/server/src/KRPCConfiguration.cs
@@ -3,6 +3,7 @@ using System.Net;
 using UnityEngine;
 using KRPC.Service;
 using KRPC.Utils;
+using KRPC.Service.Scanner;
 
 namespace KRPC
 {
@@ -19,6 +20,7 @@ namespace KRPC
         [Persistent] bool autoAcceptConnections = false;
         [Persistent] string logLevel = Logger.Severity.Info.ToString ();
         [Persistent] bool verboseErrors = false;
+        [Persistent] bool checkDocumented = false;
         [Persistent] bool oneRPCPerUpdate = false;
         [Persistent] uint maxTimePerUpdate = 5000;
         [Persistent] bool adaptiveRateControl = true;
@@ -98,6 +100,7 @@ namespace KRPC
             Address = IPAddress.Parse (address);
             Logger.Level = (Logger.Severity)Enum.Parse (typeof(Logger.Severity), logLevel);
             RPCException.VerboseErrors = verboseErrors;
+            ServicesChecker.CheckDocumented = checkDocumented;
         }
 
         protected override void BeforeSave ()
@@ -105,6 +108,7 @@ namespace KRPC
             address = Address.ToString ();
             logLevel = Logger.Level.ToString ();
             verboseErrors = RPCException.VerboseErrors;
+            checkDocumented = ServicesChecker.CheckDocumented;
         }
 
         protected override void AfterLoad ()
@@ -126,6 +130,7 @@ namespace KRPC
                 Logger.Level = Logger.Severity.Info;
             }
             RPCException.VerboseErrors = verboseErrors;
+            ServicesChecker.CheckDocumented = checkDocumented;
         }
     }
 }

--- a/server/src/Service/Scanner/Scanner.cs
+++ b/server/src/Service/Scanner/Scanner.cs
@@ -11,6 +11,8 @@ namespace KRPC.Service.Scanner
     {
         public static Assembly CurrentAssembly { get; private set; }
 
+        public static bool CheckDocumented { get; set; }
+
         public static IDictionary<string, ServiceSignature> GetServices ()
         {
             IDictionary<string, ServiceSignature> signatures = new Dictionary<string, ServiceSignature> ();

--- a/server/src/ServicesChecker.cs
+++ b/server/src/ServicesChecker.cs
@@ -1,5 +1,7 @@
 using System;
+using System.Collections.Generic;
 using KRPC.Service;
+using KRPC.Service.Scanner;
 using UnityEngine;
 
 namespace KRPC
@@ -9,16 +11,73 @@ namespace KRPC
     {
         public static bool OK { get; private set; }
 
+        public static bool CheckDocumented { get; set; }
+
+        readonly IList<string> notDocumented = new List<string> ();
+
         public void Start ()
         {
+            var config = new KRPCConfiguration ("settings.cfg");
+            config.Load ();
             OK = true;
             try {
-                Service.Scanner.Scanner.GetServices ();
+                var services = Scanner.GetServices ();
+                if (CheckDocumented)
+                    CheckDocumentation (services.Values);
             } catch (ServiceException e) {
                 OK = false;
                 var path = (e.Assembly == null ? "unknown" : e.Assembly.Location);
                 PopupDialog.SpawnPopupDialog ("kRPC service error - plugin disabled", e.Message + "\n\n" + path, "OK", true, HighLogic.Skin);
             }
+        }
+
+        void CheckDocumentation (IEnumerable<ServiceSignature> services)
+        {
+            foreach (var service in services)
+                CheckDocumentation (service);
+            if (notDocumented.Count > 0) {
+                var n = notDocumented.Count;
+                var msg = n + " item" + (n != 1 ? "s are" : " is") + " not documented.";
+                for (int i = 0; i < 10 && i < n; i++)
+                    msg += "\n" + notDocumented [i];
+                if (n > 10)
+                    msg += "\n...";
+                PopupDialog.SpawnPopupDialog ("kRPC service warning", msg, "OK", true, HighLogic.Skin);
+            }
+        }
+
+        void CheckDocumentation (ServiceSignature service)
+        {
+            CheckDocumentation (service.Name, service.Documentation);
+            foreach (var cls in service.Classes.Values)
+                CheckDocumentation (cls);
+            foreach (var enm in service.Enumerations.Values)
+                CheckDocumentation (enm);
+            foreach (var proc in service.Procedures.Values)
+                CheckDocumentation (proc);
+        }
+
+        void CheckDocumentation (ProcedureSignature proc)
+        {
+            CheckDocumentation (proc.FullyQualifiedName, proc.Documentation);
+        }
+
+        void CheckDocumentation (ClassSignature cls)
+        {
+            CheckDocumentation (cls.FullyQualifiedName, cls.Documentation);
+        }
+
+        void CheckDocumentation (EnumerationSignature enm)
+        {
+            CheckDocumentation (enm.FullyQualifiedName, enm.Documentation);
+            foreach (var enmValue in enm.Values)
+                CheckDocumentation (enmValue.FullyQualifiedName, enmValue.Documentation);
+        }
+
+        void CheckDocumentation (string fullyQualifiedName, string documentation)
+        {
+            if (documentation == "")
+                notDocumented.Add (fullyQualifiedName);
         }
     }
 }

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -18,13 +18,12 @@ mkdir -p $GAMEDATA
 cp -R \
     bazel-bin/server/KRPC.dll \
     bazel-bin/server/KRPC.xml \
-    bazel-bin/server/KRPC.json \
     bazel-bin/server/src/icons \
     bazel-bin/service/**/*.dll \
     bazel-bin/service/**/*.xml \
-    bazel-bin/service/**/*.json \
     bazel-krpc/external/csharp_protobuf_net35/Google.Protobuf.dll \
     bazel-bin/tools/TestingTools/TestingTools.dll \
+    bazel-bin/tools/TestingTools/TestingTools.xml \
     tools/settings.cfg \
     $GAMEDATA/
 

--- a/tools/settings.cfg
+++ b/tools/settings.cfg
@@ -9,6 +9,7 @@ KRPCConfiguration
   autoAcceptConnections = True
   logLevel = Info
   verboseErrors = False
+  checkDocumented = True
   oneRPCPerUpdate = False
   maxTimePerUpdate = 5000
   adaptiveRateControl = True


### PR DESCRIPTION
If enabled, checks that all RPCs are documented and, if not, displays a warning when KSP loads. Useful for checking you haven't forgotten to document something when developing services.