### PR TITLE
Remove ModuleEnginesFX logic from Engine class

### DIFF
--- a/service/SpaceCenter/src/Services/Parts/Part.cs
+++ b/service/SpaceCenter/src/Services/Parts/Part.cs
@@ -367,7 +367,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         }
 
         internal bool IsEngine {
-            get { return InternalPart.HasModule<ModuleEngines> () || InternalPart.HasModule<ModuleEnginesFX> (); }
+            get { return InternalPart.HasModule<ModuleEngines> (); }
         }
 
         internal bool IsLandingGear {


### PR DESCRIPTION
 ModuleEnginesFX inherits from ModuleEngines, so it's not needed.