### PR TITLE
Add new Service for encapsulating KSP Propellant object

### DIFF
--- a/service/SpaceCenter/src/KRPC.SpaceCenter.csproj
+++ b/service/SpaceCenter/src/KRPC.SpaceCenter.csproj
@@ -145,5 +145,6 @@
     <Compile Include="Services\WarpMode.cs" />
     <Compile Include="Utils\PIDController.cs" />
     <Compile Include="Utils\RotationRateController.cs" />
+    <Compile Include="Services\PropellantResource.cs" />
   </ItemGroup>
 </Project>

--- a/service/SpaceCenter/src/Services/Parts/Engine.cs
+++ b/service/SpaceCenter/src/Services/Parts/Engine.cs
@@ -222,7 +222,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// The names of resources that the engine consumes.
         /// </summary>
         [KRPCProperty]
-        public IList<string> Propellants {
+        public IList<string> PropellantNames {
             get { return CurrentEngine.propellants.Select (x => x.name).ToList (); }
         }
 
@@ -230,7 +230,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// The actual propellant objects that the engine consumes.
         /// </summary>
         [KRPCProperty]
-        public IList<Propellant> PropellantResources {
+        public IList<Propellant> Propellants {
             get {
                 List<Propellant> enginePropellants = CurrentEngine.propellants;
                 Part engine = CurrentEngine.part;

--- a/service/SpaceCenter/src/Services/Parts/Engine.cs
+++ b/service/SpaceCenter/src/Services/Parts/Engine.cs
@@ -227,6 +227,23 @@ namespace KRPC.SpaceCenter.Services.Parts
         }
 
         /// <summary>
+        /// The actual propellant objects that the engine consumes.
+        /// </summary>
+        [KRPCProperty]
+        public IList<Propellant> PropellantResources {
+            get {
+                List<Propellant> enginePropellants = CurrentEngine.propellants;
+                Part engine = CurrentEngine.part;
+                List<PropellantResource> propellants = new List<PropellantResource> ();
+                foreach(Propellant propellant in enginePropellants)
+                {
+                    propellants.Add(new PropellantResource(propellant, engine));
+                }
+                return propellants;
+            }
+        }
+
+        /// <summary>
         /// The ratios of resources that the engine consumes. A dictionary mapping resource names
         /// to the ratios at which they are consumed by the engine.
         /// </summary>

--- a/service/SpaceCenter/src/Services/PropellantResource.cs
+++ b/service/SpaceCenter/src/Services/PropellantResource.cs
@@ -79,7 +79,7 @@ namespace KRPC.SpaceCenter.Services
         }
 
         /// <summary>
-        /// The total amount of the underlying resource (fuel or oxidizer) currently available 
+        /// The total amount of the underlying resource currently reachable given resource flow rules 
         /// </summary>
         [KRPCProperty]
         public double TotalResourceAvailable {
@@ -88,7 +88,7 @@ namespace KRPC.SpaceCenter.Services
         }
 
         /// <summary>
-        /// The total vehicle capacity for the underyling propellant resource (fuel or oxidizer)
+        /// The total vehicle capacity for the underyling propellant resource
         /// </summary>
         [KRPCProperty]
         public double TotalResourceCapacity {
@@ -97,7 +97,7 @@ namespace KRPC.SpaceCenter.Services
         }
 
         /// <summary>
-        /// If this propellant should be ignored for Isp calculations
+        /// Ff this propellant should be ignored when calculating required mass flow given Isp
         /// </summary>
         [KRPCProperty]
         public bool IgnoreForIsp {
@@ -142,7 +142,7 @@ namespace KRPC.SpaceCenter.Services
         }
 
         /// <summary>
-        /// The resources (fuel or oxidizer) used for this propellant
+        /// The reachable resources connected to this propellant
         ///
         [KRPCProperty]
         public IList<Resource> ConnectedResources {

--- a/service/SpaceCenter/src/Services/PropellantResource.cs
+++ b/service/SpaceCenter/src/Services/PropellantResource.cs
@@ -1,0 +1,159 @@
+﻿using System.Collections.Generic;
+using KRPC.Service.Attributes;
+using KRPC.Utils;
+
+namespace KRPC.SpaceCenter.Services
+{
+    [KRPCClass (Service = "SpaceCenter")]
+    public sealed class PropellantResource : Equatable<PropellantResource>
+    {
+        readonly int resourceId;
+        readonly int partId;
+
+        internal PropellantResource (Propellant propellantResource, Part underlyingPart)
+        {
+            resourceId = propellantResource.id;
+            partId = underlyingPart.flightID;
+        }
+
+        #region implemented abstract members of Equatable
+
+        public override bool Equals (PropellantResource obj)
+        {
+            return obj.resourceId == resourceId;
+        }
+
+        public override int GetHashCode ()
+        {
+            return resourceId.GetHashCode ();
+        }
+
+        #endregion
+
+        /// <summary>
+        /// The KSP part.
+        /// </summary>
+        public Part InternalPart {
+            get { return FlightGlobals.FindPartByID (partId); }
+        }
+
+        /// <summary>
+        /// The KSP propellant resource.
+        /// </summary>
+        public Propellant InternalPropellant {
+            get
+            { 
+                ModuleEngines engineModule = InternalPart.GetComponent<ModuleEngines> () as ModuleEngines;
+                if (engineModule != null)
+                    return engineModule.propellants.Find (p => p.id == resourceId);
+                else
+                    return null;
+            }
+        }
+
+        /// <summary>
+        /// The name of the propellant.
+        /// </summary>
+        [KRPCProperty]
+        public string Name {
+            get { return InternalPropellant.name; }
+        }
+
+    
+        /// <summary>
+        /// The current amount of propellant
+        /// </summary>
+        [KRPCProperty]
+        public double CurrentAmount {
+            get
+            { return InternalPropellant.currentAmount; }
+        }
+
+        /// <summary>
+        /// The current required amount of propellant
+        /// </summary>
+        [KRPCProperty]
+        public double CurrentRequirement {
+            get
+            { return InternalPropellant.currentRequirement; }
+        }
+
+        /// <summary>
+        /// The total propellant resource available
+        /// </summary>
+        [KRPCProperty]
+        public double TotalResourceAvailable {
+            get
+            { return InternalPropellant.totalResourceAvailable; }
+        }
+
+        /// <summary>
+        /// The total propellant resource capacity
+        /// </summary>
+        [KRPCProperty]
+        public double TotalResourceCapacity {
+            get
+            { return InternalPropellant.totalResourceCapacity; }
+        }
+
+        /// <summary>
+        /// If this propellant should be ignored for Isp calculations
+        /// </summary>
+        [KRPCProperty]
+        public bool IgnoreForIsp {
+            get
+            { return InternalPropellant.ignoreForIsp; }
+        }
+
+        /// <summary>
+        /// If this propellant should be ignored for Thrust curve calculations
+        /// </summary>
+        [KRPCProperty]
+        public bool IgnoreForThrustCurve {
+            get
+            { return InternalPropellant.ignoreForThrustCurve; }
+        }
+
+        /// <summary>
+        /// If this propellant has a stack gauge or not
+        /// </summary>
+        [KRPCProperty]
+        public bool DrawStackGauge {
+            get
+            { return InternalPropellant.drawStackGauge; }
+        }
+
+        /// <summary>
+        /// If this propellant is deprived
+        /// </summary>
+        [KRPCProperty]
+        public bool IsDeprived {
+            get
+            { return InternalPropellant.isDeprived; }
+        }
+
+        /// <summary>
+        /// The propellant ratio
+        /// </summary>
+        [KRPCProperty]
+        public float Ratio {
+            get
+            { return InternalPropellant.ratio; }
+        }
+
+        [KRPCProperty]
+        public IList<Resource> ConnectedResources {
+            get {
+                List<PartResource> resources = InternalPropellant.connectedResources;
+                List<Resource> connectedResources = new List<Resource> ();
+                foreach (PartResource resource in resources)
+                {
+                    connectedResources.Add (new Resource (resource));
+                }
+                return connectedResources;
+            }
+        }
+
+    }
+}
+

--- a/service/SpaceCenter/src/Services/PropellantResource.cs
+++ b/service/SpaceCenter/src/Services/PropellantResource.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using KRPC.Service.Attributes;
 using KRPC.Utils;
 
@@ -38,7 +38,7 @@ namespace KRPC.SpaceCenter.Services
         }
 
         /// <summary>
-        /// The KSP propellant resource.
+        /// The KSP propellant
         /// </summary>
         public Propellant InternalPropellant {
             get
@@ -70,7 +70,7 @@ namespace KRPC.SpaceCenter.Services
         }
 
         /// <summary>
-        /// The current required amount of propellant
+        /// The required amount of propellant
         /// </summary>
         [KRPCProperty]
         public double CurrentRequirement {
@@ -79,7 +79,7 @@ namespace KRPC.SpaceCenter.Services
         }
 
         /// <summary>
-        /// The total propellant resource available
+        /// The total amount of the underlying resource (fuel or oxidizer) currently available 
         /// </summary>
         [KRPCProperty]
         public double TotalResourceAvailable {
@@ -88,7 +88,7 @@ namespace KRPC.SpaceCenter.Services
         }
 
         /// <summary>
-        /// The total propellant resource capacity
+        /// The total vehicle capacity for the underyling propellant resource (fuel or oxidizer)
         /// </summary>
         [KRPCProperty]
         public double TotalResourceCapacity {
@@ -141,6 +141,9 @@ namespace KRPC.SpaceCenter.Services
             { return InternalPropellant.ratio; }
         }
 
+        /// <summary>
+        /// The resources (fuel or oxidizer) used for this propellant
+        ///
         [KRPCProperty]
         public IList<Resource> ConnectedResources {
             get {
@@ -156,4 +159,3 @@ namespace KRPC.SpaceCenter.Services
 
     }
 }
-

--- a/service/SpaceCenter/src/Services/PropellantResource.cs
+++ b/service/SpaceCenter/src/Services/PropellantResource.cs
@@ -88,7 +88,7 @@ namespace KRPC.SpaceCenter.Services
         }
 
         /// <summary>
-        /// The total vehicle capacity for the underyling propellant resource
+        /// The total vehicle capacity for the underyling propellant resource, restricted by resource flow rules
         /// </summary>
         [KRPCProperty]
         public double TotalResourceCapacity {
@@ -97,7 +97,7 @@ namespace KRPC.SpaceCenter.Services
         }
 
         /// <summary>
-        /// Ff this propellant should be ignored when calculating required mass flow given Isp
+        /// If this propellant should be ignored when calculating required mass flow given Isp
         /// </summary>
         [KRPCProperty]
         public bool IgnoreForIsp {

--- a/service/SpaceCenter/src/Services/PropellantResource.cs
+++ b/service/SpaceCenter/src/Services/PropellantResource.cs
@@ -8,7 +8,7 @@ namespace KRPC.SpaceCenter.Services
     public sealed class PropellantResource : Equatable<PropellantResource>
     {
         readonly int resourceId;
-        readonly int partId;
+        readonly uint partId;
 
         internal PropellantResource (Propellant propellantResource, Part underlyingPart)
         {
@@ -59,7 +59,7 @@ namespace KRPC.SpaceCenter.Services
             get { return InternalPropellant.name; }
         }
 
-    
+
         /// <summary>
         /// The current amount of propellant
         /// </summary>


### PR DESCRIPTION
* Adds a new Service `PropellantResource` that encapsulates the KSP `Propellant` class, providing kRPC scripts with access to the base propellants which are connected to engine parts.
* As discussed, this changes the existing Engine.Propellants property to return the actual propellent objects, and the old Engine.Propellants property is now named Engine.PropellantNames as all it returns is names.  **This change is obviously not backwards compatible**
