### PR TITLE
Pyclient minor cleanup

### DIFF
--- a/client/python/krpc/__init__.py
+++ b/client/python/krpc/__init__.py
@@ -1,4 +1,3 @@
-import socket
 from krpc.connection import Connection
 from krpc.client import Client
 from krpc.encoder import Encoder
@@ -9,6 +8,7 @@ from krpc.version import __version__
 DEFAULT_ADDRESS = '127.0.0.1'
 DEFAULT_RPC_PORT = 50000
 DEFAULT_STREAM_PORT = 50001
+
 
 def connect(address=DEFAULT_ADDRESS, rpc_port=DEFAULT_RPC_PORT, stream_port=DEFAULT_STREAM_PORT, name=None):
     """

--- a/client/python/krpc/attributes.py
+++ b/client/python/krpc/attributes.py
@@ -10,6 +10,7 @@ _RE_CLASS_PROPERTY_NAME = re.compile(r'^Class\.Property\.(Get|Set)\([^,]+,([^,]+
 _RE_RETURN_TYPE = re.compile(r'^ReturnType\.(.+)$')
 _RE_PARAMETER_TYPE = re.compile(r'^ParameterType\((\d+)\)\.(.+)$')
 
+
 class Attributes(object):
     """ Methods for extracting information from procedure attributes """
 
@@ -17,8 +18,7 @@ class Attributes(object):
     def is_a_procedure(cls, attrs):
         """ Return true if the attributes are for a plain procedure,
             i.e. not a property accessor, class method etc. """
-        return not cls.is_a_property_accessor(attrs) and \
-               not cls.is_a_class_member(attrs)
+        return not (cls.is_a_property_accessor(attrs) or cls.is_a_class_member(attrs))
 
     @classmethod
     def is_a_property_accessor(cls, attrs):
@@ -38,9 +38,11 @@ class Attributes(object):
     @classmethod
     def is_a_class_member(cls, attrs):
         """ Return true if the attributes are for a class member. """
-        return cls.is_a_class_method(attrs) or \
-               cls.is_a_class_static_method(attrs) or \
-               cls.is_a_class_property_accessor(attrs)
+        return (
+            cls.is_a_class_method(attrs)
+            or cls.is_a_class_static_method(attrs)
+            or cls.is_a_class_property_accessor(attrs)
+        )
 
     @classmethod
     def is_a_class_method(cls, attrs):

--- a/client/python/krpc/client.py
+++ b/client/python/krpc/client.py
@@ -10,6 +10,7 @@ from krpc.error import RPCError
 import krpc.stream
 import krpc.schema.KRPC
 
+
 class Client(object):
     """
     A kRPC client, through which all Remote Procedure Calls are made.
@@ -93,7 +94,7 @@ class Client(object):
         return result
 
     def _build_request(self, service, procedure, args,
-                       param_names, param_types, return_type): #pylint: disable=unused-argument
+                       param_names, param_types, return_type):  # pylint: disable=unused-argument
         """ Build a KRPC.Request object """
 
         request = krpc.schema.KRPC.Request(service=service, procedure=procedure)
@@ -105,7 +106,7 @@ class Client(object):
                 try:
                     value = self._types.coerce_to(value, typ)
                 except ValueError:
-                    raise TypeError('%s.%s() argument %d must be a %s, got a %s' % \
+                    raise TypeError('%s.%s() argument %d must be a %s, got a %s' %
                                     (service, procedure, i, typ.python_type, type(value)))
             request.arguments.add(position=i, value=Encoder.encode(value, typ))
 

--- a/client/python/krpc/connection.py
+++ b/client/python/krpc/connection.py
@@ -3,6 +3,7 @@ import select
 import time
 from krpc.error import NetworkError
 
+
 class Connection(object):
     def __init__(self, address, port):
         self._address = address

--- a/client/python/krpc/decoder.py
+++ b/client/python/krpc/decoder.py
@@ -1,8 +1,9 @@
-from google.protobuf.internal import decoder as protobuf_decoder #pylint: disable=import-error,no-name-in-module
+from google.protobuf.internal import decoder as protobuf_decoder  # pylint: disable=import-error,no-name-in-module
 from krpc.types import Types, ValueType, MessageType, ClassType, EnumType
 from krpc.types import ListType, DictionaryType, SetType, TupleType
 import krpc.platform
 from krpc.platform import hexlify
+
 
 class Decoder(object):
     """ Routines for decoding messages and values from the protocol buffer serialization format """

--- a/client/python/krpc/encoder.py
+++ b/client/python/krpc/encoder.py
@@ -1,7 +1,8 @@
-from google.protobuf.internal import encoder as protobuf_encoder #pylint: disable=import-error,no-name-in-module
+from google.protobuf.internal import encoder as protobuf_encoder  # pylint: disable=import-error,no-name-in-module
 from krpc.types import Types, ValueType, MessageType, ClassType, EnumType
 from krpc.types import ListType, DictionaryType, SetType, TupleType
 from krpc.platform import bytelength
+
 
 class Encoder(object):
     """ Routines for encoding messages and values in the protocol buffer serialization format """
@@ -19,7 +20,7 @@ class Encoder(object):
         else:
             name = cls._unicode_truncate(name, 32, 'utf-8')
         name = name.encode('utf-8')
-        return name + (b'\x00' * (32-len(name)))
+        return name + (b'\x00' * (32 - len(name)))
 
     @classmethod
     def _unicode_truncate(cls, string, length, encoding='utf-8'):
@@ -81,40 +82,49 @@ class Encoder(object):
     def _encode_value(cls, value, typ):
         return getattr(_ValueEncoder, 'encode_' + typ.protobuf_type)(value)
 
+
 class _ValueEncoder(object):
     """ Routines for encoding values in the protocol buffer serialization format """
 
     @classmethod
     def encode_double(cls, value):
         data = []
+
         def write(x):
             data.append(x)
+
         encoder = protobuf_encoder.DoubleEncoder(1, False, False)
         encoder(write, value)
-        return b''.join(data[1:]) # strips the tag value
+        return b''.join(data[1:])  # strips the tag value
 
     @classmethod
     def encode_float(cls, value):
         data = []
+
         def write(x):
             data.append(x)
+
         encoder = protobuf_encoder.FloatEncoder(1, False, False)
         encoder(write, value)
-        return b''.join(data[1:]) # strips the tag value
+        return b''.join(data[1:])  # strips the tag value
 
     @classmethod
     def _encode_varint(cls, value):
         data = []
+
         def write(x):
             data.append(x)
+
         protobuf_encoder._VarintEncoder()(write, value)
         return b''.join(data)
 
     @classmethod
     def _encode_signed_varint(cls, value):
         data = []
+
         def write(x):
             data.append(x)
+
         protobuf_encoder._SignedVarintEncoder()(write, value)
         return b''.join(data)
 

--- a/client/python/krpc/error.py
+++ b/client/python/krpc/error.py
@@ -3,6 +3,7 @@ class RPCError(RuntimeError):
     def __init__(self, message):
         super(RPCError, self).__init__(message)
 
+
 class NetworkError(RuntimeError):
     """ Error raised when something goes wrong with the network connection """
     def __init__(self, address, port, message):

--- a/client/python/krpc/platform.py
+++ b/client/python/krpc/platform.py
@@ -5,16 +5,19 @@ POS_INF = 1e10000
 NEG_INF = -POS_INF
 NAN = POS_INF * 0
 
+
 def bytelength(string):
     """ Get the number of bytes in a string """
     return len(string.encode('utf-8'))
 
+
 def hexlify(value):
     return binascii.hexlify(value).decode()
+
 
 def unhexlify(data):
     value = []
     for i in range(0, len(data), 2):
-        x = data[i:i+2]
+        x = data[i:i + 2]
         value.append(int(x, 16))
     return struct.pack('%dB' % len(value), *value)

--- a/client/python/krpc/service.py
+++ b/client/python/krpc/service.py
@@ -6,6 +6,7 @@ from krpc.types import DynamicType, DefaultArgument
 from krpc.decoder import Decoder
 from krpc.utils import snake_case
 
+
 def _signature(param_types, return_type):
     """ Generate a signature for a procedure that can be used as its docstring """
     if len(param_types) == 0 and return_type is None:
@@ -15,15 +16,17 @@ def _signature(param_types, return_type):
     if len(types) == 0:
         sig = '()'
     elif len(types) > 1:
-        sig = '('+sig+')'
+        sig = '(' + sig + ')'
     if return_type is not None:
-        sig += ' -> '+return_type.python_type.__name__
+        sig += ' -> ' + return_type.python_type.__name__
     return sig
+
 
 def _as_literal(value, typ):
     if typ.python_type == str:
-        return '\''+value+'\''
+        return '\'' + value + '\''
     return str(value)
+
 
 def _update_param_names(names):
     """ Given a list of parameter names, append underscores to reserved keywords
@@ -31,11 +34,12 @@ def _update_param_names(names):
     newnames = []
     for name in names:
         if keyword.iskeyword(name):
-            name = name+'_'
+            name += '_'
             while name in names:
                 name += '_'
         newnames.append(name)
     return newnames
+
 
 def _construct_func(invoke, service_name, procedure_name, prefix_param_names, param_names,
                     param_types, param_required, param_default, return_type):
@@ -47,18 +51,18 @@ def _construct_func(invoke, service_name, procedure_name, prefix_param_names, pa
     params = []
     for name, required, default, typ in zip(param_names, param_required, param_default, param_types):
         if not required:
-            name += ' = DefaultArgument('+repr(_as_literal(default, typ))+')'
+            name += ' = DefaultArgument(' + repr(_as_literal(default, typ)) + ')'
         params.append(name)
 
     invoke_args = [
-        '\''+str(service_name)+'\'',
-        '\''+str(procedure_name)+'\'',
-        '['+','.join(param_names)+']',
+        '\'' + str(service_name) + '\'',
+        '\'' + str(procedure_name) + '\'',
+        '[' + ','.join(param_names) + ']',
         'param_names',
         'param_types',
         'return_type'
     ]
-    code = 'lambda ' + ', '.join(prefix_param_names + params) + ': invoke('+', '.join(invoke_args)+')'
+    code = 'lambda ' + ', '.join(prefix_param_names + params) + ': invoke(' + ', '.join(invoke_args) + ')'
     context = {
         'invoke': invoke,
         'DefaultArgument': DefaultArgument,
@@ -66,16 +70,18 @@ def _construct_func(invoke, service_name, procedure_name, prefix_param_names, pa
         'param_types': param_types,
         'return_type': return_type
     }
-    return eval(code, context) #pylint: disable=eval-used
+    return eval(code, context)  # pylint: disable=eval-used
+
 
 def _indent(lines, level):
     result = []
     for line in lines:
         if line:
-            result.append((' '*level)+line)
+            result.append((' ' * level) + line)
         else:
             result.append(line)
     return result
+
 
 def _parse_documentation_node(node):
     if node.tag == 'see':
@@ -102,6 +108,7 @@ def _parse_documentation_node(node):
     else:
         return node.text
 
+
 def _parse_documentation_content(node):
     desc = node.text
     for child in node:
@@ -109,6 +116,7 @@ def _parse_documentation_content(node):
         if child.tail:
             desc += child.tail
     return desc.strip()
+
 
 def _parse_documentation(xml):
     if xml.strip() == '':
@@ -130,10 +138,11 @@ def _parse_documentation(xml):
         elif node.tag == 'remarks':
             note = 'Note: %s' % _parse_documentation_content(node)
     if len(params) > 0:
-        params_str = 'Args:\n%s' % '\n'.join('    '+x for x in params)
+        params_str = 'Args:\n%s' % '\n'.join('    ' + x for x in params)
     else:
         params_str = ''
     return '\n\n'.join(x for x in (summary, params_str, returns, note) if x != '')
+
 
 def create_service(client, service):
     """ Create a new service type """
@@ -201,6 +210,7 @@ def create_service(client, service):
         cls._add_service_class_property(class_name, property_name, procedures[0], procedures[1])
 
     return cls()
+
 
 class ServiceBase(DynamicType):
     """ Base class for service objects, created at runtime using information received from the server. """
@@ -282,7 +292,7 @@ class ServiceBase(DynamicType):
     @classmethod
     def _add_service_class_method(cls, class_name, method_name, procedure):
         """ Add a method to a class """
-        class_cls = cls._client._types.as_type('Class('+cls._name+'.'+class_name+')').python_type
+        class_cls = cls._client._types.as_type('Class(' + cls._name + '.' + class_name + ')').python_type
         param_names, param_types, param_required, param_default, return_type = cls._parse_procedure(procedure)
         # Rename this to self if it doesn't cause a name clash
         if 'self' not in param_names:
@@ -299,7 +309,7 @@ class ServiceBase(DynamicType):
     @classmethod
     def _add_service_class_static_method(cls, class_name, method_name, procedure):
         """ Add a static method to a class """
-        class_cls = cls._client._types.as_type('Class('+cls._name+'.'+class_name+')').python_type
+        class_cls = cls._client._types.as_type('Class(' + cls._name + '.' + class_name + ')').python_type
         param_names, param_types, param_required, param_default, return_type = cls._parse_procedure(procedure)
         func = _construct_func(cls._client._invoke, cls._name, procedure.name, [],
                                param_names, param_types, param_required, param_default, return_type)
@@ -313,7 +323,7 @@ class ServiceBase(DynamicType):
     @classmethod
     def _add_service_class_property(cls, class_name, property_name, getter=None, setter=None):
         """ Add a property to a class """
-        class_cls = cls._client._types.as_type('Class('+cls._name+'.'+class_name+')').python_type
+        class_cls = cls._client._types.as_type('Class(' + cls._name + '.' + class_name + ')').python_type
         doc = None
         if getter:
             doc = _parse_documentation(getter.documentation)

--- a/client/python/krpc/stream.py
+++ b/client/python/krpc/stream.py
@@ -2,10 +2,12 @@ from krpc.types import Types
 from krpc.decoder import Decoder
 from krpc.error import RPCError
 
+
 class StreamExistsError(RuntimeError):
     def __init__(self, stream_id):
         super(StreamExistsError, self).__init__('stream %d already exists' % stream_id)
         self.stream_id = stream_id
+
 
 class Stream(object):
     """ A streamed request. When invoked, returns the most recent value of the request. """
@@ -64,12 +66,14 @@ class Stream(object):
         """ Update the stream's most recent value """
         self._value = value
 
+
 def add_stream(conn, func, *args, **kwargs):
     """ Create a stream and return it """
     try:
         return Stream(conn, func, *args, **kwargs)
     except StreamExistsError as ex:
         return conn._stream_cache[ex.stream_id]
+
 
 def update_thread(connection, stop, cache, cache_lock):
     stream_message_type = Types().as_type('KRPC.StreamMessage')
@@ -85,8 +89,8 @@ def update_thread(connection, stop, cache, cache_lock):
                 break
             except IndexError:
                 pass
-            except: #pylint: disable=bare-except
-                #TODO: is there a better way to catch exceptions when the
+            except:  # pylint: disable=bare-except
+                # TODO: is there a better way to catch exceptions when the
                 #      thread is forcibly stopped (e.g. by CTRL+c)?
                 return
             if stop.is_set():

--- a/client/python/krpc/test/servertestcase.py
+++ b/client/python/krpc/test/servertestcase.py
@@ -1,6 +1,7 @@
 import os
 import krpc
 
+
 class ServerTestCase(object):
 
     conn = None

--- a/client/python/krpc/test/test_attributes.py
+++ b/client/python/krpc/test/test_attributes.py
@@ -1,8 +1,8 @@
 import unittest
 from krpc.attributes import Attributes
 
-class TestTypes(unittest.TestCase):
 
+class TestTypes(unittest.TestCase):
     def test_is_a_procedure(self):
         self.assertTrue(Attributes.is_a_procedure([]))
         self.assertFalse(Attributes.is_a_procedure(

--- a/client/python/krpc/test/test_client.py
+++ b/client/python/krpc/test/test_client.py
@@ -3,8 +3,8 @@ import threading
 import krpc
 from krpc.test.servertestcase import ServerTestCase
 
-class TestClient(ServerTestCase, unittest.TestCase):
 
+class TestClient(ServerTestCase, unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         super(TestClient, cls).setUpClass()

--- a/client/python/krpc/test/test_connection.py
+++ b/client/python/krpc/test/test_connection.py
@@ -3,6 +3,7 @@ import threading
 import socket
 from krpc.connection import Connection
 
+
 def server_thread(started):
     sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     sock.bind(('', 0))
@@ -34,8 +35,8 @@ def server_thread(started):
 
 server_thread.port = None
 
-class TestConnection(unittest.TestCase):
 
+class TestConnection(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls._started_server = threading.Event()

--- a/client/python/krpc/test/test_decoder.py
+++ b/client/python/krpc/test/test_decoder.py
@@ -3,8 +3,8 @@ from krpc.decoder import Decoder
 from krpc.types import Types
 from krpc.platform import unhexlify
 
-class TestDecoder(unittest.TestCase):
 
+class TestDecoder(unittest.TestCase):
     types = Types()
 
     def test_decode_message(self):

--- a/client/python/krpc/test/test_documentation.py
+++ b/client/python/krpc/test/test_documentation.py
@@ -1,25 +1,26 @@
 import unittest
 from krpc.test.servertestcase import ServerTestCase
 
-class TestDocumentation(ServerTestCase, unittest.TestCase):
 
+class TestDocumentation(ServerTestCase, unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         super(TestDocumentation, cls).setUpClass()
 
     def test_basic(self):
-        #TODO: fix tests
+        # TODO: fix tests
         self.assertEqual('Service documentation string.', self.conn.test_service.__doc__)
         self.assertEqual('Procedure documentation string.', self.conn.test_service.float_to_string.__doc__)
-        #self.assertEqual('Property documentation string.', self.conn.test_service.string_property.__doc__)
+        # self.assertEqual('Property documentation string.', self.conn.test_service.string_property.__doc__)
         self.assertEqual('Class documentation string.', self.conn.test_service.TestClass.__doc__)
         obj = self.conn.test_service.create_test_object('Jeb')
         self.assertEqual('Method documentation string.', obj.get_value.__doc__)
-        #self.assertEqual('Property documentation string.', obj.int_property.__doc__)
+        # self.assertEqual('Property documentation string.', obj.int_property.__doc__)
         self.assertEqual('Enum documentation string.', self.conn.test_service.TestEnum.__doc__)
         self.assertEqual('Enum ValueA documentation string.', self.conn.test_service.TestEnum.value_a.__doc__)
         self.assertEqual('Enum ValueB documentation string.', self.conn.test_service.TestEnum.value_b.__doc__)
         self.assertEqual('Enum ValueC documentation string.', self.conn.test_service.TestEnum.value_c.__doc__)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/client/python/krpc/test/test_encodedecode.py
+++ b/client/python/krpc/test/test_encodedecode.py
@@ -5,8 +5,8 @@ from krpc.decoder import Decoder
 from krpc.types import Types
 from krpc.platform import hexlify, unhexlify
 
-class TestEncodeDecode(unittest.TestCase):
 
+class TestEncodeDecode(unittest.TestCase):
     types = Types()
 
     def _run_test_encode_value(self, typ, cases):
@@ -54,7 +54,7 @@ class TestEncodeDecode(unittest.TestCase):
             (300, 'ac02'),
             (-33, 'dfffffffffffffffff01'),
             (sys.maxint, 'ffffffffffffffff7f'),
-            (-sys.maxint-1, '80808080808080808001')
+            (-sys.maxint - 1, '80808080808080808001')
         ]
         self._run_test_encode_value('int32', cases)
         self._run_test_decode_value('int32', cases)
@@ -164,6 +164,7 @@ class TestEncodeDecode(unittest.TestCase):
         cases = [((1, 'jeb', False), '0a01010a04036a65620a0100')]
         self._run_test_encode_value('Tuple(int32,string,bool)', cases)
         self._run_test_decode_value('Tuple(int32,string,bool)', cases)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/client/python/krpc/test/test_encoder.py
+++ b/client/python/krpc/test/test_encoder.py
@@ -5,8 +5,8 @@ from krpc.types import ClassBase
 from krpc.platform import hexlify
 import krpc.schema.KRPC
 
-class TestEncoder(unittest.TestCase):
 
+class TestEncoder(unittest.TestCase):
     types = Types()
 
     def test_rpc_hello_message(self):
@@ -22,17 +22,17 @@ class TestEncoder(unittest.TestCase):
     def test_client_name(self):
         message = Encoder.client_name('foo')
         self.assertEqual(32, len(message))
-        self.assertEqual('666f6f'+'00'*29, hexlify(message))
+        self.assertEqual('666f6f' + '00' * 29, hexlify(message))
 
     def test_empty_client_name(self):
         message = Encoder.client_name()
         self.assertEqual(32, len(message))
-        self.assertEqual('00'*32, hexlify(message))
+        self.assertEqual('00' * 32, hexlify(message))
 
     def test_long_client_name(self):
-        message = Encoder.client_name('a'*33)
+        message = Encoder.client_name('a' * 33)
         self.assertEqual(32, len(message))
-        self.assertEqual('61'*32, hexlify(message))
+        self.assertEqual('61' * 32, hexlify(message))
 
     def test_encode_message(self):
         request = krpc.schema.KRPC.Request()
@@ -55,12 +55,12 @@ class TestEncoder(unittest.TestCase):
         request.service = 'ServiceName'
         request.procedure = 'ProcedureName'
         data = Encoder.encode_delimited(request, self.types.as_type('KRPC.Request'))
-        expected = '1c'+'0a0b536572766963654e616d65120d50726f6365647572654e616d65'
+        expected = '1c' + '0a0b536572766963654e616d65120d50726f6365647572654e616d65'
         self.assertEqual(expected, hexlify(data))
 
     def test_encode_value_delimited(self):
         data = Encoder.encode_delimited(300, self.types.as_type('int32'))
-        self.assertEqual('02'+'ac02', hexlify(data))
+        self.assertEqual('02' + 'ac02', hexlify(data))
 
     def test_encode_class(self):
         typ = self.types.as_type('Class(ServiceName.ClassName)')
@@ -81,6 +81,7 @@ class TestEncoder(unittest.TestCase):
         typ = self.types.as_type('Tuple(int32,int32,int32)')
         value = (0, 1)
         self.assertRaises(ValueError, Encoder.encode, value, typ)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/client/python/krpc/test/test_objects.py
+++ b/client/python/krpc/test/test_objects.py
@@ -1,8 +1,8 @@
 import unittest
 from krpc.test.servertestcase import ServerTestCase
 
-class TestObjects(ServerTestCase, unittest.TestCase):
 
+class TestObjects(ServerTestCase, unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         super(TestObjects, cls).setUpClass()
@@ -60,6 +60,7 @@ class TestObjects(ServerTestCase, unittest.TestCase):
         obj3 = self.conn.test_service.create_test_object('bob')
         self.assertEqual(obj1._object_id, obj2._object_id)
         self.assertNotEqual(obj1._object_id, obj3._object_id)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/client/python/krpc/test/test_performance.py
+++ b/client/python/krpc/test/test_performance.py
@@ -2,16 +2,18 @@ import unittest
 import timeit
 from krpc.test.servertestcase import ServerTestCase
 
-class TestPerformance(ServerTestCase, unittest.TestCase):
 
+class TestPerformance(ServerTestCase, unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         super(TestPerformance, cls).setUpClass()
 
     def test_performance(self):
         samples = 100
+
         def wrapper():
             self.conn.test_service.float_to_string(float(3.14159))
+
         delta_t = timeit.timeit(stmt=wrapper, number=samples)
         print
         print 'Total execution time: %.2f seconds' % delta_t

--- a/client/python/krpc/test/test_performance.py
+++ b/client/python/krpc/test/test_performance.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import unittest
 import timeit
 from krpc.test.servertestcase import ServerTestCase
@@ -15,10 +16,10 @@ class TestPerformance(ServerTestCase, unittest.TestCase):
             self.conn.test_service.float_to_string(float(3.14159))
 
         delta_t = timeit.timeit(stmt=wrapper, number=samples)
-        print
-        print 'Total execution time: %.2f seconds' % delta_t
-        print 'RPC execution rate: %d per second' % (samples/delta_t)
-        print 'Latency: %.3f milliseconds' % ((delta_t*1000)/samples)
+        print()
+        print('Total execution time: %.2f seconds' % delta_t)
+        print('RPC execution rate: %d per second' % (samples/delta_t))
+        print('Latency: %.3f milliseconds' % ((delta_t*1000)/samples))
 
 if __name__ == '__main__':
     unittest.main()

--- a/client/python/krpc/test/test_platform.py
+++ b/client/python/krpc/test/test_platform.py
@@ -1,8 +1,8 @@
 import unittest
 from krpc.platform import bytelength, hexlify, unhexlify
 
-class TestPlatform(unittest.TestCase):
 
+class TestPlatform(unittest.TestCase):
     def test_bytelength(self):
         self.assertEqual(0, bytelength(''))
         self.assertEqual(3, bytelength('foo'))

--- a/client/python/krpc/test/test_snake_case.py
+++ b/client/python/krpc/test/test_snake_case.py
@@ -1,8 +1,8 @@
 import unittest
 from krpc.utils import snake_case as t
 
-class TestSnakeCase(unittest.TestCase):
 
+class TestSnakeCase(unittest.TestCase):
     def test_examples(self):
         # Simple cases
         self.assertEqual('server', t('Server'))
@@ -22,7 +22,6 @@ class TestSnakeCase(unittest.TestCase):
         # With underscores
         self.assertEqual('_http_server', t('_HTTPServer'))
         self.assertEqual('http__server', t('HTTP_Server'))
-
 
     def test_non_camel_case_examples(self):
         self.assertEqual('foobar', t('foobar'))

--- a/client/python/krpc/test/test_stream.py
+++ b/client/python/krpc/test/test_stream.py
@@ -2,8 +2,8 @@ import unittest
 import time
 from krpc.test.servertestcase import ServerTestCase
 
-class TestStream(ServerTestCase, unittest.TestCase):
 
+class TestStream(ServerTestCase, unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         super(TestStream, cls).setUpClass()

--- a/client/python/krpc/test/test_threading.py
+++ b/client/python/krpc/test/test_threading.py
@@ -2,9 +2,11 @@ import unittest
 import threading
 from krpc.test.servertestcase import ServerTestCase
 
+
 def worker_thread(conn):
     for _ in range(100):
         conn.krpc.get_status()
+
 
 def worker_thread2(conn, test):
     for _ in range(10):
@@ -12,8 +14,8 @@ def worker_thread2(conn, test):
         test.assertEqual('3.14159', conn.test_service.double_to_string(float(3.14159)))
         test.assertEqual('42', conn.test_service.int32_to_string(42))
 
-class TestThreading(ServerTestCase, unittest.TestCase):
 
+class TestThreading(ServerTestCase, unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         super(TestThreading, cls).setUpClass()

--- a/client/python/krpc/test/test_types.py
+++ b/client/python/krpc/test/test_types.py
@@ -20,8 +20,8 @@ PROTOBUF_TO_PYTHON_VALUE_TYPE = {
     'bytes': bytes
 }
 
-class TestTypes(unittest.TestCase):
 
+class TestTypes(unittest.TestCase):
     def test_value_types(self):
         types = Types()
         for protobuf_typ in PROTOBUF_VALUE_TYPES:

--- a/client/python/krpc/types.py
+++ b/client/python/krpc/types.py
@@ -4,6 +4,7 @@ import importlib
 from enum import Enum
 from krpc.attributes import Attributes
 
+
 def _parse_type_string(typ):
     """ Given a string, extract a substring up to the first comma. Parses parentheses.
         Multiple calls can be used to separate a string by commas. """
@@ -25,7 +26,8 @@ def _parse_type_string(typ):
         return result, None
     if typ[len(result)] != ',':
         raise ValueError
-    return result, typ[len(result)+1:]
+    return result, typ[len(result) + 1:]
+
 
 PROTOBUF_VALUE_TYPES = ['double', 'float', 'int32', 'int64', 'uint32', 'uint64', 'bool', 'string', 'bytes']
 PYTHON_VALUE_TYPES = [float, int, long, bool, str, bytes]
@@ -42,6 +44,7 @@ PROTOBUF_TO_PYTHON_VALUE_TYPE = {
 }
 PROTOBUF_TO_MESSAGE_TYPE = {}
 
+
 def _load_types(package):
     """ Load all message and enum types from the given package,
         and populate PROTOBUF_TO_MESSAGE_TYPE """
@@ -52,11 +55,13 @@ def _load_types(package):
         module = importlib.import_module('krpc.schema.' + package)
         if hasattr(module, 'DESCRIPTOR'):
             for name in module.DESCRIPTOR.message_types_by_name.keys():
-                PROTOBUF_TO_MESSAGE_TYPE[package+'.'+name] = getattr(module, name)
+                PROTOBUF_TO_MESSAGE_TYPE[package + '.' + name] = getattr(module, name)
     except (KeyError, ImportError, AttributeError, ValueError):
         pass
 
+
 _load_types.loaded = set()
+
 
 class Types(object):
     """ A type store. Used to obtain type objects from protocol buffer type strings,
@@ -75,7 +80,7 @@ class Types(object):
         # TODO: add enumeration types
         # Update kRPC server to attach type attributes to parameters/return types etc. that are of type KRPCEnum
         # Will allow proper type checking of enum values passed to procedures
-        #pylint: disable=redefined-variable-type
+        # pylint: disable=redefined-variable-type
         if type_string in PROTOBUF_VALUE_TYPES:
             typ = ValueType(type_string)
         elif type_string.startswith('Class(') or type_string == 'Class':
@@ -100,7 +105,7 @@ class Types(object):
                 typ = MessageType(type_string)
             else:
                 raise ValueError('\'%s\' is not a valid type string' % type_string)
-        #pylint: enable=redefined-variable-type
+        # pylint: enable=redefined-variable-type
 
         self._types[type_string] = typ
         return typ
@@ -141,8 +146,10 @@ class Types(object):
         # Coerce identical class types from different client connections
         if isinstance(typ, ClassType) and isinstance(value, ClassBase):
             value_type = type(value)
-            if typ.python_type._service_name == value_type._service_name and \
-               typ.python_type._class_name == value_type._class_name:
+            if (
+                    typ.python_type._service_name == value_type._service_name
+                    and typ.python_type._class_name == value_type._class_name
+            ):
                 return typ.python_type(value._object_id)
         # Collection types
         try:
@@ -160,8 +167,11 @@ class Types(object):
         # Numeric types
         # See http://docs.python.org/2/reference/datamodel.html#coercion-rules
         numeric_types = (float, int, long)
-        if isinstance(value, bool) or not any(isinstance(value, t) for t in numeric_types) or \
-           typ.python_type not in numeric_types:
+        if (
+                isinstance(value, bool)
+                or not any(isinstance(value, t) for t in numeric_types)
+                or typ.python_type not in numeric_types
+        ):
             raise ValueError('Failed to coerce value ' + str(value) + ' of type ' + str(type(value)) +
                              ' to type ' + str(typ))
         if typ.python_type == float:
@@ -170,6 +180,7 @@ class Types(object):
             return int(value)
         else:
             return long(value)
+
 
 class TypeBase(object):
     """ Base class for all type objects """
@@ -191,6 +202,7 @@ class TypeBase(object):
     def __str__(self):
         return '<pbtype: \'' + self.protobuf_type + '\'>'
 
+
 class ValueType(TypeBase):
     """ A protocol buffer value type """
 
@@ -199,6 +211,7 @@ class ValueType(TypeBase):
             raise ValueError('\'%s\' is not a valid type string for a value type' % type_string)
         typ = PROTOBUF_TO_PYTHON_VALUE_TYPE[type_string]
         super(ValueType, self).__init__(type_string, typ)
+
 
 class MessageType(TypeBase):
     """ A protocol buffer message type """
@@ -211,6 +224,7 @@ class MessageType(TypeBase):
         typ = PROTOBUF_TO_MESSAGE_TYPE[type_string]
         super(MessageType, self).__init__(type_string, typ)
 
+
 class ClassType(TypeBase):
     """ A class type, represented by a uint64 identifier """
 
@@ -222,6 +236,7 @@ class ClassType(TypeBase):
         class_name = match.group(2)
         typ = _create_class_type(service_name, class_name, doc)
         super(ClassType, self).__init__(str(type_string), typ)
+
 
 class EnumType(TypeBase):
     """ An enumeration type, represented by an int32 value """
@@ -240,6 +255,7 @@ class EnumType(TypeBase):
         """ Set the python type. Creates an Enum class using the given values. """
         self._python_type = _create_enum_type(self._enum_name, values, self._doc)
 
+
 class ListType(TypeBase):
     """ A list collection type, represented by a protobuf message """
 
@@ -251,6 +267,7 @@ class ListType(TypeBase):
         self.value_type = types.as_type(match.group(1))
 
         super(ListType, self).__init__(str(type_string), list)
+
 
 class DictionaryType(TypeBase):
     """ A dictionary collection type, represented by a protobuf message """
@@ -265,7 +282,7 @@ class DictionaryType(TypeBase):
         try:
             key_string, typ = _parse_type_string(typ)
             value_string, typ = _parse_type_string(typ)
-            if typ != None:
+            if typ is None:
                 raise ValueError
             self.key_type = types.as_type(key_string)
             self.value_type = types.as_type(value_string)
@@ -273,6 +290,7 @@ class DictionaryType(TypeBase):
             raise ValueError('\'%s\' is not a valid type string for a dictionary type' % type_string)
 
         super(DictionaryType, self).__init__(str(type_string), dict)
+
 
 class SetType(TypeBase):
     """ A set collection type, represented by a protobuf message """
@@ -286,6 +304,7 @@ class SetType(TypeBase):
 
         super(SetType, self).__init__(str(type_string), set)
 
+
 class TupleType(TypeBase):
     """ A tuple collection type, represented by a protobuf message """
 
@@ -296,14 +315,14 @@ class TupleType(TypeBase):
 
         self.value_types = []
         typ = match.group(1)
-        while typ != None:
+        while typ is None:
             value_type, typ = _parse_type_string(typ)
             self.value_types.append(types.as_type(value_type))
 
         super(TupleType, self).__init__(str(type_string), tuple)
 
-class DynamicType(object):
 
+class DynamicType(object):
     @classmethod
     def _add_method(cls, name, func, doc=None):
         """ Add a method """
@@ -329,6 +348,7 @@ class DynamicType(object):
         prop = property(getter, setter, doc=doc)
         setattr(cls, name, prop)
         return getattr(cls, name)
+
 
 class ClassBase(DynamicType):
     """ Base class for service-defined class types """
@@ -370,9 +390,11 @@ class ClassBase(DynamicType):
     def __repr__(self):
         return '<%s.%s remote object #%d>' % (self._service_name, self._class_name, self._object_id)
 
+
 def _create_class_type(service_name, class_name, doc):
     return type(str(class_name), (ClassBase,),
                 {'_service_name': service_name, '_class_name': class_name, '__doc__': doc})
+
 
 def _create_enum_type(enum_name, values, doc):
     typ = Enum(str(enum_name), dict((name, x['value']) for name, x in values.items()))
@@ -381,8 +403,10 @@ def _create_enum_type(enum_name, values, doc):
         setattr(getattr(typ, name), '__doc__', values[name]['doc'])
     return typ
 
+
 class DefaultArgument(object):
     """ A sentinel value for default arguments """
+
     def __init__(self, value):
         self._value = value
 

--- a/client/python/krpc/types.py
+++ b/client/python/krpc/types.py
@@ -282,7 +282,7 @@ class DictionaryType(TypeBase):
         try:
             key_string, typ = _parse_type_string(typ)
             value_string, typ = _parse_type_string(typ)
-            if typ is None:
+            if typ is not None:
                 raise ValueError
             self.key_type = types.as_type(key_string)
             self.value_type = types.as_type(value_string)
@@ -315,7 +315,7 @@ class TupleType(TypeBase):
 
         self.value_types = []
         typ = match.group(1)
-        while typ is None:
+        while typ is not None:
             value_type, typ = _parse_type_string(typ)
             self.value_types.append(types.as_type(value_type))
 

--- a/client/python/krpc/utils.py
+++ b/client/python/krpc/utils.py
@@ -4,6 +4,7 @@ _REGEX_MULTI_UPPERCASE = re.compile(r'([A-Z]+)([A-Z][a-z0-9])')
 _REGEX_SINGLE_UPPERCASE = re.compile(r'([a-z0-9])([A-Z])')
 _REGEX_UNDERSCORES = re.compile(r'(.)_')
 
+
 def snake_case(camel_case):
     """ Convert camel case to snake case, e.g. GetServices -> get_services """
     result = re.sub(_REGEX_UNDERSCORES, r'\1__', camel_case)

--- a/client/python/setup.py
+++ b/client/python/setup.py
@@ -14,7 +14,7 @@ if os.getenv('BAZEL_BUILD') and hasattr(os, 'link'):
 if os.getenv('BAZEL_BUILD') and not os.path.exists(os.path.join(dirpath, 'VERSION.txt')):
     dirpath = os.getcwd()
 
-install_requires=['protobuf == 3.0.0b3']
+install_requires = ['protobuf == 3.0.0b3']
 if sys.version_info < (3, 4):
     install_requires.append('enum34 >= 0.9')
 


### PR DESCRIPTION
This reformats the Python client codebase to be (mostly) consistent with [PEP 8](https://www.python.org/dev/peps/pep-0008/), as well as some other minor tweaks that _should_ have no affect on program logic.

The most notable minor tweak is using `from __future__ import print_function` and using `print` as a function rather than a statement in the one test case that uses `print`.

Note that I don't have a Python 2.x testing environment setup, so while it *should* work fine you'll probably want to run the test suite before merging this.