### PR TITLE
Add Client connect constructor

### DIFF
--- a/client/cpp/include/krpc/client.hpp
+++ b/client/cpp/include/krpc/client.hpp
@@ -15,10 +15,12 @@ class Client {
   Client();
   Client(const std::shared_ptr<Connection>& rpc_connection,
          const std::shared_ptr<Connection>& stream_connection);
-
+  Client(const std::string &name, const std::string &address,
+         unsigned int rpc_port = 50000, unsigned int stream_port = 50001);
+  ~Client();
   schema::Request request(
-    const std::string& service, const std::string& procedure,
-    const std::vector<std::string>& args = std::vector<std::string>());
+      const std::string &service, const std::string &procedure,
+      const std::vector<std::string> &args = std::vector<std::string>());
   std::string invoke(const schema::Request& request);
   std::string invoke(
     const std::string& service, const std::string& procedure,

--- a/client/cpp/src/stream_manager.cpp
+++ b/client/cpp/src/stream_manager.cpp
@@ -74,7 +74,7 @@ void StreamManager::update_thread_main(StreamManager* stream_manager,
   }
 }
 
-StreamManager::StreamManager() {}
+StreamManager::StreamManager():client(NULL) {}
 
 StreamManager::StreamManager(Client * client, const std::shared_ptr<Connection>& connection)
   : client(client), connection(connection),
@@ -87,8 +87,10 @@ StreamManager::StreamManager(Client * client, const std::shared_ptr<Connection>&
 }
 
 StreamManager::~StreamManager() {
-  stop->store(true);
-  update_thread->join();
+  if(client!=NULL){
+    stop->store(true);
+    update_thread->join();
+  }
 }
 
 google::protobuf::uint64 StreamManager::add_stream(const schema::Request& request) {


### PR DESCRIPTION
I have made a change to `Client` to allow for construction with parameters like `krpc::connect`. I found this necessary because I was trying to keep a `Client` persistently in a `std::shared_ptr `. Unfortunately in C++11 it is an error to take a pointer to locally created memory, so `krpc::connect` can't be used to initialize pointers directly.

This left three options: Either I could copy krpc::connect into my own code so i can access the Client constructor,  add a `connect` function to `Client`--and use an unitialized client in the `shared_ptr`, or use a special constructor that handles everything.

I decided that because there is no way to disconnect without reaching the end of scope for the `Client`, that it was best to use that mechanism for the start of the connection too.  This works fine because `asio` will clean up our connections when they are destroyed.   The current mechanism works like this:

Connection:
`std::shared_ptr<krpc::Client> conn = std::make_shared<krpc::Client>("Name", "127.0.0.1", 50000, 50001);`
Disconnection:
`conn.reset()` or `conn = nullptr`

This works great but there was one catch.  `StreamManager`'s destructor assumed that it was initialized and performed actions that were not possible if it wasn't properly initialized. The new `Client` constructor doesn't immediately intialize `StreamManager` and it calls the default constructor once, which cannot properly be destructed without segfaulting.  

The least invasive way to fix this was simply to guard the destructors's code, and to predicate this on whether the `Client` pointer was initialized.  I also added a `null` initialization for `Client` to make sure this works.
  