### PR TITLE
1.3 Preliminary -  Fixes Target Lock Issue - Couple of new waypoint and celestial body methods for dealing with points above the ground.

### DIFF
--- a/server/src/CompatibilityChecker.cs
+++ b/server/src/CompatibilityChecker.cs
@@ -28,6 +28,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using UnityEngine;
+using UnityEngine.UI;
 
 /*-----------------------------------------*\
 |   SUBSTITUTE YOUR MOD'S NAMESPACE HERE.   |
@@ -149,7 +150,7 @@ namespace KRPC
             }
 
             if ((incompatible.Length > 0) || (incompatibleUnity.Length > 0)) {
-                PopupDialog.SpawnPopupDialog (new Vector2 (0.5f, 0.5f), new Vector2 (0.5f, 0.5f), "Incompatible Mods Detected", message, "OK", true, HighLogic.UISkin);
+                PopupDialog.SpawnPopupDialog (new Vector2 (0.5f, 0.5f), new Vector2 (0.5f, 0.5f),"IncompatibleDetected", "Incompatible Mods Detected", message, "OK", true, HighLogic.UISkin);
             }
         }
 

--- a/server/src/ServicesChecker.cs
+++ b/server/src/ServicesChecker.cs
@@ -32,7 +32,7 @@ namespace KRPC
             } catch (ServiceException e) {
                 OK = false;
                 var msg = e.Message + Environment.NewLine + (e.Assembly == null ? "unknown" : e.Assembly.Location);
-                PopupDialog.SpawnPopupDialog (new Vector2 (0.5f, 0.5f), new Vector2 (0.5f, 0.5f), "kRPC service error - plugin disabled", msg, "OK", true, HighLogic.UISkin);
+                PopupDialog.SpawnPopupDialog (new Vector2 (0.5f, 0.5f), new Vector2 (0.5f, 0.5f),"PluginDisabled", "kRPC service error - plugin disabled", msg, "OK", true, HighLogic.UISkin);
             }
         }
 
@@ -48,7 +48,8 @@ namespace KRPC
                     msg += Environment.NewLine + notDocumented [i];
                 if (n > 10)
                     msg += Environment.NewLine + "...";
-                PopupDialog.SpawnPopupDialog (new Vector2 (0.5f, 0.5f), new Vector2 (0.5f, 0.5f), "kRPC service warning", msg, "OK", true, HighLogic.UISkin);
+                PopupDialog.SpawnPopupDialog (new Vector2 (0.5f, 0.5f), new Vector2 (0.5f, 0.5f),"ServiceWarning", "kRPC service warning", msg, "OK", true, HighLogic.UISkin);
+
             }
         }
 

--- a/server/src/UI/OptionDialog.cs
+++ b/server/src/UI/OptionDialog.cs
@@ -43,7 +43,7 @@ namespace KRPC.UI
                 Visible = true;
                 Opened ();
                 EventHandlerExtensions.Invoke (OnOpen, this);
-                dialog = new MultiOptionDialog (Message, Title, Skin, Options.ToArray ());
+                dialog = new MultiOptionDialog (Message, Title,"Dialog", Skin, Options.ToArray ());
                 popup = PopupDialog.SpawnPopupDialog (new Vector2 (0.5f, 0.5f), new Vector2 (0.5f, 0.5f), dialog, false, HighLogic.UISkin);
             }
         }

--- a/server/src/Utils/APILoader.cs
+++ b/server/src/Utils/APILoader.cs
@@ -71,7 +71,8 @@ namespace KRPC.Utils
         static void Error (string message)
         {
             Logger.WriteLine ("Load API: " + message, Logger.Severity.Error);
-            PopupDialog.SpawnPopupDialog (new Vector2 (0.5f, 0.5f), new Vector2 (0.5f, 0.5f), "kRPC API Loader", message, "OK", true, HighLogic.UISkin);
+            PopupDialog.SpawnPopupDialog (new Vector2 (0.5f, 0.5f), new Vector2 (0.5f, 0.5f),"APILoader", "kRPC API Loader", message, "OK", true, HighLogic.UISkin);
+   
         }
     }
 }

--- a/service/SpaceCenter/src/Services/CelestialBody.cs
+++ b/service/SpaceCenter/src/Services/CelestialBody.cs
@@ -212,6 +212,21 @@ namespace KRPC.SpaceCenter.Services
             return PositionAt (latitude, longitude, BedrockHeight (latitude, longitude), referenceFrame);
         }
 
+        /// <summary>
+        /// The position at the given latitude, longitude, and altitude in the given
+        /// reference frame.  
+        /// </summary>
+        /// <param name="latitude">Latitude in degrees</param>
+        /// <param name="longitude">Longitude in degrees</param>
+        /// <param name="altitude">Longitude in degrees</param>
+        /// <param name="referenceFrame">Reference frame for the returned position vector</param>
+        [KRPCMethod]
+        public Tuple3 PositionAtAlt(double latitude, double longitude, double altitude, ReferenceFrame referenceFrame)
+        {
+            return PositionAt(latitude, longitude, altitude, referenceFrame);
+        }
+
+
         Tuple3 PositionAt (double latitude, double longitude, double altitude, ReferenceFrame referenceFrame)
         {
             if (ReferenceEquals (referenceFrame, null))

--- a/service/SpaceCenter/src/Services/SpaceCenter.cs
+++ b/service/SpaceCenter/src/Services/SpaceCenter.cs
@@ -89,7 +89,11 @@ namespace KRPC.SpaceCenter.Services
                 var target = FlightGlobals.fetch.VesselTarget as global::CelestialBody;
                 return target != null ? new CelestialBody (target) : null;
             }
-            set { FlightGlobals.fetch.SetVesselTarget (ReferenceEquals (value, null) ? null : value.InternalBody); }
+            set {
+                InputLockManager.lockMask &= (ulong)~ControlTypes.TARGETING;
+                FlightGlobals.fetch.SetVesselTarget (ReferenceEquals (value, null) ? null : value.InternalBody);
+                InputLockManager.lockMask &= (ulong)ControlTypes.TARGETING;
+            }
         }
 
         /// <summary>
@@ -101,7 +105,11 @@ namespace KRPC.SpaceCenter.Services
                 var target = FlightGlobals.fetch.VesselTarget as global::Vessel;
                 return target != null ? new Vessel (target) : null;
             }
-            set { FlightGlobals.fetch.SetVesselTarget (ReferenceEquals (value, null) ? null : value.InternalVessel); }
+            set {
+                InputLockManager.lockMask &= (ulong)~ControlTypes.TARGETING;
+                FlightGlobals.fetch.SetVesselTarget (ReferenceEquals (value, null) ? null : value.InternalVessel);
+                InputLockManager.lockMask &= (ulong)ControlTypes.TARGETING;
+            }
         }
 
         /// <summary>
@@ -113,7 +121,11 @@ namespace KRPC.SpaceCenter.Services
                 var target = FlightGlobals.fetch.VesselTarget as ModuleDockingNode;
                 return target != null ? new Parts.DockingPort (new Parts.Part (target.part)) : null;
             }
-            set { FlightGlobals.fetch.SetVesselTarget (ReferenceEquals (value, null) ? null : value.InternalPort); }
+            set {
+                InputLockManager.lockMask &= (ulong)~ControlTypes.TARGETING;
+                FlightGlobals.fetch.SetVesselTarget (ReferenceEquals (value, null) ? null : value.InternalPort);
+                InputLockManager.lockMask &= (ulong)ControlTypes.TARGETING;
+            }
         }
 
         /// <summary>
@@ -122,7 +134,9 @@ namespace KRPC.SpaceCenter.Services
         [KRPCProcedure]
         public static void ClearTarget ()
         {
+            InputLockManager.lockMask &= (ulong)~ControlTypes.TARGETING;
             FlightGlobals.fetch.SetVesselTarget (null);
+            InputLockManager.lockMask &= (ulong)ControlTypes.TARGETING;
         }
 
         /// <summary>

--- a/service/SpaceCenter/src/Services/Vessel.cs
+++ b/service/SpaceCenter/src/Services/Vessel.cs
@@ -220,15 +220,15 @@ namespace KRPC.SpaceCenter.Services
         /// </summary>
         [KRPCProperty]
         public float Mass {
-            get { return InternalVessel.parts.Sum (PartExtensions.WetMass); }
-        }
+            get { return InternalVessel.parts.Sum(i => i.WetMass()); }
+        } 
 
         /// <summary>
         /// The total mass of the vessel, excluding resources, in kg.
         /// </summary>
         [KRPCProperty]
         public float DryMass {
-            get { return InternalVessel.parts.Sum (PartExtensions.DryMass); }
+            get { return InternalVessel.parts.Sum(i => i.DryMass()); }
         }
 
         IEnumerable<Parts.Engine> ActiveEngines {

--- a/service/SpaceCenter/src/Services/Waypoint.cs
+++ b/service/SpaceCenter/src/Services/Waypoint.cs
@@ -28,6 +28,24 @@ namespace KRPC.SpaceCenter.Services
             InternalWaypoint.isNavigatable = true;
             FinePrint.WaypointManager.AddWaypoint (InternalWaypoint);
         }
+        /// <summary>
+        ///
+        /// Create a waypoint object with altitude specified.
+        /// </summary>
+        internal Waypoint(double latitude, double longitude, double altitude, CelestialBody body, string name)
+        {
+            InternalWaypoint = new FinePrint.Waypoint();
+            Name = name;
+            Body = body;
+            Icon = "report";
+            Latitude = latitude;
+            Color = 1115;
+            Longitude = longitude;
+            MeanAltitude = altitude;
+            InternalWaypoint.isOnSurface = Math.Abs((Body.SurfaceHeight(latitude, longitude) - altitude))>10;
+            InternalWaypoint.isNavigatable = true;
+            FinePrint.WaypointManager.AddWaypoint(InternalWaypoint);
+        }
 
         /// <summary>
         /// Create a waypoint object from a KSP waypoint.

--- a/service/SpaceCenter/src/Services/WaypointManager.cs
+++ b/service/SpaceCenter/src/Services/WaypointManager.cs
@@ -69,6 +69,23 @@ namespace KRPC.SpaceCenter.Services
         }
 
         /// <summary>
+        /// Creates a waypoint at the given position and altitude, and returns a
+        /// <see cref="Waypoint"/> object that can be used to modify it.
+        /// </summary>
+        /// <param name="latitude">Latitude of the waypoint.</param>
+        /// <param name="longitude">Longitude of the waypoint.</param>
+        /// <param name="altitude">Altitude(above sea level) of the waypoint.</param>
+        /// <param name="body">Celestial body the waypoint is attached to.</param>
+        /// <param name="name">Name of the waypoint.</param>
+        /// <returns></returns>
+        [KRPCMethod]
+        [SuppressMessage("Gendarme.Rules.Correctness", "MethodCanBeMadeStaticRule")]
+        public Waypoint AddWaypointAtAlt(double latitude, double longitude,double altitude, CelestialBody body, string name)
+        {
+            return new Waypoint(latitude, longitude, altitude, body, name);
+        }
+
+        /// <summary>
         /// Returns all available icons (from "GameData/Squad/Contracts/Icons/").
         /// </summary>
         [KRPCProperty]


### PR DESCRIPTION
I think this fix takes care of the targeting problem.  It seems to clear and immediately reset the lock.  I tested by mashing buttons wildly while the KSP application window wasn't the actively focused one and a  python script was switching targets every half second - and my vessel didn't respond to any of those control inputs -  so it seems to do the job.  

I also added a method to Celestial body to get a position at altitude and added a method to the Waypoint manager to create a waypoint with a specified altitude.   These two fixes make it a little easier and cleaner to handle points in flight, such as defining a glideslope or area for a flyover contract.   If you don't like them, my feelings aren't hurt!   

I also couldn't get the old linq code to compile on wetmass and drymass.  I don't know if that was a bug or something dumb on my end, but what I did seems to work and compile.   Thanks for tolerating me learning on your code!  Sorry if I'm a hassle!