### PR TITLE
Fix a couple of compiler warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,10 @@ bin
 obj
 KSP.log
 PartDatabase.cfg
+
+# Visual Studio Code
+.vs/
+
+# Jetbrains' Rider and friends
+.idea/
+

--- a/service/Drawing/src/Line.cs
+++ b/service/Drawing/src/Line.cs
@@ -25,7 +25,7 @@ namespace KRPC.Drawing
         {
             renderer = GameObject.GetComponent<LineRenderer> ();
             renderer.useWorldSpace = true;
-            #pragma warning disable CS0618
+            #pragma warning disable 618
             renderer.SetVertexCount (2);
             #pragma warning restore
             renderer.SetPosition (0, Vector3d.zero);
@@ -75,7 +75,7 @@ namespace KRPC.Drawing
             set {
                 color = value;
                 var rgbColor = color.ToColor ();
-                #pragma warning disable CS0618
+                #pragma warning disable 618
                 renderer.SetColors (rgbColor, rgbColor);
                 #pragma warning restore
             }
@@ -89,7 +89,7 @@ namespace KRPC.Drawing
             get { return thickness; }
             set {
                 thickness = value;
-                #pragma warning disable CS0618
+                #pragma warning disable 618
                 renderer.SetWidth (thickness, thickness);
                 #pragma warning restore
             }

--- a/service/Drawing/src/Polygon.cs
+++ b/service/Drawing/src/Polygon.cs
@@ -27,7 +27,7 @@ namespace KRPC.Drawing
             renderer = GameObject.GetComponent<LineRenderer> ();
             renderer.useWorldSpace = true;
             var numVertices = polygonVertices.Count + 1;
-            #pragma warning disable CS0618
+            #pragma warning disable 618
             renderer.SetVertexCount (numVertices);
             #pragma warning restore
             for (int i = 0; i < numVertices; i++)
@@ -80,7 +80,7 @@ namespace KRPC.Drawing
             set {
                 color = value;
                 var rgbColor = color.ToColor ();
-                #pragma warning disable CS0618
+                #pragma warning disable 618
                 renderer.SetColors (rgbColor, rgbColor);
                 #pragma warning restore
             }
@@ -94,7 +94,7 @@ namespace KRPC.Drawing
             get { return thickness; }
             set {
                 thickness = value;
-                #pragma warning disable CS0618
+                #pragma warning disable 618
                 renderer.SetWidth (thickness, thickness);
                 #pragma warning restore
             }


### PR DESCRIPTION
The Microsoft C# compiler requires that warning pragmas take a certain form, or they will themselves emit compiler warnings.

This PR makes the couple of minor comment changes required to fix those warnings.

Please see the Microsoft docs: https://docs.microsoft.com/en-us/dotnet/csharp/misc/cs1692

I've also included two minor .gitignore changes for my own sanity. I'd be happy to make those a separate PR.

Thanks @djungelorm or other maintainers for taking a look