### PR TITLE
fix cref on ContractManager

### DIFF
--- a/service/SpaceCenter/src/Services/ContractManager.cs
+++ b/service/SpaceCenter/src/Services/ContractManager.cs
@@ -8,7 +8,7 @@ namespace KRPC.SpaceCenter.Services
 {
     /// <summary>
     /// Contracts manager.
-    /// Obtained by calling <see cref="SpaceCenter.WaypointManager"/>.
+    /// Obtained by calling <see cref="SpaceCenter.ContractManager"/>.
     /// </summary>
     [KRPCClass (Service = "SpaceCenter")]
     public class ContractManager : Equatable<ContractManager>


### PR DESCRIPTION
ContractManager class has a cref to `SpaceCenter.WaypointManager` in its summary, it seems to be typo of `SpaceCenter.ContractManager`.