### PR TITLE
cnano clients boudrate is adjustable now

### DIFF
--- a/client/cnano/src/communication.c
+++ b/client/cnano/src/communication.c
@@ -48,7 +48,7 @@ krpc_error_t krpc_write(krpc_connection_t connection, const uint8_t * buf, size_
 #if defined(KRPC_COMMUNICATION_ARDUINO)
 
 krpc_error_t krpc_open(krpc_connection_t * connection, const void * arg) {
-  (*connection)->begin(9600);
+  (*connection)->begin(arg);
   while (!*connection) {
   }
   return KRPC_OK;


### PR DESCRIPTION
Updated cnano client so the boudrate can be adjusted via the arg-param.