### PR TITLE
Make Java Connection implement AutoCloseable (since JRE 1.7)

### DIFF
--- a/client/java/src/krpc/client/Connection.java
+++ b/client/java/src/krpc/client/Connection.java
@@ -17,7 +17,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
-public class Connection {
+public class Connection implements AutoCloseable {
   private final Object connectionLock = new Object();
 
   private Socket rpcSocket;
@@ -180,6 +180,7 @@ public class Connection {
   }
 
   /** Close the connection. */
+  @Override
   public void close() throws IOException {
     synchronized (connectionLock) {
       rpcSocket.close();


### PR DESCRIPTION
Benefits:
- Connection is closed when exception is thrown
- Simpler usage:
  
  (before)
  ```
  try {
      Connection connection = Connection.newInstance("Launch into orbit");
       //your code
       connection.close();
   }
   ```
   (after)
   ```
   try(Connection connection = Connection.newInstance("Launch into orbit")) {
       //your code
   }
   ```