### PR TITLE
G force is given in g's, not m/s^2

### DIFF
--- a/service/SpaceCenter/src/Services/Flight.cs
+++ b/service/SpaceCenter/src/Services/Flight.cs
@@ -232,7 +232,7 @@ namespace KRPC.SpaceCenter.Services
         }
 
         /// <summary>
-        /// The current G force acting on the vessel in <math>m/s^2</math>.
+        /// The current G force acting on the vessel in <math>g</math>.
         /// </summary>
         [KRPCProperty]
         public float GForce {


### PR DESCRIPTION
Only a summary change since G forces are given in g's, not m/s^2