### PR TITLE
Fixed SimulateAerodynamicForceAt's velocity calculation

### DIFF
--- a/service/SpaceCenter/src/Services/Flight.cs
+++ b/service/SpaceCenter/src/Services/Flight.cs
@@ -537,7 +537,7 @@ namespace KRPC.SpaceCenter.Services
             } else {
                 Vector3 torque;
                 var altitude = (worldPosition - body.InternalBody.position).magnitude - body.InternalBody.Radius;
-                FAR.CalculateVesselAeroForces(vessel, out worldForce, out torque, worldVelocity, altitude);
+                FAR.CalculateVesselAeroForces(vessel, out worldForce, out torque, worldVelocity - body.InternalBody.getRFrmVel(worldPosition), altitude);
             }
             return referenceFrame.DirectionFromWorldSpace(worldForce).ToTuple();
         }


### PR DESCRIPTION
Partially closes #496 by correctly calculating air-relative velocity for FAR. Despite being named `velocityWorldVector`, CalculateVesselAeroForces is actually expecting a velocity in the air-relative frame. This patch corrects for the rotation of the planet before calling into FAR.