### PR TITLE
Fix SimulateAerodynamicForceAt without FAR

### DIFF
--- a/service/SpaceCenter/src/Services/Flight.cs
+++ b/service/SpaceCenter/src/Services/Flight.cs
@@ -535,7 +535,8 @@ namespace KRPC.SpaceCenter.Services
             var worldPosition = referenceFrame.PositionToWorldSpace(position.ToVector());
             Vector3 worldForce;
             if (!FAR.IsAvailable) {
-                worldForce = StockAerodynamics.SimAeroForce(body.InternalBody, vessel, worldVelocity, worldPosition);
+                var relativeWorldVelocity = worldVelocity - body.InternalBody.getRFrmVel(worldPosition);
+                worldForce = StockAerodynamics.SimAeroForce(body.InternalBody, vessel, relativeWorldVelocity, worldPosition);
             } else {
                 Vector3 torque;
                 var altitude = (worldPosition - body.InternalBody.position).magnitude - body.InternalBody.Radius;


### PR DESCRIPTION
`SimAeroForce` just uses input parameter as air velocity, so it should not be world velocity relative to body in world coordinate system. Tested without FAR.