### PR TITLE
Update C# dependencies

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -332,10 +332,10 @@ filegroup(
         '//tools/build/mono-4.5:Google.Protobuf.dll',
         '//tools/build/ksp:Google.Protobuf.dll',
         '//tools/build/ksp:KRPC.IO.Ports.dll',
-        '//protobuf:csharp_3.9.1',
-        '@csharp_nunit//:nunit_framework',
-        '@csharp_moq//:lib/net40/Moq.dll',
-        '@csharp_json//:lib/net35/Newtonsoft.Json.dll',
+        '//protobuf:csharp_unity',
+        '@csharp_nunit//:lib/net45/nunit.framework.dll',
+        '@csharp_moq//:lib/net45/Moq.dll',
+        '@csharp_json//:lib/net45/Newtonsoft.Json.dll',
         '@csharp_options//:lib/NDesk.Options.dll'
     ]
 )

--- a/BUILD
+++ b/BUILD
@@ -329,13 +329,6 @@ filegroup(
         '//tools/ServiceDefinitions',
         '//tools/TestingTools',
         '//tools/TestServer',
-        '//tools/build/mono-4.5:Google.Protobuf.dll',
-        '//tools/build/ksp:Google.Protobuf.dll',
-        '//tools/build/ksp:KRPC.IO.Ports.dll',
-        '//protobuf:csharp_unity',
-        '@csharp_nunit//:lib/net45/nunit.framework.dll',
-        '@csharp_moq//:lib/net45/Moq.dll',
-        '@csharp_json//:lib/net45/Newtonsoft.Json.dll',
-        '@csharp_options//:lib/NDesk.Options.dll'
+        '//tools/build/ksp:KRPC.IO.Ports.dll'
     ]
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -256,10 +256,18 @@ http_archive(
 
 http_archive(
     name = 'csharp_moq',
-    url = 'http://www.nuget.org/api/v2/package/Moq/4.2.1510.2205',
-    sha256 = '7a86f2ed0e134601e75a4fa28c7f7c399f6abc33f091dbc024ad8b212b8c3c85',
+    url = 'http://www.nuget.org/api/v2/package/Moq/4.17.2',
+    sha256 = '121803242a31ec27b21b3a1742767d0d1447d481442ed48d71ae81e8a552e9fc',
     type = 'zip',
-    build_file_content = "exports_files(['lib/net40/Moq.dll'])"
+    build_file_content = "exports_files(['lib/net45/Moq.dll'])"
+)
+
+http_archive(
+    name = 'csharp_castle_core',
+    url = 'http://www.nuget.org/api/v2/package/Castle.Core/4.4.1',
+    sha256 = '278352f29f4aa9bb8b97a24c98dc29b6c7dc707dfb4df84084fc17da6550b28d',
+    type = 'zip',
+    build_file_content = "exports_files(['lib/net45/Castle.Core.dll'])"
 )
 
 http_archive(

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -136,30 +136,30 @@ http_archive(
 )
 
 http_archive(
-    name = 'protoc_3.9.1_linux_x86_32',
-    url = 'https://github.com/protocolbuffers/protobuf/releases/download/v3.9.1/protoc-3.9.1-linux-x86_32.zip',
-    sha256 = '1094d7896f93b8987b0e05c110c0635bab7cf63aa24592c5d34cd37b590b5aeb',
+    name = 'protoc_unity_linux_x86_32',
+    url = 'https://github.com/protocolbuffers/protobuf/releases/download/v3.10.1/protoc-3.10.1-linux-x86_32.zip',
+    sha256 = '0c97a75c8f8fafc55323599053626a0a822e5b66299f6643a2b086f859b56afd',
     build_file_content = "exports_files(['bin/protoc'])"
 )
 
 http_archive(
-    name = 'protoc_3.9.1_linux_x86_64',
-    url = 'https://github.com/protocolbuffers/protobuf/releases/download/v3.9.1/protoc-3.9.1-linux-x86_64.zip',
-    sha256 = '77410d08e9a3c1ebb68afc13ee0c0fb4272c01c20bfd289adfb51b1c622bab07',
+    name = 'protoc_unity_linux_x86_64',
+    url = 'https://github.com/protocolbuffers/protobuf/releases/download/v3.10.1/protoc-3.10.1-linux-x86_64.zip',
+    sha256 = '0c97a75c8f8fafc55323599053626a0a822e5b66299f6643a2b086f859b56afd',
     build_file_content = "exports_files(['bin/protoc'])"
 )
 
 http_archive(
-    name = 'protoc_3.9.1_osx_x86_32',
-    url = 'https://github.com/protocolbuffers/protobuf/releases/download/v3.9.1/protoc-3.9.1-osx-x86_32.zip',
-    sha256 = 'e7b7377917f6b9ec22c80188936c60380edc684e5bdc96c2993fc79e3e54c042',
+    name = 'protoc_unity_osx_x86_32',
+    url = 'https://github.com/protocolbuffers/protobuf/releases/download/v3.10.1/protoc-3.10.1-osx-x86_64.zip',
+    sha256 = 'ee3f4051e55830596729efe48183218bdb44cf2f83b188460859bd63b2a09576',
     build_file_content = "exports_files(['bin/protoc'])"
 )
 
 http_archive(
-    name = 'protoc_3.9.1_win32',
-    url = 'https://github.com/protocolbuffers/protobuf/releases/download/v3.9.1/protoc-3.9.1-win32.zip',
-    sha256 = '6543fe3fffb6caeb9c8a091afeefbb1a7e7112bc0e00d7b7e89e69e3a1844069',
+    name = 'protoc_unity_win32',
+    url = 'https://github.com/protocolbuffers/protobuf/releases/download/v3.10.1/protoc-3.10.1-win32.zip',
+    sha256 = '964f055db26372e46d8232a09fe6d661de3ca1b82fbbc1ede33696b1e379a11b',
     build_file_content = "exports_files(['bin/protoc.exe'])"
 )
 
@@ -213,17 +213,11 @@ http_archive(
 )
 
 http_archive(
-    name = 'csharp_protobuf_3.9.1',
-    url = 'https://www.nuget.org/api/v2/package/Google.Protobuf/3.9.1',
-    sha256 = 'b4363bb9d1c2b6721624571936e3e1f14ebdf2ecd8788d2584b549c6dce8348b',
+    name = 'csharp_protobuf_unity',
+    url = 'https://www.nuget.org/api/v2/package/Google.Protobuf/3.10.1',
+    sha256 = '17eb7c37e702750d3aa53823571be7662a87a2111c6b2c844ba1c20641424084',
     type = 'zip',
     build_file_content = "exports_files(['lib/net45/Google.Protobuf.dll'])"
-)
-
-http_file(
-    name = 'csharp_protobuf_3.9.1_net35',
-    url = 'https://s3.amazonaws.com/krpc/lib/protobuf-3.9.1-net35/Google.Protobuf.dll',
-    sha256 = 'd0ddb80510810fa53ee124afbd57845e657eaa9016ed7a6edd4d8ecffedf66b5'
 )
 
 http_file(

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -240,28 +240,18 @@ http_file(
 
 http_archive(
     name = 'csharp_nunit',
-    url = 'https://github.com/nunit/nunitv2/releases/download/2.6.4/NUnit-2.6.4.zip',
-    sha256 = '1bd925514f31e7729ccde40a38a512c2accd86895f93465f3dfe6d0b593d7170',
-    strip_prefix = 'NUnit-2.6.4',
-    build_file_content = """
-filegroup(
-    name = 'nunit_exe',
-    srcs = ['bin/nunit-console.exe'],
-    visibility = ['//visibility:public'],
+    url = 'http://www.nuget.org/api/v2/package/NUnit/3.13.3',
+    sha256 = '667fac24817b89e36abbfb76470271e963c56f58e5f54b8d1e275bfcfc74bf71',
+    type = 'zip',
+    build_file_content = "exports_files(['lib/net45/nunit.framework.dll'])"
 )
 
-filegroup(
-    name = 'nunit_exe_libs',
-    srcs = glob(['bin/lib/*.dll']),
-    visibility = ['//visibility:public'],
-)
-
-filegroup(
-    name = 'nunit_framework',
-    srcs = ['bin/framework/nunit.framework.dll'],
-    visibility = ['//visibility:public'],
-)
-"""
+http_archive(
+    name = 'csharp_nunit_consolerunner',
+    url = 'https://www.nuget.org/api/v2/package/NUnit.ConsoleRunner/3.16.3',
+    sha256 = '31056acd318b87da12628f58f8fc3a66b443e58b411da8b650c649775c07b1e4',
+    type = 'zip',
+    build_file_content = "exports_files(['tools/nunit3-console.exe', 'tools/nunit.engine.dll', 'tools/nunit.engine.core.dll', 'tools/nunit.engine.api.dll', 'tools/testcentric.engine.metadata.dll'])"
 )
 
 http_archive(

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -200,8 +200,8 @@ filegroup(
 
 http_file(
     name = 'csharp_nuget',
-    url = 'https://dist.nuget.org/win-x86-commandline/v4.7.1/nuget.exe',
-    sha256 = '82e3aa0205415cd18d8ae34613911717dad3ed4e8ac58143e55ca432a5bf3c0a'
+    url = 'https://dist.nuget.org/win-x86-commandline/v6.4.0/nuget.exe',
+    sha256 = '26730829b240581a3e6a4e276b9ace088930032df0c680d5591beccf6452374e'
 )
 
 http_archive(

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -274,10 +274,10 @@ http_archive(
 
 http_archive(
     name = 'csharp_json',
-    url = 'https://www.nuget.org/api/v2/package/Newtonsoft.Json/9.0.1',
-    sha256 = '998081ae052120917346e2cb57d488888147a2fcdf47c52ea9f83a7b4f049e55',
+    url = 'https://www.nuget.org/api/v2/package/Newtonsoft.Json/13.0.2',
+    sha256 = '112ca3b7f47bcbd743befcf949fb68ce4f9eff73ad9f7f1b39c2c61a1ebd3add',
     type = 'zip',
-    build_file_content = "exports_files(['lib/net35/Newtonsoft.Json.dll', 'lib/net40/Newtonsoft.Json.dll', 'lib/net45/Newtonsoft.Json.dll'])"
+    build_file_content = "exports_files(['lib/net45/Newtonsoft.Json.dll'])"
 )
 
 http_archive(

--- a/client/csharp/BUILD
+++ b/client/csharp/BUILD
@@ -187,7 +187,12 @@ csharp_assembly_info(
     cls_compliant = False
 )
 
-test_deps = [':KRPC.Client', '//tools/build/mono-4.5:Moq'] + deps
+test_deps = [
+    ':KRPC.Client',
+    '//tools/build/mono-4.5:Moq',
+    '//tools/build/mono-4.5:System.Threading.Tasks.Extensions',
+    '//tools/build/mono-4.5:Castle.Core'
+] + deps
 
 csharp_library(
     name = 'KRPC.Client.Test',

--- a/client/csharp/test/ConnectionTest.cs
+++ b/client/csharp/test/ConnectionTest.cs
@@ -257,14 +257,14 @@ namespace KRPC.Client.Test
         public void InvalidOperationException ()
         {
             var exn = Assert.Throws<System.InvalidOperationException> (() => Connection.TestService ().ThrowInvalidOperationException ());
-            Assert.That (exn.Message, Is.StringContaining ("Invalid operation"));
+            Assert.That (exn.Message, Does.Contain ("Invalid operation"));
         }
 
         [Test]
         public void ArgumentException ()
         {
             var exn = Assert.Throws<System.ArgumentException> (() => Connection.TestService ().ThrowArgumentException ());
-            Assert.That (exn.Message, Is.StringContaining ("Invalid argument"));
+            Assert.That (exn.Message, Does.Contain ("Invalid argument"));
         }
 
         [Test]
@@ -272,7 +272,7 @@ namespace KRPC.Client.Test
         public void ArgumentNullException ()
         {
             var exn = Assert.Throws<System.ArgumentNullException> (() => Connection.TestService ().ThrowArgumentNullException (string.Empty));
-            Assert.That (exn.Message, Is.StringContaining ("Value cannot be null.\nParameter name: foo"));
+            Assert.That (exn.Message, Does.Contain ("Value cannot be null.\nParameter name: foo"));
         }
 
         [Test]
@@ -280,14 +280,14 @@ namespace KRPC.Client.Test
         public void ArgumentOutOfRangeException ()
         {
             var exn = Assert.Throws<System.ArgumentOutOfRangeException> (() => Connection.TestService ().ThrowArgumentOutOfRangeException (0));
-            Assert.That (exn.Message, Is.StringContaining ("Specified argument was out of the range of valid values.\nParameter name: foo"));
+            Assert.That (exn.Message, Does.Contain ("Specified argument was out of the range of valid values.\nParameter name: foo"));
         }
 
         [Test]
         public void CustomException ()
         {
             var exn = Assert.Throws<CustomException> (() => Connection.TestService ().ThrowCustomException ());
-            Assert.That (exn.Message, Is.StringContaining ("A custom kRPC exception"));
+            Assert.That (exn.Message, Does.Contain ("A custom kRPC exception"));
         }
 
         [TestCase ("foo\nbar")]

--- a/client/csharp/test/KRPC.Client.Test.csproj
+++ b/client/csharp/test/KRPC.Client.Test.csproj
@@ -34,11 +34,11 @@
       <HintPath>..\..\..\bazel-bin\tools\build\mono-4.5\Google.Protobuf.dll</HintPath>
     </Reference>
     <Reference Include="nunit.framework">
-      <HintPath>..\..\..\bazel-krpc\external\csharp_nunit\bin\framework\nunit.framework.dll</HintPath>
+      <HintPath>..\..\..\bazel-krpc\external\csharp_nunit\lib\net45\nunit.framework.dll</HintPath>
       <Package>nunit</Package>
     </Reference>
     <Reference Include="Moq">
-      <HintPath>..\..\..\bazel-krpc\external\csharp_moq\lib\net40\Moq.dll</HintPath>
+      <HintPath>..\..\..\bazel-krpc\external\csharp_moq\lib\net45\Moq.dll</HintPath>
       <Package>Moq</Package>
     </Reference>
   </ItemGroup>

--- a/client/csharp/test/StreamTest.cs
+++ b/client/csharp/test/StreamTest.cs
@@ -228,7 +228,7 @@ namespace KRPC.Client.Test
             var s = Connection.AddStream (
                 () => Connection.TestService ().ThrowCustomException ());
             var exn = Assert.Throws<CustomException> (() => s.Get ());
-            Assert.That (exn.Message, Is.StringContaining ("A custom kRPC exception"));
+            Assert.That (exn.Message, Does.Contain ("A custom kRPC exception"));
         }
 
         [Test]
@@ -245,7 +245,7 @@ namespace KRPC.Client.Test
                         s.Get ();
                     }
                 });
-            Assert.That (exn.Message, Is.StringContaining ("A custom kRPC exception"));
+            Assert.That (exn.Message, Does.Contain ("A custom kRPC exception"));
         }
 
         [Test]

--- a/lib/BUILD
+++ b/lib/BUILD
@@ -7,6 +7,7 @@ exports_files ([
     'mono-4.5/System.Xml.dll',
     'mono-4.5/System.Memory.dll',
     'mono-4.5/System.Runtime.CompilerServices.Unsafe.dll',
+    'mono-4.5/System.Threading.Tasks.Extensions.dll',
 
     'ksp/KSP_Data/Managed/Assembly-CSharp.dll',
     'ksp/KSP_Data/Managed/Assembly-CSharp-firstpass.dll',

--- a/protobuf/BUILD
+++ b/protobuf/BUILD
@@ -16,10 +16,10 @@ protobuf_csharp(
 )
 
 protobuf_csharp(
-    name = 'csharp_3.9.1',
-    out = 'KRPC_3_9_1.cs',
+    name = 'csharp_unity',
+    out = 'KRPC_unity.cs',
     src = 'krpc.proto',
-    protoc = '//tools/build/protobuf:protoc_3.9.1'
+    protoc = '//tools/build/protobuf:protoc_unity'
 )
 
 protobuf_py(

--- a/server/BUILD
+++ b/server/BUILD
@@ -104,7 +104,9 @@ test_deps = [
     '//tools/build/mono-4.5:Moq',
     '//tools/build/ksp:Google.Protobuf',
     '//tools/build/ksp:KRPC.IO.Ports',
-    '//tools/build/mono-4.5:Newtonsoft.Json'
+    '//tools/build/mono-4.5:Newtonsoft.Json',
+    '//tools/build/mono-4.5:System.Threading.Tasks.Extensions',
+    '//tools/build/mono-4.5:Castle.Core'
 ] + ksp_unity_libs + mono_net_libs
 
 csharp_library(
@@ -114,7 +116,7 @@ csharp_library(
     nunit_test = True,
     optimize = False,
     define = ['CODE_ANALYSIS'],
-    nowarn = ['1591'],
+    nowarn = ['1591', '1685'],
     visibility = ['//:__pkg__']
 )
 

--- a/server/BUILD
+++ b/server/BUILD
@@ -61,7 +61,7 @@ filegroup(
     visibility = ['//tools/ServiceDefinitions:__pkg__']
 )
 
-srcs = [':KRPC-src', ':AssemblyInfo', '//protobuf:csharp_3.9.1']
+srcs = [':KRPC-src', ':AssemblyInfo', '//protobuf:csharp_unity']
 
 deps = [
     '//tools/build/ksp:Google.Protobuf',

--- a/server/CHANGES.txt
+++ b/server/CHANGES.txt
@@ -1,3 +1,6 @@
+v1.0.0
+ * Update to protobuf v3.10.1
+
 v0.5.0
  * Support for KSP 1.8+
  * Update to protobuf v3.9.1

--- a/server/src/KRPC.csproj
+++ b/server/src/KRPC.csproj
@@ -96,7 +96,7 @@
     <Compile Include="..\..\bazel-bin\server\AssemblyInfo.cs">
       <Link>AssemblyInfo.cs</Link>
     </Compile>
-    <Compile Include="..\..\bazel-bin/protobuf/KRPC_3_9_1.cs">
+    <Compile Include="..\..\bazel-bin/protobuf/KRPC_unity.cs">
       <Link>KRPC.cs</Link>
     </Compile>
     <Compile Include="Addon.cs" />

--- a/server/src/Service/Scanner/ClassSignature.cs
+++ b/server/src/Service/Scanner/ClassSignature.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Runtime.Serialization;
 
 namespace KRPC.Service.Scanner
@@ -5,6 +6,7 @@ namespace KRPC.Service.Scanner
     /// <summary>
     /// Signature information for a class, including class name and documentation.
     /// </summary>
+    [Serializable]
     sealed class ClassSignature : ISerializable
     {
         /// <summary>

--- a/server/src/Service/Scanner/EnumerationSignature.cs
+++ b/server/src/Service/Scanner/EnumerationSignature.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Runtime.Serialization;
 
@@ -6,6 +7,7 @@ namespace KRPC.Service.Scanner
     /// <summary>
     /// Signature information for an enumeration type, including name, values and documentation.
     /// </summary>
+    [Serializable]
     sealed class EnumerationSignature : ISerializable
     {
         /// <summary>

--- a/server/src/Service/Scanner/EnumerationValueSignature.cs
+++ b/server/src/Service/Scanner/EnumerationValueSignature.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Runtime.Serialization;
 
 namespace KRPC.Service.Scanner
@@ -5,6 +6,7 @@ namespace KRPC.Service.Scanner
     /// <summary>
     /// Signature information for an enumeration type, including name, values and documentation.
     /// </summary>
+    [Serializable]
     sealed class EnumerationValueSignature : ISerializable
     {
         /// <summary>

--- a/server/src/Service/Scanner/ExceptionSignature.cs
+++ b/server/src/Service/Scanner/ExceptionSignature.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Runtime.Serialization;
 
 namespace KRPC.Service.Scanner
@@ -5,6 +6,7 @@ namespace KRPC.Service.Scanner
     /// <summary>
     /// Signature information for an exception, including class name and documentation.
     /// </summary>
+    [Serializable]
     sealed class ExceptionSignature : ISerializable
     {
         /// <summary>

--- a/server/src/Service/Scanner/ParameterSignature.cs
+++ b/server/src/Service/Scanner/ParameterSignature.cs
@@ -6,6 +6,7 @@ namespace KRPC.Service.Scanner
     /// <summary>
     /// Signature information for a parameter.
     /// </summary>
+    [Serializable]
     sealed class ParameterSignature : ISerializable
     {
         /// <summary>

--- a/server/src/Service/Scanner/ProcedureSignature.cs
+++ b/server/src/Service/Scanner/ProcedureSignature.cs
@@ -10,6 +10,7 @@ namespace KRPC.Service.Scanner
     /// Signature information for a procedure, including procedure name,
     /// parameter types and return types.
     /// </summary>
+    [Serializable]
     sealed class ProcedureSignature : ISerializable
     {
         /// <summary>

--- a/server/src/Service/Scanner/ServiceSignature.cs
+++ b/server/src/Service/Scanner/ServiceSignature.cs
@@ -6,6 +6,7 @@ using KRPC.Utils;
 
 namespace KRPC.Service.Scanner
 {
+    [Serializable]
     sealed class ServiceSignature : ISerializable
     {
         /// <summary>

--- a/server/src/ignores.txt
+++ b/server/src/ignores.txt
@@ -155,6 +155,7 @@ R: Gendarme.Rules.Serialization.ImplementISerializableCorrectlyRule
 T: KRPC.Service.Scanner.ClassSignature
 T: KRPC.Service.Scanner.EnumerationSignature
 T: KRPC.Service.Scanner.EnumerationValueSignature
+T: KRPC.Service.Scanner.ExceptionSignature
 T: KRPC.Service.Scanner.ParameterSignature
 T: KRPC.Service.Scanner.ProcedureSignature
 T: KRPC.Service.Scanner.ServiceSignature

--- a/server/test/KRPC.Test.csproj
+++ b/server/test/KRPC.Test.csproj
@@ -96,11 +96,11 @@
       <HintPath>..\..\bazel-bin\tools\build\ksp\KRPC.IO.Ports.dll</HintPath>
     </Reference>
     <Reference Include="nunit.framework">
-      <HintPath>..\..\bazel-krpc\external\csharp_nunit\bin\framework\nunit.framework.dll</HintPath>
+      <HintPath>..\..\bazel-krpc\external\csharp_nunit\lib\net45\nunit.framework.dll</HintPath>
       <Package>nunit</Package>
     </Reference>
     <Reference Include="Moq">
-      <HintPath>..\..\bazel-krpc\external\csharp_moq\lib\net40\Moq.dll</HintPath>
+      <HintPath>..\..\bazel-krpc\external\csharp_moq\lib\net45\Moq.dll</HintPath>
       <Package>Moq</Package>
     </Reference>
     <Reference Include="Newtonsoft.Json">

--- a/server/test/Server/TCP/NetworkInformationTest.cs
+++ b/server/test/Server/TCP/NetworkInformationTest.cs
@@ -17,7 +17,7 @@ namespace KRPC.Test.Server.TCP
         }
 
         [Test]
-        [Ignore]
+        [Ignore("returns empty string")]
         public void GetLoopbackSubnetMask ()
         {
             Assert.AreEqual (string.Empty, NetworkInformation.GetSubnetMask (IPAddress.Loopback).ToString ());

--- a/tools/ServiceDefinitions/BUILD
+++ b/tools/ServiceDefinitions/BUILD
@@ -29,13 +29,11 @@ csharp_assembly_info(
     ]
 )
 
-# Build KRPC.dll using .Net 4.5 libraries as references instead of KSP libraries
-# to work around issue with KSP libraries failing strong name validation
 csharp_library(
     name = 'KRPC',
-    srcs = ['//server:KRPC-src', '//server:AssemblyInfo', '//protobuf:csharp_3.9.1'],
+    srcs = ['//server:KRPC-src', '//server:AssemblyInfo', '//protobuf:csharp_unity'],
     deps = [
-        '//tools/build/protobuf-3.9.1:Google.Protobuf',
+        '//tools/build/ksp:Google.Protobuf',
         '//tools/build/ksp:KRPC.IO.Ports'
     ] + ksp_unity_libs + mono_net_libs,
     visibility = ['//tools/krpctools:__pkg__', '//tools/TestServer:__pkg__']

--- a/tools/TestServer/BUILD
+++ b/tools/TestServer/BUILD
@@ -19,7 +19,7 @@ csharp_assembly_info(
 srcs = ['src/TestService.cs', ':AssemblyInfo']
 deps = [
     '//tools/ServiceDefinitions:KRPC',
-    '//tools/build/protobuf-3.9.1:Google.Protobuf',
+    '//tools/build/ksp:Google.Protobuf',
     '//tools/build/ksp:KRPC.IO.Ports'
 ] + mono_net_libs
 
@@ -40,7 +40,6 @@ pkg_zip(
         'tools/build/protobuf/LICENSE': 'LICENSE.protobuf',
         'tools/build/mono-4.5/': '',
         'tools/build/ksp/': '',
-        'tools/build/protobuf-3.9.1/': '',
         'tools/ServiceDefinitions/': ''
     },
     exclude = ['*.mdb', 'tools/TestServer/TestServer'],

--- a/tools/build/ksp/BUILD
+++ b/tools/build/ksp/BUILD
@@ -24,4 +24,4 @@ csharp_reference(name = 'System.Core', file = '//lib:ksp/KSP_Data/Managed/System
 csharp_reference(name = 'System.Xml', file = '//lib:ksp/KSP_Data/Managed/System.Xml.dll')
 csharp_reference(name = 'KRPC.IO.Ports', file = '@csharp_krpc_io_ports//file')
 
-csharp_reference(name = 'Google.Protobuf', file = '@csharp_protobuf_3.9.1_net35//file')
+csharp_reference(name = 'Google.Protobuf', file = '@csharp_protobuf_unity//:lib/net45/Google.Protobuf.dll')

--- a/tools/build/mono-4.5/BUILD
+++ b/tools/build/mono-4.5/BUILD
@@ -10,8 +10,10 @@ csharp_reference(name = 'System.IO', file = '//lib:mono-4.5/Facades/System.IO.dl
 csharp_reference(name = 'System.Xml', file = '//lib:mono-4.5/System.Xml.dll')
 csharp_reference(name = 'System.Memory', file = '//lib:mono-4.5/System.Memory.dll')
 csharp_reference(name = 'System.Runtime.CompilerServices.Unsafe', file = '//lib:mono-4.5/System.Runtime.CompilerServices.Unsafe.dll')
+csharp_reference(name = 'System.Threading.Tasks.Extensions', file = '//lib:mono-4.5/System.Threading.Tasks.Extensions.dll')
 
 csharp_reference(name = 'Google.Protobuf', file = '@csharp_protobuf//:lib/net45/Google.Protobuf.dll')
 csharp_reference(name = 'Newtonsoft.Json', file = '@csharp_json//:lib/net45/Newtonsoft.Json.dll')
 csharp_reference(name = 'NDesk.Options', file = '@csharp_options//:lib/NDesk.Options.dll')
-csharp_reference(name = 'Moq', file = '@csharp_moq//:lib/net40/Moq.dll')
+csharp_reference(name = 'Moq', file = '@csharp_moq//:lib/net45/Moq.dll')
+csharp_reference(name = 'Castle.Core', file = '@csharp_castle_core//:lib/net45/Castle.Core.dll')

--- a/tools/build/protobuf-3.9.1/BUILD
+++ b/tools/build/protobuf-3.9.1/BUILD
@@ -1,5 +1,0 @@
-load('//tools/build:csharp.bzl', 'csharp_reference')
-
-package(default_visibility = ['//visibility:public'])
-
-csharp_reference(name = 'Google.Protobuf', file = '@csharp_protobuf_3.9.1//:lib/net45/Google.Protobuf.dll')

--- a/tools/build/protobuf/BUILD
+++ b/tools/build/protobuf/BUILD
@@ -21,16 +21,16 @@ filegroup(
 )
 
 filegroup(
-    name = 'protoc_3.9.1',
+    name = 'protoc_unity',
     srcs = select({
-        ':windows_mingw': ['@protoc_3.9.1_win32//:bin/protoc.exe'],
-        ':windows_msys64_mingw64': ['@protoc_3.9.1_win32//:bin/protoc.exe'],
-        ':windows_msys64': ['@protoc_3.9.1_win32//:bin/protoc.exe'],
-        ':windows_clang': ['@protoc_3.9.1_win32//:bin/protoc.exe'],
-        ':darwin': ['@protoc_3.9.1_osx_x86_32//:bin/protoc'],
-        ':k8': ['@protoc_3.9.1_linux_x86_64//:bin/protoc'],
-        ':piii': ['@protoc_3.9.1_linux_x86_32//:bin/protoc'],
-        ':freebsd': ['@protoc_3.9.1_linux_x86_32//:bin/protoc']
+        ':windows_mingw': ['@protoc_unity_win32//:bin/protoc.exe'],
+        ':windows_msys64_mingw64': ['@protoc_unity_win32//:bin/protoc.exe'],
+        ':windows_msys64': ['@protoc_unity_win32//:bin/protoc.exe'],
+        ':windows_clang': ['@protoc_unity_win32//:bin/protoc.exe'],
+        ':darwin': ['@protoc_unity_osx_x86_32//:bin/protoc'],
+        ':k8': ['@protoc_unity_linux_x86_64//:bin/protoc'],
+        ':piii': ['@protoc_unity_linux_x86_32//:bin/protoc'],
+        ':freebsd': ['@protoc_unity_linux_x86_32//:bin/protoc']
     }),
     visibility = ['//visibility:public']
 )

--- a/tools/dist/genfiles.sh
+++ b/tools/dist/genfiles.sh
@@ -8,4 +8,21 @@ VERSION=`tools/krpc-version.sh`
 FILE=bazel-bin/krpc-genfiles-$VERSION.zip
 
 rm -f $FILE
-zip -r $FILE generated_deps
+zip -r $FILE \
+    bazel-bin/server/AssemblyInfo.cs \
+    bazel-bin/server/TestAssemblyInfo.cs \
+    bazel-bin/protobuf/KRPC_unity.cs \
+    bazel-bin/client/csharp/AssemblyInfo.cs \
+    bazel-bin/protobuf/KRPC.cs \
+    bazel-bin/client/csharp/Services/ \
+    bazel-bin/service/*/AssemblyInfo.cs \
+    bazel-bin/tools/*/AssemblyInfo.cs \
+    bazel-krpc/external/csharp_protobuf_unity \
+    bazel-krpc/external/csharp_protobuf \
+    bazel-krpc/external/csharp_nunit \
+    bazel-krpc/external/csharp_moq \
+    bazel-krpc/external/csharp_json \
+    bazel-krpc/external/csharp_options \
+    bazel-bin/tools/build/ksp/Google.Protobuf.dll \
+    bazel-bin/tools/build/ksp/KRPC.IO.Ports.dll \
+    bazel-bin/tools/build/mono-4.5/Google.Protobuf.dll

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -44,7 +44,7 @@ cp -R -L \
     bazel-bin/service/DockingCamera/KRPC.DockingCamera.dll \
     bazel-bin/service/DockingCamera/KRPC.DockingCamera.xml \
     service/UI/KRPC.UI.ksp \
-    bazel-bin/tools/cslibs/net35/Google.Protobuf.dll \
+    bazel-bin/tools/cslibs/unity/Google.Protobuf.dll \
     bazel-bin/tools/cslibs/KRPC.IO.Ports.dll \
     bazel-bin/tools/TestingTools/TestingTools.dll \
     bazel-bin/tools/TestingTools/TestingTools.xml \

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -50,13 +50,13 @@ cp -R -L \
     bazel-bin/tools/TestingTools/TestingTools.xml \
     service/SpaceCenter/src/module-manager.cfg \
     $GAMEDATA/
-cp -L bazel-bin/tools/cslibs/ModuleManager.4.1.3.dll $GAMEDATA/../
+cp -L bazel-bin/tools/cslibs/ModuleManager.4.2.2.dll $GAMEDATA/../
 
 mkdir -p $GAMEDATA/PluginData
 cp tools/settings.cfg $GAMEDATA/PluginData/
 
 find $GAMEDATA -type f -exec chmod 644 {} \;
 find $GAMEDATA -type d -exec chmod 755 {} \;
-chmod 644 $GAMEDATA/../ModuleManager.4.1.3.dll
+chmod 644 $GAMEDATA/../ModuleManager.4.2.2.dll
 
 ls -lR $GAMEDATA


### PR DESCRIPTION
 - Update C# libraries and nuget to latest versions, where possible.
   - Note: protobuf is updated to 3.10.1 (for the server) as this is the latest version that works with KSP's version of Unity.
 - Update genfiles to include all of the required files for building using the csproj and sln files.

Related to #638 
