### PR TITLE
Add sphinxcontrib-jquery to docs

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -707,6 +707,13 @@ http_file(
 )
 
 http_file(
+    name = 'python_sphinxcontrib_jquery',
+    url = 'https://files.pythonhosted.org/packages/38/e8/8ba91a585a8d0b6a1952eeeb8ea392e025e4efc7c860f4679794a776b116/sphinxcontrib-jquery-2.0.0.tar.gz',
+    sha256 = '8fb65f6dba84bf7bcd1aea1f02ab3955ac34611d838bcc95d4983b805b234daa',
+    downloaded_file_path = 'sphinxcontrib-jquery-2.0.0.tar.gz'
+)
+
+http_file(
     name = 'python_sphinxcontrib_jsmath',
     url = 'https://files.pythonhosted.org/packages/b2/e8/9ed3830aeed71f17c026a07a5097edcf44b692850ef215b161b8ad875729/sphinxcontrib-jsmath-1.0.1.tar.gz',
     sha256 = 'a9925e4a4587247ed2191a22df5f6970656cb8ca2bd6284309578f2153e0c4b8',

--- a/doc/BUILD
+++ b/doc/BUILD
@@ -75,6 +75,7 @@ py_script(
         '@python_sphinxcontrib_applehelp//file',
         '@python_sphinxcontrib_devhelp//file',
         '@python_sphinxcontrib_htmlhelp//file',
+        '@python_sphinxcontrib_jquery//file',
         '@python_sphinxcontrib_jsmath//file',
         '@python_sphinxcontrib_luadomain//file',
         '@python_sphinxcontrib_qthelp//file',

--- a/doc/conf.py.tmpl
+++ b/doc/conf.py.tmpl
@@ -6,8 +6,17 @@ author = ''
 
 master_doc = 'index'
 source_suffix = '.rst'
-extensions = ['sphinx.ext.mathjax', 'sphinxcontrib.spelling', 'sphinx.ext.todo', 'sphinx.ext.extlinks',
-              'sphinxcontrib.luadomain', 'sphinx_csharp.csharp', 'javasphinx', 'sphinx_tabs.tabs']
+extensions = [
+    'sphinx.ext.mathjax',
+    'sphinx.ext.todo',
+    'sphinx.ext.extlinks',
+    'sphinxcontrib.spelling',
+    'sphinxcontrib.jquery',
+    'sphinx_tabs.tabs',
+    'sphinxcontrib.luadomain',
+    'sphinx_csharp.csharp',
+    'javasphinx'
+]
 templates_path = ['_templates']
 
 pygments_style = 'sphinx'

--- a/tools/serve-docs.sh
+++ b/tools/serve-docs.sh
@@ -29,6 +29,7 @@ if [ ! -d "$env" ]; then
   pip install \
       "sphinx_rtd_theme==1.2.0" \
       "sphinxcontrib_spelling==8.0.0" \
+      "sphinxcontrib-jquery==2.0.0" \
       "sphinx-csharp==0.1.8" \
       "sphinx-tabs==3.4.1" \
       "sphinxcontrib-luadomain==1.1.2" \


### PR DESCRIPTION
Sphinx 6.0.0 removes jquery, but it is still needed for sphinx_rtd_theme. We therefore need sphinxcontrib-jquery to provide jquery.js until sphinx_rtd_theme is updated.