### PR TITLE
Documentation fixes

### DIFF
--- a/doc/api/docking-camera.tmpl
+++ b/doc/api/docking-camera.tmpl
@@ -6,7 +6,7 @@ Docking Camera API
 
 .. toctree::
    :includehidden:
-   :maxdepth: 2
+   :maxdepth: 1
 
    docking-camera/docking-camera
    docking-camera/camera

--- a/doc/api/docking-camera.tmpl
+++ b/doc/api/docking-camera.tmpl
@@ -4,6 +4,8 @@
 Docking Camera API
 ==================
 
+Provides RPCs to interact with the `Docking Camera <https://github.com/nullprofile/DockingCam>`_ mod.
+
 .. toctree::
    :includehidden:
    :maxdepth: 1

--- a/doc/api/drawing.tmpl
+++ b/doc/api/drawing.tmpl
@@ -6,7 +6,7 @@ Drawing API
 
 .. toctree::
    :includehidden:
-   :maxdepth: 2
+   :maxdepth: 1
 
    drawing/drawing
    drawing/line

--- a/doc/api/infernal-robotics.tmpl
+++ b/doc/api/infernal-robotics.tmpl
@@ -8,7 +8,7 @@ Provides RPCs to interact with `Infernal Robotics Next`_. Provides the following
 
 .. toctree::
    :includehidden:
-   :maxdepth: 2
+   :maxdepth: 1
 
    infernal-robotics/infernal-robotics
    infernal-robotics/servo-group

--- a/doc/api/kerbal-alarm-clock.tmpl
+++ b/doc/api/kerbal-alarm-clock.tmpl
@@ -9,7 +9,7 @@ following classes:
 
 .. toctree::
    :includehidden:
-   :maxdepth: 2
+   :maxdepth: 1
 
    kerbal-alarm-clock/kerbal-alarm-clock
    kerbal-alarm-clock/alarm

--- a/doc/api/krpc.tmpl
+++ b/doc/api/krpc.tmpl
@@ -6,7 +6,7 @@ KRPC API
 
 .. toctree::
    :includehidden:
-   :maxdepth: 2
+   :maxdepth: 1
 
    krpc/krpc
    krpc/expressions

--- a/doc/api/lidar.tmpl
+++ b/doc/api/lidar.tmpl
@@ -4,6 +4,8 @@
 LiDAR API
 =========
 
+Provides RPCs to interact with the `LaserDist <https://github.com/nullprofile/LaserDist>`_ mod.
+
 .. toctree::
    :includehidden:
    :maxdepth: 1

--- a/doc/api/lidar.tmpl
+++ b/doc/api/lidar.tmpl
@@ -6,7 +6,7 @@ LiDAR API
 
 .. toctree::
    :includehidden:
-   :maxdepth: 2
+   :maxdepth: 1
 
    lidar/lidar
    lidar/laser

--- a/doc/api/lidar/laser.tmpl
+++ b/doc/api/lidar/laser.tmpl
@@ -3,7 +3,7 @@
 {{ domain.currentmodule('LiDAR') }}
 {% import domain.macros as macros with context %}
 
-LiDAR
+Laser
 =====
 
 {{ macros.class(services['LiDAR'].classes['Laser']) }}

--- a/doc/api/remote-tech.tmpl
+++ b/doc/api/remote-tech.tmpl
@@ -8,7 +8,7 @@ Provides RPCs to interact with the `RemoteTech`_ mod. Provides the following cla
 
 .. toctree::
    :includehidden:
-   :maxdepth: 2
+   :maxdepth: 1
 
    remote-tech/remote-tech
    remote-tech/comms

--- a/doc/api/space-center.tmpl
+++ b/doc/api/space-center.tmpl
@@ -6,7 +6,7 @@ SpaceCenter API
 
 .. toctree::
    :includehidden:
-   :maxdepth: 2
+   :maxdepth: 1
 
    space-center/space-center
    space-center/vessel

--- a/doc/api/ui.tmpl
+++ b/doc/api/ui.tmpl
@@ -6,7 +6,7 @@ User Interface API
 
 .. toctree::
    :includehidden:
-   :maxdepth: 2
+   :maxdepth: 1
 
    ui/ui
    ui/canvas

--- a/doc/conf.py.tmpl
+++ b/doc/conf.py.tmpl
@@ -38,11 +38,6 @@ javadoc_url_map = {
     'org.javatuples' : ('http://www.javatuples.org/apidocs/', 'javadoc')
 }
 
-extlinks = {
-    'github-download-zip': ('https://github.com/krpc/krpc/releases/download/v'+version+'/%s-'+version+'.zip', None),
-    'github-download-jar': ('https://github.com/krpc/krpc/releases/download/v'+version+'/%s-'+version+'.jar', None)
-}
-
 add_module_names = False
 
 sphinx_tabs_nowarn = True

--- a/doc/src/cnano.rst
+++ b/doc/src/cnano.rst
@@ -2,6 +2,7 @@ C-nano
 ======
 
 .. toctree::
+   :maxdepth: 2
 
    cnano/client
    cnano/api/krpc

--- a/doc/src/cnano.rst
+++ b/doc/src/cnano.rst
@@ -8,9 +8,9 @@ C-nano
    cnano/api/krpc
    cnano/api/space-center
    cnano/api/drawing
+   cnano/api/ui
    cnano/api/infernal-robotics
    cnano/api/kerbal-alarm-clock
    cnano/api/remote-tech
-   cnano/api/ui
    cnano/api/lidar
    cnano/api/docking-camera

--- a/doc/src/cnano/client.rst
+++ b/doc/src/cnano/client.rst
@@ -14,8 +14,8 @@ Manually include the source in your project
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The source files can be included in your project manually, by downloading and extracting the
-:github-download-zip:`source archive <krpc-cnano>`. The header files can be found in the ``include``
-directory and the source files are in ``src``.
+source archive from the `GitHub release page <https://github.com/krpc/krpc/releases>`_.
+The header files can be found in the ``include`` directory and the source files are in ``src``.
 
 Arduino Library Manager
 ^^^^^^^^^^^^^^^^^^^^^^^
@@ -33,8 +33,8 @@ Using the configure script
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 You can build and install the client library and headers using the configure script provided with
-the source. :github-download-zip:`Download the source archive <krpc-cnano>`, extract it and then
-execute the following:
+the source. `Download the source archive <https://github.com/krpc/krpc/releases>_`, extract it
+and then execute the following:
 
 .. code-block:: bash
 
@@ -46,8 +46,8 @@ execute the following:
 Using CMake
 ^^^^^^^^^^^
 
-Alternatively, you can install the client library and headers using
-CMake. :github-download-zip:`Download the source archive <krpc-cnano>`, extract it and execute the
+Alternatively, you can install the client library and headers using CMake.
+`Download the source archive <https://github.com/krpc/krpc/releases>_`, extract it and execute the
 following:
 
 .. code-block:: bash

--- a/doc/src/compiling.rst
+++ b/doc/src/compiling.rst
@@ -108,8 +108,9 @@ scripts. You need to run ``bazel build //:csproj`` to generate these files
 before the solution can be built.
 
 Alternatively, if you are unable to run Bazel to build these files, you can
-:github-download-zip:`download them from GitHub<krpc-genfiles>`. Simply extract
-this archive over your copy of the source and you are good to go.
+`download them from GitHub <https://github.com/krpc/krpc/releases>`_.
+Download the latest krpc-genfiles.zip, extract the archive over your copy of the source and you
+are good to go.
 
 Running the Tests
 ^^^^^^^^^^^^^^^^^

--- a/doc/src/cpp.rst
+++ b/doc/src/cpp.rst
@@ -8,9 +8,9 @@ C++
    cpp/api/krpc
    cpp/api/space-center
    cpp/api/drawing
+   cpp/api/ui
    cpp/api/infernal-robotics
    cpp/api/kerbal-alarm-clock
    cpp/api/remote-tech
-   cpp/api/ui
    cpp/api/lidar
    cpp/api/docking-camera

--- a/doc/src/cpp.rst
+++ b/doc/src/cpp.rst
@@ -2,6 +2,7 @@ C++
 ===
 
 .. toctree::
+   :maxdepth: 2
 
    cpp/client
    cpp/api/krpc

--- a/doc/src/cpp/client.rst
+++ b/doc/src/cpp/client.rst
@@ -33,8 +33,9 @@ Using the configure script
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Once the dependencies have been installed, you can install the kRPC client library and headers using
-the configure script provided with the source. :github-download-zip:`Download the source archive
-<krpc-cpp>`, extract it and then execute the following:
+the configure script provided with the source.
+`Download the source archive <https://github.com/krpc/krpc/releases>`_,
+extract it and then execute the following:
 
 .. code-block:: bash
 
@@ -46,8 +47,8 @@ the configure script provided with the source. :github-download-zip:`Download th
 Using CMake
 ^^^^^^^^^^^
 
-Alternatively, you can install the client library and headers using
-CMake. :github-download-zip:`Download the source archive <krpc-cpp>`, extract it and execute the
+Alternatively, you can install the client library and headers using CMake.
+`Download the source archive <https://github.com/krpc/krpc/releases>`_, extract it and execute the
 following:
 
 .. code-block:: bash

--- a/doc/src/csharp.rst
+++ b/doc/src/csharp.rst
@@ -2,6 +2,7 @@ C#
 ==
 
 .. toctree::
+   :maxdepth: 2
 
    csharp/client
    csharp/api/krpc

--- a/doc/src/csharp.rst
+++ b/doc/src/csharp.rst
@@ -8,9 +8,9 @@ C#
    csharp/api/krpc
    csharp/api/space-center
    csharp/api/drawing
+   csharp/api/ui
    csharp/api/infernal-robotics
    csharp/api/kerbal-alarm-clock
    csharp/api/remote-tech
-   csharp/api/ui
    csharp/api/lidar
    csharp/api/docking-camera

--- a/doc/src/csharp/client.rst
+++ b/doc/src/csharp/client.rst
@@ -11,7 +11,7 @@ Installing the Library
 ----------------------
 
 The C# client can be `installed using NuGet <https://www.nuget.org/packages/KRPC.Client>`_ or
-:github-download-zip:`downloaded from GitHub <krpc-csharp>`. The client is compatible with .NET 4.5+.
+`downloaded from GitHub <https://github.com/krpc/krpc/releases>`_. The client is compatible with .NET 4.5+.
 
 You also need to `install Google.Protobuf using NuGet
 <https://www.nuget.org/packages/Google.Protobuf>`_.

--- a/doc/src/getting-started.rst
+++ b/doc/src/getting-started.rst
@@ -14,7 +14,7 @@ Installation
 
 1. Download and install the kRPC server plugin from one of these locations:
 
- * :github-download-zip:`Github <krpc>`
+ * `Github <https://github.com/krpc/krpc/releases>`_
  * `SpaceDock <https://spacedock.info/mod/69/kRPC>`_
  * `Curse <https://mods.curse.com/ksp-mods/kerbal/220219-krpc-control-the-game-using-c-c-java-lua-python>`_
  * Or the install it using `CKAN <https://forum.kerbalspaceprogram.com/index.php?/topic/90246-the-comprehensive-kerbal-archive-network-ckan-package-manager-v1180-19-june-2016/>`_

--- a/doc/src/java.rst
+++ b/doc/src/java.rst
@@ -8,9 +8,9 @@ Java
    java/api/krpc
    java/api/space-center
    java/api/drawing
+   java/api/ui
    java/api/infernal-robotics
    java/api/kerbal-alarm-clock
    java/api/remote-tech
-   java/api/ui
    java/api/lidar
    java/api/docking-camera

--- a/doc/src/java.rst
+++ b/doc/src/java.rst
@@ -2,6 +2,7 @@ Java
 ====
 
 .. toctree::
+   :maxdepth: 2
 
    java/client
    java/api/krpc

--- a/doc/src/java/client.rst
+++ b/doc/src/java/client.rst
@@ -5,8 +5,8 @@ Java Client
 ===========
 
 This client provides a Java API for interacting with a kRPC server. A jar containing the
-``krpc.client`` package can be :github-download-jar:`downloaded from GitHub <krpc-java>`. It
-requires Java version 1.8.
+``krpc.client`` package can be `downloaded from GitHub <https://github.com/krpc/krpc/releases>`_.
+It requires Java version 1.8.
 
 Using the Library
 -----------------

--- a/doc/src/lua.rst
+++ b/doc/src/lua.rst
@@ -8,9 +8,9 @@ Lua
    lua/api/krpc
    lua/api/space-center
    lua/api/drawing
+   lua/api/ui
    lua/api/infernal-robotics
    lua/api/kerbal-alarm-clock
    lua/api/remote-tech
-   lua/api/ui
    lua/api/lidar
    lua/api/docking-camera

--- a/doc/src/lua.rst
+++ b/doc/src/lua.rst
@@ -2,6 +2,7 @@ Lua
 ===
 
 .. toctree::
+   :maxdepth: 2
 
    lua/client
    lua/api/krpc

--- a/doc/src/lua/client.rst
+++ b/doc/src/lua/client.rst
@@ -7,7 +7,7 @@ Lua Client
 This client provides functionality to interact with a kRPC server from programs
 written in Lua. It can be `installed using LuaRocks
 <https://luarocks.org/modules/djungelorm/krpc>`_ or
-:github-download-zip:`downloaded from GitHub <krpc-lua>`.
+`downloaded from GitHub <https://github.com/krpc/krpc/releases>`_.
 
 Installing the Library
 ----------------------

--- a/doc/src/python.rst
+++ b/doc/src/python.rst
@@ -2,6 +2,7 @@ Python
 ======
 
 .. toctree::
+   :maxdepth: 2
 
    python/client
    python/api/krpc

--- a/doc/src/python.rst
+++ b/doc/src/python.rst
@@ -8,9 +8,9 @@ Python
    python/api/krpc
    python/api/space-center
    python/api/drawing
+   python/api/ui
    python/api/infernal-robotics
    python/api/kerbal-alarm-clock
    python/api/remote-tech
-   python/api/ui
    python/api/lidar
    python/api/docking-camera

--- a/doc/src/python/client.rst
+++ b/doc/src/python/client.rst
@@ -10,7 +10,7 @@ Installing the Library
 ----------------------
 
 The library can be found on `PyPI <https://pypi.python.org/pypi/krpc>`_ or
-:github-download-zip:`downloaded from GitHub <krpc-python>`.
+`downloaded from GitHub <https://github.com/krpc/krpc/releases>`_.
 
 To install using pip on Linux:
 

--- a/tools/do-serve-docs.py
+++ b/tools/do-serve-docs.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 
 """ Auto-build and auto-serve the docs """
 


### PR DESCRIPTION
 - Fix links for client downloads. Just link to the github release page, rather than trying to link to a release archive that may not exist (due to bugfix release versions possibly not existing for a client)
 - Improve tables of contents
 - Improve docs for LiDAR and DockingCamera