### PR TITLE
Change trigger for ci workflow to just pull_request

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: ci
 
-on: [push, pull_request]
+on: pull_request
 
 jobs:
   build:


### PR DESCRIPTION
Was triggered on `pull_request, push` which leads to the workflow being triggered multiple times for a pull request.