### PR TITLE
Use protobuf lite

### DIFF
--- a/client/cpp/BUILD
+++ b/client/cpp/BUILD
@@ -144,7 +144,7 @@ cc_library(
     srcs = srcs + [':protobuf'],
     hdrs = hdrs + [':protobuf'],
     includes = ['include'],
-    deps = ['@com_google_protobuf//:protobuf', '@cpp_asio//:asio'],
+    deps = ['@com_google_protobuf//:protobuf_lite', '@cpp_asio//:asio'],
     visibility = ['//visibility:public']
 )
 

--- a/client/cpp/CHANGES.txt
+++ b/client/cpp/CHANGES.txt
@@ -1,3 +1,6 @@
+v0.5.2
+ * Use protobuf-lite messages
+
 v0.5.0
  * Update to protobuf v3.22.0
  * Update to ASIO 1.24.0

--- a/client/cpp/include/krpc/decoder.hpp
+++ b/client/cpp/include/krpc/decoder.hpp
@@ -13,7 +13,7 @@
 
 namespace google {
 namespace protobuf {
-class Message;
+class MessageLite;
 }
 }
 
@@ -38,7 +38,8 @@ void decode(google::protobuf::uint64& value, const std::string& data, Client * c
 void decode(bool& value, const std::string& data, Client * client = nullptr);
 void decode(std::string& value, const std::string& data, Client * client = nullptr);
 void decode(Event& event, const std::string& data, Client * client = nullptr);
-void decode(google::protobuf::Message& message, const std::string& data, Client * client = nullptr);
+void decode(google::protobuf::MessageLite& message, const std::string& data,
+            Client * client = nullptr);
 
 template <typename T> void decode(Object<T>& object, const std::string& data,
                                   Client * client = nullptr);

--- a/client/cpp/include/krpc/encoder.hpp
+++ b/client/cpp/include/krpc/encoder.hpp
@@ -12,7 +12,7 @@
 
 namespace google {
 namespace protobuf {
-class Message;
+class MessageLite;
 }
 }
 
@@ -31,7 +31,7 @@ std::string encode(google::protobuf::uint64 value);
 std::string encode(bool value);
 std::string encode(const char* value);
 std::string encode(const std::string& value);
-std::string encode(const google::protobuf::Message& message);
+std::string encode(const google::protobuf::MessageLite& message);
 template <typename T> std::string encode(const Object<T>& object);
 
 template <typename T> std::string encode(const std::vector<T>& list);
@@ -59,7 +59,7 @@ template <typename T0, typename T1, typename T2, typename T3, typename T4>
 std::string encode(const std::tuple<T0, T1, T2, T3, T4>& tuple);
 // [[[end]]]
 
-std::string encode_message_with_size(const google::protobuf::Message& message);
+std::string encode_message_with_size(const google::protobuf::MessageLite& message);
 
 template <typename T>
 inline std::string encode(const Object<T>& object) {

--- a/client/cpp/src/decoder.cpp
+++ b/client/cpp/src/decoder.cpp
@@ -1,7 +1,7 @@
 #include "krpc/decoder.hpp"
 
 #include <google/protobuf/io/coded_stream.h>
-#include <google/protobuf/message.h>
+#include <google/protobuf/message_lite.h>
 #include <google/protobuf/wire_format_lite.h>
 
 #include <string>
@@ -94,7 +94,7 @@ void decode(Event& event, const std::string& data, Client* client) {
   event = Event(client, message);
 }
 
-void decode(pb::Message& message, const std::string& data, Client* client) {
+void decode(pb::MessageLite& message, const std::string& data, Client* client) {
   if (!message.ParseFromString(data))
     throw EncodingError("Failed to decode message");
 }

--- a/client/cpp/src/encoder.cpp
+++ b/client/cpp/src/encoder.cpp
@@ -1,7 +1,7 @@
 #include "krpc/encoder.hpp"
 
 #include <google/protobuf/io/coded_stream.h>
-#include <google/protobuf/message.h>
+#include <google/protobuf/message_lite.h>
 #include <google/protobuf/wire_format_lite.h>
 
 #include <cstddef>
@@ -82,14 +82,14 @@ std::string encode(const std::string& value) {
   return data;
 }
 
-std::string encode(const pb::Message& message) {
+std::string encode(const pb::MessageLite& message) {
   std::string data;
   if (!message.SerializeToString(&data))
     throw EncodingError("Failed to encode message");
   return data;
 }
 
-std::string encode_message_with_size(const pb::Message& message) {
+std::string encode_message_with_size(const pb::MessageLite& message) {
   size_t length = message.ByteSizeLong();
   size_t header_length = pb::io::CodedOutputStream::VarintSize64(length);
   std::string data(header_length + length, 0);

--- a/protobuf/krpc.proto
+++ b/protobuf/krpc.proto
@@ -4,6 +4,7 @@ option csharp_namespace = 'KRPC.Schema.KRPC';
 option java_package = 'krpc.schema';
 option java_outer_classname = 'KRPC';
 option objc_class_prefix = "KRPC";
+option optimize_for = LITE_RUNTIME;
 
 // Messages for connecting to the server
 


### PR DESCRIPTION
Update the schema to compile for protobuf-lite and update the C++ client to build with protobuf-lite.

We do not use any of the additional features provided by the full protobuf library, and using protobuf-lite speeds up compilation of the C++ client considerably.