### PR TITLE
Test static class properties

### DIFF
--- a/client/cnano/test/test_client.cpp
+++ b/client/cnano/test/test_client.cpp
@@ -147,6 +147,11 @@ TEST_F(test_client, test_class_properties) {
   krpc_TestService_TestClass_t object3;
   ASSERT_EQ(KRPC_OK, krpc_TestService_TestClass_ObjectProperty(conn, &object3, object));
   ASSERT_EQ(object2, object3);
+  krpc_TestService_TestClass_set_StringPropertyPrivateGet(conn, object, "bob");
+  auto string = new char[32];
+  krpc_TestService_TestClass_StringPropertyPrivateSet(conn, &string, object);
+  ASSERT_STREQ("bob", string);
+  delete[] string;
 }
 
 TEST_F(test_client, test_blocking_procedure) {

--- a/client/cpp/test/test_client.cpp
+++ b/client/cpp/test/test_client.cpp
@@ -163,6 +163,8 @@ TEST_F(test_client, test_class_properties) {
   krpc::services::TestService::TestClass object2 = test_service.create_test_object("kermin");
   object.set_object_property(object2);
   ASSERT_EQ(object2, object.object_property());
+  object.set_string_property_private_get("bob");
+  ASSERT_EQ("bob", object.string_property_private_set());
 }
 
 TEST_F(test_client, test_optional_arguments) {

--- a/client/csharp/test/ConnectionTest.cs
+++ b/client/csharp/test/ConnectionTest.cs
@@ -140,6 +140,8 @@ namespace KRPC.Client.Test
             var obj2 = Connection.TestService ().CreateTestObject ("kermin");
             obj.ObjectProperty = obj2;
             Assert.AreEqual (obj2.id, obj.ObjectProperty.id);
+            obj.StringPropertyPrivateGet = "bob";
+            Assert.AreEqual("bob", obj.StringPropertyPrivateSet);
         }
 
         [Test]

--- a/client/java/test/krpc/client/ConnectionTest.java
+++ b/client/java/test/krpc/client/ConnectionTest.java
@@ -146,6 +146,8 @@ public class ConnectionTest {
     TestService.TestClass obj2 = testService.createTestObject("kermin");
     obj.setObjectProperty(obj2);
     assertEquals(obj2, obj.getObjectProperty());
+    obj.setStringPropertyPrivateGet("bob");
+    assertEquals("bob", obj.getStringPropertyPrivateSet());
   }
 
   @Test

--- a/client/lua/krpc/test/test_client.lua
+++ b/client/lua/krpc/test/test_client.lua
@@ -115,6 +115,8 @@ function TestClient:test_class_properties()
   local obj2 = self.conn.test_service.create_test_object('kermin')
   obj.object_property = obj2
   luaunit.assertEquals(obj2._object_id, obj.object_property._object_id)
+  obj.string_property_private_get = 'bob'
+  luaunit.assertEquals('bob', obj.string_property_private_set)
 end
 
 function TestClient:test_optional_arguments()

--- a/client/python/krpc/test/test_client.py
+++ b/client/python/krpc/test/test_client.py
@@ -147,6 +147,8 @@ class TestClient(ServerTestCase, unittest.TestCase):
         obj2 = self.conn.test_service.create_test_object('kermin')
         obj.object_property = obj2
         self.assertEqual(obj2._object_id, obj.object_property._object_id)
+        obj.string_property_private_get = "bob"
+        self.assertEqual("bob", obj.string_property_private_set)
 
     def test_optional_arguments(self):
         self.assertEqual('jebfoobarnull',
@@ -419,6 +421,9 @@ class TestClient(ServerTestCase, unittest.TestCase):
                 'int_property',
 
                 'object_property',
+
+                'string_property_private_get',
+                'string_property_private_set',
 
                 'optional_arguments',
                 'static_method'

--- a/tools/TestServer/src/TestService.cs
+++ b/tools/TestServer/src/TestService.cs
@@ -163,6 +163,7 @@ namespace TestServer
             public TestClass ObjectProperty { get; set; }
 
             [KRPCProperty]
+            [SuppressMessage ("Gendarme.Rules.Design", "AvoidPropertiesWithoutGetAccessorRule")]
             public string StringPropertyPrivateGet {
                 set { instanceValue = value; }
             }

--- a/tools/TestServer/src/TestService.cs
+++ b/tools/TestServer/src/TestService.cs
@@ -115,7 +115,7 @@ namespace TestServer
         [SuppressMessage ("Gendarme.Rules.Design", "ImplementEqualsAndGetHashCodeInPairRule")]
         public sealed class TestClass : Equatable<TestClass>
         {
-            internal readonly string instanceValue;
+            internal string instanceValue;
 
             public TestClass (string value)
             {
@@ -161,6 +161,16 @@ namespace TestServer
 
             [KRPCProperty (Nullable = true)]
             public TestClass ObjectProperty { get; set; }
+
+            [KRPCProperty]
+            public string StringPropertyPrivateGet {
+                set { instanceValue = value; }
+            }
+
+            [KRPCProperty]
+            public string StringPropertyPrivateSet {
+                get { return instanceValue; }
+            }
 
             [KRPCMethod]
             [SuppressMessage ("Gendarme.Rules.Correctness", "MethodCanBeMadeStaticRule")]

--- a/tools/krpctools/krpctools/test/clientgen-TestService-cnano.txt
+++ b/tools/krpctools/krpctools/test/clientgen-TestService-cnano.txt
@@ -337,6 +337,10 @@ krpc_error_t krpc_TestService_TestClass_ObjectProperty(krpc_connection_t connect
 
 krpc_error_t krpc_TestService_TestClass_set_ObjectProperty(krpc_connection_t connection, krpc_TestService_TestClass_t instance, krpc_TestService_TestClass_t value);
 
+krpc_error_t krpc_TestService_TestClass_set_StringPropertyPrivateGet(krpc_connection_t connection, krpc_TestService_TestClass_t instance, const char * value);
+
+krpc_error_t krpc_TestService_TestClass_StringPropertyPrivateSet(krpc_connection_t connection, char * * returnValue, krpc_TestService_TestClass_t instance);
+
 // Implementation
 
 #ifndef KRPC_IMPL_TYPE_DICTIONARY_INT32_BOOL
@@ -2006,6 +2010,36 @@ inline krpc_error_t krpc_TestService_TestClass_set_ObjectProperty(krpc_connectio
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
   KRPC_CHECK(krpc_invoke(connection, &_result.message, &_call.message));
+  KRPC_CHECK(krpc_free_result(&_result));
+  return KRPC_OK;
+}
+
+inline krpc_error_t krpc_TestService_TestClass_set_StringPropertyPrivateGet(krpc_connection_t connection, krpc_TestService_TestClass_t instance, const char * value) {
+  krpc_call_t _call;
+  krpc_argument_t _arguments[2];
+  KRPC_CHECK(krpc_call(&_call, 9999, 54, 2, _arguments));
+  KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_uint64, &instance));
+  KRPC_CHECK(krpc_add_argument(&_call, 1, &krpc_encode_callback_string, &value));
+  krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
+  KRPC_CHECK(krpc_init_result(&_result));
+  KRPC_CHECK(krpc_invoke(connection, &_result.message, &_call.message));
+  KRPC_CHECK(krpc_free_result(&_result));
+  return KRPC_OK;
+}
+
+inline krpc_error_t krpc_TestService_TestClass_StringPropertyPrivateSet(krpc_connection_t connection, char * * returnValue, krpc_TestService_TestClass_t instance) {
+  krpc_call_t _call;
+  krpc_argument_t _arguments[1];
+  KRPC_CHECK(krpc_call(&_call, 9999, 55, 1, _arguments));
+  KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_uint64, &instance));
+  krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
+  KRPC_CHECK(krpc_init_result(&_result));
+  KRPC_CHECK(krpc_invoke(connection, &_result.message, &_call.message));
+  if (returnValue) {
+    pb_istream_t _stream;
+    KRPC_CHECK(krpc_get_return_value(&_result, &_stream));
+    KRPC_CHECK(krpc_decode_string(&_stream, returnValue));
+  }
   KRPC_CHECK(krpc_free_result(&_result));
   return KRPC_OK;
 }

--- a/tools/krpctools/krpctools/test/clientgen-TestService-cpp.txt
+++ b/tools/krpctools/krpctools/test/clientgen-TestService-cpp.txt
@@ -344,6 +344,10 @@ class TestService : public Service {
 
     void set_object_property(TestService::TestClass value);
 
+    void set_string_property_private_get(std::string value);
+
+    std::string string_property_private_set();
+
     ::krpc::Stream<std::string> float_to_string_stream(float x);
 
     ::krpc::Stream<std::string> get_value_stream();
@@ -357,6 +361,8 @@ class TestService : public Service {
     ::krpc::Stream<int32_t> int_property_stream();
 
     ::krpc::Stream<TestService::TestClass> object_property_stream();
+
+    ::krpc::Stream<std::string> string_property_private_set_stream();
 
     ::krpc::schema::ProcedureCall float_to_string_call(float x);
 
@@ -375,6 +381,10 @@ class TestService : public Service {
     ::krpc::schema::ProcedureCall object_property_call();
 
     ::krpc::schema::ProcedureCall set_object_property_call(TestService::TestClass value);
+
+    ::krpc::schema::ProcedureCall set_string_property_private_get_call(std::string value);
+
+    ::krpc::schema::ProcedureCall string_property_private_set_call();
   };
 };
 
@@ -1322,6 +1332,22 @@ inline void TestService::TestClass::set_object_property(TestService::TestClass v
   this->_client->invoke("TestService", "TestClass_set_ObjectProperty", _args);
 }
 
+inline void TestService::TestClass::set_string_property_private_get(std::string value) {
+  std::vector<std::string> _args;
+  _args.push_back(encoder::encode(*this));
+  _args.push_back(encoder::encode(value));
+  this->_client->invoke("TestService", "TestClass_set_StringPropertyPrivateGet", _args);
+}
+
+inline std::string TestService::TestClass::string_property_private_set() {
+  std::vector<std::string> _args;
+  _args.push_back(encoder::encode(*this));
+  std::string _data = this->_client->invoke("TestService", "TestClass_get_StringPropertyPrivateSet", _args);
+  std::string _result;
+  decoder::decode(_result, _data, this->_client);
+  return _result;
+}
+
 inline std::string TestService::TestClass::static_method(Client& _client, std::string a = "", std::string b = "") {
     std::vector<std::string> _args;
   _args.push_back(encoder::encode(a));
@@ -1372,6 +1398,12 @@ inline ::krpc::Stream<TestService::TestClass> TestService::TestClass::object_pro
   std::vector<std::string> _args;
   _args.push_back(encoder::encode(*this));
   return ::krpc::Stream<TestService::TestClass>(this->_client, this->_client->build_call("TestService", "TestClass_get_ObjectProperty", _args));
+}
+
+inline ::krpc::Stream<std::string> TestService::TestClass::string_property_private_set_stream() {
+  std::vector<std::string> _args;
+  _args.push_back(encoder::encode(*this));
+  return ::krpc::Stream<std::string>(this->_client, this->_client->build_call("TestService", "TestClass_get_StringPropertyPrivateSet", _args));
 }
 
 inline ::krpc::Stream<std::string> TestService::TestClass::static_method_stream(Client& _client, std::string a = "", std::string b = "") {
@@ -1435,6 +1467,19 @@ inline ::krpc::schema::ProcedureCall TestService::TestClass::set_object_property
   _args.push_back(encoder::encode(*this));
   _args.push_back(encoder::encode(value));
   return this->_client->build_call("TestService", "TestClass_set_ObjectProperty", _args);
+}
+
+inline ::krpc::schema::ProcedureCall TestService::TestClass::set_string_property_private_get_call(std::string value) {
+  std::vector<std::string> _args;
+  _args.push_back(encoder::encode(*this));
+  _args.push_back(encoder::encode(value));
+  return this->_client->build_call("TestService", "TestClass_set_StringPropertyPrivateGet", _args);
+}
+
+inline ::krpc::schema::ProcedureCall TestService::TestClass::string_property_private_set_call() {
+  std::vector<std::string> _args;
+  _args.push_back(encoder::encode(*this));
+  return this->_client->build_call("TestService", "TestClass_get_StringPropertyPrivateSet", _args);
 }
 
 inline ::krpc::schema::ProcedureCall TestService::TestClass::static_method_call(Client& _client, std::string a = "", std::string b = "") {

--- a/tools/krpctools/krpctools/test/clientgen-TestService-csharp.txt
+++ b/tools/krpctools/krpctools/test/clientgen-TestService-csharp.txt
@@ -622,5 +622,26 @@ namespace KRPC.Client.Services.TestService
                 connection.Invoke ("TestService", "TestClass_set_ObjectProperty", _args);
             }
         }
+
+        public string StringPropertyPrivateGet {
+            set {
+                var _args = new ByteString[] {
+                    global::KRPC.Client.Encoder.Encode (this, typeof(TestService.TestClass)),
+                    global::KRPC.Client.Encoder.Encode (value, typeof(string))
+                };
+                connection.Invoke ("TestService", "TestClass_set_StringPropertyPrivateGet", _args);
+            }
+        }
+
+        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "TestClass_get_StringPropertyPrivateSet")]
+        public string StringPropertyPrivateSet {
+            get {
+                var _args = new ByteString[] {
+                    global::KRPC.Client.Encoder.Encode (this, typeof(TestService.TestClass))
+                };
+                ByteString _data = connection.Invoke ("TestService", "TestClass_get_StringPropertyPrivateSet", _args);
+                return (string)global::KRPC.Client.Encoder.Decode (_data, typeof(string), connection);
+            }
+        }
     }
 }

--- a/tools/krpctools/krpctools/test/clientgen-TestService-java.txt
+++ b/tools/krpctools/krpctools/test/clientgen-TestService-java.txt
@@ -614,6 +614,28 @@ public class TestService {
         }
 
         @SuppressWarnings({ "unchecked" })
+        @RPCInfo(service = "TestService", procedure = "TestClass_set_StringPropertyPrivateGet", types = _Types.class)
+        public void setStringPropertyPrivateGet(String value) throws RPCException
+        {
+            ByteString[] _args = new ByteString[] {
+                Encoder.encode(this, krpc.client.Types.createClass("TestService", "TestClass")),
+                Encoder.encode(value, krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.STRING))
+            };
+            this.connection.invoke("TestService", "TestClass_set_StringPropertyPrivateGet", _args);
+        }
+
+        @SuppressWarnings({ "unchecked" })
+        @RPCInfo(service = "TestService", procedure = "TestClass_get_StringPropertyPrivateSet", types = _Types.class)
+        public String getStringPropertyPrivateSet() throws RPCException
+        {
+            ByteString[] _args = new ByteString[] {
+                Encoder.encode(this, krpc.client.Types.createClass("TestService", "TestClass"))
+            };
+            ByteString _data = this.connection.invoke("TestService", "TestClass_get_StringPropertyPrivateSet", _args);
+            return (String) Encoder.decode(_data, krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.STRING), this.connection);
+        }
+
+        @SuppressWarnings({ "unchecked" })
         @RPCInfo(service = "TestService", procedure = "TestClass_static_StaticMethod", types = _Types.class)
         public static String staticMethod(Connection connection, String a, String b) throws RPCException
         {
@@ -735,6 +757,10 @@ public class TestService {
                 return krpc.client.Types.createClass("TestService", "TestClass");
             case "TestClass_set_ObjectProperty":
                 return null;
+            case "TestClass_set_StringPropertyPrivateGet":
+                return null;
+            case "TestClass_get_StringPropertyPrivateSet":
+                return krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.STRING);
             }
             throw new IllegalArgumentException("Procedure '" + procedure +"' not found");
         }
@@ -952,6 +978,15 @@ public class TestService {
             case "TestClass_set_ObjectProperty":
                 return new krpc.schema.KRPC.Type[] {
                     krpc.client.Types.createClass("TestService", "TestClass"),
+                    krpc.client.Types.createClass("TestService", "TestClass")
+                };
+            case "TestClass_set_StringPropertyPrivateGet":
+                return new krpc.schema.KRPC.Type[] {
+                    krpc.client.Types.createClass("TestService", "TestClass"),
+                    krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.STRING)
+                };
+            case "TestClass_get_StringPropertyPrivateSet":
+                return new krpc.schema.KRPC.Type[] {
                     krpc.client.Types.createClass("TestService", "TestClass")
                 };
             case "TestClass_static_StaticMethod":

--- a/tools/krpctools/krpctools/test/clientgentest.py
+++ b/tools/krpctools/krpctools/test/clientgentest.py
@@ -11,6 +11,12 @@ class ClientGenTestCase:
         g = self.generator(
             macro_template, service_name, defs[service_name])
         actual = g.generate()
+
+        # with open('/home/alex/workspaces/krpc/krpc/' +
+        #           'tools/krpctools/krpctools/test/' +
+        #           'clientgen-'+name+'-'+self.language+'.txt', 'w') as f:
+        #     f.write(actual)
+
         expected = resource_string(
             'krpctools.test',
             'clientgen-'+name+'-'+self.language+'.txt').decode('utf-8')

--- a/tools/krpctools/krpctools/test/docgen-TestService-cnano.rst
+++ b/tools/krpctools/krpctools/test/docgen-TestService-cnano.rst
@@ -467,6 +467,18 @@ Service TestService
 
       :Game Scenes: All
 
+   .. function:: void krpc_TestService_TestClass_set_StringPropertyPrivateGet(const char * value)
+
+
+
+      :Game Scenes: All
+
+   .. function:: krpc_error_t krpc_TestService_TestClass_StringPropertyPrivateSet(krpc_connection_t connection, char * * result)
+
+
+
+      :Game Scenes: All
+
 
 
 .. type:: krpc_TestService_TestEnum_t

--- a/tools/krpctools/krpctools/test/docgen-TestService-cpp.rst
+++ b/tools/krpctools/krpctools/test/docgen-TestService-cpp.rst
@@ -472,6 +472,18 @@
 
       :Game Scenes: All
 
+   .. function:: void set_string_property_private_get(std::string value)
+
+
+
+      :Game Scenes: All
+
+   .. function:: std::string string_property_private_set()
+
+
+
+      :Game Scenes: All
+
 
 
 .. namespace:: krpc::services::TestService

--- a/tools/krpctools/krpctools/test/docgen-TestService-csharp.rst
+++ b/tools/krpctools/krpctools/test/docgen-TestService-csharp.rst
@@ -463,6 +463,18 @@
 
       :Game Scenes: All
 
+   .. property:: string StringPropertyPrivateGet { set; }
+
+
+
+      :Game Scenes: All
+
+   .. property:: string StringPropertyPrivateSet { get; }
+
+
+
+      :Game Scenes: All
+
 
 
 .. enum:: TestEnum

--- a/tools/krpctools/krpctools/test/docgen-TestService-java.rst
+++ b/tools/krpctools/krpctools/test/docgen-TestService-java.rst
@@ -363,6 +363,19 @@
       :param String b:
       :Game Scenes: All
 
+   .. method:: void setStringPropertyPrivateGet(String value)
+
+
+
+      :Game Scenes: All
+
+   .. method:: String getStringPropertyPrivateSet()
+
+
+
+
+      :Game Scenes: All
+
 
 
 .. type:: public enum TestEnum

--- a/tools/krpctools/krpctools/test/docgen-TestService-lua.rst
+++ b/tools/krpctools/krpctools/test/docgen-TestService-lua.rst
@@ -484,6 +484,20 @@ Service documentation string.
       :param string b:
       :rtype: string
 
+   .. attribute:: string_property_private_get: string
+
+
+
+      :Attribute: Write-only, cannot be read
+      :rtype: string
+
+   .. attribute:: string_property_private_set: string
+
+
+
+      :Attribute: Read-only, cannot be set
+      :rtype: string
+
 
 
 .. class:: TestEnum

--- a/tools/krpctools/krpctools/test/docgen-TestService-python.rst
+++ b/tools/krpctools/krpctools/test/docgen-TestService-python.rst
@@ -575,6 +575,22 @@ Service documentation string.
       :rtype: str
       :Game Scenes: All
 
+   .. attribute:: string_property_private_get
+
+
+
+      :Attribute: Write-only, cannot be read
+      :rtype: str
+      :Game Scenes: All
+
+   .. attribute:: string_property_private_set
+
+
+
+      :Attribute: Read-only, cannot be set
+      :rtype: str
+      :Game Scenes: All
+
 
 
 .. class:: TestEnum

--- a/tools/krpctools/krpctools/test/docgentest.py
+++ b/tools/krpctools/krpctools/test/docgentest.py
@@ -61,7 +61,7 @@ class DocGenTestCase:
 
         actual, _ = process_file(domain, services, path)
 
-        # with open('/home/alex/workspaces/ksp/krpc/' +
+        # with open('/home/alex/workspaces/krpc/krpc/' +
         #           'tools/krpctools/krpctools/test/' +
         #           'docgen-'+name+'-'+self.language+'.rst', 'w') as f:
         #     f.write(actual)


### PR DESCRIPTION
Add tests for `[KRPCProperty]` that are static class properties in all clients.