### PR TITLE
Add KRPCNullableAttribute

### DIFF
--- a/server/src/KRPC.csproj
+++ b/server/src/KRPC.csproj
@@ -174,6 +174,7 @@
     <Compile Include="Service\Attributes\KRPCEnumAttribute.cs" />
     <Compile Include="Service\Attributes\KRPCExceptionAttribute.cs" />
     <Compile Include="Service\Attributes\KRPCMethodAttribute.cs" />
+    <Compile Include="Service\Attributes\KRPCNullableAttribute.cs" />
     <Compile Include="Service\Attributes\KRPCProcedureAttribute.cs" />
     <Compile Include="Service\Attributes\KRPCPropertyAttribute.cs" />
     <Compile Include="Service\Attributes\KRPCServiceAttribute.cs" />

--- a/server/src/Service/Attributes/KRPCNullableAttribute.cs
+++ b/server/src/Service/Attributes/KRPCNullableAttribute.cs
@@ -1,0 +1,13 @@
+using System;
+
+namespace KRPC.Service.Attributes
+{
+    /// <summary>
+    /// A nullable parameter in a kRPC procedure, method or property.
+    /// This attribute can be used to mark a parameter as being nullable.
+    /// </summary>
+    [AttributeUsage (AttributeTargets.Parameter)]
+    public sealed class KRPCNullableAttribute : Attribute
+    {
+    }
+}

--- a/server/src/Service/ProcedureParameter.cs
+++ b/server/src/Service/ProcedureParameter.cs
@@ -19,6 +19,8 @@ namespace KRPC.Service
             get { return DefaultValue != DBNull.Value; }
         }
 
+        public bool Nullable { get; private set; }
+
         [SuppressMessage ("Gendarme.Rules.Maintainability", "AvoidUnnecessarySpecializationRule")]
         public ProcedureParameter (MethodInfo method, ParameterInfo parameter)
         {
@@ -29,6 +31,7 @@ namespace KRPC.Service
             var defaultAttribute = Reflection.GetAttributes<KRPCDefaultValueAttribute> (method).FirstOrDefault (x => x.Name == Name);
             if (defaultAttribute != null)
                 DefaultValue = defaultAttribute.Value;
+            Nullable = Reflection.HasAttribute<KRPCNullableAttribute> (parameter);
         }
 
         public ProcedureParameter (Type type, string name)

--- a/server/src/Service/Scanner/ParameterSignature.cs
+++ b/server/src/Service/Scanner/ParameterSignature.cs
@@ -29,6 +29,11 @@ namespace KRPC.Service.Scanner
         /// </summary>
         public object DefaultValue { get; private set; }
 
+        /// <summary>
+        /// True if this parameter is nullable.
+        /// </summary>
+        public bool Nullable { get; private set; }
+
         public ParameterSignature (string fullProcedureName, ProcedureParameter parameter)
         {
             Name = parameter.Name;
@@ -41,6 +46,7 @@ namespace KRPC.Service.Scanner
             HasDefaultValue = parameter.HasDefaultValue;
             if (HasDefaultValue)
                 DefaultValue = parameter.DefaultValue;
+            Nullable = parameter.Nullable;
         }
 
         public void GetObjectData (SerializationInfo info, StreamingContext context)
@@ -49,6 +55,9 @@ namespace KRPC.Service.Scanner
             info.AddValue ("type", TypeUtils.SerializeType (Type));
             if (HasDefaultValue)
                 info.AddValue ("default_value", Server.ProtocolBuffers.Encoder.Encode (DefaultValue).ToByteArray ());
+            if (Nullable) {
+                info.AddValue ("nullable", Nullable);
+            }
         }
     }
 }

--- a/tools/TestServer/src/TestService.cs
+++ b/tools/TestServer/src/TestService.cs
@@ -93,7 +93,7 @@ namespace TestServer
         }
 
         [KRPCProcedure (Nullable = true)]
-        public static TestClass EchoTestObject (TestClass value)
+        public static TestClass EchoTestObject ([KRPCNullable] TestClass value)
         {
             return value;
         }

--- a/tools/krpctools/krpctools/docgen/nodes.py
+++ b/tools/krpctools/krpctools/docgen/nodes.py
@@ -122,7 +122,8 @@ class Class(Appendable):
 
 class Parameter(Appendable):
     # pylint: disable=redefined-builtin
-    def __init__(self, name, type, documentation, default_value=None):
+    def __init__(self, name, type, documentation,
+                 default_value=None, nullable=False):
         super().__init__()
         self.name = name
         self.type = as_type(self.types, type)
@@ -130,6 +131,7 @@ class Parameter(Appendable):
         if default_value is not None:
             default_value = decode_default_value(default_value, self.type)
         self.default_value = default_value
+        self.nullable = nullable
         self.documentation = documentation
 
 


### PR DESCRIPTION
Adds attribute to mark RPC parameters as "nullable", i.e. whether a parameter of object type could be null.

#678 