### PR TITLE
Fix flaky check for whether the test server has started in client tests

### DIFF
--- a/tools/build/client_test.bzl
+++ b/tools/build/client_test.bzl
@@ -53,9 +53,10 @@ def _impl(ctx):
         test_env = 'PORT=$CLIENT_PORT'
 
     sub_commands.extend([
-        '(cd server-executable.runfiles/krpc; %s %s >stdout) &' % (ctx.executable.server_executable.short_path, server_args),
+        'echo "" > %s' % stdout,
+        '(cd server-executable.runfiles/krpc; %s %s >> stdout) &' % (ctx.executable.server_executable.short_path, server_args),
         'SERVER_PID=$!',
-        'while ! grep "Server started successfully" %s >/dev/null 2>&1; do sleep 0.1 ; done' % stdout
+        'tail -n0 -f %s | sed "/Server started successfully/ q"' % stdout
     ] + get_server_settings + [
         '(cd test-executable.runfiles/krpc/%s.runfiles/krpc; %s ../../%s)' % (ctx.executable.test_executable.short_path, test_env, ctx.executable.test_executable.basename),
         'RESULT=$?',


### PR DESCRIPTION
Sometimes client tests fail due to the build script incorrectly thinking that the test server has started, and getting the wrong port numbers for it. This is hard to debug as it's not easily reproduced. It only happens occasionally.

Using tail and sed instead of "while grep" seems to work better. I have not observed any failures with this method.