### PR TITLE
Issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/krpc-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/krpc-bug-report.yml
@@ -1,4 +1,4 @@
-﻿name: "🪲 kRPC Bug report"
+name: "🪲 kRPC Bug report"
 description: Tell us about the bug so we can improve kRPC!
 labels: ['bug', 'request']
 title: '[Enter a bug title]'

--- a/.github/ISSUE_TEMPLATE/krpc-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/krpc-bug-report.yml
@@ -1,0 +1,30 @@
+﻿name: "🪲 kRPC Bug report"
+description: Tell us about the bug so we can improve kRPC!
+labels: ['bug', 'request']
+title: '[Enter a bug title]'
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: What happened?
+      description: |
+        Please provide a clear and concise description of what the bug is. If applicable, add screenshots to help explain your problem.
+    validations:
+      required: true
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Anything else we need to know?
+
+  - type: dropdown
+    id: environment
+    attributes:
+      label: What is your environment?
+      multiple: true
+      options:
+        - linux
+        - windows
+        - other
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/krpc-doc-issue.yml
+++ b/.github/ISSUE_TEMPLATE/krpc-doc-issue.yml
@@ -1,0 +1,28 @@
+name: "📑 kRPC Documentation issues"
+description: Found a kRPC documentation error? Help us correct it!
+labels: ['documentation', 'request']
+title: '[Enter a docs issue title]'
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ❗ This is for all kRPC documentation hosted by this repository including....`README.md`, `Contributing,md`, and `Development-Guide.md`
+
+        The kRPC docs are located here 👉 [kRPC Documentation](https://krpc.github.io/krpc/)
+  - type: textarea
+    id: affected
+    attributes:
+      label: Where is the issue located?
+      description: |
+        Please provide links or provide the location of the issue.
+    validations:
+      required: false
+
+  - type: textarea
+    id: suggested
+    attributes:
+      label: What are your suggested changes?
+      description: |
+        Give as much detail as you can to help us understand the changes you want to see.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/krpc-feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/krpc-feature-request.yml
@@ -1,0 +1,20 @@
+name: "🚀 kRPC Feature request"
+description: Suggest a new feature/enhancement for kRPC!
+labels: ['feature', 'request']
+title: '[feat req]'
+body:
+  - type: textarea
+    id: feature
+    attributes:
+      label: What would you like to be added?
+      description: |
+        Please check existing issues to avoid making duplicates. Any duplicate issue will be closed immediately.
+    validations:
+      required: true
+
+  - type: textarea
+    id: reasoning
+    attributes:
+      label: Why is this needed?
+    validations:
+      required: true


### PR DESCRIPTION
### Request for issue template integration
* Added .github/ISSUE_TEMPLATE folder (default for generating templates in issues tab)
* Add 3 templates
  * krpc-bug-report.yml: Provides text field inputs and 2 labels; [bug] and [request]
    * request is to help identify bugs not reveiwed by devs. Once validated/triaged, request label can be replaced with proper label
  * krpc-doc-issue.yml: A doc issue template. Same concept but [docmentation] and [request] tabs
  * krpc-features-request.yml: Template for new features. 