### PR TITLE
732 add pull request template to GitHub

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/01-general-pull-request.md
+++ b/.github/PULL_REQUEST_TEMPLATE/01-general-pull-request.md
@@ -24,22 +24,16 @@
 
 ---
 
-🚀***Add issue number below, example( `Fixes # 101`):*** 
+🚀***Add issue number below, example( `Fixes #101`):*** 
 
-Fixes # (issue)
-
-🚀***List any dependencies that are required for this change.***
-
-1) [Dependency name]
-2) [Dependency name]
-3) [...]
+Fixes #(issue)
 
 ### 🚀Type of request
 
 - [ ] Bug fix (non-breaking change which fixes an issue)
-- [ ] feature request (non-breaking change which adds functionality)
-- [ ] documentation update: [Link to Doc Page](url)
-- [ ] other
+- [ ] Feature request (non-breaking change which adds functionality)
+- [ ] Documentation update: [Link to Doc Page](url)
+- [ ] Other
 
 ### 🚀Compliance checklist:
 

--- a/.github/PULL_REQUEST_TEMPLATE/01-general-pull-request.md
+++ b/.github/PULL_REQUEST_TEMPLATE/01-general-pull-request.md
@@ -48,4 +48,4 @@ Fixes # (issue)
 - [ ] My changes generate no new warnings
 - [ ] My code has been tested 
 - [ ] I have included any new tests in my submission
-- [ ] Any dependent changes have been merged and downstream
+- [ ] Any dependent changes have been merged downstream

--- a/.github/PULL_REQUEST_TEMPLATE/01-general-pull-request.md
+++ b/.github/PULL_REQUEST_TEMPLATE/01-general-pull-request.md
@@ -35,11 +35,7 @@ Fixes #(issue)
 - [ ] Documentation update: [Link to Doc Page](url)
 - [ ] Other
 
-### 🚀Compliance checklist:
+### 🚀Compliance check:
 
 - [ ] My code follows the style guidelines of this project contained above and in `Contributing.md`
-- [ ] I have performed a self-review of my own code
-- [ ] My changes generate no new warnings
-- [ ] My code has been tested 
-- [ ] I have included any new tests in my submission
-- [ ] Any dependent changes have been merged downstream
+

--- a/.github/PULL_REQUEST_TEMPLATE/01-general-pull-request.md
+++ b/.github/PULL_REQUEST_TEMPLATE/01-general-pull-request.md
@@ -1,0 +1,51 @@
+# Thanks for contributing to kRPC
+## 🛰️Follow these Guidelines for Pull Requests
+
+ * Focus on one thing. A pull request should only have code changes that fix/add one
+   bug/feature. The exception to this is if there are many small bugs in one part of the code. These
+   can be submitted in a single Pull Request.
+ * Don’t fix code style in code that are not directly related to changes in your Pull Request. If
+   you want to fix the other lines of code, do it in a separate Pull Request.
+ * Keep a clean commit history and use meaningful commit messages. This makes the Pull Request
+   easier to review. You can use git rebasing to clean up your commit history or bring in more
+   recent changes from the main branch.
+ * Keep your Pull Request up to date with the main branch. If there are merge conflicts, they will
+   need to be resolved before the Pull Request can be merged.
+ * Automated tests should pass. It is best to run the tests locally before submitting a Pull
+   Requests to check that they are likely to pass.
+  
+   
+## ⚠️ Please Complete the below requirements and checklist prior to submission 
+
+---
+📑**Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.** 
+
+***Summary text here***
+
+---
+
+🚀***Add issue number below, example( `Fixes # 101`):*** 
+
+Fixes # (issue)
+
+🚀***List any dependencies that are required for this change.***
+
+1) [Dependency name]
+2) [Dependency name]
+3) [...]
+
+### 🚀Type of request
+
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] feature request (non-breaking change which adds functionality)
+- [ ] documentation update: [Link to Doc Page](url)
+- [ ] other
+
+### 🚀Compliance checklist:
+
+- [ ] My code follows the style guidelines of this project contained above and in `Contributing.md`
+- [ ] I have performed a self-review of my own code
+- [ ] My changes generate no new warnings
+- [ ] My code has been tested 
+- [ ] I have included any new tests in my submission
+- [ ] Any dependent changes have been merged and downstream


### PR DESCRIPTION
Unable to confirm that this will populate as it will only work on the base branch. 
- Added .github/PULL_REQUEST_TEMPLATE/pull_request_template.md
- Consistent with pull request template example in github docs
- Only a template and can be modified to suit changing needs
- Multiple templates specific to issue categories can be added to help decrease time with bugs. 