### PR TITLE
Update TestServer docker image to be hosted on ghcr

### DIFF
--- a/tools/TestServer/BUILD
+++ b/tools/TestServer/BUILD
@@ -30,7 +30,7 @@ pkg_zip(
     name = 'archive',
     out = 'TestServer-%s.zip' % version,
     files = [
-        ':README.txt',
+        ':README.md',
         ':TestServer',
         '//:version',
         '//tools/build/protobuf:LICENSE'

--- a/tools/TestServer/README.md
+++ b/tools/TestServer/README.md
@@ -1,17 +1,15 @@
-kRPC TestServer
-===============
+# kRPC TestServer
 
 This program can be used to run a kRPC server without needing to launch the
 game. It's intended purpose is for automated testing of kRPC clients.
 
-Usage
------
+## Usage
 
 To run, execute "TestServer.exe" from a command line.
 Run "TestServer.exe --help" for more information on configuring the server.
 
 Note:
- - The version of KRPC.dll in this archive will not work with KSP. It is
-   built for Mono 4.5, and is only intended for use with TestServer.
- - The Mono DLLs included are from Mono 4.5 - they are not the
+ * The version of KRPC.dll in this archive will not work with KSP. It is
+   only intended for use with TestServer outside of the game.
+ * The Mono DLLs included are from Mono 4.5 - they are not the
    same as those used by KSP.

--- a/tools/TestServer/docker/Makefile
+++ b/tools/TestServer/docker/Makefile
@@ -6,13 +6,13 @@ build:
 	bazel build //tools/TestServer:archive
 	rm -f TestServer.zip
 	cp ../../../bazel-bin/tools/TestServer/TestServer-$(VERSION).zip ./TestServer.zip
-	docker build -t krpc/testserver .
+	docker build -t ghcr.io/krpc/testserver:$(VERSION) .
+	docker tag ghcr.io/krpc/testserver:$(VERSION) ghcr.io/krpc/testserver:latest
 	rm -f TestServer.zip
-	docker tag krpc/testserver krpc/testserver:$(VERSION)
 
 test:
-	docker run -t -i -p 50000:50000 -p 50001:50001 krpc/testserver:$(VERSION)
+	docker run -t -i -p 50000:50000 -p 50001:50001 ghcr.io/krpc/testserver:$(VERSION)
 
 deploy:
-	docker push krpc/testserver
-	docker push krpc/testserver:$(VERSION)
+	docker push ghcr.io/krpc/testserver:$(VERSION)
+	docker push ghcr.io/krpc/testserver:latest

--- a/tools/TestServer/docker/README.md
+++ b/tools/TestServer/docker/README.md
@@ -1,26 +1,27 @@
-kRPC TestServer
-===============
+# kRPC TestServer
 
 This image contains the kRPC TestServer, which can be run directly using docker.
 
 To run the server use:
 ```
-docker run -t -i -p 50000:50000 -p 50001:50001 krpc/testserver
+docker run -t -i -p 50000:50000 -p 50001:50001 ghcr.io/krpc/testserver
 ```
 
 This runs the server listening on RPC port 50000 and stream port 50001.
 
-Additional flags can be passed by including them at the end of the docker run command. For example, to pass the --debug flag run the following:
+Additional flags can be passed by including them at the end of the docker run command.
+For example, to pass the --debug flag run the following:
 ```
-docker run -t -i -p 50000:50000 -p 50001:50001 krpc/testserver --debug
+docker run -t -i -p 50000:50000 -p 50001:50001 ghcr.io/krpc/testserver --debug
 ```
 
 For help on additional options and to see other usage instructions, pass the `--help` flag:
 ```
-docker run -t -i -p 50000:50000 -p 50001:50001 krpc/testserver --help
+docker run -t -i -p 50000:50000 -p 50001:50001 ghcr.io/krpc/testserver --help
 ```
 
-To use an RPC and Stream port other than the defaults, runt the following command replacing `RPC_PORT` and `STREAM_PORT` with the ports of your choice:
+To use an RPC and Stream port other than the defaults, runt the following command replacing
+`RPC_PORT` and `STREAM_PORT` with the ports of your choice:
 ```
-docker run -t -i -p RPC_PORT:50000 -p STREAM_PORT:50001 krpc/testserver
+docker run -t -i -p RPC_PORT:50000 -p STREAM_PORT:50001 ghcr.io/krpc/testserver
 ```


### PR DESCRIPTION
It's now hosted here: https://github.com/orgs/krpc/packages/container/package/testserver
Rather than on docker hub