### PR TITLE
Fix TestServer scanning for services twice

### DIFF
--- a/tools/TestServer/src/Program.cs
+++ b/tools/TestServer/src/Program.cs
@@ -115,8 +115,6 @@ namespace TestServer
                 return;
             }
 
-            KRPC.Service.Scanner.Scanner.GetServices ();
-
             var core = Core.Instance;
             CallContext.GameScene = GameScene.SpaceCenter;
             core.OnClientRequestingConnection += (s, e) => e.Request.Allow ();


### PR DESCRIPTION
KRPC.Core was updated recently to do the scanning on construction, so this line is unnecessary and causes duplicate scanning.