### PR TITLE
Fix major memory leak after referencing crewmembers

### DIFF
--- a/service/SpaceCenter/src/Services/CrewMember.cs
+++ b/service/SpaceCenter/src/Services/CrewMember.cs
@@ -18,7 +18,7 @@ namespace KRPC.SpaceCenter.Services
         /// </summary>
         public CrewMember (ProtoCrewMember crewMember)
         {
-            InternalCrewMember = crewMember;
+            m_protoCrewMemberName = crewMember.name;
         }
 
         /// <summary>
@@ -34,13 +34,20 @@ namespace KRPC.SpaceCenter.Services
         /// </summary>
         public override int GetHashCode ()
         {
-            return InternalCrewMember.GetHashCode ();
+            return m_protoCrewMemberName.GetHashCode ();
         }
 
         /// <summary>
         /// The KSP crew member.
         /// </summary>
-        public ProtoCrewMember InternalCrewMember { get; private set; }
+        public ProtoCrewMember InternalCrewMember
+        {
+            get
+            {
+                return HighLogic.CurrentGame?.CrewRoster?[m_protoCrewMemberName];
+            }
+        }
+        private string m_protoCrewMemberName;
 
         /// <summary>
         /// The crew members name.


### PR DESCRIPTION
After referencing a CrewMember, it will be stored in that server's ObjectStore.  The KRPC CrewMember object has a reference to the KSP ProtoCrewMember associated with the kerbal.  But this object has a reference to the part where they are sitting in, which in turn has a reference to the vessel, which in turn has references to all of its parts.  That means that after loading a quicksave, if you had ever referenced a crew member through KRPC, you will leak the entire loaded vessel hierarchy each time a quicksave is loaded.