### PR TITLE
Fix streams for dynamic services

### DIFF
--- a/client/python/BUILD.bazel
+++ b/client/python/BUILD.bazel
@@ -150,6 +150,7 @@ test_suite(
     name = "test",
     tests = [
         ":client",
+        ":client_base",
         ":lint",
     ],
 )
@@ -162,12 +163,29 @@ client_test(
     test_executable = ":clienttest",
 )
 
+client_test(
+    name = "client_base",
+    size = "medium",
+    server_executable = "//tools/TestServer",
+    tags = ["requires-network"],
+    test_executable = ":clienttest_base",
+)
+
 deps = ["@python_protobuf//file"]
 
 py_test(
     name = "clienttest",
     size = "small",
     src = ":python",
+    pkg = "krpc-" + python_version,
+    tags = ["requires-network"],
+    deps = deps,
+)
+
+py_test(
+    name = "clienttest_base",
+    size = "small",
+    src = ":python_base",
     pkg = "krpc-" + python_version,
     tags = ["requires-network"],
     deps = deps,

--- a/client/python/krpc/client.py
+++ b/client/python/krpc/client.py
@@ -139,28 +139,17 @@ class Client(krpc.services.Client):
                  *args: object, **kwargs: object) -> KRPC.ProcedureCall:
         """ Convert a remote procedure call to a KRPC.ProcedureCall message """
         if func == getattr:
-            attr = func(args[0].__class__, args[1]).fget
-            if hasattr(attr, '_build_call'):
-                builder = attr._build_call
-            else:
-                builder = getattr(args[0], '_build_call_' + attr.__name__)
-            args = (args[0],)
+            name = args[1]
+            builder = getattr(args[0], '_build_call_' + name)
+            args = tuple()
             kwargs = {}
         elif func == setattr:
             raise StreamError('Cannot create a call for a property setter')
         else:
-            if hasattr(func, '_build_call'):
-                builder = func._build_call
-                if hasattr(func, '__self__'):
-                    new_args = [func.__self__]
-                    new_args.extend(args)
-                    args = tuple(new_args)
-            else:
-                builder = getattr(
-                    func.__self__,  # type: ignore[attr-defined]
-                    '_build_call_' + func.__name__
-                )
-
+            builder = getattr(
+                func.__self__,  # type: ignore[attr-defined]
+                '_build_call_' + func.__name__
+            )
         return cast(KRPC.ProcedureCall, builder(*args, **kwargs))
 
     @staticmethod
@@ -169,27 +158,15 @@ class Client(krpc.services.Client):
                          **kwargs: object) -> TypeBase:
         """ Get the return type for a remote procedure call """
         if func == getattr:
-            attr = func(args[0].__class__, args[1]).fget
-            if hasattr(attr, '_return_type'):
-                return_type_fn = getattr(attr, '_return_type')
-            else:
-                return_type_fn = getattr(args[0], '_return_type_' + attr.__name__)
+            name = args[1]
+            return_type_fn = getattr(args[0], '_return_type_' + name)
         elif func == setattr:
             raise StreamError('Cannot get return type for a property setter')
         else:
-            if hasattr(func, '_return_type'):
-                return_type_fn = getattr(func, '_return_type')
-            else:
-                return_type_fn = getattr(
-                    func.__self__,  # type: ignore[attr-defined]
-                    '_return_type_' + func.__name__
-                )
-
-        if isinstance(return_type_fn, TypeBase):
-            # FIXME: this is a workaround for dynamically created services setting
-            # _return_type to a value, rather than a zero-argument function that returns
-            # a value. This should be cleaned up.
-            return return_type_fn
+            return_type_fn = getattr(
+                func.__self__,  # type: ignore[attr-defined]
+                '_return_type_' + func.__name__
+            )
         return cast(TypeBase, return_type_fn())
 
     def _invoke(self, service: str, procedure: str, args: Iterable[object],

--- a/client/python/krpc/types.py
+++ b/client/python/krpc/types.py
@@ -430,14 +430,14 @@ class DynamicType:
         return getattr(cls, name)
 
     @classmethod
-    def _add_static_method(cls,
-                           name: str,
-                           func: Callable,  # type: ignore[type-arg]
-                           doc: Optional[str] = None) -> object:
+    def _add_class_method(cls,
+                          name: str,
+                          func: Callable,  # type: ignore[type-arg]
+                          doc: Optional[str] = None) -> object:
         """ Add a static method """
         func.__name__ = name
         func.__doc__ = doc
-        static_func = staticmethod(func)
+        static_func = classmethod(func)
         setattr(cls, name, static_func)
         return getattr(cls, name)
 


### PR DESCRIPTION
Fix logic to determine RPC call message and return type for streams in the python client, when the service is dynamic (has no pre-generated stubs).

Fixes #763 

Also run all python client tests with the "base" client that contains no pre-generated stubs, so that this use case is thoroughly tested.