### PR TITLE
csproj updates: change debug type to portable and framework version to 4.8

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -95,7 +95,7 @@ genrule(
 pkg_zip(
     name = "krpc",
     out = "krpc-%s.zip" % version,
-    exclude = ["*.mdb"],
+    exclude = ["*.mdb", "*.pdb"],
     files = [
         ":readme",
         ":license",

--- a/client/csharp/BUILD.bazel
+++ b/client/csharp/BUILD.bazel
@@ -7,7 +7,7 @@ load("//:config.bzl", "assembly_version", "author", "nuget_version", "version")
 pkg_zip(
     name = "csharp",
     out = "krpc-csharp-%s.zip" % version,
-    exclude = ["*.mdb"],
+    exclude = ["*.mdb", "*.pdb"],
     files = [
         "CHANGES.txt",
         "LICENSE",

--- a/client/csharp/src/KRPC.Client.csproj
+++ b/client/csharp/src/KRPC.Client.csproj
@@ -7,8 +7,8 @@
     <OutputType>Library</OutputType>
     <RootNamespace>KRPC.Client</RootNamespace>
     <AssemblyName>KRPC.Client</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
-    <DebugType>full</DebugType>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
+    <DebugType>portable</DebugType>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>

--- a/client/csharp/test/KRPC.Client.Test.csproj
+++ b/client/csharp/test/KRPC.Client.Test.csproj
@@ -8,8 +8,8 @@
     <OutputType>Library</OutputType>
     <RootNamespace>KRPC.Client.Test</RootNamespace>
     <AssemblyName>KRPC.Client.Test</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
-    <DebugType>full</DebugType>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
+    <DebugType>portable</DebugType>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>

--- a/core/src/KRPC.Core.csproj
+++ b/core/src/KRPC.Core.csproj
@@ -7,9 +7,9 @@
     <OutputType>Library</OutputType>
     <RootNamespace>KRPC</RootNamespace>
     <AssemblyName>KRPC.Core</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <NoStdLib>true</NoStdLib>
-    <DebugType>full</DebugType>
+    <DebugType>portable</DebugType>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>

--- a/core/test/KRPC.Core.Test.csproj
+++ b/core/test/KRPC.Core.Test.csproj
@@ -8,9 +8,9 @@
     <OutputType>Library</OutputType>
     <RootNamespace>KRPC.Test</RootNamespace>
     <AssemblyName>KRPC.Core.Test</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <NoStdLib>true</NoStdLib>
-    <DebugType>full</DebugType>
+    <DebugType>portable</DebugType>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>

--- a/server/src/KRPC.csproj
+++ b/server/src/KRPC.csproj
@@ -7,9 +7,9 @@
     <OutputType>Library</OutputType>
     <RootNamespace>KRPC</RootNamespace>
     <AssemblyName>KRPC</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <NoStdLib>true</NoStdLib>
-    <DebugType>full</DebugType>
+    <DebugType>portable</DebugType>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>

--- a/service/DockingCamera/src/KRPC.DockingCamera.csproj
+++ b/service/DockingCamera/src/KRPC.DockingCamera.csproj
@@ -7,9 +7,9 @@
     <OutputType>Library</OutputType>
     <RootNamespace>KRPC.DockingCamera</RootNamespace>
     <AssemblyName>KRPC.DockingCamera</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <NoStdLib>true</NoStdLib>
-    <DebugType>full</DebugType>
+    <DebugType>portable</DebugType>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>

--- a/service/Drawing/src/KRPC.Drawing.csproj
+++ b/service/Drawing/src/KRPC.Drawing.csproj
@@ -7,9 +7,9 @@
     <OutputType>Library</OutputType>
     <RootNamespace>KRPC.Drawing</RootNamespace>
     <AssemblyName>KRPC.Drawing</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <NoStdLib>true</NoStdLib>
-    <DebugType>full</DebugType>
+    <DebugType>portable</DebugType>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>

--- a/service/InfernalRobotics/src/KRPC.InfernalRobotics.csproj
+++ b/service/InfernalRobotics/src/KRPC.InfernalRobotics.csproj
@@ -7,9 +7,9 @@
     <OutputType>Library</OutputType>
     <RootNamespace>KRPC.InfernalRobotics</RootNamespace>
     <AssemblyName>KRPC.InfernalRobotics</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <NoStdLib>true</NoStdLib>
-    <DebugType>full</DebugType>
+    <DebugType>portable</DebugType>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>

--- a/service/KerbalAlarmClock/src/KRPC.KerbalAlarmClock.csproj
+++ b/service/KerbalAlarmClock/src/KRPC.KerbalAlarmClock.csproj
@@ -7,9 +7,9 @@
     <OutputType>Library</OutputType>
     <RootNamespace>KRPC.KerbalAlarmClock</RootNamespace>
     <AssemblyName>KRPC.KerbalAlarmClock</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <NoStdLib>true</NoStdLib>
-    <DebugType>full</DebugType>
+    <DebugType>portable</DebugType>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>

--- a/service/LiDAR/src/KRPC.LiDAR.csproj
+++ b/service/LiDAR/src/KRPC.LiDAR.csproj
@@ -7,9 +7,9 @@
     <OutputType>Library</OutputType>
     <RootNamespace>KRPC.LiDAR</RootNamespace>
     <AssemblyName>KRPC.LiDAR</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <NoStdLib>true</NoStdLib>
-    <DebugType>full</DebugType>
+    <DebugType>portable</DebugType>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>

--- a/service/RemoteTech/src/KRPC.RemoteTech.csproj
+++ b/service/RemoteTech/src/KRPC.RemoteTech.csproj
@@ -7,9 +7,9 @@
     <OutputType>Library</OutputType>
     <RootNamespace>KRPC.RemoteTech</RootNamespace>
     <AssemblyName>KRPC.RemoteTech</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <NoStdLib>true</NoStdLib>
-    <DebugType>full</DebugType>
+    <DebugType>portable</DebugType>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>

--- a/service/SpaceCenter/src/KRPC.SpaceCenter.csproj
+++ b/service/SpaceCenter/src/KRPC.SpaceCenter.csproj
@@ -7,9 +7,9 @@
     <OutputType>Library</OutputType>
     <RootNamespace>KRPC.SpaceCenter</RootNamespace>
     <AssemblyName>KRPC.SpaceCenter</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <NoStdLib>true</NoStdLib>
-    <DebugType>full</DebugType>
+    <DebugType>portable</DebugType>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>

--- a/service/UI/src/KRPC.UI.csproj
+++ b/service/UI/src/KRPC.UI.csproj
@@ -7,9 +7,9 @@
     <OutputType>Library</OutputType>
     <RootNamespace>KRPC.UI</RootNamespace>
     <AssemblyName>KRPC.UI</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <NoStdLib>true</NoStdLib>
-    <DebugType>full</DebugType>
+    <DebugType>portable</DebugType>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>

--- a/tools/ServiceDefinitions/src/ServiceDefinitions.csproj
+++ b/tools/ServiceDefinitions/src/ServiceDefinitions.csproj
@@ -8,10 +8,10 @@
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <RootNamespace>ServiceDefinitions</RootNamespace>
     <AssemblyName>ServiceDefinitions</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <NoStdLib>true</NoStdLib>
     <Externalconsole>true</Externalconsole>
-    <DebugType>full</DebugType>
+    <DebugType>portable</DebugType>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>

--- a/tools/TestServer/BUILD.bazel
+++ b/tools/TestServer/BUILD.bazel
@@ -35,6 +35,7 @@ pkg_zip(
     out = "TestServer-%s.zip" % version,
     exclude = [
         "*.mdb",
+        "*.pdb",
         "tools/TestServer/TestServer",
     ],
     files = [

--- a/tools/TestServer/src/TestServer.csproj
+++ b/tools/TestServer/src/TestServer.csproj
@@ -9,9 +9,9 @@
     <Externalconsole>true</Externalconsole>
     <RootNamespace>TestServer</RootNamespace>
     <AssemblyName>TestServer</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <NoStdLib>true</NoStdLib>
-    <DebugType>full</DebugType>
+    <DebugType>portable</DebugType>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>

--- a/tools/TestingTools/src/TestingTools.csproj
+++ b/tools/TestingTools/src/TestingTools.csproj
@@ -7,9 +7,9 @@
     <OutputType>Library</OutputType>
     <RootNamespace>TestingTools</RootNamespace>
     <AssemblyName>TestingTools</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <NoStdLib>true</NoStdLib>
-    <DebugType>full</DebugType>
+    <DebugType>portable</DebugType>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>


### PR DESCRIPTION
This makes it easier for people to compile and debug on windows; 4.8 is the version installed by default and works fine with KSP.