### PR TITLE
fix vessel recovery

### DIFF
--- a/service/SpaceCenter/src/Services/Vessel.cs
+++ b/service/SpaceCenter/src/Services/Vessel.cs
@@ -10,6 +10,7 @@ using Tuple3 = System.Tuple<double, double, double>;
 using Tuple4 = System.Tuple<double, double, double, double>;
 using TupleV3 = System.Tuple<Vector3d, Vector3d>;
 using TupleT3 = System.Tuple<System.Tuple<double, double, double>, System.Tuple<double, double, double>>;
+using System.Collections;
 
 namespace KRPC.SpaceCenter.Services
 {
@@ -107,9 +108,18 @@ namespace KRPC.SpaceCenter.Services
         [KRPCMethod]
         public void Recover ()
         {
-            if (!Recoverable)
+            var vessel = InternalVessel;
+            if (!vessel.IsRecoverable)
                 throw new InvalidOperationException ("Vessel is not recoverable");
-            GameEvents.OnVesselRecoveryRequested.Fire (InternalVessel);
+            vessel.StartCoroutine(RecoverVesselCoroutine(vessel));
+        }
+
+        static IEnumerator RecoverVesselCoroutine(global::Vessel vessel)
+        {
+			// calling OnVesselRecoveryRequested.Fire from Update will cause issues.  Using WaitUntil makes it execute after Update and before LateUpdate:
+			// https://docs.unity3d.com/ScriptReference/WaitUntil.html
+			yield return new WaitUntil(() => true);
+            GameEvents.OnVesselRecoveryRequested.Fire(vessel);
         }
 
         /// <summary>


### PR DESCRIPTION
I've been using something similar to this in tpksp for years.  Calling the event directly can spew nullrefs and softlock you out of buildings.

My initial fix was to add a component that fires the event in LateUpdate, but this also works and is simpler (tested on my stream).

I suspect the issue occurs because the event is normally fired from the stock ui code which runs late in the frame.

for reference, I originally hit this in RPM with the vessel recovery prop.  This is the code I’d been using in tpksp as well: https://github.com/JonnyOThan/RasterPropMonitor/blob/958720c1d9ad2145cacf5f5098d8984682f5e00e/RasterPropMonitor/Core/JSIVesselRecovery.cs#L27