### PR TITLE
Fix scaled camera distance clamp

### DIFF
--- a/service/SpaceCenter/src/Services/Camera.cs
+++ b/service/SpaceCenter/src/Services/Camera.cs
@@ -173,7 +173,7 @@ namespace KRPC.SpaceCenter.Services
                 case CameraMode.Map:
                     {
                         var camera = PlanetariumCamera.fetch;
-                        camera.SetDistance (value.Clamp (camera.minDistance, camera.maxDistance) / ScaledSpace.ScaleFactor);
+                        camera.SetDistance ((value / ScaledSpace.ScaleFactor).Clamp (camera.minDistance, camera.maxDistance));
                         break;
                     }
                 case CameraMode.IVA:


### PR DESCRIPTION
-the scaled camera min and max distances are set in scaled space, while krpc only works in meters