### PR TITLE
Fix decoupler crashes with stack separators

### DIFF
--- a/service/SpaceCenter/src/Services/Parts/Decoupler.cs
+++ b/service/SpaceCenter/src/Services/Parts/Decoupler.cs
@@ -87,7 +87,7 @@ namespace KRPC.SpaceCenter.Services.Parts
             if (wait < 10 || !Decoupled)
                 throw new YieldException<Func<Vessel>> (() => PostDecouple(preVesselIds, wait + 1));
             // Return the newly created vessel
-            return new Vessel (FlightGlobals.Vessels.Select (v => v.id).Except (preVesselIds).Single ());
+            return new Vessel (FlightGlobals.Vessels.Select (v => v.id).Except (preVesselIds).First ());
         }
 
         /// <summary>


### PR DESCRIPTION
This crash seems to stem from the fact that there are two vessels made by stack separators: the main separated vessel and the stack separator debris. Based on some cursory testing, this seems to select the separated vessel and not the debris. There may be some edge cases here, but they haven't cropped up in my testing as of yet.

This fixes #765.