### PR TITLE
Force throttle to 0 when attempting timewarp

### DIFF
--- a/service/SpaceCenter/src/Services/SpaceCenter.cs
+++ b/service/SpaceCenter/src/Services/SpaceCenter.cs
@@ -652,7 +652,11 @@ namespace KRPC.SpaceCenter.Services
         [KRPCProperty (GameScene = GameScene.Flight)]
         public static int RailsWarpFactor {
             get { return WarpMode == WarpMode.Rails ? TimeWarp.CurrentRateIndex : 0; }
-            set { SetWarpFactor (TimeWarp.Modes.HIGH, value.Clamp (0, MaximumRailsWarpFactor)); }
+            set {
+                // Set throttle to 0 when attempting to warp; can't warp when throttled up
+                FlightInputHandler.state.mainThrottle = 0;
+                SetWarpFactor (TimeWarp.Modes.HIGH, value.Clamp (0, MaximumRailsWarpFactor));
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
This is an attempt to address #792 .

When attempting to time warp, we call `SetWarpFactor`, which caps us at MaximumRailsWarpFactor. But the logic for `MaximumRailsWarpFactor` locks out all warping if we have a nonzero throttle setting.

KSP allows timewarping with nonzero throttle, as long as you aren't firing engines (meaning despite nonzero throttle, no engines are able to operate, due to being deactivated, starved of fuel, or simply not existing), you can still time-warp. If you do this, KSP will set your throttle to zero for you.

In kRPC as it currently stands, a nonzero throttle will prevent any time warping. It is therefore required that the user set throttle to zero before timewarping. Instead, this PR makes it so that any attempt to set a rails warp factor will automatically set throttle to zero, prior to invoking the `SetWarpFactor` call. This should be a nice quality-of-life improvement. For me, the zero-throttle requirement was confusing and difficult to understand initially as a player, and I only found out it existed by compiling the mod myself and inserting debug statements until I found the logic that was preventing my timewarps.

This is my first contribution to this repo (or indeed, any KSP mod), so I hope this PR is acceptable. The contributing guidelines say I should open an issue and wait for feedback before opening the PR, but given the simplicity here, I hope this is okay to submit immediately.

Thank you!