### PR TITLE
Pre-release fixes

### DIFF
--- a/config.bzl
+++ b/config.bzl
@@ -3,7 +3,7 @@
 author = "djungelorm"
 version = "0.5.2"
 ksp_version_max = "1.12.5.3190"
-ksp_version_min = "1.8.0.2686"
+ksp_version_min = "1.12.3.3173"
 ksp_version_max_parts = ksp_version_max.split(".")
 ksp_version_min_parts = ksp_version_min.split(".")
 

--- a/tools/build-against-all-versions.sh
+++ b/tools/build-against-all-versions.sh
@@ -7,7 +7,9 @@ mkdir -p bazel-bin/lib
 pushd bazel-bin/lib
 
 read -d '' versions << EOM || true
-1.10.1.2939
+1.12.5
+1.12.4
+1.12.3
 EOM
 
 # Save lib/ksp symlink
@@ -17,13 +19,13 @@ pushd bazel-bin/lib
 
 for version in $versions; do
     # Download and extract ksp libs
-    if [ ! -f ksp-$version.tar.gz ]; then
-        wget -O ksp-$version.tar.gz https://krpc.s3.amazonaws.com/lib/ksp-$version.tar.gz
+    if [ ! -f ksp-$version.zip ]; then
+        wget -O ksp-$version.zip https://github.com/krpc/ksp-lib/raw/main/ksp/ksp-$version.zip
     fi
     if [ ! -d ksp-$version ]; then
         mkdir ksp-$version
         pushd ksp-$version
-        tar -xf ../ksp-$version.tar.gz
+        unzip ../ksp-$version.zip
         popd
     fi
 

--- a/tools/dist/changes.py
+++ b/tools/dist/changes.py
@@ -4,12 +4,15 @@ import argparse
 import re
 
 def main():
-    config = ''.join(open('config.bzl', 'r').readlines())
-    m = re.search('^version\s*=\s*\'(.+)\'$', config, re.MULTILINE)
-    if not m:
+    config = open('config.bzl', 'r').readlines()
+    current_version = None
+    for line in config:
+        m = re.search('^version\s*=\s*\"(.+)\"$', line)
+        if m:
+            current_version = m.group(1)
+    if current_version is None:
         print('Failed to get version from config.bzl')
         return 1
-    current_version = m.group(1)
 
     parser = argparse.ArgumentParser()
     parser.add_argument('site', choices=('github', 'spacedock', 'curse'))

--- a/tools/krpctools/krpctools/servicedefs/__init__.py
+++ b/tools/krpctools/krpctools/servicedefs/__init__.py
@@ -95,13 +95,13 @@ def servicedefs(ksp, service, assemblies):
              '--output=%s' % tmpout, service] + assemblies,
             stderr=subprocess.STDOUT)
     except subprocess.CalledProcessError as ex:
-        shutil.rmtree(binpath)
+        shutil.rmtree(bindir)
         raise RuntimeError(ex.output) from ex
 
     with open(tmpout, 'r') as fp:
         return fp.read()
 
-    shutil.rmtree(binpath)
+    shutil.rmtree(bindir)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
 - Update supported KSP versions
 - Fix build-against-all-versions script
 - Fix changelog generation script
 - Fix bug in servicedefs tool where wrong temporary path is deleted (#759)