### PR TITLE
Fix pdf docs release

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@
 kRPC allows you to control Kerbal Space Program from scripts running outside of
 the game, and comes with client libraries for many popular languages.
 
- * [Documentation](https://krpc.github.io/krpc)
+ * [Web Documentation](https://krpc.github.io/krpc)
+ * [PDF Documentation](https://github.com/krpc/krpc/releases)
  * [Forum release thread](http://forum.kerbalspaceprogram.com/index.php?/topic/130742-105-krpc-remote-control-your-ships-using-python-c-c-lua-v021-10th-feb-2016/)
  * [Discord](https://discord.gg/bXuaTrj)
 

--- a/Release-Guide.md
+++ b/Release-Guide.md
@@ -15,7 +15,7 @@ This document details the steps necessary to make a release of kRPC.
 1. Run `tools/dist/genfiles.sh` to build the genfiles archive to include in the release.
 1. Do the release on Github:
    1. Use `tools/dist/changes.py github` to get changelog to include with the release
-   1. Upload the release archive, krpctools, genfiles, TestServer and all clients (10 files in total)
+   1. Upload the release archive, krpctools, genfiles, TestServer, documentation and all clients (11 files in total)
 1. Update the documentation website by merging the vx.x.x commit into the docs branch.
    Push it to GitHub. The docs GitHub workflow should automatically build and deploy the new website.
 1. Do a release on Curse

--- a/doc/BUILD.bazel
+++ b/doc/BUILD.bazel
@@ -105,7 +105,7 @@ sphinx_build(
 sphinx_build(
     name = "pdf",
     srcs = [":srcs"],
-    out = "krpc-%s.pdf" % version,
+    out = "krpc-doc-%s.pdf" % version,
     builder = "latex",
     opts = {"version": version},
     sphinx_build = ":sphinx-build",

--- a/tools/dist/github-changes.tmpl
+++ b/tools/dist/github-changes.tmpl
@@ -1,4 +1,5 @@
- * [Documentation](http://krpc.github.io/krpc)
+ * [Web Documentation](http://krpc.github.io/krpc)
+ * PDF Documentation - available to download from assets
  * [Forum release thread](http://forum.kerbalspaceprogram.com/index.php?/topic/130742-105-krpc-remote-control-your-ships-using-python-c-c-lua-v021-10th-feb-2016)
  * [Forum development thread](http://forum.kerbalspaceprogram.com/threads/69313)
 


### PR DESCRIPTION
Docs pdf is now included in the assets on the release page. Also added links to it from the main readme.