### PR TITLE
Add Camera IVA controls

### DIFF
--- a/build-out
+++ b/build-out
@@ -1,1 +1,0 @@
-//wsl$/Ubuntu/root/.cache/bazel/_bazel_root/de0ac7c6e695e9ce1f3f94f98c102022/execroot/krpc/bazel-out/k8-fastbuild/bin

--- a/build-out
+++ b/build-out
@@ -1,0 +1,1 @@
+//wsl$/Ubuntu/root/.cache/bazel/_bazel_root/de0ac7c6e695e9ce1f3f94f98c102022/execroot/krpc/bazel-out/k8-fastbuild/bin

--- a/doc/order.txt
+++ b/doc/order.txt
@@ -1152,6 +1152,7 @@ SpaceCenter.Camera.DefaultFoV
 SpaceCenter.Camera.FocussedBody
 SpaceCenter.Camera.FocussedVessel
 SpaceCenter.Camera.FocussedNode
+SpaceCenter.Camera.FocussedCrewMember
 SpaceCenter.CameraMode
 SpaceCenter.CameraMode.Automatic
 SpaceCenter.CameraMode.Free
@@ -1160,6 +1161,7 @@ SpaceCenter.CameraMode.Locked
 SpaceCenter.CameraMode.Orbital
 SpaceCenter.CameraMode.IVA
 SpaceCenter.CameraMode.Map
+SpaceCenter.Camera.NextCamera
 SpaceCenter.WaypointManager
 SpaceCenter.WaypointManager.Waypoints
 SpaceCenter.WaypointManager.AddWaypoint

--- a/doc/order.txt
+++ b/doc/order.txt
@@ -1140,11 +1140,15 @@ SpaceCenter.Camera.Mode
 SpaceCenter.Camera.Pitch
 SpaceCenter.Camera.Heading
 SpaceCenter.Camera.Distance
+SpaceCenter.Camera.FoV
 SpaceCenter.Camera.MinPitch
 SpaceCenter.Camera.MaxPitch
 SpaceCenter.Camera.MinDistance
 SpaceCenter.Camera.MaxDistance
+SpaceCenter.Camera.MinFoV
+SpaceCenter.Camera.MaxFoV
 SpaceCenter.Camera.DefaultDistance
+SpaceCenter.Camera.DefaultFoV
 SpaceCenter.Camera.FocussedBody
 SpaceCenter.Camera.FocussedVessel
 SpaceCenter.Camera.FocussedNode

--- a/service/SpaceCenter/src/ExtensionMethods/InternalCameraExtensions.cs
+++ b/service/SpaceCenter/src/ExtensionMethods/InternalCameraExtensions.cs
@@ -1,0 +1,93 @@
+﻿using System;
+using System.Linq.Expressions;
+using System.Reflection;
+
+namespace KRPC.SpaceCenter.ExtensionMethods
+{
+    /// <summary>
+    /// A few small utility functions for getting and setting private members of the internal camera.
+    /// </summary>
+    public static class InternalCameraExtensions
+    {
+        private static readonly Lazy<Action<InternalCamera, object>> _setPitch =
+            new Lazy<Action<InternalCamera, object>>(() => CreateFieldSetter<InternalCamera>("currentPitch"));
+
+        private static readonly Lazy<Func<InternalCamera, object>> _getPitch =
+            new Lazy<Func<InternalCamera, object>>(() => CreateFieldGetter<InternalCamera>("currentPitch"));
+
+        private static readonly Lazy<Action<InternalCamera, object>> _setRot =
+            new Lazy<Action<InternalCamera, object>>(() => CreateFieldSetter<InternalCamera>("currentRot"));
+
+        private static readonly Lazy<Action<InternalCamera, object>> _setZoom =
+            new Lazy<Action<InternalCamera, object>>(() => CreateFieldSetter<InternalCamera>("currentZoom"));
+
+        private static readonly Lazy<Func<InternalCamera, object>> _getRot =
+            new Lazy<Func<InternalCamera, object>>(() => CreateFieldGetter<InternalCamera>("currentRot"));
+
+        private static readonly Lazy<Func<InternalCamera, object>> _getFoV =
+            new Lazy<Func<InternalCamera, object>>(() => CreateFieldGetter<InternalCamera>("currentFoV"));
+
+        private static readonly Lazy<Func<InternalCamera, object>> _getDefaultFoV =
+            new Lazy<Func<InternalCamera, object>>(() => CreateFieldGetter<InternalCamera>("initialZoom"));
+
+        /// <summary>
+        /// Sets the pitch of the internal camera.
+        /// </summary>
+        public static Action<InternalCamera, object> SetPitch => _setPitch.Value;
+
+        /// <summary>
+        /// Gets the pitch of the internal camera.
+        /// </summary>
+        public static Func<InternalCamera, object> GetPitch => _getPitch.Value;
+
+        /// <summary>
+        /// Sets the rotation of the internal camera.
+        /// </summary>
+        public static Action<InternalCamera, object> SetRot => _setRot.Value;
+
+        /// <summary>
+        /// Sets the current zoom of the internal camera.
+        /// </summary>
+        public static Action<InternalCamera, object> SetZoom => _setZoom.Value;
+
+        /// <summary>
+        /// Gets the rotation of the internal camera.
+        /// </summary>
+        public static Func<InternalCamera, object> GetRot => _getRot.Value;
+
+        /// <summary>
+        /// Gets the field of view of the internal camera.
+        /// </summary>
+        public static Func<InternalCamera, object> GetFoV => _getFoV.Value;
+
+        /// <summary>
+        /// Gets the default field of view of the internal camera.
+        /// </summary>
+        public static Func<InternalCamera, object> GetDefaultFoV => _getDefaultFoV.Value;
+
+        private static Action<T, object> CreateFieldSetter<T>(string fieldName)
+        {
+            var parameterExpression = Expression.Parameter(typeof(T), "target");
+            var valueExpression = Expression.Parameter(typeof(object), "value");
+
+            var field = typeof(T).GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Instance);
+            var fieldExpression = Expression.Field(parameterExpression, field);
+            var assignExpression = Expression.Assign(fieldExpression, Expression.Convert(valueExpression, field.FieldType));
+
+            var lambdaExpression = Expression.Lambda<Action<T, object>>(assignExpression, parameterExpression, valueExpression);
+            return lambdaExpression.Compile();
+        }
+
+        private static Func<T, object> CreateFieldGetter<T>(string fieldName)
+        {
+            var parameterExpression = Expression.Parameter(typeof(T), "target");
+
+            var field = typeof(T).GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Instance);
+            var fieldExpression = Expression.Field(parameterExpression, field);
+            var convertExpression = Expression.Convert(fieldExpression, typeof(object));
+
+            var lambdaExpression = Expression.Lambda<Func<T, object>>(convertExpression, parameterExpression);
+            return lambdaExpression.Compile();
+        }
+    }
+}

--- a/service/SpaceCenter/src/KRPC.SpaceCenter.csproj
+++ b/service/SpaceCenter/src/KRPC.SpaceCenter.csproj
@@ -118,6 +118,7 @@
     <Compile Include="ExtensionMethods\GameModeExtensions.cs" />
     <Compile Include="ExtensionMethods\GeometryExtensions.cs" />
     <Compile Include="ExtensionMethods\HopTypeExtensions.cs" />
+    <Compile Include="ExtensionMethods\InternalCameraExtensions.cs" />
     <Compile Include="ExtensionMethods\ITorqueProviderExtensions.cs" />
     <Compile Include="ExtensionMethods\KerbalTypeExtensions.cs" />
     <Compile Include="ExtensionMethods\MotorStateExtensions.cs" />

--- a/service/SpaceCenter/src/Services/Camera.cs
+++ b/service/SpaceCenter/src/Services/Camera.cs
@@ -80,8 +80,17 @@ namespace KRPC.SpaceCenter.Services
                         FlightCamera.SetMode (FlightCamera.Modes.ORBITAL);
                         break;
                     case CameraMode.IVA:
-                        CameraManager.Instance.SetCameraIVA ();
-                        break;
+                        {
+                            var camera = CameraManager.Instance;
+
+                            if (camera.currentCameraMode == CameraManager.CameraMode.IVA)
+                            {
+                                camera.NextCameraIVA();
+                                break;
+                            }
+                            camera.SetCameraIVA();
+                            break;
+                        }
                     }
                 }
             }
@@ -98,7 +107,8 @@ namespace KRPC.SpaceCenter.Services
                 case CameraMode.Map:
                     return PlanetariumCamera.fetch.getPitch ();
                 case CameraMode.IVA:
-                    throw new NotImplementedException ();
+                    var camera = InternalCamera.Instance;
+                    return (float) InternalCameraExtensions.GetPitch(camera);
                 default:
                     return FlightCamera.fetch.getPitch ();
                 }
@@ -112,7 +122,11 @@ namespace KRPC.SpaceCenter.Services
                         break;
                     }
                 case CameraMode.IVA:
-                    throw new NotImplementedException ();
+                    {
+                        var camera = InternalCamera.Instance;
+                        InternalCameraExtensions.SetPitch(camera, value.Clamp(camera.minPitch, camera.maxPitch));
+                        break;
+                    }
                 default:
                     {
                         var camera = FlightCamera.fetch;
@@ -133,7 +147,8 @@ namespace KRPC.SpaceCenter.Services
                 case CameraMode.Map:
                     return PlanetariumCamera.fetch.getYaw ();
                 case CameraMode.IVA:
-                    throw new NotImplementedException ();
+                    var camera = InternalCamera.Instance;
+                    return (float) InternalCameraExtensions.GetRot(camera);
                 default:
                     return FlightCamera.fetch.getYaw ();
                 }
@@ -144,7 +159,9 @@ namespace KRPC.SpaceCenter.Services
                     PlanetariumCamera.fetch.camHdg = GeometryExtensions.ToRadians (value);
                     break;
                 case CameraMode.IVA:
-                    throw new NotImplementedException ();
+                    var camera = InternalCamera.Instance;
+                    InternalCameraExtensions.SetRot(camera, value.Clamp(-camera.maxRot, camera.maxRot));
+                    break;
                 default:
                     FlightCamera.fetch.camHdg = GeometryExtensions.ToRadians (value);
                     break;
@@ -182,6 +199,43 @@ namespace KRPC.SpaceCenter.Services
                     {
                         var camera = FlightCamera.fetch;
                         camera.SetDistance (value.Clamp (camera.minDistance, camera.maxDistance));
+                        break;
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// The Field of View of the camera, in degrees.
+        /// A value between <see cref="MinFoV"/> and <see cref="MaxFoV"/>.
+        /// </summary>
+        [KRPCProperty]
+        public float FoV {
+            get {
+                switch (Mode) {
+                case CameraMode.Map:
+                    throw new NotImplementedException ();
+                case CameraMode.IVA:
+                    var camera = InternalCamera.Instance;
+                    return (float) InternalCameraExtensions.GetFoV(camera);
+                default:
+                    return FlightCamera.fetch.FieldOfView;
+                }
+            }
+            set {
+                switch (Mode) {
+                case CameraMode.Map:
+                    throw new NotImplementedException ();
+                case CameraMode.IVA:
+                    {
+                        var camera = InternalCamera.Instance;
+                        InternalCameraExtensions.SetZoom(camera, (value / (float) InternalCameraExtensions.GetDefaultFoV(camera)).Clamp(camera.maxZoom, camera.minZoom));
+                        break;
+                    }
+                default:
+                    {
+                        var camera = FlightCamera.fetch;
+                        camera.SetFoV(value.Clamp (camera.fovMin, camera.fovMax));
                         break;
                     }
                 }
@@ -269,6 +323,60 @@ namespace KRPC.SpaceCenter.Services
                     throw new NotImplementedException ();
                 default:
                     return FlightCamera.fetch.startDistance;
+                }
+            }
+        }
+
+        /// <summary>
+        /// The maximum field of view the camera in degrees.
+        /// </summary>
+        [KRPCProperty]
+        public float MaxFoV {
+            get {
+                switch (Mode) {
+                    case CameraMode.Map:
+                        throw new NotImplementedException();
+                    case CameraMode.IVA:
+                        var camera = InternalCamera.Instance;
+                        return (float) InternalCameraExtensions.GetDefaultFoV(camera) * camera.minZoom;
+                    default:
+                        return FlightCamera.fetch.fovMax;
+                }
+            }
+        }
+
+        /// <summary>
+        /// The maximum field of view the camera in degrees.
+        /// </summary>
+        [KRPCProperty]
+        public float MinFoV {
+            get {
+                switch (Mode) {
+                    case CameraMode.Map:
+                        throw new NotImplementedException();
+                    case CameraMode.IVA:
+                        var camera = InternalCamera.Instance;
+                        return (float) InternalCameraExtensions.GetDefaultFoV(camera) * camera.maxZoom;
+                    default:
+                        return FlightCamera.fetch.fovMin;
+                }
+            }
+        }
+
+        /// <summary>
+        /// The maximum field of view the camera in degrees.
+        /// </summary>
+        [KRPCProperty]
+        public float DefaultFoV {
+            get {
+                switch (Mode) {
+                    case CameraMode.Map:
+                        throw new NotImplementedException();
+                    case CameraMode.IVA:
+                        var camera = InternalCamera.Instance;
+                        return (float) InternalCameraExtensions.GetDefaultFoV(camera);
+                    default:
+                        return FlightCamera.fetch.fovDefault;
                 }
             }
         }

--- a/service/SpaceCenter/src/Services/Camera.cs
+++ b/service/SpaceCenter/src/Services/Camera.cs
@@ -346,7 +346,7 @@ namespace KRPC.SpaceCenter.Services
         }
 
         /// <summary>
-        /// The maximum field of view the camera in degrees.
+        /// The minimum field of view the camera in degrees.
         /// </summary>
         [KRPCProperty]
         public float MinFoV {
@@ -364,7 +364,7 @@ namespace KRPC.SpaceCenter.Services
         }
 
         /// <summary>
-        /// The maximum field of view the camera in degrees.
+        /// The default field of view the camera in degrees.
         /// </summary>
         [KRPCProperty]
         public float DefaultFoV {

--- a/service/SpaceCenter/src/Services/Camera.cs
+++ b/service/SpaceCenter/src/Services/Camera.cs
@@ -80,20 +80,20 @@ namespace KRPC.SpaceCenter.Services
                         FlightCamera.SetMode (FlightCamera.Modes.ORBITAL);
                         break;
                     case CameraMode.IVA:
-                        {
-                            var camera = CameraManager.Instance;
-
-                            if (camera.currentCameraMode == CameraManager.CameraMode.IVA)
-                            {
-                                camera.NextCameraIVA();
-                                break;
-                            }
-                            camera.SetCameraIVA();
-                            break;
-                        }
+                        CameraManager.Instance.SetCameraIVA();
+                        break;
                     }
                 }
             }
+        }
+
+        /// <summary>
+        /// Switch to the next available camera
+        /// </summary>
+        [KRPCMethod]
+        public void NextCamera()
+        {
+            CameraManager.Instance.NextCamera();
         }
 
         /// <summary>
@@ -438,6 +438,32 @@ namespace KRPC.SpaceCenter.Services
                 CheckCameraFocus ();
                 var mapObject = PlanetariumCamera.fetch.targets.Single (x => x.maneuverNode == value.InternalNode);
                 PlanetariumCamera.fetch.SetTarget (mapObject);
+            }
+        }
+
+        /// <summary>
+        /// When the internal camera is active the kerbal that is in focus
+        /// Returns an error if the camera is not in IVA mode.
+        /// </summary>
+        [KRPCProperty (Nullable = true)]
+        public CrewMember FocussedCrewMember
+        {
+            get
+            {
+                var camera = CameraManager.Instance;
+
+                if (camera.currentCameraMode == CameraManager.CameraMode.IVA)
+                {
+                    return new CrewMember(camera.IVACameraActiveKerbal.protoCrewMember);
+                }
+                throw new InvalidOperationException ("There is no focussed kerbal when the camera is not in IVA mode.");
+            }
+            set
+            {
+                if (FlightGlobals.ActiveVessel.GetVesselCrew().Contains(value.InternalCrewMember))
+                {
+                    CameraManager.Instance.SetCameraIVA(value.InternalCrewMember.KerbalRef, true);
+                }
             }
         }
 


### PR DESCRIPTION
Resolves #255 

- Added support for the internal camera to the existing Pitch and Heading KRPCProperties.
- Added a few new KRPCProperties related to the Camera FoV both for the InternalCamera and the FlightCamera.
- Made requesting the IVA camera while in IVA cycle through the available kerbals (W.I.P)

As stated in the changelog above, the system to Cycle through the kerbals in the InternalCamera is marked as W.I.P, it works fine but i'm not convinced this is the correct implementation for this feature.
If you're fine with it as is I'm happy for it to get merged but suggestions as to how to implement this feature are welcome.
Lastly I feel like the code is understandible but if comments are desired let me know and i'll be happy to add those.