### PR TITLE
Fix check for whether reference frame rotates with vessel

### DIFF
--- a/service/SpaceCenter/src/Services/AutoPilot.cs
+++ b/service/SpaceCenter/src/Services/AutoPilot.cs
@@ -177,11 +177,23 @@ namespace KRPC.SpaceCenter.Services
             set {
                 if (ReferenceEquals (value, null))
                     throw new ArgumentNullException ("ReferenceFrame");
-                if ((value.Type == ReferenceFrameType.Vessel && value.Vessel.Id == vesselId) ||
-                    ((value.Type == ReferenceFrameType.Part || value.Type == ReferenceFrameType.PartCenterOfMass ||
-                    value.Type == ReferenceFrameType.DockingPort || value.Type == ReferenceFrameType.Thrust) &&
-                    value.Part.InternalPart.vessel.id == vesselId))
+                var rotatesWithVessel = false;
+                switch (value.Type) {
+                case ReferenceFrameType.Vessel:
+                    rotatesWithVessel = value.Vessel.Id == vesselId;
+                    break;
+                case ReferenceFrameType.Part:
+                case ReferenceFrameType.PartCenterOfMass:
+                case ReferenceFrameType.Thrust:
+                    rotatesWithVessel = value.Part.InternalPart.vessel.id == vesselId;
+                    break;
+                case ReferenceFrameType.DockingPort:
+                    rotatesWithVessel = value.DockingPort.Part.InternalPart.vessel.id == vesselId;
+                    break;
+                }
+                if (rotatesWithVessel) {
                     throw new ArgumentException ("Invalid reference frame; must not rotate with the vessel");
+                }
                 attitudeController.ReferenceFrame = value;
             }
         }


### PR DESCRIPTION
When setting the reference frame for the autopilot, it checks if the reference frame rotates with the vessel. This check fails if the reference frame is that of a docking port.