### PR TITLE
Add AltimeterMode property

### DIFF
--- a/doc/api/space-center.tmpl
+++ b/doc/api/space-center.tmpl
@@ -25,3 +25,4 @@ SpaceCenter API
    space-center/contracts
    space-center/geometry-types
    space-center/alarms
+   space-center/altimeter-mode

--- a/doc/api/space-center/altimeter-mode.tmpl
+++ b/doc/api/space-center/altimeter-mode.tmpl
@@ -1,0 +1,9 @@
+.. default-domain:: {{ domain.sphinxname }}
+.. highlight:: {{ domain.highlight }}
+{{ domain.currentmodule('SpaceCenter') }}
+{% import domain.macros as macros with context %}
+
+AltimeterMode
+======
+
+{{ macros.enumeration(services['SpaceCenter'].enumerations['AltimeterMode']) }}

--- a/doc/api/space-center/altimeter-mode.tmpl
+++ b/doc/api/space-center/altimeter-mode.tmpl
@@ -4,6 +4,6 @@
 {% import domain.macros as macros with context %}
 
 AltimeterMode
-======
+=============
 
 {{ macros.enumeration(services['SpaceCenter'].enumerations['AltimeterMode']) }}

--- a/doc/order.txt
+++ b/doc/order.txt
@@ -104,6 +104,10 @@ SpaceCenter.TransferCrew
 SpaceCenter.Camera
 SpaceCenter.UIVisible
 SpaceCenter.Navball
+SpaceCenter.AltimeterMode
+SpaceCenter.AltimeterMode.DEFAULT
+SpaceCenter.AltimeterMode.ASL
+SpaceCenter.AltimeterMode.AGL
 SpaceCenter.UT
 SpaceCenter.G
 SpaceCenter.WarpMode

--- a/service/SpaceCenter/src/KRPC.SpaceCenter.csproj
+++ b/service/SpaceCenter/src/KRPC.SpaceCenter.csproj
@@ -149,6 +149,7 @@
     <Compile Include="Services\AlarmManager.cs" />
     <Compile Include="Services\AutoPilot.cs" />
     <Compile Include="Services\Camera.cs" />
+    <Compile Include="Services\AltimeterMode.cs" />
     <Compile Include="Services\CameraMode.cs" />
     <Compile Include="Services\CelestialBody.cs" />
     <Compile Include="Services\LaunchSite.cs" />

--- a/service/SpaceCenter/src/Services/AltimeterMode.cs
+++ b/service/SpaceCenter/src/Services/AltimeterMode.cs
@@ -1,0 +1,27 @@
+using System;
+using KRPC.Service.Attributes;
+
+namespace KRPC.SpaceCenter.Services
+{
+    /// <summary>
+    /// The mode of the altitude reported on the altimeter.
+    /// See <see cref="SpaceCenter.AltimeterMode"/>.
+    /// </summary>
+    [Serializable]
+    [KRPCEnum (Service = "SpaceCenter")]
+    public enum AltimeterMode
+    {
+        /// <summary>
+        /// The altimeter is in the default mode.
+        /// </summary>
+        DEFAULT,
+        /// <summary>
+        /// The altimeter is in the "Above Sea Level" mode.
+        /// </summary>
+        ASL,
+        /// <summary>
+        /// The altimeter is in the "Above Ground Level" mode.
+        /// </summary>
+        AGL
+    }
+}

--- a/service/SpaceCenter/src/Services/SpaceCenter.cs
+++ b/service/SpaceCenter/src/Services/SpaceCenter.cs
@@ -582,6 +582,16 @@ namespace KRPC.SpaceCenter.Services
         }
 
         /// <summary>
+        /// The current mode of the altimeter.
+        /// </summary>
+        [KRPCProperty (GameScene = GameScene.Flight)]
+        public static AltimeterMode AltimeterMode
+        {
+            get { return (AltimeterMode) AltitudeTumbler.Instance.CurrentMode; }
+            set { AltitudeTumbler.Instance.SetModeTumbler((AltimeterDisplayState) value); }
+        }
+
+        /// <summary>
         /// The current universal time in seconds.
         /// </summary>
         [KRPCProperty]


### PR DESCRIPTION
Resolves #806 

- Added AltimeterMode property to the SpaceCenter service for getting and setting the current mode of the altimeter at the top of the screen.