### PR TITLE
Added PreviousCamera method

### DIFF
--- a/doc/order.txt
+++ b/doc/order.txt
@@ -1166,6 +1166,7 @@ SpaceCenter.CameraMode.Orbital
 SpaceCenter.CameraMode.IVA
 SpaceCenter.CameraMode.Map
 SpaceCenter.Camera.NextCamera
+SpaceCenter.Camera.PreviousCamera
 SpaceCenter.WaypointManager
 SpaceCenter.WaypointManager.Waypoints
 SpaceCenter.WaypointManager.AddWaypoint

--- a/service/SpaceCenter/src/ExtensionMethods/InternalCameraExtensions.cs
+++ b/service/SpaceCenter/src/ExtensionMethods/InternalCameraExtensions.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 
@@ -65,7 +67,19 @@ namespace KRPC.SpaceCenter.ExtensionMethods
         /// </summary>
         public static Func<InternalCamera, object> GetDefaultFoV => _getDefaultFoV.Value;
 
-        private static Action<T, object> CreateFieldSetter<T>(string fieldName)
+        /// <summary>
+        /// Gets the index of the previous kerbal for the IVA camera
+        /// </summary>
+        /// <param name="ptc">List of ProtoCrewmembers</param>
+        /// <param name="cameraManager">Instance of the current CameraManager to get the active index.</param>
+        /// <returns></returns>
+        public static int GetPreviousIVA(List<ProtoCrewMember> ptc, CameraManager cameraManager)
+        {
+            int num = cameraManager.IVACameraActiveKerbalIndex;
+            return (num + ptc.Count() - 1) % ptc.Count;
+        }
+
+    	private static Action<T, object> CreateFieldSetter<T>(string fieldName)
         {
             var parameterExpression = Expression.Parameter(typeof(T), "target");
             var valueExpression = Expression.Parameter(typeof(object), "value");


### PR DESCRIPTION
Resolves #807

- Added a new kRPC method for cycling to the previous camera in the InternalCamea or in the FlightCamera.
- Added GetPreviousIVA to the InternalCameraExtensions for use in the PreviousCamera method.
- Added previously forgotten call to fire a gameevent when the InternalCamera is changed with the FocussedKerbal property