### PR TITLE
Fix build on NixOS

### DIFF
--- a/tools/build/autotools.bzl
+++ b/tools/build/autotools.bzl
@@ -60,6 +60,7 @@ def _impl(ctx):
         inputs = inputs + macros,
         outputs = [output],
         progress_message = "Running autotools and creating package %s" % output.short_path,
+        use_default_shell_env = True,
         command = " &&\\\n".join(sub_commands),
     )
 

--- a/tools/build/csharp.bzl
+++ b/tools/build/csharp.bzl
@@ -11,6 +11,7 @@ def _ref_impl(ctx):
         mnemonic = "CSharpReference",
         inputs = [input],
         outputs = [output],
+        use_default_shell_env = True,
         command = 'cp "%s" "%s"' % (input.path, output.path),
     )
 
@@ -77,6 +78,7 @@ def _lib_impl(ctx):
         mnemonic = "CSharpCompile",
         inputs = inputs,
         outputs = outputs,
+        use_default_shell_env = True,
         command = "%s %s" % (cmd, " ".join(args)),
     )
 
@@ -116,6 +118,7 @@ def _bin_impl(ctx):
         mnemonic = "CSharpCompile",
         inputs = inputs,
         outputs = outputs,
+        use_default_shell_env = True,
         command = "%s %s" % (cmd, " ".join(args)),
     )
 
@@ -367,6 +370,7 @@ def _nuget_package_impl(ctx):
         mnemonic = "NuGetPackage",
         inputs = inputs,
         outputs = [ctx.outputs.out],
+        use_default_shell_env = True,
         command = " && ".join(sub_commands),
         execution_requirements = {"local": "1"},  # FIXME: nuget.exe does not work with the sandbox
     )

--- a/tools/build/image.bzl
+++ b/tools/build/image.bzl
@@ -7,6 +7,7 @@ def _impl(ctx):
         inputs = [input],
         outputs = [output],
         progress_message = "Generating PNG image %s" % output.short_path,
+        use_default_shell_env = True,
         command = "rsvg-convert --format=png -o %s %s" % (output.path, input.path),
     )
 

--- a/tools/build/pkg.bzl
+++ b/tools/build/pkg.bzl
@@ -48,6 +48,7 @@ def _stage_files_impl(ctx):
             mnemonic = "StageFile",
             inputs = [src],
             outputs = [out],
+            use_default_shell_env = True,
             command = " && ".join(sub_commands),
         )
         outs.append(out)
@@ -93,6 +94,7 @@ def _pkg_zip_impl(ctx):
         inputs = inputs,
         outputs = [output],
         progress_message = "Packaging files into %s" % output.short_path,
+        use_default_shell_env = True,
         command = "\n".join(sub_commands),
     )
 

--- a/tools/build/python.bzl
+++ b/tools/build/python.bzl
@@ -60,6 +60,7 @@ def _sdist_impl(ctx):
             mnemonic = "PackageFile",
             inputs = [input],
             outputs = [staging_file],
+            use_default_shell_env = True,
             command = 'cp "%s" "%s"' % (input.path, staging_file.path),
         )
         staging_inputs.append(staging_file)
@@ -77,6 +78,7 @@ def _sdist_impl(ctx):
         inputs = staging_inputs,
         outputs = [output],
         progress_message = "Packaging files into %s" % output.short_path,
+        use_default_shell_env = True,
         command = " && ".join(sub_commands),
     )
 


### PR DESCRIPTION
This fixes building kRPC on NixOS (under a `nixpkgs.buildFHSEnv` environment). As NixOS (by default) does not put binaries in `/usr/bin`, instead putting them in various subdirectories of `/nix/store`, the default `$PATH` of `bash` in nixpkgs does not contain `/usr/bin`. By taking the environment variables defined either by `--action_env` or by Bazel, the path `/usr/bin` *is* put into the path.

Building *may* require `--action_env="PATH=/usr/bin:$PATH"` appended to the build command in some cases, but in my testing with a simple FHS setup this worked.

Let me know if this has any unintended repercussions.