### PR TITLE
Ensure logs are written to both KSP.log and Player.log

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,8 +7,6 @@ generated_deps
 KRPC.userprefs
 bin
 obj
-KSP.log
-PartDatabase.cfg
 lib/mono-4.5
 *.user
 *.pyc

--- a/core/CHANGES.txt
+++ b/core/CHANGES.txt
@@ -1,2 +1,5 @@
+v1.0.1
+ * Make logger configurable in where it writes to (#780)
+
 v1.0.0
  * Initial version, split off from KRPC.dll

--- a/core/src/Utils/Logger.cs
+++ b/core/src/Utils/Logger.cs
@@ -61,12 +61,19 @@ namespace KRPC.Utils
         }
 
         /// <summary>
+        /// Delegate that performs the actual log output. Defaults to Console.WriteLine.
+        /// Replace this in the KSP plugin entry point to route through UnityEngine.Debug.
+        /// </summary>
+        public static Action<string, Severity> Writer { get; set; } =
+            (msg, _) => Console.WriteLine (msg);
+
+        /// <summary>
         /// Write a message to the log.
         /// </summary>
         public static void WriteLine (string message, Severity severity = Severity.Info)
         {
             if (ShouldLog (severity))
-                Console.WriteLine (string.Format (format, DateTime.Now, severity, message));
+                Writer (string.Format (format, DateTime.Now, severity, message), severity);
         }
 
         internal static bool ShouldLog (Severity severity)

--- a/server/CHANGES.txt
+++ b/server/CHANGES.txt
@@ -1,3 +1,6 @@
+v0.6.0
+ * Fix Logger to write to both KSP.log and Player.log (#780)
+
 v0.5.4
  * Fix memory leaks when switching game scene (#779)
 

--- a/server/src/Addon.cs
+++ b/server/src/Addon.cs
@@ -29,8 +29,27 @@ namespace KRPC
         /// </summary>
         public static Addon Instance { get; private set; }
 
+        internal static void InitLogger ()
+        {
+            KRPC.Utils.Logger.Writer = (msg, severity) => {
+                switch (severity) {
+                    case KRPC.Utils.Logger.Severity.Warning:
+                        UnityEngine.Debug.LogWarning (msg);
+                        break;
+                    case KRPC.Utils.Logger.Severity.Error:
+                        UnityEngine.Debug.LogError (msg);
+                        break;
+                    default:
+                        UnityEngine.Debug.Log (msg);
+                        break;
+                }
+            };
+        }
+
         static void Init ()
         {
+            InitLogger ();
+
             if (core == null) {
                 core = Core.Instance;
                 config = ConfigurationFile.Instance;

--- a/server/src/ServicesChecker.cs
+++ b/server/src/ServicesChecker.cs
@@ -24,6 +24,7 @@ namespace KRPC
         /// </summary>
         public void Start ()
         {
+            Addon.InitLogger ();
             OK = true;
             var errors = new List<string>();
             var services = Scanner.GetServices (errors);

--- a/tools/run-ksp.sh
+++ b/tools/run-ksp.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 tools/install.sh
-"${KSP_DIR:-lib/ksp}/KSP.x86_64" &
+(cd "${KSP_DIR:-lib/ksp}"; ./KSP.x86_64) &
 trap 'kill $(jobs -p)' EXIT
 sleep 3
-tail -f "$HOME/.config/unity3d/Squad/Kerbal Space Program/Player.log"
+tail -f "$KSP_DIR/KSP.log" | grep -i krpc


### PR DESCRIPTION
Change to using Unity debug log, so that logs are written to both KSP.log and Player.log. `Console.WriteLine` is still used when the server is run outside of the game.

Fixes #780

Also fix `run-ksp.sh` so that it launches the game with `$KSP_DIR` as the current working directory, so that KSP.log is written to the correct place.