### PR TITLE
Add Control.EngineGimbals and Control.AeroSurfaces

### DIFF
--- a/doc/order.txt
+++ b/doc/order.txt
@@ -385,6 +385,8 @@ SpaceCenter.Control.State
 SpaceCenter.Control.SAS
 SpaceCenter.Control.SASMode
 SpaceCenter.Control.SpeedMode
+SpaceCenter.Control.EngineGimbals
+SpaceCenter.Control.AeroSurfaces
 SpaceCenter.Control.RCS
 SpaceCenter.Control.ReactionWheels
 SpaceCenter.Control.Gear

--- a/service/SpaceCenter/CHANGES.txt
+++ b/service/SpaceCenter/CHANGES.txt
@@ -5,6 +5,8 @@ v0.6.0
  * Guard ContractManager against null ContractSystem in non-career game modes (#819)
  * Fix waypoint mean altitude not including bedrock height (#801)
  * Add Flight.SimulateAerodynamicTorqueAt (#825)
+ * Add Control.AeroSurfaces to enable/disable pitch, yaw and roll on all control surfaces (#827)
+ * Add Control.EngineGimbals to enable/disable gimbal on all gimballed engines (#827)
 
 v0.5.4
  * Fix vessel recovery (#782)

--- a/service/SpaceCenter/src/Services/Control.cs
+++ b/service/SpaceCenter/src/Services/Control.cs
@@ -149,6 +149,39 @@ namespace KRPC.SpaceCenter.Services
         }
 
         /// <summary>
+        /// Returns whether all gimballed engines on the vessel have gimbal enabled,
+        /// and sets the gimbal enabled state of all gimballed engines.
+        /// See <see cref="Parts.Engine.GimbalLocked"/>.
+        /// </summary>
+        [KRPCProperty]
+        public bool EngineGimbals {
+            get { return parts.Engines.Where (e => e.Gimballed).All (e => !e.GimbalLocked); }
+            set {
+                foreach (var e in parts.Engines.Where (e => e.Gimballed))
+                    e.GimbalLocked = !value;
+            }
+        }
+
+        /// <summary>
+        /// Returns whether all control surfaces on the vessel have pitch, yaw and roll enabled,
+        /// and sets the pitch, yaw and roll enabled state of all control surfaces.
+        /// See <see cref="Parts.ControlSurface.PitchEnabled"/>,
+        /// <see cref="Parts.ControlSurface.YawEnabled"/> and
+        /// <see cref="Parts.ControlSurface.RollEnabled"/>.
+        /// </summary>
+        [KRPCProperty]
+        public bool AeroSurfaces {
+            get { return parts.ControlSurfaces.All (s => s.PitchEnabled && s.YawEnabled && s.RollEnabled); }
+            set {
+                foreach (var s in parts.ControlSurfaces) {
+                    s.PitchEnabled = value;
+                    s.YawEnabled = value;
+                    s.RollEnabled = value;
+                }
+            }
+        }
+
+        /// <summary>
         /// The state of the landing gear/legs.
         /// </summary>
         [KRPCProperty]


### PR DESCRIPTION
Add convenience functions to enable/disable all engine gimblas/aero surfaces on the vessel, so that controls can be easily switched to only affect thurst vector control or aero surfaces.

Related to #827 