### PR TITLE
fixed ModuleManager DLL version in install.sh (4.2.2 -> 4.2.3)

### DIFF
--- a/tools/install.sh
+++ b/tools/install.sh
@@ -53,13 +53,13 @@ cp -R -L \
     bazel-bin/tools/TestingTools/TestingTools.xml \
     service/SpaceCenter/src/module-manager.cfg \
     "$GAMEDATA/"
-cp -L bazel-krpc/external/_main~_repo_rules~module_manager/file/ModuleManager.4.2.2.dll "$GAMEDATA/../"
+cp -L bazel-krpc/external/_main~_repo_rules~module_manager/file/ModuleManager.4.2.3.dll "$GAMEDATA/../"
 
 mkdir -p "$GAMEDATA/PluginData"
 cp tools/settings.cfg "$GAMEDATA/PluginData/"
 
 find "$GAMEDATA" -type f -exec chmod 644 {} \;
 find "$GAMEDATA" -type d -exec chmod 755 {} \;
-chmod 644 "$GAMEDATA/../ModuleManager.4.2.2.dll"
+chmod 644 "$GAMEDATA/../ModuleManager.4.2.3.dll"
 
 ls -lR "$GAMEDATA"


### PR DESCRIPTION
The ModuleManager dependency was bumped to 4.2.3 in MODULE.bazel and BUILD.bazel, but tools/install.sh still referenced 4.2.2, causing the install step to fail with:
```
cp: cannot stat '.../file/ModuleManager.4.2.2.dll': No such file or directory
```
Updated both the cp and chmod lines to 4.2.3 to match the Bazel config.