### PR TITLE
Improve cmake fetch content options and documentation

### DIFF
--- a/client/cpp/CHANGES.txt
+++ b/client/cpp/CHANGES.txt
@@ -4,8 +4,9 @@ v0.6.0
  * Drop autotools build; CMake is now the only supported build system
  * Modernise CMake build: require CMake 3.15+, C++17, target-based usage requirements (#834)
  * Add CMake package config so consumers can use find_package(krpc CONFIG REQUIRED)
- * Protobuf and ASIO are fetched automatically via CMake FetchContent if not found on
- the system. Can be forced by passing options to CMake
+ * CMake dependency options (KRPC_FETCH_PROTOBUF, KRPC_FETCH_ASIO, KRPC_FETCH_ABSL): when OFF
+   (default) the system install is required; when ON FetchContent is used.
+ * Add KRPC_FETCH_DEPS option to enable FetchContent for all dependencies at once
 
 v0.5.2
  * Use protobuf-lite

--- a/client/cpp/CMakeLists.txt.tmpl
+++ b/client/cpp/CMakeLists.txt.tmpl
@@ -6,25 +6,29 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 include(FetchContent)
 
-option(KRPC_FETCH_PROTOBUF "Fetch protobuf via FetchContent, ignoring any system install" OFF)
-option(KRPC_FETCH_ASIO     "Fetch ASIO via FetchContent, ignoring any system install"     OFF)
-option(KRPC_FETCH_ABSL     "Fetch abseil via FetchContent, ignoring any system install"   OFF)
+option(KRPC_FETCH_DEPS     "Use FetchContent for all dependencies (protobuf, ASIO, abseil)" OFF)
+option(KRPC_FETCH_PROTOBUF "Use FetchContent for protobuf"                                  OFF)
+option(KRPC_FETCH_ASIO     "Use FetchContent for ASIO"                                      OFF)
+option(KRPC_FETCH_ABSL     "Use FetchContent for abseil (only relevant when KRPC_FETCH_PROTOBUF=ON)" OFF)
+
+if(KRPC_FETCH_DEPS)
+  set(KRPC_FETCH_PROTOBUF ON)
+  set(KRPC_FETCH_ASIO ON)
+  set(KRPC_FETCH_ABSL ON)
+endif()
 
 # ---- Protobuf ----
-if(NOT KRPC_FETCH_PROTOBUF)
-  find_package(protobuf CONFIG)
-endif()
-if(protobuf_FOUND)
-  message(STATUS "Found protobuf ${protobuf_VERSION}")
-else()
-  message(STATUS "Fetching protobuf via FetchContent (builds abseil too)...")
+if(KRPC_FETCH_PROTOBUF)
+  message(STATUS "Fetching protobuf via FetchContent...")
   set(protobuf_BUILD_TESTS       OFF CACHE BOOL "" FORCE)
   set(protobuf_BUILD_CONFORMANCE OFF CACHE BOOL "" FORCE)
   set(protobuf_BUILD_EXAMPLES    OFF CACHE BOOL "" FORCE)
   if(NOT KRPC_FETCH_ABSL)
     find_package(absl QUIET)
-  endif()
-  if(absl_FOUND)
+    if(NOT absl_FOUND)
+      message(FATAL_ERROR "abseil not found. Install abseil or set KRPC_FETCH_ABSL=ON "
+              "(or KRPC_FETCH_DEPS=ON) to download it automatically via FetchContent.")
+    endif()
     set(protobuf_ABSL_PROVIDER "package" CACHE STRING "" FORCE)
   endif()
   set(protobuf_INSTALL ON CACHE BOOL "" FORCE)
@@ -35,14 +39,18 @@ else()
   FetchContent_MakeAvailable(protobuf)
   include("${protobuf_SOURCE_DIR}/cmake/protobuf-generate.cmake")
   set(KRPC_PROTO_EXTRA_INCLUDE "${protobuf_SOURCE_DIR}/third_party/utf8_range")
+else()
+  find_package(protobuf CONFIG)
+  if(NOT protobuf_FOUND)
+    message(FATAL_ERROR "protobuf not found. Install protobuf or set KRPC_FETCH_PROTOBUF=ON "
+            "(or KRPC_FETCH_DEPS=ON) to download it automatically via FetchContent.")
+  endif()
+  message(STATUS "Found protobuf ${protobuf_VERSION}")
 endif()
 
 # ---- ASIO (standalone, header-only) ----
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
-if(NOT KRPC_FETCH_ASIO)
-  find_package(Asio)
-endif()
-if(NOT Asio_FOUND)
+if(KRPC_FETCH_ASIO)
   message(STATUS "Fetching ASIO via FetchContent...")
   FetchContent_Declare(asio
     URL      https://github.com/chriskohlhoff/asio/archive/refs/tags/asio-1-38-0.tar.gz
@@ -56,6 +64,12 @@ if(NOT Asio_FOUND)
   set_target_properties(asio::asio PROPERTIES
     INTERFACE_INCLUDE_DIRECTORIES "${asio_SOURCE_DIR}/asio/include")
   set(asio_FETCHED TRUE)
+else()
+  find_package(Asio)
+  if(NOT Asio_FOUND)
+    message(FATAL_ERROR "ASIO not found. Install ASIO, set ASIO_ROOT to its location, "
+            "or set KRPC_FETCH_ASIO=ON (or KRPC_FETCH_DEPS=ON) to download it automatically via FetchContent.")
+  endif()
 endif()
 
 # ---- Generate proto at build time ----

--- a/client/cpp/INSTALL.txt
+++ b/client/cpp/INSTALL.txt
@@ -1,9 +1,13 @@
 Installing the kRPC C++ client library
 ======================================
 
-CMake 3.15 or later is required. ASIO and protobuf are fetched automatically
-via CMake FetchContent if not found on the system, so no manual dependency
-installation is required.
+CMake 3.15 or later is required. By default, CMake looks for system-installed
+protobuf and ASIO. On Ubuntu:
+
+    sudo apt-get install libasio-dev libprotobuf-dev protobuf-compiler
+
+Alternatively, CMake can download them automatically via FetchContent — see
+"Using FetchContent for dependencies" below.
 
 To compile and install the library:
 
@@ -23,16 +27,20 @@ Pass CMAKE_INSTALL_PREFIX to the configure step:
     cmake --install build
 
 
-Forcing dependency fetching
-----------------------------
+Using FetchContent for dependencies
+------------------------------------
 
-By default CMake searches for system-installed protobuf and ASIO before
-falling back to FetchContent. To force a fetch regardless, pass one or both
-options:
+To download all dependencies (protobuf, ASIO, abseil) automatically at build
+time instead of using system packages, pass KRPC_FETCH_DEPS=ON:
 
-    cmake -B build -DKRPC_FETCH_PROTOBUF=ON -DKRPC_FETCH_ASIO=ON
+    cmake -B build -DKRPC_FETCH_DEPS=ON
     cmake --build build
     sudo cmake --install build
+
+To enable FetchContent for individual dependencies only, use the fine-grained
+options (KRPC_FETCH_PROTOBUF, KRPC_FETCH_ASIO, KRPC_FETCH_ABSL). When an
+option is OFF (the default), the system package is required and CMake will
+error if it cannot be found.
 
 
 Using the installed library from another CMake project

--- a/client/cpp/test-build.sh
+++ b/client/cpp/test-build.sh
@@ -118,12 +118,10 @@ if [[ "$mode" == "system" || "$mode" == "all" ]]; then
   consumer_test "$out/system/install" "$out/system/consumer"
 fi
 
-# 2) FetchContent protobuf + ASIO + abseil
+# 2) FetchContent protobuf + ASIO + abseil via global option
 if [[ "$mode" == "fetch" || "$mode" == "all" ]]; then
   build_install "$out/fetch/build" "$out/fetch/install" "$out/fetch/configure.log" \
-    -DKRPC_FETCH_PROTOBUF=ON \
-    -DKRPC_FETCH_ASIO=ON \
-    -DKRPC_FETCH_ABSL=ON
+    -DKRPC_FETCH_DEPS=ON
   check_present "$out/fetch/configure.log" "Fetching protobuf via FetchContent"
   check_present "$out/fetch/configure.log" "Fetching ASIO via FetchContent"
   check_absent  "$out/fetch/configure.log" "Found protobuf"

--- a/doc/src/cpp/client.rst
+++ b/doc/src/cpp/client.rst
@@ -13,15 +13,15 @@ Dependencies
 ^^^^^^^^^^^^
 
 The kRPC C++ client requires `ASIO <http://think-async.com/>`_ (for network communication) and
-`protobuf <https://github.com/google/protobuf>`_ (for message serialization). CMake will
-automatically fetch both via FetchContent if they are not found on the system, so no manual
-installation is required.
-
-To use system-installed packages instead, on Ubuntu:
+`protobuf <https://github.com/google/protobuf>`_ (for message serialization). By default, CMake
+looks for system-installed packages. On Ubuntu:
 
 .. code-block:: bash
 
    sudo apt-get install libasio-dev libprotobuf-dev protobuf-compiler
+
+Alternatively, CMake can download dependencies automatically via FetchContent — pass
+``-DKRPC_FETCH_DEPS=ON`` to the configure step (see below).
 
 Using CMake
 ^^^^^^^^^^^
@@ -44,8 +44,10 @@ To install to a custom prefix:
    cmake --build build
    cmake --install build
 
-To force CMake to fetch protobuf or ASIO even when a system version is present, pass
-``-DKRPC_FETCH_PROTOBUF=ON`` or ``-DKRPC_FETCH_ASIO=ON`` to the configure step.
+To download all dependencies automatically via FetchContent instead of using system packages,
+pass ``-DKRPC_FETCH_DEPS=ON`` to the configure step. Fine-grained options
+``-DKRPC_FETCH_PROTOBUF=ON``, ``-DKRPC_FETCH_ASIO=ON``, and ``-DKRPC_FETCH_ABSL=ON`` are also
+available. When an option is OFF (the default), the system package is required.
 
 After installation, downstream CMake projects can link the library with:
 


### PR DESCRIPTION
 * CMake dependency options (KRPC_FETCH_PROTOBUF, KRPC_FETCH_ASIO, KRPC_FETCH_ABSL): when OFF   (default) the system install is required; when ON FetchContent is used.
 * Add KRPC_FETCH_DEPS option to enable FetchContent for all dependencies at once