### PR TITLE
Expose part module fields hidden from the PAW

### DIFF
--- a/doc/order.txt
+++ b/doc/order.txt
@@ -649,6 +649,7 @@ SpaceCenter.Module.Name
 SpaceCenter.Module.Part
 SpaceCenter.Module.Fields
 SpaceCenter.Module.FieldsById
+SpaceCenter.Module.AllFieldsById
 SpaceCenter.Module.HasField
 SpaceCenter.Module.HasFieldWithId
 SpaceCenter.Module.GetField

--- a/service/SpaceCenter/CHANGES.txt
+++ b/service/SpaceCenter/CHANGES.txt
@@ -7,6 +7,11 @@ v0.6.0
  * Add Flight.SimulateAerodynamicTorqueAt (#825)
  * Add Control.AeroSurfaces to enable/disable pitch, yaw and roll on all control surfaces (#827)
  * Add Control.EngineGimbals to enable/disable gimbal on all gimballed engines (#827)
+ * Add Module.AllFieldsById to expose all part module field values, including those not
+   visible in the UI (#858)
+ * Allow Module.HasFieldWithId, GetFieldById, SetFieldIntById, SetFieldFloatById,
+   SetFieldStringById, SetFieldBoolById and ResetFieldById to also access fields not
+   visible in the UI (#858)
 
 v0.5.4
  * Fix vessel recovery (#782)

--- a/service/SpaceCenter/src/Services/Parts/Module.cs
+++ b/service/SpaceCenter/src/Services/Parts/Module.cs
@@ -57,8 +57,12 @@ namespace KRPC.SpaceCenter.Services.Parts
         [KRPCProperty]
         public Part Part { get; private set; }
 
-        IEnumerable<BaseField> AllFields {
+        IEnumerable<BaseField> VisibleFields {
             get { return module.Fields.Cast<BaseField> ().Where (f => f != null && (HighLogic.LoadedSceneIsEditor ? f.guiActiveEditor : f.guiActive)); }
+        }
+
+        IEnumerable<BaseField> AllBaseFields {
+            get { return module.Fields.Cast<BaseField> ().Where (f => f != null); }
         }
 
         IEnumerable<BaseEvent> AllEvents {
@@ -81,7 +85,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         public IDictionary<string,string> Fields {
             get {
                 var result = new Dictionary<string,string> ();
-                foreach (var field in AllFields)
+                foreach (var field in VisibleFields)
                     result.Add (field.guiName, field.GetValue (module).ToString ());
                 return result;
             }
@@ -95,7 +99,25 @@ namespace KRPC.SpaceCenter.Services.Parts
         public IDictionary<string,string> FieldsById {
             get {
                 var result = new Dictionary<string,string> ();
-                foreach (var field in AllFields)
+                foreach (var field in VisibleFields)
+                    result.Add (field.name, field.GetValue (module).ToString ());
+                return result;
+            }
+        }
+
+        /// <summary>
+        /// The modules field identifiers and their associated values, as a dictionary.
+        /// This is the same as <see cref="FieldsById"/>, except that it also includes
+        /// fields that are not visible in the right-click menu of the part.
+        /// </summary>
+        /// <remarks>
+        /// Throws an exception if there is more than one field with the same identifier.
+        /// </remarks>
+        [KRPCProperty]
+        public IDictionary<string,string> AllFieldsById {
+            get {
+                var result = new Dictionary<string,string> ();
+                foreach (var field in AllBaseFields)
                     result.Add (field.name, field.GetValue (module).ToString ());
                 return result;
             }
@@ -108,7 +130,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         [KRPCMethod]
         public bool HasField (string name)
         {
-            return AllFields.Any (x => x.guiName == name);
+            return VisibleFields.Any (x => x.guiName == name);
         }
 
         /// <summary>
@@ -118,17 +140,17 @@ namespace KRPC.SpaceCenter.Services.Parts
         [KRPCMethod]
         public bool HasFieldWithId (string id)
         {
-            return AllFields.Any (x => x.name == id);
+            return AllBaseFields.Any (x => x.name == id);
         }
 
         BaseField GetBaseFieldByName (string name)
         {
-            return AllFields.First (x => x.guiName == name);
+            return VisibleFields.First (x => x.guiName == name);
         }
 
         BaseField GetBaseFieldById (string id)
         {
-            return AllFields.First (x => x.name == id);
+            return VisibleFields.FirstOrDefault (x => x.name == id) ?? AllBaseFields.First (x => x.name == id);
         }
 
         /// <summary>
@@ -275,6 +297,9 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// Set the value of a field to its original value.
         /// </summary>
         /// <param name="id">Identifier of the field.</param>
+        /// <remarks>
+        /// Has no effect on fields that are not visible in the right-click menu of the part.
+        /// </remarks>
         [KRPCMethod]
         public void ResetFieldById (string id)
         {

--- a/service/SpaceCenter/test/test_parts_module.py
+++ b/service/SpaceCenter/test/test_parts_module.py
@@ -78,6 +78,52 @@ class TestPartsModule(krpctest.TestCase):
         module.set_field_int("Brakes", 100)
         self.assertEqual({"Brakes": "100"}, module.fields)
 
+    def test_all_fields_by_id(self):
+        part = self.parts.with_title("Mk1-3 Command Pod")[0]
+        module = next(m for m in part.modules if m.name == "ModuleCommand")
+        all_fields = module.all_fields_by_id
+        # Hidden fields, not shown in the right-click menu, are included.
+        self.assertEqual("1", all_fields["minimumCrew"])
+        self.assertNotIn("minimumCrew", module.fields_by_id)
+        # The visible fields are a subset of all fields, with matching values.
+        for identifier, value in module.fields_by_id.items():
+            self.assertEqual(value, all_fields[identifier])
+
+    def test_get_field_by_id_fallback(self):
+        part = self.parts.with_title("Mk1-3 Command Pod")[0]
+        module = next(m for m in part.modules if m.name == "ModuleCommand")
+        # minimumCrew is hidden (not in the right-click menu), so the by-id
+        # lookups reach it only via the fallback to all fields.
+        self.assertNotIn("minimumCrew", module.fields_by_id)
+        self.assertTrue(module.has_field_with_id("minimumCrew"))
+        self.assertEqual("1", module.get_field_by_id("minimumCrew"))
+        # Visible fields are still reachable by id; the fallback only applies
+        # when there is no visible match, so existing behavior is unchanged.
+        for identifier, value in module.fields_by_id.items():
+            self.assertEqual(value, module.get_field_by_id(identifier))
+
+    def test_set_and_reset_field_by_id_fallback(self):
+        part = self.parts.with_title("Mk1-3 Command Pod")[0]
+        module = next(m for m in part.modules if m.name == "ModuleCommand")
+        # minimumCrew is hidden, so set/reset-by-id reach it via the fallback.
+        self.assertNotIn("minimumCrew", module.fields_by_id)
+        # reset_field_by_id cannot restore a hidden field (see below), so restore
+        # the original value on cleanup with an explicit set instead.
+        self.addCleanup(module.set_field_int_by_id, "minimumCrew", 1)
+        self.assertEqual("1", module.get_field_by_id("minimumCrew"))
+        module.set_field_int_by_id("minimumCrew", 2)
+        self.wait(1)
+        self.assertEqual("2", module.get_field_by_id("minimumCrew"))
+        # reset_field_by_id reaches the field via the same fallback (it raised
+        # before this change), but KSP only snapshots a field's original value
+        # when its GUI control is created, so reset is a no-op for hidden fields
+        # and we don't assert the resulting value.
+        module.reset_field_by_id("minimumCrew")
+        # Restore the original value with an explicit set.
+        module.set_field_int_by_id("minimumCrew", 1)
+        self.wait(1)
+        self.assertEqual("1", module.get_field_by_id("minimumCrew"))
+
     def test_events(self):
         part = self.parts.with_title("Illuminator Mk1")[0]
         module = next(m for m in part.modules if m.name == "ModuleLight")


### PR DESCRIPTION
## Summary

- Add `Module.AllFieldsById`, a read-only counterpart to `FieldsById` that also includes fields not visible in the part's PAW
- Extend the by-id accessors (`HasFieldWithId`, `GetFieldById`, `SetField*ById`, `ResetFieldById`) to fall back to hidden fields when no visible field matches; visible matches resolve exactly as before, so existing behavior is unchanged
- Document that `ResetFieldById` has no effect on hidden fields (KSP only restores the original value of fields shown in the GUI)
- Internal: rename the private `AllFields` helper to `VisibleFields` and add an unfiltered `AllBaseFields`

## Design Choices

Why a separate property, keyed by id?

- `Fields` and `FieldsById` are documented as the values visible in the PAW; relaxing them in place would change that contract and the visible-only semantics existing scripts rely on
- Once unfiltered the keys collide: `guiName` (the `Fields` key) is empty for many hidden fields, so a guiName-keyed view yields duplicate `""` keys and throws, hence there is no `AllFields` counterpart, only `AllFieldsById`
- `name` (the `FieldsById` key) is not perfectly unique either (e.g. control surfaces shadow `transformName` via base/derived), so `AllFieldsById` keeps `FieldsById`'s throw-on-duplicate behavior

## Test plan

- [ ] `service/SpaceCenter/test/test_parts_module.py` integration tests: the all-fields view includes the hidden `minimumCrew` field; `get`/`has`-by-id fall back to hidden fields; `set`/`reset`-by-id reach hidden fields (reset is exercised but, per the note above, its value is not asserted)

## Suggested changelog

```
 * Add Module.AllFieldsById to expose all part module field values, including those not visible in the PAW
 * Allow Module.HasFieldWithId, GetFieldById, SetFieldIntById, SetFieldFloatById, SetFieldStringById, SetFieldBoolById and ResetFieldById to also access fields not visible in the PAW
```