### PR TITLE
Add ConfigNode access for parts and modules

### DIFF
--- a/doc/api/space-center/parts.tmpl
+++ b/doc/api/space-center/parts.tmpl
@@ -69,6 +69,11 @@ Module
 
 {{ macros.class(services['SpaceCenter'].classes['Module']) }}
 
+Config Node
+-----------
+
+{{ macros.class(services['SpaceCenter'].classes['ConfigNode']) }}
+
 Specific Types of Part
 ----------------------
 

--- a/doc/order.txt
+++ b/doc/order.txt
@@ -551,6 +551,7 @@ SpaceCenter.Parts.Wheels
 SpaceCenter.Part
 SpaceCenter.Part.Name
 SpaceCenter.Part.Title
+SpaceCenter.Part.Config
 SpaceCenter.Part.Tag
 SpaceCenter.Part.FlagURL
 SpaceCenter.Part.Highlighted
@@ -650,6 +651,7 @@ SpaceCenter.Force.Remove
 SpaceCenter.Module
 SpaceCenter.Module.Name
 SpaceCenter.Module.Part
+SpaceCenter.Module.Config
 SpaceCenter.Module.Fields
 SpaceCenter.Module.FieldsById
 SpaceCenter.Module.AllFieldsById
@@ -679,6 +681,16 @@ SpaceCenter.Module.HasAction
 SpaceCenter.Module.HasActionWithId
 SpaceCenter.Module.SetAction
 SpaceCenter.Module.SetActionById
+SpaceCenter.ConfigNode
+SpaceCenter.ConfigNode.Name
+SpaceCenter.ConfigNode.Values
+SpaceCenter.ConfigNode.HasValue
+SpaceCenter.ConfigNode.GetValue
+SpaceCenter.ConfigNode.GetValues
+SpaceCenter.ConfigNode.Nodes
+SpaceCenter.ConfigNode.HasNode
+SpaceCenter.ConfigNode.GetNode
+SpaceCenter.ConfigNode.GetNodes
 SpaceCenter.Antenna
 SpaceCenter.Antenna.Part
 SpaceCenter.Antenna.State

--- a/doc/src/dictionary.txt
+++ b/doc/src/dictionary.txt
@@ -5,6 +5,7 @@ Bazel
 Bitwise
 CMake
 Cnano
+Config
 Ferram
 GameData
 IDisposable

--- a/service/SpaceCenter/CHANGES.txt
+++ b/service/SpaceCenter/CHANGES.txt
@@ -19,6 +19,8 @@ v0.6.0
  * Fix NullReferenceException raised every frame after creating or removing an alarm (#853)
  * Add Control.PitchTrim, Control.YawTrim and Control.RollTrim to get/set the persistent
    pitch, yaw and roll trim of the active vessel (#863)
+ * Add Part.Config, Module.Config and ConfigNode for accessing part and module static
+   configuration (#831)
 
 v0.5.4
  * Fix vessel recovery (#782)

--- a/service/SpaceCenter/src/KRPC.SpaceCenter.csproj
+++ b/service/SpaceCenter/src/KRPC.SpaceCenter.csproj
@@ -129,6 +129,7 @@
     <Compile Include="Services\Parts\AutoStrutMode.cs" />
     <Compile Include="Services\Parts\CargoBay.cs" />
     <Compile Include="Services\Parts\CargoBayState.cs" />
+    <Compile Include="Services\Parts\ConfigNode.cs" />
     <Compile Include="Services\Parts\ControlSurface.cs" />
     <Compile Include="Services\Parts\Decoupler.cs" />
     <Compile Include="Services\Parts\DockingPort.cs" />

--- a/service/SpaceCenter/src/Services/Parts/ConfigNode.cs
+++ b/service/SpaceCenter/src/Services/Parts/ConfigNode.cs
@@ -6,7 +6,7 @@ using KRPC.Utils;
 namespace KRPC.SpaceCenter.Services.Parts
 {
     /// <summary>
-    /// Represents a configuration node, as found in a part's config file. A node has a
+    /// Represents a configuration node, as found in a part's configuration file. A node has a
     /// name, a set of named values and a set of child nodes. This is used to access the
     /// static configuration of a part or part module, for example via
     /// <see cref="Part.Config"/> and <see cref="Module.Config"/>.

--- a/service/SpaceCenter/src/Services/Parts/ConfigNode.cs
+++ b/service/SpaceCenter/src/Services/Parts/ConfigNode.cs
@@ -28,7 +28,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         public override bool Equals (ConfigNode other)
         {
-            return !ReferenceEquals (other, null) && node == other.node;
+            return !ReferenceEquals (other, null) && ReferenceEquals (node, other.node);
         }
 
         /// <summary>

--- a/service/SpaceCenter/src/Services/Parts/ConfigNode.cs
+++ b/service/SpaceCenter/src/Services/Parts/ConfigNode.cs
@@ -1,0 +1,154 @@
+using System;
+using System.Collections.Generic;
+using KRPC.Service.Attributes;
+using KRPC.Utils;
+
+namespace KRPC.SpaceCenter.Services.Parts
+{
+    /// <summary>
+    /// Represents a configuration node, as found in a part's config file. A node has a
+    /// name, a set of named values and a set of child nodes. This is used to access the
+    /// static configuration of a part or part module, for example via
+    /// <see cref="Part.Config"/> and <see cref="Module.Config"/>.
+    /// </summary>
+    [KRPCClass (Service = "SpaceCenter")]
+    public class ConfigNode : Equatable<ConfigNode>
+    {
+        readonly global::ConfigNode node;
+
+        internal ConfigNode (global::ConfigNode configNode)
+        {
+            if (ReferenceEquals (configNode, null))
+                throw new ArgumentNullException (nameof (configNode));
+            node = configNode;
+        }
+
+        /// <summary>
+        /// Returns true if the objects are equal.
+        /// </summary>
+        public override bool Equals (ConfigNode other)
+        {
+            return !ReferenceEquals (other, null) && node == other.node;
+        }
+
+        /// <summary>
+        /// Hash code for the object.
+        /// </summary>
+        public override int GetHashCode ()
+        {
+            return node.GetHashCode ();
+        }
+
+        /// <summary>
+        /// The name of the configuration node. For example "MODULE".
+        /// </summary>
+        [KRPCProperty]
+        public string Name {
+            get { return node.name; }
+        }
+
+        /// <summary>
+        /// The values stored in the node, as a dictionary mapping names to values.
+        /// </summary>
+        /// <remarks>
+        /// If a name appears more than once, only the first value is included. Use
+        /// <see cref="GetValues"/> to get all of the values with a given name.
+        /// </remarks>
+        [KRPCProperty]
+        public IDictionary<string,string> Values {
+            get {
+                var result = new Dictionary<string,string> ();
+                for (int i = 0; i < node.values.Count; i++) {
+                    var value = node.values [i];
+                    if (!result.ContainsKey (value.name))
+                        result.Add (value.name, value.value);
+                }
+                return result;
+            }
+        }
+
+        /// <summary>
+        /// Returns <c>true</c> if the node has a value with the given name.
+        /// </summary>
+        /// <param name="name">Name of the value.</param>
+        [KRPCMethod]
+        public bool HasValue (string name)
+        {
+            return node.HasValue (name);
+        }
+
+        /// <summary>
+        /// Returns the value with the given name. If there is more than one value with
+        /// the given name, the first is returned. Throws an exception if there is no
+        /// value with the given name.
+        /// </summary>
+        /// <param name="name">Name of the value.</param>
+        [KRPCMethod]
+        public string GetValue (string name)
+        {
+            if (!node.HasValue (name))
+                throw new InvalidOperationException ("Config node does not have a value with the given name");
+            return node.GetValue (name);
+        }
+
+        /// <summary>
+        /// Returns all of the values with the given name, as a list.
+        /// </summary>
+        /// <param name="name">Name of the values.</param>
+        [KRPCMethod]
+        public IList<string> GetValues (string name)
+        {
+            return new List<string> (node.GetValues (name));
+        }
+
+        /// <summary>
+        /// The child nodes contained in this node.
+        /// </summary>
+        [KRPCProperty]
+        public IList<ConfigNode> Nodes {
+            get {
+                var result = new List<ConfigNode> ();
+                for (int i = 0; i < node.nodes.Count; i++)
+                    result.Add (new ConfigNode (node.nodes [i]));
+                return result;
+            }
+        }
+
+        /// <summary>
+        /// Returns <c>true</c> if the node has a child node with the given name.
+        /// </summary>
+        /// <param name="name">Name of the child node.</param>
+        [KRPCMethod]
+        public bool HasNode (string name)
+        {
+            return node.HasNode (name);
+        }
+
+        /// <summary>
+        /// Returns the child node with the given name. If there is more than one child
+        /// node with the given name, the first is returned. Throws an exception if there
+        /// is no child node with the given name.
+        /// </summary>
+        /// <param name="name">Name of the child node.</param>
+        [KRPCMethod]
+        public ConfigNode GetNode (string name)
+        {
+            if (!node.HasNode (name))
+                throw new InvalidOperationException ("Config node does not have a child node with the given name");
+            return new ConfigNode (node.GetNode (name));
+        }
+
+        /// <summary>
+        /// Returns all of the child nodes with the given name, as a list.
+        /// </summary>
+        /// <param name="name">Name of the child nodes.</param>
+        [KRPCMethod]
+        public IList<ConfigNode> GetNodes (string name)
+        {
+            var result = new List<ConfigNode> ();
+            foreach (var child in node.GetNodes (name))
+                result.Add (new ConfigNode (child));
+            return result;
+        }
+    }
+}

--- a/service/SpaceCenter/src/Services/Parts/Module.cs
+++ b/service/SpaceCenter/src/Services/Parts/Module.cs
@@ -61,7 +61,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// The static configuration of the module, as found in the part's
         /// <a href="https://wiki.kerbalspaceprogram.com/wiki/CFG_File_Documentation#MODULES">cfg file</a>.
         /// This provides access to data that is not exposed as a field, such as the
-        /// resources produced by a generator. Returns <c>null</c> if the modules
+        /// resources produced by a generator. Returns <c>null</c> if the module's
         /// configuration node cannot be found.
         /// </summary>
         [KRPCProperty]

--- a/service/SpaceCenter/src/Services/Parts/Module.cs
+++ b/service/SpaceCenter/src/Services/Parts/Module.cs
@@ -57,6 +57,47 @@ namespace KRPC.SpaceCenter.Services.Parts
         [KRPCProperty]
         public Part Part { get; private set; }
 
+        /// <summary>
+        /// The static configuration of the module, as found in the part's
+        /// <a href="https://wiki.kerbalspaceprogram.com/wiki/CFG_File_Documentation#MODULES">cfg file</a>.
+        /// This provides access to data that is not exposed as a field, such as the
+        /// resources produced by a generator. Returns <c>null</c> if the modules
+        /// configuration node cannot be found.
+        /// </summary>
+        [KRPCProperty]
+        public ConfigNode Config {
+            get {
+                var node = FindConfigNode ();
+                return node == null ? null : new ConfigNode (node);
+            }
+        }
+
+        global::ConfigNode FindConfigNode ()
+        {
+            var info = Part.InternalPart.partInfo;
+            if (info == null || info.partConfig == null)
+                return null;
+            // Find the position of this module among the modules on the part that share
+            // its name, then return the config node for the same occurrence.
+            int occurrence = 0;
+            var modules = Part.InternalPart.Modules;
+            for (int i = 0; i < modules.Count; i++) {
+                if (ReferenceEquals (modules [i], module))
+                    break;
+                if (modules [i].moduleName == module.moduleName)
+                    occurrence++;
+            }
+            int seen = 0;
+            foreach (var moduleNode in info.partConfig.GetNodes ("MODULE")) {
+                if (moduleNode.GetValue ("name") == module.moduleName) {
+                    if (seen == occurrence)
+                        return moduleNode;
+                    seen++;
+                }
+            }
+            return null;
+        }
+
         IEnumerable<BaseField> VisibleFields {
             get { return module.Fields.Cast<BaseField> ().Where (f => f != null && (HighLogic.LoadedSceneIsEditor ? f.guiActiveEditor : f.guiActive)); }
         }

--- a/service/SpaceCenter/src/Services/Parts/Part.cs
+++ b/service/SpaceCenter/src/Services/Parts/Part.cs
@@ -77,7 +77,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// The static configuration of the part, as found in its
         /// <a href="https://wiki.kerbalspaceprogram.com/wiki/CFG_File_Documentation">part cfg file</a>.
         /// This provides access to data that is not exposed elsewhere, such as the
-        /// configuration of the parts modules. Returns <c>null</c> if the part has no
+        /// configuration of the part's modules. Returns <c>null</c> if the part has no
         /// associated configuration node.
         /// </summary>
         [KRPCProperty]

--- a/service/SpaceCenter/src/Services/Parts/Part.cs
+++ b/service/SpaceCenter/src/Services/Parts/Part.cs
@@ -74,6 +74,23 @@ namespace KRPC.SpaceCenter.Services.Parts
         }
 
         /// <summary>
+        /// The static configuration of the part, as found in its
+        /// <a href="https://wiki.kerbalspaceprogram.com/wiki/CFG_File_Documentation">part cfg file</a>.
+        /// This provides access to data that is not exposed elsewhere, such as the
+        /// configuration of the parts modules. Returns <c>null</c> if the part has no
+        /// associated configuration node.
+        /// </summary>
+        [KRPCProperty]
+        public ConfigNode Config {
+            get {
+                var info = InternalPart.partInfo;
+                if (info == null || info.partConfig == null)
+                    return null;
+                return new ConfigNode (info.partConfig);
+            }
+        }
+
+        /// <summary>
         /// The name tag for the part. Can be set to a custom string using the
         /// in-game user interface.
         /// </summary>

--- a/service/SpaceCenter/test/test_parts_module.py
+++ b/service/SpaceCenter/test/test_parts_module.py
@@ -164,6 +164,8 @@ class TestPartsModule(krpctest.TestCase):
         self.assertTrue(config.has_value("name"))
         self.assertFalse(config.has_value("DoesntExist"))
         self.assertRaises(RuntimeError, config.get_value, "DoesntExist")
+        self.assertEqual("ModuleCommand", config.values["name"])
+        self.assertEqual(["ModuleCommand"], config.get_values("name"))
 
         # Part.config returns the whole part cfg, including module and resource nodes.
         part_config = part.config
@@ -171,6 +173,7 @@ class TestPartsModule(krpctest.TestCase):
         self.assertTrue(part_config.has_node("MODULE"))
         module_names = [n.get_value("name") for n in part_config.get_nodes("MODULE")]
         self.assertIn("ModuleCommand", module_names)
+        self.assertIn("MODULE", [n.name for n in part_config.nodes])
         self.assertFalse(part_config.has_node("DoesntExist"))
         self.assertRaises(RuntimeError, part_config.get_node, "DoesntExist")
 
@@ -185,15 +188,27 @@ class TestPartsModule(krpctest.TestCase):
         # The static rate of a generator (issue #831): the electric charge it
         # produces is in an OUTPUT_RESOURCE node of its config, not in a field.
         generator = next(
-            m for p in self.parts.all for m in p.modules if m.name == "ModuleGenerator"
+            (
+                m
+                for p in self.parts.all
+                for m in p.modules
+                if m.name == "ModuleGenerator"
+            ),
+            None,
         )
+        self.assertIsNotNone(generator)
         gen_config = generator.config
+        self.assertIsNotNone(gen_config)
         self.assertEqual("ModuleGenerator", gen_config.get_value("name"))
         output = next(
-            n
-            for n in gen_config.get_nodes("OUTPUT_RESOURCE")
-            if n.get_value("name") == "ElectricCharge"
+            (
+                n
+                for n in gen_config.get_nodes("OUTPUT_RESOURCE")
+                if n.get_value("name") == "ElectricCharge"
+            ),
+            None,
         )
+        self.assertIsNotNone(output)
         self.assertGreater(float(output.get_value("rate")), 0)
 
 

--- a/service/SpaceCenter/test/test_parts_module.py
+++ b/service/SpaceCenter/test/test_parts_module.py
@@ -152,6 +152,50 @@ class TestPartsModule(krpctest.TestCase):
         self.assertTrue(module.has_event("Lights On"))
         self.assertFalse(module.has_event("Lights Off"))
 
+    def test_config_node(self):
+        part = self.parts.with_title("Mk1-3 Command Pod")[0]
+        module = next(m for m in part.modules if m.name == "ModuleCommand")
+
+        # Module.config returns the module's MODULE node from the part's cfg file.
+        config = module.config
+        self.assertIsNotNone(config)
+        self.assertEqual("MODULE", config.name)
+        self.assertEqual("ModuleCommand", config.get_value("name"))
+        self.assertTrue(config.has_value("name"))
+        self.assertFalse(config.has_value("DoesntExist"))
+        self.assertRaises(RuntimeError, config.get_value, "DoesntExist")
+
+        # Part.config returns the whole part cfg, including module and resource nodes.
+        part_config = part.config
+        self.assertIsNotNone(part_config)
+        self.assertTrue(part_config.has_node("MODULE"))
+        module_names = [n.get_value("name") for n in part_config.get_nodes("MODULE")]
+        self.assertIn("ModuleCommand", module_names)
+        self.assertFalse(part_config.has_node("DoesntExist"))
+        self.assertRaises(RuntimeError, part_config.get_node, "DoesntExist")
+
+        # Static data not exposed as a field: the electric charge stored by the pod.
+        electric_charge = next(
+            r
+            for r in part_config.get_nodes("RESOURCE")
+            if r.get_value("name") == "ElectricCharge"
+        )
+        self.assertGreater(float(electric_charge.get_value("amount")), 0)
+
+        # The static rate of a generator (issue #831): the electric charge it
+        # produces is in an OUTPUT_RESOURCE node of its config, not in a field.
+        generator = next(
+            m for p in self.parts.all for m in p.modules if m.name == "ModuleGenerator"
+        )
+        gen_config = generator.config
+        self.assertEqual("ModuleGenerator", gen_config.get_value("name"))
+        output = next(
+            n
+            for n in gen_config.get_nodes("OUTPUT_RESOURCE")
+            if n.get_value("name") == "ElectricCharge"
+        )
+        self.assertGreater(float(output.get_value("rate")), 0)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- Add a read-only `ConfigNode` class wrapping KSP's `ConfigNode`: its `Name`, the values it stores (`Values`, `HasValue`, `GetValue`, `GetValues`) and its child nodes (`Nodes`, `HasNode`, `GetNode`, `GetNodes`)
- Add `Part.Config`, the part's full configuration as read from `partInfo.partConfig`
- Add `Module.Config`, the module's own `MODULE` node, located by matching the module name and its position among same-named modules on the part
- `GetValue`/`GetNode` throw when nothing matches (like `Module.GetField`); use `HasValue`/`HasNode` to test first. Both `Config` properties return `null` when there is no associated config node

## Design Choices

### Why a config-node API, separate from the fields API?

This complements PR #858. Relaxing the field filter exposes hidden runtime `[KSPField]` values, but it cannot reach data that exists only as static config (e.g. a generator's electric-charge rate, stored in an `OUTPUT_RESOURCE` node rather than a field). Issue #831 asked for a general way to read those config nodes, which this adds.

A class rather than flat dictionaries: a config node is a tree (nodes contain values and child nodes), so a wrapper exposing node traversal is required; a flat name -> value map can't represent `OUTPUT_RESOURCE { ... }` and similar
`Config` nodes may repeat a name, so `Values` keeps the first value per name while `GetValues`/`GetNodes` return all of them, mirroring KSP's `ConfigNode` and the existing `Fields`/`FieldsById` split

### Why two accessors:

`Part.Config` is the reliable entry point as it comes straight from `partInfo.partConfig`. `Module.Config` is a convenience: KSP has no direct "config node for this `PartModule`" lookup, so it matches by module name + occurrence index. That's robust for stock parts but can be ambiguous under heavy ModuleManager reordering, in which case navigate from `Part.Config` instead.

Read-only: `partConfig` is the prefab config shared by every instance of a part, so it isn't meaningful to mutate per-vessel

## Test plan

- [ ] `service/SpaceCenter/test/test_parts_module.py` integration tests: `Module.Config` and `Part.Config` on the Mk1-3 pod expose its `MODULE`/`RESOURCE` nodes and values, and missing names raise; reading a launch clamp's `ModuleGenerator` `OUTPUT_RESOURCE` electric-charge rate (the issue #831 use case) returns a positive value

## Suggested changelog

```
 * Add Part.Config, Module.Config and ConfigNode for accessing part and module static configuration (#831)
```