### PR TITLE
Clean up cmake on Windows

### DIFF
--- a/client/cpp/CMakeLists.txt.tmpl
+++ b/client/cpp/CMakeLists.txt.tmpl
@@ -113,6 +113,9 @@ target_include_directories(krpc PUBLIC
   "$<BUILD_INTERFACE:${PROTO_COMPAT_DIR}>"
   "$<INSTALL_INTERFACE:include>")
 target_compile_definitions(krpc PUBLIC ASIO_STANDALONE)
+if(WIN32)
+  target_compile_definitions(krpc PUBLIC _WIN32_WINNT=0x0601)
+endif()
 target_link_libraries(krpc PRIVATE protobuf::libprotobuf-lite)
 if(KRPC_PROTO_EXTRA_INCLUDE)
   # utf8_range header dir: only needed when building against FetchContent protobuf

--- a/client/cpp/CMakeLists.txt.tmpl
+++ b/client/cpp/CMakeLists.txt.tmpl
@@ -121,25 +121,6 @@ if(KRPC_PROTO_EXTRA_INCLUDE)
 endif()
 target_link_libraries(krpc PUBLIC asio::asio)
 
-if(WIN32 OR CYGWIN)
-  target_compile_definitions(krpc PUBLIC
-    _SCL_SECURE_NO_WARNINGS
-    _WIN32_WINNT=0x0501
-    __USE_W32_SOCKETS)
-  target_link_libraries(krpc PUBLIC ws2_32 mswsock)
-endif()
-
-if(MSVC)
-  set_target_properties(krpc PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS ON)
-  foreach(flag_var
-      CMAKE_CXX_FLAGS CMAKE_CXX_FLAGS_DEBUG CMAKE_CXX_FLAGS_RELEASE
-      CMAKE_CXX_FLAGS_MINSIZEREL CMAKE_CXX_FLAGS_RELWITHDEBINFO)
-    if(${flag_var} MATCHES "/MD")
-      string(REGEX REPLACE "/MD" "/MT" ${flag_var} "${${flag_var}}")
-    endif()
-  endforeach()
-endif()
-
 set_target_properties(krpc PROPERTIES
   VERSION   ${PROJECT_VERSION}
   SOVERSION ${PROJECT_VERSION_MAJOR})


### PR DESCRIPTION
 - Remove unnecessary compile flags
 - Indicate support for Windows 7 and later