### PR TITLE
Add pitch, yaw and roll trim to Control

### DIFF
--- a/doc/order.txt
+++ b/doc/order.txt
@@ -408,6 +408,9 @@ SpaceCenter.Control.InputMode
 SpaceCenter.Control.Pitch
 SpaceCenter.Control.Yaw
 SpaceCenter.Control.Roll
+SpaceCenter.Control.PitchTrim
+SpaceCenter.Control.YawTrim
+SpaceCenter.Control.RollTrim
 SpaceCenter.Control.Forward
 SpaceCenter.Control.Up
 SpaceCenter.Control.Right

--- a/service/SpaceCenter/CHANGES.txt
+++ b/service/SpaceCenter/CHANGES.txt
@@ -17,6 +17,8 @@ v0.6.0
  * Add AlarmType, AlarmWarpAction and AlarmMessageAction enumerations (#853)
  * Add Alarm.Remove to delete an alarm (#853)
  * Fix NullReferenceException raised every frame after creating or removing an alarm (#853)
+ * Add Control.PitchTrim, Control.YawTrim and Control.RollTrim to get/set the persistent
+   pitch, yaw and roll trim of the active vessel (#863)
 
 v0.5.4
  * Fix vessel recovery (#782)

--- a/service/SpaceCenter/src/Services/Control.cs
+++ b/service/SpaceCenter/src/Services/Control.cs
@@ -438,6 +438,51 @@ namespace KRPC.SpaceCenter.Services
         }
 
         /// <summary>
+        /// The state of the pitch trim.
+        /// A value between -1 and 1.
+        /// Equivalent to the Alt+W and Alt+S keys.
+        /// This is a persistent trim that remains latched until changed or reset,
+        /// and can only be accessed for the active vessel.
+        /// Unlike the pitch, yaw and roll control inputs, the trim is not cleared
+        /// when clients disconnect.
+        /// </summary>
+        [KRPCProperty]
+        public float PitchTrim {
+            get { CheckActiveVessel (); return FlightInputHandler.state.pitchTrim; }
+            set { CheckActiveVessel (); FlightInputHandler.state.pitchTrim = value.Clamp (-1f, 1f); }
+        }
+
+        /// <summary>
+        /// The state of the yaw trim.
+        /// A value between -1 and 1.
+        /// Equivalent to the Alt+A and Alt+D keys.
+        /// This is a persistent trim that remains latched until changed or reset,
+        /// and can only be accessed for the active vessel.
+        /// Unlike the pitch, yaw and roll control inputs, the trim is not cleared
+        /// when clients disconnect.
+        /// </summary>
+        [KRPCProperty]
+        public float YawTrim {
+            get { CheckActiveVessel (); return FlightInputHandler.state.yawTrim; }
+            set { CheckActiveVessel (); FlightInputHandler.state.yawTrim = value.Clamp (-1f, 1f); }
+        }
+
+        /// <summary>
+        /// The state of the roll trim.
+        /// A value between -1 and 1.
+        /// Equivalent to the Alt+Q and Alt+E keys.
+        /// This is a persistent trim that remains latched until changed or reset,
+        /// and can only be accessed for the active vessel.
+        /// Unlike the pitch, yaw and roll control inputs, the trim is not cleared
+        /// when clients disconnect.
+        /// </summary>
+        [KRPCProperty]
+        public float RollTrim {
+            get { CheckActiveVessel (); return FlightInputHandler.state.rollTrim; }
+            set { CheckActiveVessel (); FlightInputHandler.state.rollTrim = value.Clamp (-1f, 1f); }
+        }
+
+        /// <summary>
         /// The state of the forward translational control.
         /// A value between -1 and 1.
         /// Equivalent to the h and n keys.

--- a/service/SpaceCenter/test/test_control.py
+++ b/service/SpaceCenter/test/test_control.py
@@ -76,6 +76,33 @@ class TestControlMixin:
         diff = self.orbital_flight.roll - roll
         self.assertGreater(diff, 0)
 
+    def check_trim(self, axis):
+        name = axis + "_trim"
+        # Trim is only available for the active vessel
+        if self.vessel != self.space_center.active_vessel:
+            self.assertRaises(RuntimeError, getattr, self.control, name)
+            self.assertRaises(RuntimeError, setattr, self.control, name, 0.5)
+            return
+        self.auto_pilot.sas = False
+        try:
+            setattr(self.control, name, 0.5)
+            self.assertAlmostEqual(0.5, getattr(self.control, name), places=3)
+            setattr(self.control, name, 2)  # clamped to 1
+            self.assertAlmostEqual(1, getattr(self.control, name), places=3)
+            setattr(self.control, name, 0)  # explicitly clears the axis
+            self.assertEqual(0, getattr(self.control, name))
+        finally:
+            setattr(self.control, name, 0)
+
+    def test_pitch_trim(self):
+        self.check_trim("pitch")
+
+    def test_yaw_trim(self):
+        self.check_trim("yaw")
+
+    def test_roll_trim(self):
+        self.check_trim("roll")
+
     def test_sas_mode(self):
         sas_mode = self.space_center.SASMode
         self.control.sas = True


### PR DESCRIPTION
## Summary

As per issue #863.

- Add read/write `Control.PitchTrim`, `Control.YawTrim` and `Control.RollTrim` (generated `pitch_trim`/`yaw_trim`/`roll_trim`): the active vessel's persistent control trim, a value between -1 and 1, clamped like the existing `Pitch`/`Yaw`/`Roll`. Equivalent to the in-game Alt+W/S, Alt+A/D and Alt+Q/E keys
- Trim is latched: it remains until changed or reset, matching normal in-game trim. Set an axis to `0` to clear it
- Only available for the active vessel: accessing it for any other vessel throws (like the other active-vessel-only members), rather than silently affecting the active vessel

## Design Choices

### Why write through `FlightInputHandler.state`, not the per-frame control inputs?

Trim is a latched/persistent value, not a transient per-frame input. KSP keeps it in the global `FlightInputHandler.state` (the same place the throttle is latched), so the properties read and write `pitchTrim`/`yawTrim`/`rollTrim` there directly, mirroring the existing throttle handling in `PilotAddon`/`SpaceCenter`.

Routing trim through the `PilotAddon` manual-input layer (as `Pitch`/`Yaw`/`Roll` do) would be wrong: those inputs are zeroed when all clients disconnect, which would break trim's latched behavior. As a deliberate consequence, and unlike `Pitch`/`Yaw`/`Roll`, trim is **not** cleared when clients disconnect. That is what trim is, and the doc-comments call it out.

## Test plan

- [x] `service/SpaceCenter/test/test_control.py` integration tests (run against a live KSP): `pitch_trim`/`yaw_trim`/`roll_trim` round-trip on the active vessel (set a value and read it back, an out-of-range value clamps to ±1, and `0` clears the axis), and accessing them on a non-active vessel raises

## Suggested changelog

```
 * Add Control.PitchTrim, Control.YawTrim and Control.RollTrim to get/set the persistent pitch, yaw and roll trim of the active vessel (#863)
```