### PR TITLE
Windows support for Cnano client

### DIFF
--- a/client/cnano/BUILD.bazel
+++ b/client/cnano/BUILD.bazel
@@ -21,6 +21,7 @@ pkg_zip(
         "LICENSE",
         "src/krpc.options",
         ":cmake",
+        ":protobuf",
         ":services-dockingcamera",
         ":services-drawing",
         ":services-infernalrobotics",

--- a/client/cnano/CHANGES.txt
+++ b/client/cnano/CHANGES.txt
@@ -7,6 +7,7 @@ v0.6.0
  * CMake dependency options (KRPC_FETCH_PROTOBUF, KRPC_FETCH_NANOPB): when OFF
    (default) the system install is required; when ON FetchContent is used.
  * Add KRPC_FETCH_DEPS option to enable FetchContent for all dependencies at once
+ * Add support for socket communication on Windows
 
 v0.5.2
  * The arduino compatible version of the library now uses the same "krpc_cnano/..." include directory as the version released on GitHub.

--- a/client/cnano/CMakeLists.txt.tmpl
+++ b/client/cnano/CMakeLists.txt.tmpl
@@ -6,44 +6,49 @@ set(CMAKE_C_STANDARD_REQUIRED ON)
 
 include(FetchContent)
 
-option(KRPC_FETCH_DEPS      "Use FetchContent for all dependencies (nanopb, protobuf)" OFF)
-option(KRPC_FETCH_NANOPB    "Use FetchContent for nanopb"                              OFF)
-option(KRPC_FETCH_PROTOBUF  "Use FetchContent for protobuf (for protoc)"               OFF)
-option(KRPC_FETCH_ABSL      "Use FetchContent for abseil (only relevant when KRPC_FETCH_PROTOBUF=ON)" OFF)
+option(KRPC_FETCH_DEPS       "Use FetchContent for all dependencies (nanopb, protobuf)" OFF)
+option(KRPC_FETCH_NANOPB     "Use FetchContent for nanopb"                              OFF)
+option(KRPC_FETCH_PROTOBUF   "Use FetchContent for protobuf (for protoc; only used with KRPC_REGENERATE_PROTO=ON)" OFF)
+option(KRPC_FETCH_ABSL       "Use FetchContent for abseil (only relevant when KRPC_FETCH_PROTOBUF=ON)"             OFF)
+option(KRPC_REGENERATE_PROTO "Re-run protoc+nanopb to regenerate proto sources (requires Python protobuf package)" OFF)
 
 if(KRPC_FETCH_DEPS)
   set(KRPC_FETCH_NANOPB ON)
-  set(KRPC_FETCH_PROTOBUF ON)
+  if(KRPC_REGENERATE_PROTO)
+    set(KRPC_FETCH_PROTOBUF ON)
+  endif()
 endif()
 
-# ---- Protobuf (protoc) ----
-if(KRPC_FETCH_PROTOBUF)
-  message(STATUS "Fetching protobuf via FetchContent...")
-  set(protobuf_BUILD_TESTS       OFF CACHE BOOL "" FORCE)
-  set(protobuf_BUILD_CONFORMANCE OFF CACHE BOOL "" FORCE)
-  set(protobuf_BUILD_EXAMPLES    OFF CACHE BOOL "" FORCE)
-  set(protobuf_INSTALL           ON  CACHE BOOL "" FORCE)
-  if(NOT KRPC_FETCH_ABSL)
-    find_package(absl QUIET)
-    if(NOT absl_FOUND)
-      message(FATAL_ERROR "abseil not found. Install abseil or set KRPC_FETCH_ABSL=ON "
+# ---- Protobuf (protoc, only needed when regenerating) ----
+if(KRPC_REGENERATE_PROTO)
+  if(KRPC_FETCH_PROTOBUF)
+    message(STATUS "Fetching protobuf via FetchContent...")
+    set(protobuf_BUILD_TESTS       OFF CACHE BOOL "" FORCE)
+    set(protobuf_BUILD_CONFORMANCE OFF CACHE BOOL "" FORCE)
+    set(protobuf_BUILD_EXAMPLES    OFF CACHE BOOL "" FORCE)
+    set(protobuf_INSTALL           ON  CACHE BOOL "" FORCE)
+    if(NOT KRPC_FETCH_ABSL)
+      find_package(absl QUIET)
+      if(NOT absl_FOUND)
+        message(FATAL_ERROR "abseil not found. Install abseil or set KRPC_FETCH_ABSL=ON "
+                "(or KRPC_FETCH_DEPS=ON) to download it automatically via FetchContent.")
+      endif()
+      set(protobuf_ABSL_PROVIDER "package" CACHE STRING "" FORCE)
+    endif()
+    FetchContent_Declare(protobuf
+      GIT_REPOSITORY https://github.com/protocolbuffers/protobuf.git
+      GIT_TAG        v35.1
+      GIT_SHALLOW    TRUE)
+    FetchContent_MakeAvailable(protobuf)
+    include("${protobuf_SOURCE_DIR}/cmake/protobuf-generate.cmake")
+  else()
+    find_package(protobuf CONFIG)
+    if(NOT protobuf_FOUND)
+      message(FATAL_ERROR "protobuf not found. Install protobuf or set KRPC_FETCH_PROTOBUF=ON "
               "(or KRPC_FETCH_DEPS=ON) to download it automatically via FetchContent.")
     endif()
-    set(protobuf_ABSL_PROVIDER "package" CACHE STRING "" FORCE)
+    message(STATUS "Found protobuf ${protobuf_VERSION}")
   endif()
-  FetchContent_Declare(protobuf
-    GIT_REPOSITORY https://github.com/protocolbuffers/protobuf.git
-    GIT_TAG        v35.1
-    GIT_SHALLOW    TRUE)
-  FetchContent_MakeAvailable(protobuf)
-  include("${protobuf_SOURCE_DIR}/cmake/protobuf-generate.cmake")
-else()
-  find_package(protobuf CONFIG)
-  if(NOT protobuf_FOUND)
-    message(FATAL_ERROR "protobuf not found. Install protobuf or set KRPC_FETCH_PROTOBUF=ON "
-            "(or KRPC_FETCH_DEPS=ON) to download it automatically via FetchContent.")
-  endif()
-  message(STATUS "Found protobuf ${protobuf_VERSION}")
 endif()
 
 # ---- nanopb ----
@@ -56,8 +61,10 @@ if(KRPC_FETCH_NANOPB)
     GIT_SHALLOW    TRUE)
   FetchContent_MakeAvailable(nanopb)
   set(NANOPB_INCLUDE_DIRS "${nanopb_SOURCE_DIR}")
-  set(NANOPB_GENERATOR_PLUGIN "${nanopb_SOURCE_DIR}/generator/protoc-gen-nanopb")
   add_library(nanopb::protobuf-nanopb-static ALIAS protobuf-nanopb-static)
+  if(KRPC_REGENERATE_PROTO)
+    set(NANOPB_GENERATOR_PLUGIN "${nanopb_SOURCE_DIR}/generator/protoc-gen-nanopb")
+  endif()
 else()
   find_package(nanopb CONFIG)
   if(NOT nanopb_FOUND)
@@ -66,7 +73,13 @@ else()
   endif()
   message(STATUS "Found nanopb ${nanopb_VERSION}")
   get_target_property(NANOPB_INCLUDE_DIRS nanopb::protobuf-nanopb-static INTERFACE_INCLUDE_DIRECTORIES)
-  find_program(NANOPB_GENERATOR_PLUGIN protoc-gen-nanopb REQUIRED)
+  if(KRPC_REGENERATE_PROTO)
+    get_filename_component(_nanopb_prefix "${nanopb_DIR}/../../.." ABSOLUTE)
+    find_program(NANOPB_GENERATOR_PLUGIN
+      NAMES protoc-gen-nanopb protoc-gen-nanopb.bat
+      HINTS "${_nanopb_prefix}/tools/nanopb"
+      REQUIRED)
+  endif()
 endif()
 
 # Copy nanopb headers into krpc_cnano/ so <krpc_cnano/pb.h> etc. resolve.
@@ -74,45 +87,51 @@ set(NANOPB_COMPAT_DIR "${CMAKE_CURRENT_BINARY_DIR}/nanopb_compat")
 file(GLOB _nanopb_pub_hdrs "${NANOPB_INCLUDE_DIRS}/*.h")
 file(COPY ${_nanopb_pub_hdrs} DESTINATION "${NANOPB_COMPAT_DIR}/krpc_cnano")
 
-# ---- Generate proto at build time ----
-protobuf_generate(
-  PROTOS          "${CMAKE_CURRENT_SOURCE_DIR}/protobuf/krpc.proto"
-  LANGUAGE        nanopb
-  PLUGIN          "protoc-gen-nanopb=${NANOPB_GENERATOR_PLUGIN}"
-  PROTOC_OPTIONS  "--nanopb_opt=-I${CMAKE_CURRENT_SOURCE_DIR}/protobuf"
-  GENERATE_EXTENSIONS .pb.c .pb.h
-  OUT_VAR         PROTO_GENERATED
-  PROTOC_OUT_DIR  "${CMAKE_CURRENT_BINARY_DIR}"
-  IMPORT_DIRS     "${CMAKE_CURRENT_SOURCE_DIR}/protobuf"
-  DEPENDENCIES    "${CMAKE_CURRENT_SOURCE_DIR}/protobuf/krpc.options")
+# ---- Proto sources ----
+if(KRPC_REGENERATE_PROTO)
+  # Re-generate krpc.pb.c / krpc.pb.h from krpc.proto using protoc + nanopb.
+  protobuf_generate(
+    PROTOS          "${CMAKE_CURRENT_SOURCE_DIR}/protobuf/krpc.proto"
+    LANGUAGE        nanopb
+    PLUGIN          "protoc-gen-nanopb=${NANOPB_GENERATOR_PLUGIN}"
+    PROTOC_OPTIONS  "--nanopb_opt=-I${CMAKE_CURRENT_SOURCE_DIR}/protobuf"
+    GENERATE_EXTENSIONS .pb.c .pb.h
+    OUT_VAR         PROTO_GENERATED
+    PROTOC_OUT_DIR  "${CMAKE_CURRENT_BINARY_DIR}"
+    IMPORT_DIRS     "${CMAKE_CURRENT_SOURCE_DIR}/protobuf"
+    DEPENDENCIES    "${CMAKE_CURRENT_SOURCE_DIR}/protobuf/krpc.options")
 
-foreach(_f ${PROTO_GENERATED})
-  if(_f MATCHES "\\.h$")
-    set(PROTO_HDR_GEN "${_f}")
-  elseif(_f MATCHES "\\.c$")
-    list(APPEND PROTO_SRCS "${_f}")
-  endif()
-endforeach()
+  foreach(_f ${PROTO_GENERATED})
+    if(_f MATCHES "\\.h$")
+      set(PROTO_HDR_GEN "${_f}")
+    elseif(_f MATCHES "\\.c$")
+      list(APPEND PROTO_SRCS "${_f}")
+    endif()
+  endforeach()
 
-# Copy generated header to krpc_cnano/krpc.pb.h
-set(PROTO_HDR_COMPAT "${CMAKE_CURRENT_BINARY_DIR}/krpc_cnano/krpc.pb.h")
-add_custom_command(
-  OUTPUT "${PROTO_HDR_COMPAT}"
-  COMMAND "${CMAKE_COMMAND}" -E make_directory "${CMAKE_CURRENT_BINARY_DIR}/krpc_cnano"
-  COMMAND "${CMAKE_COMMAND}" -E copy "${PROTO_HDR_GEN}" "${PROTO_HDR_COMPAT}"
-  DEPENDS "${PROTO_HDR_GEN}")
-add_custom_target(krpc_cnano_proto_hdr DEPENDS "${PROTO_HDR_COMPAT}")
+  set(PROTO_HDR_COMPAT "${CMAKE_CURRENT_BINARY_DIR}/krpc_cnano/krpc.pb.h")
+  add_custom_command(
+    OUTPUT "${PROTO_HDR_COMPAT}"
+    COMMAND "${CMAKE_COMMAND}" -E make_directory "${CMAKE_CURRENT_BINARY_DIR}/krpc_cnano"
+    COMMAND "${CMAKE_COMMAND}" -E copy "${PROTO_HDR_GEN}" "${PROTO_HDR_COMPAT}"
+    DEPENDS "${PROTO_HDR_GEN}")
+  add_custom_target(krpc_cnano_proto_hdr DEPENDS "${PROTO_HDR_COMPAT}")
+endif()
 
 # ---- Library ----
+# When not regenerating, the glob picks up the pre-generated src/krpc.pb.c.
 file(GLOB KRPC_CNANO_SRC "${CMAKE_CURRENT_SOURCE_DIR}/src/*.c")
-add_library(krpc_cnano STATIC ${KRPC_CNANO_SRC} ${PROTO_SRCS})
+if(KRPC_REGENERATE_PROTO)
+  add_library(krpc_cnano STATIC ${KRPC_CNANO_SRC} ${PROTO_SRCS})
+  add_dependencies(krpc_cnano krpc_cnano_proto_hdr)
+else()
+  add_library(krpc_cnano STATIC ${KRPC_CNANO_SRC})
+endif()
 add_library(krpc_cnano::krpc_cnano ALIAS krpc_cnano)
-add_dependencies(krpc_cnano krpc_cnano_proto_hdr)
 
 target_include_directories(krpc_cnano PUBLIC
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
   "$<BUILD_INTERFACE:${NANOPB_COMPAT_DIR}>"
-  "$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>"
   "$<INSTALL_INTERFACE:include>")
 
 target_link_libraries(krpc_cnano PUBLIC
@@ -130,8 +149,10 @@ install(TARGETS krpc_cnano
   LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
   ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
 install(DIRECTORY include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
-install(FILES "${PROTO_HDR_COMPAT}"
-  DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/krpc_cnano")
+if(KRPC_REGENERATE_PROTO)
+  install(FILES "${PROTO_HDR_COMPAT}"
+    DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/krpc_cnano")
+endif()
 install(DIRECTORY "${NANOPB_COMPAT_DIR}/krpc_cnano/"
   DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/krpc_cnano")
 

--- a/client/cnano/include/krpc_cnano/communication.h
+++ b/client/cnano/include/krpc_cnano/communication.h
@@ -12,7 +12,9 @@
     #error "Require a C++ compiler to build kRPC for Arduino"
     #endif
     #include <HardwareSerial.h>
-  #elif !defined(KRPC_COMMUNICATION_CUSTOM)
+  #elif defined(_WIN32)
+    #define KRPC_COMMUNICATION_WINDOWS
+  #else
     #define KRPC_COMMUNICATION_POSIX
   #endif
 #endif
@@ -23,6 +25,11 @@ extern "C" {
 
 #ifdef KRPC_COMMUNICATION_POSIX
 typedef int krpc_connection_t;
+typedef char krpc_connection_config_t;
+#endif
+
+#ifdef KRPC_COMMUNICATION_WINDOWS
+typedef void * krpc_connection_t;
 typedef char krpc_connection_config_t;
 #endif
 

--- a/client/cnano/src/communication.c
+++ b/client/cnano/src/communication.c
@@ -45,6 +45,51 @@ krpc_error_t krpc_write(krpc_connection_t connection, const uint8_t * buf, size_
 
 #endif
 
+#if defined(KRPC_COMMUNICATION_WINDOWS)
+
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#include <windows.h>
+
+krpc_error_t krpc_open(krpc_connection_t * connection, const krpc_connection_config_t * arg) {
+  const char * port = arg;
+  HANDLE handle = CreateFileA(
+    port, GENERIC_READ | GENERIC_WRITE, 0, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
+  if (handle == INVALID_HANDLE_VALUE)
+    KRPC_RETURN_ERROR(IO, "failed to open serial port");
+  *connection = handle;
+  return KRPC_OK;
+}
+
+krpc_error_t krpc_close(krpc_connection_t connection) {
+  CloseHandle((HANDLE)connection);
+  return KRPC_OK;
+}
+
+krpc_error_t krpc_read(krpc_connection_t connection, uint8_t * buf, size_t count) {
+  size_t total = 0;
+  while (total < count) {
+    DWORD bytes_read = 0;
+    if (!ReadFile((HANDLE)connection, buf + total, (DWORD)(count - total), &bytes_read, NULL))
+      KRPC_RETURN_ERROR(IO, "read failed");
+    if (bytes_read == 0)
+      KRPC_RETURN_ERROR(EOF, "eof received");
+    total += bytes_read;
+  }
+  return KRPC_OK;
+}
+
+krpc_error_t krpc_write(krpc_connection_t connection, const uint8_t * buf, size_t count) {
+  DWORD bytes_written = 0;
+  if (!WriteFile((HANDLE)connection, buf, (DWORD)count, &bytes_written, NULL) ||
+      bytes_written != (DWORD)count)
+    KRPC_RETURN_ERROR(IO, "write failed");
+  return KRPC_OK;
+}
+
+#endif
+
 #if defined(KRPC_COMMUNICATION_ARDUINO)
 
 krpc_error_t krpc_open(krpc_connection_t * connection, const krpc_connection_config_t * arg) {

--- a/tools/krpctools/krpctools/clientgen/cnano.tmpl
+++ b/tools/krpctools/krpctools/clientgen/cnano.tmpl
@@ -9,8 +9,12 @@
 #include <krpc_cnano/types.h>
 {% macro call(service_id, procedure_id, parameters) %}
 krpc_call_t _call;
+{% if parameters | length > 0 %}
 krpc_argument_t _arguments[{{ parameters | length }}];
 KRPC_CHECK(krpc_call(&_call, {{ service_id }}, {{ procedure_id }}, {{ parameters | length }}, _arguments));
+{% else %}
+KRPC_CHECK(krpc_call(&_call, {{ service_id }}, {{ procedure_id }}, 0, NULL));
+{% endif %}
 {% for x in parameters %}
 KRPC_CHECK(krpc_add_argument(&_call, {{ loop.index0 }}, &krpc_encode_callback_{{ x.type.name }}, {{ x.type.getptr }}{{ x.name }}));
 {% endfor %}

--- a/tools/krpctools/krpctools/test/clientgen-TestService-cnano.txt
+++ b/tools/krpctools/krpctools/test/clientgen-TestService-cnano.txt
@@ -1371,8 +1371,7 @@ inline krpc_error_t krpc_TestService_EnumEcho(krpc_connection_t connection, krpc
 
 inline krpc_error_t krpc_TestService_EnumReturn(krpc_connection_t connection, krpc_TestService_TestEnum_t * returnValue) {
   krpc_call_t _call;
-  krpc_argument_t _arguments[0];
-  KRPC_CHECK(krpc_call(&_call, 9999, 13, 0, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 13, 0, NULL));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
   KRPC_CHECK(krpc_invoke(connection, &_result.message, &_call.message));
@@ -1595,8 +1594,7 @@ inline krpc_error_t krpc_TestService_OptionalArguments(krpc_connection_t connect
 
 inline krpc_error_t krpc_TestService_ResetCustomExceptionLater(krpc_connection_t connection) {
   krpc_call_t _call;
-  krpc_argument_t _arguments[0];
-  KRPC_CHECK(krpc_call(&_call, 9999, 35, 0, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 35, 0, NULL));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
   KRPC_CHECK(krpc_invoke(connection, &_result.message, &_call.message));
@@ -1606,8 +1604,7 @@ inline krpc_error_t krpc_TestService_ResetCustomExceptionLater(krpc_connection_t
 
 inline krpc_error_t krpc_TestService_ResetInvalidOperationExceptionLater(krpc_connection_t connection) {
   krpc_call_t _call;
-  krpc_argument_t _arguments[0];
-  KRPC_CHECK(krpc_call(&_call, 9999, 29, 0, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 29, 0, NULL));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
   KRPC_CHECK(krpc_invoke(connection, &_result.message, &_call.message));
@@ -1617,8 +1614,7 @@ inline krpc_error_t krpc_TestService_ResetInvalidOperationExceptionLater(krpc_co
 
 inline krpc_error_t krpc_TestService_ReturnNullWhenNotAllowed(krpc_connection_t connection, krpc_TestService_TestClass_t * returnValue) {
   krpc_call_t _call;
-  krpc_argument_t _arguments[0];
-  KRPC_CHECK(krpc_call(&_call, 9999, 11, 0, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 11, 0, NULL));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
   KRPC_CHECK(krpc_invoke(connection, &_result.message, &_call.message));
@@ -1667,8 +1663,7 @@ inline krpc_error_t krpc_TestService_StringToInt32(krpc_connection_t connection,
 
 inline krpc_error_t krpc_TestService_ThrowArgumentException(krpc_connection_t connection, int32_t * returnValue) {
   krpc_call_t _call;
-  krpc_argument_t _arguments[0];
-  KRPC_CHECK(krpc_call(&_call, 9999, 31, 0, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 31, 0, NULL));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
   KRPC_CHECK(krpc_invoke(connection, &_result.message, &_call.message));
@@ -1717,8 +1712,7 @@ inline krpc_error_t krpc_TestService_ThrowArgumentOutOfRangeException(krpc_conne
 
 inline krpc_error_t krpc_TestService_ThrowCustomException(krpc_connection_t connection, int32_t * returnValue) {
   krpc_call_t _call;
-  krpc_argument_t _arguments[0];
-  KRPC_CHECK(krpc_call(&_call, 9999, 34, 0, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 34, 0, NULL));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
   KRPC_CHECK(krpc_invoke(connection, &_result.message, &_call.message));
@@ -1733,8 +1727,7 @@ inline krpc_error_t krpc_TestService_ThrowCustomException(krpc_connection_t conn
 
 inline krpc_error_t krpc_TestService_ThrowCustomExceptionLater(krpc_connection_t connection, int32_t * returnValue) {
   krpc_call_t _call;
-  krpc_argument_t _arguments[0];
-  KRPC_CHECK(krpc_call(&_call, 9999, 36, 0, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 36, 0, NULL));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
   KRPC_CHECK(krpc_invoke(connection, &_result.message, &_call.message));
@@ -1749,8 +1742,7 @@ inline krpc_error_t krpc_TestService_ThrowCustomExceptionLater(krpc_connection_t
 
 inline krpc_error_t krpc_TestService_ThrowInvalidOperationException(krpc_connection_t connection, int32_t * returnValue) {
   krpc_call_t _call;
-  krpc_argument_t _arguments[0];
-  KRPC_CHECK(krpc_call(&_call, 9999, 28, 0, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 28, 0, NULL));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
   KRPC_CHECK(krpc_invoke(connection, &_result.message, &_call.message));
@@ -1765,8 +1757,7 @@ inline krpc_error_t krpc_TestService_ThrowInvalidOperationException(krpc_connect
 
 inline krpc_error_t krpc_TestService_ThrowInvalidOperationExceptionLater(krpc_connection_t connection, int32_t * returnValue) {
   krpc_call_t _call;
-  krpc_argument_t _arguments[0];
-  KRPC_CHECK(krpc_call(&_call, 9999, 30, 0, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 30, 0, NULL));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
   KRPC_CHECK(krpc_invoke(connection, &_result.message, &_call.message));
@@ -1798,8 +1789,7 @@ inline krpc_error_t krpc_TestService_TupleDefault(krpc_connection_t connection, 
 
 inline krpc_error_t krpc_TestService_ObjectProperty(krpc_connection_t connection, krpc_TestService_TestClass_t * returnValue) {
   krpc_call_t _call;
-  krpc_argument_t _arguments[0];
-  KRPC_CHECK(krpc_call(&_call, 9999, 43, 0, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 43, 0, NULL));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
   KRPC_CHECK(krpc_invoke(connection, &_result.message, &_call.message));
@@ -1826,8 +1816,7 @@ inline krpc_error_t krpc_TestService_set_ObjectProperty(krpc_connection_t connec
 
 inline krpc_error_t krpc_TestService_StringProperty(krpc_connection_t connection, char * * returnValue) {
   krpc_call_t _call;
-  krpc_argument_t _arguments[0];
-  KRPC_CHECK(krpc_call(&_call, 9999, 39, 0, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 39, 0, NULL));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
   KRPC_CHECK(krpc_invoke(connection, &_result.message, &_call.message));
@@ -1866,8 +1855,7 @@ inline krpc_error_t krpc_TestService_set_StringPropertyPrivateGet(krpc_connectio
 
 inline krpc_error_t krpc_TestService_StringPropertyPrivateSet(krpc_connection_t connection, char * * returnValue) {
   krpc_call_t _call;
-  krpc_argument_t _arguments[0];
-  KRPC_CHECK(krpc_call(&_call, 9999, 42, 0, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 42, 0, NULL));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
   KRPC_CHECK(krpc_invoke(connection, &_result.message, &_call.message));


### PR DESCRIPTION
 - Add support for socket communication on Windows
 - Avoid 0-sized C arrays (not supported by MSVC)
 - Don't require Python to be installed when building with CMake (include pre-generated protobuf files in the release archive). `KRPC_REGENERATE_PROTO` option can be used to regenerate them.