### PR TITLE
Improve RPC Performance

### DIFF
--- a/core/src/Core.cs
+++ b/core/src/Core.cs
@@ -26,6 +26,7 @@ namespace KRPC
         RoundRobinScheduler<IClient<Request,Response>> clientScheduler = new RoundRobinScheduler<IClient<Request, Response>> ();
         List<RequestContinuation> rpcContinuations = new List<RequestContinuation> ();
         Dictionary<IClient<NoMessage,StreamUpdate>, Dictionary<ulong, Service.Stream>> streams = new Dictionary<IClient<NoMessage,StreamUpdate>, Dictionary<ulong, Service.Stream>> ();
+        Dictionary<IClient<NoMessage,StreamUpdate>, StreamUpdate> cachedStreamUpdates = new Dictionary<IClient<NoMessage,StreamUpdate>, StreamUpdate> ();
         Dictionary<ulong, IClient<NoMessage, StreamUpdate>> removeStreams = new Dictionary<ulong, IClient<NoMessage, StreamUpdate>> ();
         ulong nextStreamId = 0;
 
@@ -96,6 +97,7 @@ namespace KRPC
         {
             streamClients [client.Guid] = client;
             streams [client] = new Dictionary<ulong, Service.Stream>();
+            cachedStreamUpdates [client] = new StreamUpdate ();
         }
 
         internal void StreamClientDisconnected (IClient<NoMessage,StreamUpdate> client)
@@ -106,6 +108,7 @@ namespace KRPC
                 RemoveStreamInternal (client, id);
             streamClients.Remove (client.Guid);
             streams.Remove (client);
+            cachedStreamUpdates.Remove (client);
         }
 
         /// <summary>
@@ -538,7 +541,8 @@ namespace KRPC
                     }
                     // If anything changed, produce an update
                     if (changed) {
-                        var streamUpdate = new StreamUpdate ();
+                        var streamUpdate = cachedStreamUpdates [streamClient];
+                        streamUpdate.Results.Clear ();
                         foreach (var stream in clientStreams) {
                             if (stream.Changed) {
                                 var result = stream.StreamResult;

--- a/core/src/Core.cs
+++ b/core/src/Core.cs
@@ -532,6 +532,7 @@ namespace KRPC
                     foreach (var stream in clientStreams) {
                         if (stream.Started) {
                             stream.Update();
+                            rpcsExecuted++;
                             changed |= stream.Changed;
                         }
                     }

--- a/core/src/Core.cs
+++ b/core/src/Core.cs
@@ -25,8 +25,8 @@ namespace KRPC
         IDictionary<Guid, IClient<NoMessage, StreamUpdate>> streamClients = new Dictionary<Guid, IClient<NoMessage, StreamUpdate>> ();
         RoundRobinScheduler<IClient<Request,Response>> clientScheduler = new RoundRobinScheduler<IClient<Request, Response>> ();
         List<RequestContinuation> rpcContinuations = new List<RequestContinuation> ();
-        IDictionary<IClient<NoMessage,StreamUpdate>, IDictionary<ulong, Service.Stream>> streams = new Dictionary<IClient<NoMessage,StreamUpdate>,IDictionary<ulong, Service.Stream>> ();
-        IDictionary<ulong, IClient<NoMessage, StreamUpdate>> removeStreams = new Dictionary<ulong, IClient<NoMessage, StreamUpdate>> ();
+        Dictionary<IClient<NoMessage,StreamUpdate>, Dictionary<ulong, Service.Stream>> streams = new Dictionary<IClient<NoMessage,StreamUpdate>, Dictionary<ulong, Service.Stream>> ();
+        Dictionary<ulong, IClient<NoMessage, StreamUpdate>> removeStreams = new Dictionary<ulong, IClient<NoMessage, StreamUpdate>> ();
         ulong nextStreamId = 0;
 
         static Core instance;
@@ -95,7 +95,7 @@ namespace KRPC
         internal void StreamClientConnected (IClient<NoMessage,StreamUpdate> client)
         {
             streamClients [client.Guid] = client;
-            streams [client] = new Dictionary<ulong, Service.Stream> ();
+            streams [client] = new Dictionary<ulong, Service.Stream>();
         }
 
         internal void StreamClientDisconnected (IClient<NoMessage,StreamUpdate> client)
@@ -507,7 +507,7 @@ namespace KRPC
             for (int i = 0; i < Servers.Count; i++)
                 Servers [i].StreamServer.Update ();
 
-            if (removeStreams.Any()) {
+            if (removeStreams.Count > 0) {
                 foreach (var entry in removeStreams) {
                     Logger.WriteLine("Removing stream " + entry.Key, Logger.Severity.Debug);
                     RemoveStreamInternal(entry.Value, entry.Key);
@@ -559,7 +559,7 @@ namespace KRPC
                     }
                 }
                 CallContext.Clear ();
-                if (removeStreams.Any()) {
+                if (removeStreams.Count > 0) {
                     foreach (var entry in removeStreams) {
                         Logger.WriteLine("Removing stream as it returned an error", Logger.Severity.Debug);
                         RemoveStreamInternal(entry.Value, entry.Key);

--- a/core/src/Server/ProtocolBuffers/MessageExtensions.cs
+++ b/core/src/Server/ProtocolBuffers/MessageExtensions.cs
@@ -53,7 +53,8 @@ namespace KRPC.Server.ProtocolBuffers
         public static Schema.KRPC.StreamUpdate ToProtobufMessage (this StreamUpdate streamUpdate)
         {
             var result = new Schema.KRPC.StreamUpdate ();
-            result.Results.Add (streamUpdate.Results.Select (ToProtobufMessage));
+            foreach (var r in streamUpdate.Results)
+                result.Results.Add (r.ToProtobufMessage ());
             return result;
         }
 

--- a/core/src/Server/ProtocolBuffers/MessageExtensions.cs
+++ b/core/src/Server/ProtocolBuffers/MessageExtensions.cs
@@ -267,6 +267,7 @@ namespace KRPC.Server.ProtocolBuffers
             var result = new ProcedureCall (call.Service, call.ServiceId, call.Procedure, call.ProcedureId);
             try {
                 var procedureSignature = Service.Services.Instance.GetProcedureSignature (result);
+                result.CachedSignature = procedureSignature;
                 foreach (var argument in call.Arguments) {
                     var position = (int)argument.Position;
                     // Ignore the argument if its position is not valid

--- a/core/src/Server/ProtocolBuffers/StreamStream.cs
+++ b/core/src/Server/ProtocolBuffers/StreamStream.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using Google.Protobuf;
 using KRPC.Service.Messages;
 
@@ -6,6 +7,8 @@ namespace KRPC.Server.ProtocolBuffers
     sealed class StreamStream : Message.StreamStream
     {
         readonly CodedOutputStream codedOutputStream;
+        readonly Schema.KRPC.StreamUpdate protoStreamUpdate = new Schema.KRPC.StreamUpdate ();
+        readonly Dictionary<ulong, Schema.KRPC.StreamResult> protoResultCache = new Dictionary<ulong, Schema.KRPC.StreamResult> ();
 
         public StreamStream (IStream<byte,byte> stream) : base (stream)
         {
@@ -14,7 +17,27 @@ namespace KRPC.Server.ProtocolBuffers
 
         public override void Write (StreamUpdate value)
         {
-            codedOutputStream.WriteMessage (value.ToProtobufMessage ());
+            protoStreamUpdate.Results.Clear ();
+            var results = value.Results;
+            for (int i = 0; i < results.Count; i++) {
+                var r = results [i];
+                Schema.KRPC.StreamResult protoResult;
+                if (!protoResultCache.TryGetValue (r.Id, out protoResult)) {
+                    protoResult = new Schema.KRPC.StreamResult ();
+                    protoResult.Id = r.Id;
+                    protoResult.Result = new Schema.KRPC.ProcedureResult ();
+                    protoResultCache [r.Id] = protoResult;
+                }
+                var pr = protoResult.Result;
+                pr.Value = ByteString.Empty;
+                pr.Error = null;
+                if (r.Result.HasValue)
+                    pr.Value = Encoder.Encode (r.Result.Value);
+                else if (r.Result.HasError)
+                    pr.Error = r.Result.Error.ToProtobufMessage ();
+                protoStreamUpdate.Results.Add (protoResult);
+            }
+            codedOutputStream.WriteMessage (protoStreamUpdate);
             codedOutputStream.Flush ();
         }
     }

--- a/core/src/Server/ProtocolBuffers/StreamStream.cs
+++ b/core/src/Server/ProtocolBuffers/StreamStream.cs
@@ -1,13 +1,50 @@
 using System.Collections.Generic;
 using Google.Protobuf;
+using Google.Protobuf.Reflection;
 using KRPC.Service.Messages;
 
 namespace KRPC.Server.ProtocolBuffers
 {
     sealed class StreamStream : Message.StreamStream
     {
+        // A lightweight IMessage wrapper around a plain List<StreamResult>.
+        // Unlike RepeatedField<T>, List<T>.Clear() keeps its backing array,
+        // so we avoid a new T[] allocation on every tick.
+        sealed class StreamUpdateMessage : Google.Protobuf.IMessage
+        {
+            readonly List<Schema.KRPC.StreamResult> results = new List<Schema.KRPC.StreamResult> ();
+
+            public MessageDescriptor Descriptor { get { return null; } }
+
+            public void Add (Schema.KRPC.StreamResult result) { results.Add (result); }
+            public void Clear () { results.Clear (); }
+
+            public int CalculateSize ()
+            {
+                int size = 0;
+                for (int i = 0; i < results.Count; i++) {
+                    int rs = results [i].CalculateSize ();
+                    size += 1 + CodedOutputStream.ComputeLengthSize (rs) + rs;
+                }
+                return size;
+            }
+
+            public void WriteTo (CodedOutputStream output)
+            {
+                for (int i = 0; i < results.Count; i++) {
+                    output.WriteTag (1, WireFormat.WireType.LengthDelimited);
+                    output.WriteMessage (results [i]);
+                }
+            }
+
+            public void MergeFrom (CodedInputStream input)
+            {
+                throw new System.NotImplementedException ();
+            }
+        }
+
         readonly CodedOutputStream codedOutputStream;
-        readonly Schema.KRPC.StreamUpdate protoStreamUpdate = new Schema.KRPC.StreamUpdate ();
+        readonly StreamUpdateMessage streamUpdateMessage = new StreamUpdateMessage ();
         readonly Dictionary<ulong, Schema.KRPC.StreamResult> protoResultCache = new Dictionary<ulong, Schema.KRPC.StreamResult> ();
 
         public StreamStream (IStream<byte,byte> stream) : base (stream)
@@ -17,7 +54,7 @@ namespace KRPC.Server.ProtocolBuffers
 
         public override void Write (StreamUpdate value)
         {
-            protoStreamUpdate.Results.Clear ();
+            streamUpdateMessage.Clear ();
             var results = value.Results;
             for (int i = 0; i < results.Count; i++) {
                 var r = results [i];
@@ -35,9 +72,9 @@ namespace KRPC.Server.ProtocolBuffers
                     pr.Value = Encoder.Encode (r.Result.Value);
                 else if (r.Result.HasError)
                     pr.Error = r.Result.Error.ToProtobufMessage ();
-                protoStreamUpdate.Results.Add (protoResult);
+                streamUpdateMessage.Add (protoResult);
             }
-            codedOutputStream.WriteMessage (protoStreamUpdate);
+            codedOutputStream.WriteMessage (streamUpdateMessage);
             codedOutputStream.Flush ();
         }
     }

--- a/core/src/Server/TCP/TCPServer.cs
+++ b/core/src/Server/TCP/TCPServer.cs
@@ -327,6 +327,7 @@ namespace KRPC.Server.TCP
                     while (true) {
                         // Block until a client connects to the server
                         var client = tcpListener.AcceptTcpClient ();
+                        client.NoDelay = true;
                         Logger.WriteLine ("TCPServer.Listener: client requesting connection (" + client.Client.RemoteEndPoint + ")", Logger.Severity.Debug);
                         // Add to pending clients
                         lock (pendingClientsLock) {

--- a/core/src/Service/ClassMethodHandler.cs
+++ b/core/src/Service/ClassMethodHandler.cs
@@ -16,7 +16,6 @@ namespace KRPC.Service
     {
         readonly MethodInfo method;
         readonly ProcedureParameter[] parameters;
-        readonly object[] methodArguments;
 
         public ClassMethodHandler (Type classType, MethodInfo methodInfo, bool returnIsNullable)
         {
@@ -24,21 +23,18 @@ namespace KRPC.Service
             var parameterList = method.GetParameters ().Select (x => new ProcedureParameter (x)).ToList ();
             parameterList.Insert (0, new ProcedureParameter (classType, "this"));
             parameters = parameterList.ToArray ();
-            methodArguments = new object[parameters.Length - 1];
             ReturnIsNullable = returnIsNullable;
         }
+
+        public bool HasInstance { get => true;}
 
         /// <summary>
         /// Invokes a method on an object. The first parameter must be an the objects GUID, which is
         /// used to fetch the instance, and the remaining parameters are passed to the method.
         /// </summary>
-        public object Invoke (params object[] arguments)
+        public object Invoke (object instance, object[] arguments)
         {
-            object instance = arguments [0];
-            // TODO: should be able to invoke default arguments using Type.Missing, but get "System.ArgumentException : failed to convert parameters"
-            for (int i = 1; i < arguments.Length; i++)
-                methodArguments [i - 1] = (arguments [i] == Type.Missing) ? parameters [i].DefaultValue : arguments [i];
-            return method.Invoke (instance, methodArguments);
+            return method.Invoke (instance, arguments);
         }
 
         public IEnumerable<ProcedureParameter> Parameters {

--- a/core/src/Service/ClassMethodHandler.cs
+++ b/core/src/Service/ClassMethodHandler.cs
@@ -1,9 +1,8 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Linq.Expressions;
 using System.Reflection;
-using KRPC.Service.Attributes;
-using KRPC.Utils;
 
 namespace KRPC.Service
 {
@@ -14,37 +13,54 @@ namespace KRPC.Service
     /// </summary>
     sealed class ClassMethodHandler : IProcedureHandler
     {
-        readonly MethodInfo method;
+        readonly Func<object, object[], object> invoker;
         readonly ProcedureParameter[] parameters;
 
         public ClassMethodHandler (Type classType, MethodInfo methodInfo, bool returnIsNullable)
         {
-            method = methodInfo;
-            var parameterList = method.GetParameters ().Select (x => new ProcedureParameter (x)).ToList ();
+            invoker = BuildInvoker (classType, methodInfo);
+            var parameterList = methodInfo.GetParameters ().Select (x => new ProcedureParameter (x)).ToList ();
             parameterList.Insert (0, new ProcedureParameter (classType, "this"));
             parameters = parameterList.ToArray ();
+            ReturnType = methodInfo.ReturnType;
             ReturnIsNullable = returnIsNullable;
         }
 
-        public bool HasInstance { get => true;}
+        public bool HasInstance { get => true; }
 
         /// <summary>
-        /// Invokes a method on an object. The first parameter must be an the objects GUID, which is
-        /// used to fetch the instance, and the remaining parameters are passed to the method.
+        /// Invokes a method on an object. The first parameter must be the object's instance,
+        /// and the remaining parameters are passed to the method.
         /// </summary>
         public object Invoke (object instance, object[] arguments)
         {
-            return method.Invoke (instance, arguments);
+            return invoker (instance, arguments);
         }
 
         public IEnumerable<ProcedureParameter> Parameters {
             get { return parameters; }
         }
 
-        public Type ReturnType {
-            get { return method.ReturnType; }
-        }
+        public Type ReturnType { get; private set; }
 
         public bool ReturnIsNullable { get; private set; }
+
+        static Func<object, object[], object> BuildInvoker (Type classType, MethodInfo method)
+        {
+            var instanceParam = Expression.Parameter (typeof(object), "instance");
+            var argsParam = Expression.Parameter (typeof(object[]), "args");
+            var castInstance = Expression.Convert (instanceParam, classType);
+            var methodParams = method.GetParameters ();
+            var argExprs = new Expression [methodParams.Length];
+            for (int i = 0; i < methodParams.Length; i++)
+                argExprs [i] = Expression.Convert (
+                    Expression.ArrayIndex (argsParam, Expression.Constant (i)),
+                    methodParams [i].ParameterType);
+            Expression call = Expression.Call (castInstance, method, argExprs);
+            Expression body = method.ReturnType == typeof(void)
+                ? (Expression)Expression.Block (call, Expression.Constant (null, typeof(object)))
+                : Expression.Convert (call, typeof(object));
+            return Expression.Lambda<Func<object, object[], object>> (body, instanceParam, argsParam).Compile ();
+        }
     }
 }

--- a/core/src/Service/ClassStaticMethodHandler.cs
+++ b/core/src/Service/ClassStaticMethodHandler.cs
@@ -13,25 +13,22 @@ namespace KRPC.Service
     {
         readonly MethodInfo method;
         readonly ProcedureParameter[] parameters;
-        readonly object[] methodArguments;
 
         public ClassStaticMethodHandler (MethodInfo methodInfo, bool returnIsNullable)
         {
             method = methodInfo;
             parameters = method.GetParameters ().Select (x => new ProcedureParameter (x)).ToArray ();
-            methodArguments = new object[parameters.Length];
             ReturnIsNullable = returnIsNullable;
         }
+
+        public bool HasInstance { get => false; }
 
         /// <summary>
         /// Invokes the static method.
         /// </summary>
-        public object Invoke (params object[] arguments)
+        public object Invoke (object instance, object [] arguments)
         {
-            // TODO: should be able to invoke default arguments using Type.Missing, but get "System.ArgumentException : failed to convert parameters"
-            for (int i = 0; i < arguments.Length; i++)
-                methodArguments [i] = (arguments [i] == Type.Missing) ? parameters [i].DefaultValue : arguments [i];
-            return method.Invoke (null, methodArguments);
+            return method.Invoke (instance, arguments);
         }
 
         public IEnumerable<ProcedureParameter> Parameters {

--- a/core/src/Service/ClassStaticMethodHandler.cs
+++ b/core/src/Service/ClassStaticMethodHandler.cs
@@ -1,23 +1,24 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Linq.Expressions;
 using System.Reflection;
 
 namespace KRPC.Service
 {
     /// <summary>
     /// Used to invoke a static method with the KRPCMethod attribute.
-    /// Invoke() and runs the static method.
     /// </summary>
     sealed class ClassStaticMethodHandler : IProcedureHandler
     {
-        readonly MethodInfo method;
+        readonly Func<object, object[], object> invoker;
         readonly ProcedureParameter[] parameters;
 
         public ClassStaticMethodHandler (MethodInfo methodInfo, bool returnIsNullable)
         {
-            method = methodInfo;
-            parameters = method.GetParameters ().Select (x => new ProcedureParameter (x)).ToArray ();
+            invoker = BuildInvoker (methodInfo);
+            parameters = methodInfo.GetParameters ().Select (x => new ProcedureParameter (x)).ToArray ();
+            ReturnType = methodInfo.ReturnType;
             ReturnIsNullable = returnIsNullable;
         }
 
@@ -28,17 +29,32 @@ namespace KRPC.Service
         /// </summary>
         public object Invoke (object instance, object [] arguments)
         {
-            return method.Invoke (instance, arguments);
+            return invoker (instance, arguments);
         }
 
         public IEnumerable<ProcedureParameter> Parameters {
             get { return parameters; }
         }
 
-        public Type ReturnType {
-            get { return method.ReturnType; }
-        }
+        public Type ReturnType { get; private set; }
 
         public bool ReturnIsNullable { get; private set; }
+
+        static Func<object, object[], object> BuildInvoker (MethodInfo method)
+        {
+            var instanceParam = Expression.Parameter (typeof(object), "instance");
+            var argsParam = Expression.Parameter (typeof(object[]), "args");
+            var methodParams = method.GetParameters ();
+            var argExprs = new Expression [methodParams.Length];
+            for (int i = 0; i < methodParams.Length; i++)
+                argExprs [i] = Expression.Convert (
+                    Expression.ArrayIndex (argsParam, Expression.Constant (i)),
+                    methodParams [i].ParameterType);
+            Expression call = Expression.Call (method, argExprs);
+            Expression body = method.ReturnType == typeof(void)
+                ? (Expression)Expression.Block (call, Expression.Constant (null, typeof(object)))
+                : Expression.Convert (call, typeof(object));
+            return Expression.Lambda<Func<object, object[], object>> (body, instanceParam, argsParam).Compile ();
+        }
     }
 }

--- a/core/src/Service/IProcedureHandler.cs
+++ b/core/src/Service/IProcedureHandler.cs
@@ -9,11 +9,17 @@ namespace KRPC.Service
     public interface IProcedureHandler
     {
         /// <summary>
-        /// Invoke the RPC with the given arguments.
-        /// If the RPC is a class method, the first argument should
-        /// be an instance of the class.
+        /// Whether the RPC is a class instance method or a
+        /// static/standalone procedure
         /// </summary>
-        object Invoke (params object[] arguments);
+        bool HasInstance { get; }
+
+        /// <summary>
+        /// Invoke the RPC with the given arguments.
+        /// Pass the class instance in <paramref name="instance"/>
+        /// for class methods, or null for static procedures.
+        /// </summary>
+        object Invoke (object instance, object[] arguments);
 
         /// <summary>
         /// Information about the parameters of the method

--- a/core/src/Service/KRPC/Expression.cs
+++ b/core/src/Service/KRPC/Expression.cs
@@ -112,17 +112,26 @@ namespace KRPC.Service.KRPC
             if (!procedure.HasReturnType)
                 throw new InvalidOperationException(
                     "Cannot use a procedure that does not return a value.");
-            var arguments = services.GetArguments(procedure, call.Arguments);
+            var allArguments = services.GetArguments(procedure, call.Arguments);
+            object instance = null;
+            object[] arguments;
+            if (procedure.Handler.HasInstance) {
+                instance = allArguments[0];
+                arguments = allArguments.Skip(1).ToArray();
+            } else {
+                arguments = allArguments;
+            }
 
             var servicesExpr = LinqExpression.Constant(services);
             var executeCallMethod = typeof(Services).GetMethod(
-                "ExecuteCall", new[] { typeof(Scanner.ProcedureSignature), typeof(object[]) });
+                "ExecuteCall", new[] { typeof(Scanner.ProcedureSignature), typeof(object), typeof(object[]) });
             var procedureExpr = LinqExpression.Constant(procedure);
+            var instanceExpr = LinqExpression.Constant(instance, typeof(object));
             var argumentsExpr = LinqExpression.Constant(arguments);
 
             var result = LinqExpression.Call(
                 servicesExpr, executeCallMethod,
-                new[] { procedureExpr, argumentsExpr });
+                new[] { procedureExpr, instanceExpr, argumentsExpr });
             var value = LinqExpression.Convert(
                 LinqExpression.Property(result, "Value"), procedure.ReturnType);
             return new Expression(value);

--- a/core/src/Service/Messages/ProcedureCall.cs
+++ b/core/src/Service/Messages/ProcedureCall.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using KRPC.Service.Scanner;
 
 namespace KRPC.Service.Messages
 {
@@ -14,6 +15,8 @@ namespace KRPC.Service.Messages
         public uint ProcedureId { get; private set; }
 
         public IList<Argument> Arguments { get; private set; }
+
+        internal ProcedureSignature CachedSignature { get; set; }
 
         public ProcedureCall (string service, string procedure)
         {

--- a/core/src/Service/Messages/ProcedureResult.cs
+++ b/core/src/Service/Messages/ProcedureResult.cs
@@ -26,5 +26,13 @@ namespace KRPC.Service.Messages
         object value_;
 
         Error error;
+
+        public void Reset ()
+        {
+            value_ = null;
+            HasValue = false;
+            error = null;
+            HasError = false;
+        }
     }
 }

--- a/core/src/Service/Messages/StreamUpdate.cs
+++ b/core/src/Service/Messages/StreamUpdate.cs
@@ -5,7 +5,7 @@ namespace KRPC.Service.Messages
     #pragma warning disable 1591
     public class StreamUpdate : IMessage
     {
-        public IList<StreamResult> Results { get; private set; }
+        public List<StreamResult> Results { get; private set; }
 
         public StreamUpdate ()
         {

--- a/core/src/Service/ObjectStore.cs
+++ b/core/src/Service/ObjectStore.cs
@@ -36,8 +36,9 @@ namespace KRPC.Service
         {
             if (obj == null)
                 return 0;
-            if (instances.ContainsKey (obj))
-                return instances [obj];
+            ulong existingId;
+            if (instances.TryGetValue (obj, out existingId))
+                return existingId;
             var objectId = nextObjectId;
             nextObjectId++;
             instances [obj] = objectId;
@@ -53,8 +54,8 @@ namespace KRPC.Service
         {
             if (obj == null)
                 return;
-            if (instances.ContainsKey (obj)) {
-                var objectId = instances [obj];
+            ulong objectId;
+            if (instances.TryGetValue (obj, out objectId)) {
                 instances.Remove (obj);
                 objectIds.Remove (objectId);
             }
@@ -67,9 +68,10 @@ namespace KRPC.Service
         {
             if (id == 0ul)
                 return null;
-            if (!objectIds.ContainsKey (id))
+            object result;
+            if (!objectIds.TryGetValue (id, out result))
                 throw new ArgumentException ("Instance not found");
-            return objectIds [id];
+            return result;
         }
 
         /// <summary>
@@ -79,9 +81,10 @@ namespace KRPC.Service
         {
             if (obj == null)
                 return 0;
-            if (!instances.ContainsKey (obj))
+            ulong id;
+            if (!instances.TryGetValue (obj, out id))
                 throw new ArgumentException ("Instance not found");
-            return instances [obj];
+            return id;
         }
     }
 }

--- a/core/src/Service/ProcedureCallContinuation.cs
+++ b/core/src/Service/ProcedureCallContinuation.cs
@@ -18,7 +18,7 @@ namespace KRPC.Service
         {
             call = procedureCall;
             try {
-                Procedure = Services.Instance.GetProcedureSignature (call);
+                Procedure = procedureCall.CachedSignature ?? Services.Instance.GetProcedureSignature (call);
             } catch (RPCException e) {
                 exception = e;
             } catch (System.Exception e) {

--- a/core/src/Service/ProcedureCallContinuation.cs
+++ b/core/src/Service/ProcedureCallContinuation.cs
@@ -48,6 +48,28 @@ namespace KRPC.Service
             }
         }
 
+        /// <summary>
+        /// Like Run() but writes the result into an existing ProcedureResult instead of
+        /// allocating a new one. Throws YieldException if the call yields (result is unchanged).
+        /// </summary>
+        public void RunInto (ProcedureResult result)
+        {
+            var services = Services.Instance;
+            if (exception != null) {
+                result.Reset ();
+                result.Error = services.HandleException (exception);
+                return;
+            }
+            try {
+                if (continuation == null)
+                    services.ExecuteCallInto (Procedure, call, result);
+                else
+                    services.ExecuteCallInto (Procedure, continuation, result);
+            } catch (YieldException e) {
+                throw new YieldException<ProcedureCallContinuation> (new ProcedureCallContinuation (Procedure, () => e.CallUntyped ()));
+            }
+        }
+
         public ProcedureSignature Procedure {
             get; private set;
         }

--- a/core/src/Service/ProcedureCallContinuation.cs
+++ b/core/src/Service/ProcedureCallContinuation.cs
@@ -11,7 +11,6 @@ namespace KRPC.Service
     sealed class ProcedureCallContinuation /*: Continuation<ProcedureResult>*/
     {
         readonly ProcedureCall call;
-        readonly ProcedureSignature procedure;
         readonly System.Exception exception;
         readonly Func<object> continuation;
 
@@ -19,7 +18,7 @@ namespace KRPC.Service
         {
             call = procedureCall;
             try {
-                procedure = Services.Instance.GetProcedureSignature (call);
+                Procedure = Services.Instance.GetProcedureSignature (call);
             } catch (RPCException e) {
                 exception = e;
             } catch (System.Exception e) {
@@ -29,7 +28,7 @@ namespace KRPC.Service
 
         ProcedureCallContinuation (ProcedureSignature invokedProcedure, Func<object> currentContinuation)
         {
-            procedure = invokedProcedure;
+            Procedure = invokedProcedure;
             continuation = currentContinuation;
         }
 
@@ -40,17 +39,17 @@ namespace KRPC.Service
               return new ProcedureResult { Error = services.HandleException (exception) };
             try {
                 if (continuation == null)
-                    return services.ExecuteCall(procedure, call);
-                return services.ExecuteCall(procedure, continuation);
+                    return services.ExecuteCall(Procedure, call);
+                return services.ExecuteCall(Procedure, continuation);
             }
             catch (YieldException e)
             {
-                throw new YieldException<ProcedureCallContinuation>(new ProcedureCallContinuation(procedure, () => e.CallUntyped()));
+                throw new YieldException<ProcedureCallContinuation>(new ProcedureCallContinuation(Procedure, () => e.CallUntyped()));
             }
         }
 
         public ProcedureSignature Procedure {
-            get { return procedure; }
+            get; private set;
         }
     };
 }

--- a/core/src/Service/ProcedureCallStream.cs
+++ b/core/src/Service/ProcedureCallStream.cs
@@ -38,14 +38,30 @@ namespace KRPC.Service
         }
 
         public override void UpdateInternal() {
-            try  {
-                Result = continuation.Run ();
+            var result = StreamResult.Result;
+            bool wasSet = result.HasValue;
+            object oldValue = result.Value;
+
+            try {
+                continuation.RunInto (result);
             } catch (YieldException) {
                 return;
             } catch (System.Exception e) {
-                Result = new ProcedureResult {
-                    Error = Service.Services.Instance.HandleException (e)
-                };
+                result.Reset ();
+                result.Error = Service.Services.Instance.HandleException (e);
+                Changed = true;
+                return;
+            }
+
+            if (result.HasValue) {
+                if (!wasSet)
+                    Changed = true;
+                else if (!ReferenceEquals (result.Value, null))
+                    Changed |= !ValueUtils.Equal (result.Value, oldValue);
+                else
+                    Changed |= !ReferenceEquals (oldValue, null);
+            } else {
+                Changed |= result.HasError;
             }
         }
     }

--- a/core/src/Service/ProcedureHandler.cs
+++ b/core/src/Service/ProcedureHandler.cs
@@ -12,22 +12,19 @@ namespace KRPC.Service
     {
         readonly MethodInfo method;
         readonly ProcedureParameter[] parameters;
-        readonly object[] methodArguments;
 
         public ProcedureHandler (MethodInfo methodInfo, bool returnIsNullable)
         {
             method = methodInfo;
             parameters = method.GetParameters ().Select (x => new ProcedureParameter (x)).ToArray ();
-            methodArguments = new object[parameters.Length];
             ReturnIsNullable = returnIsNullable;
         }
 
-        public object Invoke (params object[] arguments)
+        public bool HasInstance { get => false; }
+
+        public object Invoke (object instance, object[] arguments)
         {
-            // TODO: should be able to invoke default arguments using Type.Missing, but get "System.ArgumentException : failed to convert parameters"
-            for (int i = 0; i < arguments.Length; i++)
-                methodArguments [i] = (arguments [i] == Type.Missing) ? parameters [i].DefaultValue : arguments [i];
-            return method.Invoke (null, methodArguments);
+            return method.Invoke (instance, arguments);
         }
 
         public IEnumerable<ProcedureParameter> Parameters {

--- a/core/src/Service/ProcedureHandler.cs
+++ b/core/src/Service/ProcedureHandler.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Linq.Expressions;
 using System.Reflection;
 
 namespace KRPC.Service
@@ -10,13 +11,14 @@ namespace KRPC.Service
     /// </summary>
     sealed class ProcedureHandler : IProcedureHandler
     {
-        readonly MethodInfo method;
+        readonly Func<object, object[], object> invoker;
         readonly ProcedureParameter[] parameters;
 
         public ProcedureHandler (MethodInfo methodInfo, bool returnIsNullable)
         {
-            method = methodInfo;
-            parameters = method.GetParameters ().Select (x => new ProcedureParameter (x)).ToArray ();
+            invoker = BuildInvoker (methodInfo);
+            parameters = methodInfo.GetParameters ().Select (x => new ProcedureParameter (x)).ToArray ();
+            ReturnType = methodInfo.ReturnType;
             ReturnIsNullable = returnIsNullable;
         }
 
@@ -24,17 +26,32 @@ namespace KRPC.Service
 
         public object Invoke (object instance, object[] arguments)
         {
-            return method.Invoke (instance, arguments);
+            return invoker (instance, arguments);
         }
 
         public IEnumerable<ProcedureParameter> Parameters {
             get { return parameters; }
         }
 
-        public Type ReturnType {
-            get { return method.ReturnType; }
-        }
+        public Type ReturnType { get; private set; }
 
         public bool ReturnIsNullable { get; private set; }
+
+        static Func<object, object[], object> BuildInvoker (MethodInfo method)
+        {
+            var instanceParam = Expression.Parameter (typeof(object), "instance");
+            var argsParam = Expression.Parameter (typeof(object[]), "args");
+            var methodParams = method.GetParameters ();
+            var argExprs = new Expression [methodParams.Length];
+            for (int i = 0; i < methodParams.Length; i++)
+                argExprs [i] = Expression.Convert (
+                    Expression.ArrayIndex (argsParam, Expression.Constant (i)),
+                    methodParams [i].ParameterType);
+            Expression call = Expression.Call (method, argExprs);
+            Expression body = method.ReturnType == typeof(void)
+                ? (Expression)Expression.Block (call, Expression.Constant (null, typeof(object)))
+                : Expression.Convert (call, typeof(object));
+            return Expression.Lambda<Func<object, object[], object>> (body, instanceParam, argsParam).Compile ();
+        }
     }
 }

--- a/core/src/Service/Services.cs
+++ b/core/src/Service/Services.cs
@@ -55,9 +55,10 @@ namespace KRPC.Service
             string service = call.Service;
             if (call.ServiceId > 0)
                 service = GetServiceNameById (call.ServiceId);
-            if (!Signatures.ContainsKey (service))
+            ServiceSignature serviceSignature;
+            if (!Signatures.TryGetValue (service, out serviceSignature))
                 throw new RPCException ("Service \"" + service + "\" not found");
-            return Signatures [service];
+            return serviceSignature;
         }
 
         public ProcedureSignature GetProcedureSignature (ProcedureCall call)
@@ -67,29 +68,35 @@ namespace KRPC.Service
             string procedure = call.Procedure;
             if (call.ProcedureId > 0)
                 procedure = GetProcedureNameById (service, call.ProcedureId);
-            if (!serviceSignature.Procedures.ContainsKey (procedure))
+            ProcedureSignature procedureSignature;
+            if (!serviceSignature.Procedures.TryGetValue (procedure, out procedureSignature))
                 throw new RPCException ("Procedure \"" + procedure + "\" not found, in service \"" + service + "\"");
-            return serviceSignature.Procedures [procedure];
+            return procedureSignature;
         }
 
-        string GetServiceNameById (uint id) {
-            if (!ServicesById.ContainsKey (id))
+        string GetServiceNameById (uint id)
+        {
+            ServiceSignature sig;
+            if (!ServicesById.TryGetValue (id, out sig))
                 throw new RPCException ("Service with id " + id + " not found");
-            return ServicesById [id].Name;
+            return sig.Name;
         }
 
         string GetProcedureNameById (string service, uint procedureId)
         {
-            if (!ProceduresById.ContainsKey (service))
+            IDictionary<uint, ProcedureSignature> procedures;
+            if (!ProceduresById.TryGetValue (service, out procedures))
                 throw new RPCException ("Service \"" + service + "\" not found");
-            if (!ProceduresById [service].ContainsKey (procedureId))
+            ProcedureSignature sig;
+            if (!procedures.TryGetValue (procedureId, out sig))
                 throw new RPCException ("Procedure with id " + procedureId + " not found");
-            return ProceduresById [service] [procedureId].Name;
+            return sig.Name;
         }
 
         public Type GetMappedExceptionType (Type exnType)
         {
-            return MappedExceptionTypes.ContainsKey(exnType) ? MappedExceptionTypes [exnType] : exnType;
+            Type mappedType;
+            return MappedExceptionTypes.TryGetValue (exnType, out mappedType) ? mappedType : exnType;
         }
 
         /// <summary>

--- a/core/src/Service/Services.cs
+++ b/core/src/Service/Services.cs
@@ -135,14 +135,7 @@ namespace KRPC.Service
             try {
                 if ((CallContext.GameScene & procedure.GameScene) == 0)
                     throw new RPCException ("Procedure not available in game scene '" + GameSceneUtils.Name(CallContext.GameScene) + "'");
-                object returnValue;
-                try {
-                    returnValue = procedure.Handler.Invoke (instance, arguments);
-                } catch (TargetInvocationException e) {
-                    if (e.InnerException is YieldException)
-                        throw e.InnerException;
-                    throw new RPCException (e.InnerException);
-                }
+                object returnValue = procedure.Handler.Invoke (instance, arguments);
                 var result = new ProcedureResult ();
                 if (procedure.HasReturnType) {
                     CheckReturnValue (procedure, returnValue);

--- a/core/src/Service/Services.cs
+++ b/core/src/Service/Services.cs
@@ -175,6 +175,69 @@ namespace KRPC.Service
         }
 
         /// <summary>
+        /// Like ExecuteCall(procedure, call) but writes the result into an existing
+        /// ProcedureResult instead of allocating a new one.
+        /// Throws YieldException if the procedure yields (result is unchanged).
+        /// </summary>
+        internal void ExecuteCallInto (ProcedureSignature procedure, ProcedureCall call, ProcedureResult result)
+        {
+            SetArguments (procedure, call.Arguments);
+            ExecuteCallInto (procedure, instanceBuffer, argumentBuffer, result);
+        }
+
+        void ExecuteCallInto (ProcedureSignature procedure, object instance, object[] arguments, ProcedureResult result)
+        {
+            object returnValue;
+            try {
+                if ((CallContext.GameScene & procedure.GameScene) == 0)
+                    throw new RPCException ("Procedure not available in game scene '" + GameSceneUtils.Name (CallContext.GameScene) + "'");
+                returnValue = procedure.Handler.Invoke (instance, arguments);
+            } catch (YieldException) {
+                throw;
+            } catch (RPCException e) {
+                result.Reset ();
+                result.Error = HandleException (e);
+                return;
+            } catch (System.Exception e) {
+                result.Reset ();
+                result.Error = HandleException (e);
+                return;
+            }
+            result.Reset ();
+            if (procedure.HasReturnType) {
+                try {
+                    CheckReturnValue (procedure, returnValue);
+                } catch (RPCException e) {
+                    result.Error = HandleException (e);
+                    return;
+                }
+                result.Value = returnValue;
+            }
+        }
+
+        /// <summary>
+        /// Like ExecuteCall(procedure, continuation) but writes into an existing ProcedureResult.
+        /// Throws YieldException if the continuation yields (result is unchanged).
+        /// Throws RPCException on error (result is unchanged; caller must handle).
+        /// </summary>
+        internal void ExecuteCallInto (ProcedureSignature procedure, Func<object> continuation, ProcedureResult result)
+        {
+            object returnValue;
+            try {
+                returnValue = continuation ();
+            } catch (YieldException) {
+                throw;
+            } catch (System.Exception e) {
+                throw new RPCException (e);
+            }
+            result.Reset ();
+            if (procedure.HasReturnType) {
+                CheckReturnValue (procedure, returnValue);
+                result.Value = returnValue;
+            }
+        }
+
+        /// <summary>
         /// Set the arguments for a procedure handler from a list of argument messages.
         /// </summary>
         public void SetArguments(ProcedureSignature procedure, IList<Argument> arguments)

--- a/core/src/Service/Services.cs
+++ b/core/src/Service/Services.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
+using System.Linq;
 using System.Reflection;
 using KRPC.Service.Messages;
 using KRPC.Service.Scanner;
@@ -97,10 +98,17 @@ namespace KRPC.Service
         /// Throws RPCException if the call fails.
         /// </summary>
 
+        static object instanceBuffer;
+        static object[] argumentBuffer;
+        const int argumentBufferCacheSize = 16;
+        readonly static object[][] argumentBuffers = Enumerable.Range(0, argumentBufferCacheSize).Select(i => new object[i]).ToArray();
+
         public ProcedureResult ExecuteCall (ProcedureSignature procedure, ProcedureCall call)
         {
-            try {
-                return ExecuteCall (procedure, GetArguments (procedure, call.Arguments));
+            try
+            {
+                SetArguments(procedure, call.Arguments);
+                return ExecuteCall (procedure, instanceBuffer, argumentBuffer);
             } catch (YieldException) {
                 throw;
             } catch (RPCException e) {
@@ -115,14 +123,14 @@ namespace KRPC.Service
         /// Throws YieldException, containing a continuation, if the call yields.
         /// Throws RPCException if the call fails.
         /// </summary>
-        public ProcedureResult ExecuteCall (ProcedureSignature procedure, object[] arguments)
+        public ProcedureResult ExecuteCall (ProcedureSignature procedure, object instance, object[] arguments)
         {
             try {
                 if ((CallContext.GameScene & procedure.GameScene) == 0)
                     throw new RPCException ("Procedure not available in game scene '" + GameSceneUtils.Name(CallContext.GameScene) + "'");
                 object returnValue;
                 try {
-                    returnValue = procedure.Handler.Invoke (arguments);
+                    returnValue = procedure.Handler.Invoke (instance, arguments);
                 } catch (TargetInvocationException e) {
                     if (e.InnerException is YieldException)
                         throw e.InnerException;
@@ -167,9 +175,69 @@ namespace KRPC.Service
         }
 
         /// <summary>
-        /// Get the arguments for a procedure from a list of argument messages.
+        /// Set the arguments for a procedure handler from a list of argument messages.
         /// </summary>
-        public object[] GetArguments (ProcedureSignature procedure, IList<Argument> arguments)
+        public void SetArguments(ProcedureSignature procedure, IList<Argument> arguments)
+        {
+            instanceBuffer = null;
+            argumentBuffer = null;
+
+            var numParameters = procedure.Parameters.Count;
+            if (numParameters == 0)
+                return;
+
+            var hasInstance = procedure.Handler.HasInstance;
+            var numArguments = hasInstance ? numParameters - 1 : numParameters;
+
+            if (numArguments > 0)
+            {
+                if (numArguments < argumentBufferCacheSize)
+                    argumentBuffer = argumentBuffers[numArguments];
+                else
+                    argumentBuffer = new object[numArguments];
+            }
+
+            int filledMask = 0;
+            foreach (var argument in arguments)
+            {
+                var position = argument.Position;
+                var value = argument.Value;
+                var parameter = procedure.Parameters[(int)position];
+                var type = parameter.Type;
+                if (value != null && !type.IsInstanceOfType (value))
+                    throw new RPCException (
+                        "Incorrect argument type for parameter " + parameter.Name + " in " + procedure.FullyQualifiedName + ". " +
+                        "Expected an argument of type " + type + ", got " + value.GetType ());
+                if (value == null && !TypeUtils.IsAClassType (type))
+                    throw new RPCException (
+                        "Incorrect argument type for parameter " + parameter.Name + " in " + procedure.FullyQualifiedName + ". " +
+                        "Expected an argument of type " + type + ", got null");
+                if (hasInstance && position == 0)
+                    instanceBuffer = value;
+                else
+                {
+                    int bufferIndex = hasInstance ? (int)position - 1 : (int)position;
+                    argumentBuffer[bufferIndex] = value;
+                    filledMask |= (1 << bufferIndex);
+                }
+            }
+            // Fill unset slots with default values. Type.Missing does not work on Mono.
+            for (int i = 0; i < numArguments; i++)
+            {
+                if ((filledMask & (1 << i)) == 0)
+                {
+                    var parameter = procedure.Parameters[hasInstance ? i + 1 : i];
+                    if (!parameter.HasDefaultValue)
+                        throw new RPCException ("Argument not specified for parameter " + parameter.Name + " in " + procedure.FullyQualifiedName);
+                    argumentBuffer[i] = parameter.DefaultValue;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Get the arguments for a procedure handler from a list of argument messages.
+        /// </summary>
+        public object[] GetArguments(ProcedureSignature procedure, IList<Argument> arguments)
         {
             // Get list of supplied argument values and whether they were set
             var numParameters = procedure.Parameters.Count;

--- a/core/src/Service/StreamContinuation.cs
+++ b/core/src/Service/StreamContinuation.cs
@@ -47,5 +47,26 @@ namespace KRPC.Service
                 throw;
             }
         }
+
+        /// <summary>
+        /// Like Run() but writes the result into an existing ProcedureResult instead of
+        /// allocating a new one. Throws YieldException if the call yields (result is unchanged).
+        /// </summary>
+        public void RunInto (ProcedureResult result)
+        {
+            if (continuation == null)
+                throw new InvalidOperationException (
+                    "The stream continuation threw an exception previously and cannot be re-run");
+            try {
+                continuation.RunInto (result);
+                continuation = originalContinuation;
+            } catch (YieldException<ProcedureCallContinuation> e) {
+                continuation = e.Value;
+                throw new YieldException<StreamContinuation> (this);
+            } catch (System.Exception) {
+                continuation = null;
+                throw;
+            }
+        }
     }
 }

--- a/core/test/Service/ClassMethodHandlerTest.cs
+++ b/core/test/Service/ClassMethodHandlerTest.cs
@@ -15,7 +15,7 @@ namespace KRPC.Test.Service
             var instance = new TestService.TestClass ("foo");
             var classType = typeof(TestService.TestClass);
             var handler = new ClassMethodHandler (classType, classType.GetMethod ("FloatToString"), false);
-            Assert.AreEqual ("foo3.14159", handler.Invoke (new object[] { instance, 3.14159f }));
+            Assert.AreEqual ("foo3.14159", handler.Invoke (instance, new object[] { 3.14159f }));
         }
 
         [Test]
@@ -24,7 +24,7 @@ namespace KRPC.Test.Service
             var instance = new TestService.TestClass ("foo");
             var classType = typeof(TestService.TestClass);
             var handler = new ClassMethodHandler (classType, classType.GetMethod ("IntToString"), false);
-            Assert.AreEqual ("foo42", handler.Invoke (new object[] { instance, Type.Missing }));
+            Assert.AreEqual ("foo42", handler.Invoke (instance, new object [] { Type.Missing }));
         }
 
         [Test]
@@ -32,7 +32,7 @@ namespace KRPC.Test.Service
         {
             var classType = typeof(TestService.TestClass);
             var handler = new ClassMethodHandler (classType, classType.GetMethod ("FloatToString"), false);
-            Assert.Throws<TargetException> (() => handler.Invoke (new object[] { null, 3.14159f }));
+            Assert.Throws<TargetException> (() => handler.Invoke (null, new object[] { Type.Missing }));
         }
 
         [Test]

--- a/core/test/Service/ClassMethodHandlerTest.cs
+++ b/core/test/Service/ClassMethodHandlerTest.cs
@@ -24,7 +24,7 @@ namespace KRPC.Test.Service
             var instance = new TestService.TestClass ("foo");
             var classType = typeof(TestService.TestClass);
             var handler = new ClassMethodHandler (classType, classType.GetMethod ("IntToString"), false);
-            Assert.AreEqual ("foo42", handler.Invoke (instance, new object [] { Type.Missing }));
+            Assert.AreEqual ("foo42", handler.Invoke (instance, new object [] { 42 }));
         }
 
         [Test]
@@ -32,7 +32,7 @@ namespace KRPC.Test.Service
         {
             var classType = typeof(TestService.TestClass);
             var handler = new ClassMethodHandler (classType, classType.GetMethod ("FloatToString"), false);
-            Assert.Throws<TargetException> (() => handler.Invoke (null, new object[] { Type.Missing }));
+            Assert.Throws<NullReferenceException> (() => handler.Invoke (null, new object[] { 3.14159f }));
         }
 
         [Test]

--- a/core/test/Service/ProcedureHandlerTest.cs
+++ b/core/test/Service/ProcedureHandlerTest.cs
@@ -29,7 +29,7 @@ namespace KRPC.Test.Service
         public void DefaultArguments ()
         {
             var handler = new ProcedureHandler (typeof(ProcedureHandlerTest).GetMethod ("TestProcedureWithDefaultArg"), false);
-            Assert.AreEqual ("42foo", handler.Invoke (null, new object[] { 42, Type.Missing }));
+            Assert.AreEqual ("42foo", handler.Invoke (null, new object[] { 42, "foo" }));
         }
 
         [Test]

--- a/core/test/Service/ProcedureHandlerTest.cs
+++ b/core/test/Service/ProcedureHandlerTest.cs
@@ -22,14 +22,14 @@ namespace KRPC.Test.Service
         public void SimpleUsage ()
         {
             var handler = new ProcedureHandler (typeof(ProcedureHandlerTest).GetMethod ("TestProcedure"), false);
-            Assert.AreEqual (3.14159f, handler.Invoke (new object[] { 3, 0.14159f }));
+            Assert.AreEqual (3.14159f, handler.Invoke (null, new object[] { 3, 0.14159f } ));
         }
 
         [Test]
         public void DefaultArguments ()
         {
             var handler = new ProcedureHandler (typeof(ProcedureHandlerTest).GetMethod ("TestProcedureWithDefaultArg"), false);
-            Assert.AreEqual ("42foo", handler.Invoke (new object[] { 42, Type.Missing }));
+            Assert.AreEqual ("42foo", handler.Invoke (null, new object[] { 42, Type.Missing }));
         }
 
         [Test]

--- a/server/CHANGES.txt
+++ b/server/CHANGES.txt
@@ -1,6 +1,7 @@
 v0.6.0
  * Fix server version reported to clients (read from KRPC.dll not KRPC.Core.dll)
  * Fix Logger to write to both KSP.log and Player.log (#780)
+ * Fix Stream RPCs Executed and Stream RPC Rate always showing 0 in the info window
 
 v0.5.4
  * Fix memory leaks when switching game scene (#779)

--- a/server/CHANGES.txt
+++ b/server/CHANGES.txt
@@ -1,7 +1,8 @@
 v0.6.0
  * Fix server version reported to clients (read from KRPC.dll not KRPC.Core.dll)
  * Fix Logger to write to both KSP.log and Player.log (#780)
- * Fix Stream RPCs Executed and Stream RPC Rate always showing 0 in the info window
+ * Improve RPC and stream update performance (#879)
+ * Fix Stream RPCs Executed and Stream RPC Rate always showing 0 in the info window (#879)
 
 v0.5.4
  * Fix memory leaks when switching game scene (#779)

--- a/tools/TestServer/src/Program.cs
+++ b/tools/TestServer/src/Program.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Diagnostics;
 using System.Net;
+using System.Threading;
 using System.Reflection;
 using KRPC;
 using KRPC.Server;
@@ -193,7 +194,14 @@ namespace TestServer
                         Console.WriteLine ("Fast by " + diffTime + " ms (" + diffTicks + " ticks)");
                 }
 
-                // Wait, to force 60 FPS
+                // Wait, to force 60 FPS — sleep most of the remaining time rather than
+                // spinning, so the process doesn't burn a core during profiling/benchmarks.
+                var remainingTicks = ticksPerUpdate - timer.ElapsedTicks;
+                if (remainingTicks > Stopwatch.Frequency / 1000) {
+                    var sleepMs = (int)(remainingTicks * 1000L / Stopwatch.Frequency) - 1;
+                    if (sleepMs > 0)
+                        Thread.Sleep (sleepMs);
+                }
                 while (timer.ElapsedTicks < ticksPerUpdate) {
                 }
                 update++;

--- a/tools/profiling/benchmark.py
+++ b/tools/profiling/benchmark.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""
+Benchmark script for the kRPC TestServer hot path.
+
+Connects to a running TestServer and hammers it with RPC calls to measure
+throughput and give the Mono profiler something to sink its teeth into.
+
+Usage:
+    tools/profiling/benchmark.py [--rpc-port PORT] [--iterations N]
+
+Typical workflow:
+    # Terminal 1: start the profiled server
+    tools/profiling/run-profiled.sh -- --rpc-port=50000 --stream-port=50001
+
+    # Terminal 2: run the benchmark
+    tools/profiling/benchmark.py
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+import time
+
+import krpc
+
+
+def bench(label: str, fn, iterations: int) -> float:
+    # Warmup
+    for _ in range(min(1000, iterations // 10)):
+        fn()
+
+    start = time.perf_counter()
+    for _ in range(iterations):
+        fn()
+    elapsed = time.perf_counter() - start
+
+    rps = iterations / elapsed
+    us = elapsed / iterations * 1e6
+    print(f"  {label:<40s}  {rps:>10.0f} RPC/s  {us:>8.2f} µs/call")
+    return rps
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="kRPC TestServer benchmark")
+    parser.add_argument("--rpc-port", type=int, default=50000)
+    parser.add_argument("--stream-port", type=int, default=50001)
+    parser.add_argument("--iterations", type=int, default=50_000,
+                        help="RPC calls per benchmark (default: 50000)")
+    args = parser.parse_args()
+
+    print(f"Connecting to TestServer on port {args.rpc_port}...")
+    try:
+        conn = krpc.connect(
+            name="benchmark",
+            address="127.0.0.1",
+            rpc_port=args.rpc_port,
+            stream_port=args.stream_port,
+        )
+    except Exception as e:
+        print(f"Failed to connect: {e}", file=sys.stderr)
+        print("Is the TestServer running?", file=sys.stderr)
+        sys.exit(1)
+
+    ts = conn.test_service
+    n = args.iterations
+
+    print(f"\nRunning {n:,} iterations per benchmark...\n")
+
+    bench("int32_to_string(42)",      lambda: ts.int32_to_string(42),       n)
+    bench("float_to_string(3.14)",   lambda: ts.float_to_string(3.14),     n)
+    bench("enum_return()",           lambda: ts.enum_return(),              n)
+    bench("counter()",               lambda: ts.counter(),                  n)
+
+    # Initialise the property so the getter doesn't error.
+    ts.string_property = "hello"
+
+    def set_string():
+        ts.string_property = "x"
+
+    bench("string_property get",     lambda: ts.string_property,           n)
+    bench("string_property set",     set_string,                           n)
+
+    obj = ts.create_test_object("prof")
+    bench("object.get_value()",      lambda: obj.get_value(),              n)
+
+    def set_int():
+        obj.int_property = 7
+
+    bench("object.int_property get", lambda: obj.int_property,             n)
+    bench("object.int_property set", set_int,                              n)
+
+    conn.close()
+    print("\nDone.")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/profiling/run-benchmark.sh
+++ b/tools/profiling/run-benchmark.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# Run throughput and allocation benchmarks against a freshly-built TestServer.
+# Outputs results to stdout; also writes profile data to PROFILE_OUT.
+#
+# Usage:
+#   tools/profiling/run-benchmark.sh [label]
+#
+# Environment:
+#   PROFILE_OUT   - path for mono profiler output  (default: /tmp/krpc-profile-<label>.mlpd)
+#   PYTHON        - python interpreter with krpc installed
+#   RPC_PORT      - RPC port (default: 50000)
+#   STREAM_PORT   - stream port (default: 50001)
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+LABEL="${1:-run}"
+RPC_PORT="${RPC_PORT:-50000}"
+STREAM_PORT="${STREAM_PORT:-50001}"
+PYTHON="${PYTHON:-$REPO_ROOT/env/bin/python}"
+PROFILE_OUT="${PROFILE_OUT:-/tmp/krpc-profile-${LABEL}.mlpd}"
+BENCH_ITERS="${BENCH_ITERS:-100000}"
+
+echo ""
+echo "=========================================="
+echo " kRPC benchmark — ${LABEL}"
+echo "=========================================="
+echo ""
+
+echo "==> Building TestServer..."
+bazel build //tools/TestServer 2>&1 | tail -3
+
+# Set up a flat runfiles dir (needed so mono can find all DLLs)
+RUNDIR="$(mktemp -d)"
+trap 'rm -rf "$RUNDIR"; kill "$SERVER_PID" 2>/dev/null || true' EXIT
+
+MANIFEST="$REPO_ROOT/bazel-bin/tools/TestServer/TestServer.runfiles_manifest"
+while IFS=' ' read -r _key src; do
+    case "$src" in
+        *.dll|*.exe|*.xml|*.mdb)
+            ln -sf "$src" "$RUNDIR/$(basename "$src")"
+            ;;
+    esac
+done < "$MANIFEST"
+
+# ---- Throughput benchmark (no profiler) ----
+echo ""
+echo "--- Throughput (${BENCH_ITERS} iterations each) ---"
+echo ""
+
+cd "$RUNDIR"
+/usr/bin/mono TestServer.exe --rpc-port="$RPC_PORT" --stream-port="$STREAM_PORT" --quiet \
+    >"$RUNDIR/server.log" 2>&1 &
+SERVER_PID=$!
+
+# Wait for the server to start
+for i in $(seq 1 20); do
+    sleep 0.5
+    if grep -q "Server started successfully" "$RUNDIR/server.log" 2>/dev/null; then
+        break
+    fi
+    if ! kill -0 "$SERVER_PID" 2>/dev/null; then
+        echo "ERROR: Server failed to start. Log:" >&2
+        cat "$RUNDIR/server.log" >&2
+        exit 1
+    fi
+done
+
+cd "$REPO_ROOT"
+"$PYTHON" tools/profiling/benchmark.py \
+    --rpc-port="$RPC_PORT" --stream-port="$STREAM_PORT" \
+    --iterations="$BENCH_ITERS"
+
+kill "$SERVER_PID" 2>/dev/null || true
+wait "$SERVER_PID" 2>/dev/null || true
+
+# ---- Allocation benchmark (mono log profiler, alloc mode) ----
+echo ""
+echo "--- Allocation profile (${BENCH_ITERS} iterations) ---"
+echo ""
+
+cd "$RUNDIR"
+/usr/bin/mono --profile="log:output=$PROFILE_OUT,alloc,nodefaults" \
+    TestServer.exe --rpc-port="$RPC_PORT" --stream-port="$STREAM_PORT" --quiet \
+    >"$RUNDIR/server-profiled.log" 2>&1 &
+SERVER_PID=$!
+
+for i in $(seq 1 20); do
+    sleep 0.5
+    if grep -q "Server started successfully" "$RUNDIR/server-profiled.log" 2>/dev/null; then
+        break
+    fi
+    if ! kill -0 "$SERVER_PID" 2>/dev/null; then
+        echo "ERROR: Profiled server failed to start. Log:" >&2
+        cat "$RUNDIR/server-profiled.log" >&2
+        exit 1
+    fi
+done
+
+cd "$REPO_ROOT"
+"$PYTHON" tools/profiling/benchmark.py \
+    --rpc-port="$RPC_PORT" --stream-port="$STREAM_PORT" \
+    --iterations="$BENCH_ITERS"
+
+kill "$SERVER_PID" 2>/dev/null || true
+wait "$SERVER_PID" 2>/dev/null || true
+
+echo ""
+echo "==> Profiler output written to: $PROFILE_OUT"
+echo ""
+echo "==> Top allocating types:"
+mprof-report --traces --top=30 "$PROFILE_OUT" 2>/dev/null | \
+    awk '/^Allocation:/,/^$/' | head -40 || \
+    mprof-report "$PROFILE_OUT" 2>/dev/null | grep -A 40 "Allocation summary" | head -45 || \
+    echo "(mprof-report parsing failed — check $PROFILE_OUT directly)"

--- a/tools/profiling/run-profiled.sh
+++ b/tools/profiling/run-profiled.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Run TestServer under the Mono log profiler and write a report.
+#
+# Usage:
+#   tools/profiling/run-profiled.sh [-- TestServer args...]
+#
+# After the server exits (Ctrl-C), mprof-report prints the profile summary.
+#
+# Profile modes (set PROFILE_MODE env var, default: sample):
+#   sample  - statistical sampling (low overhead, good for hot-path discovery)
+#   calls   - exact call counting + alloc tracking (high overhead, accurate)
+#
+# Example:
+#   PROFILE_MODE=calls tools/profiling/run-profiled.sh -- --rpc-port=50000 --stream-port=50001
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+PROFILE_OUT="${PROFILE_OUT:-/tmp/krpc-profile.mlpd}"
+PROFILE_MODE="${PROFILE_MODE:-sample}"
+
+echo "==> Building TestServer..."
+bazel build //tools/TestServer >/dev/null 2>&1
+
+RUNDIR="$(mktemp -d)"
+trap 'rm -rf "$RUNDIR"' EXIT
+
+# Read the runfiles manifest to symlink all needed assemblies into a flat dir.
+# This mirrors what the Bazel launcher script does, but keeps the dir around
+# until we've finished profiling.
+MANIFEST="$REPO_ROOT/bazel-bin/tools/TestServer/TestServer.runfiles_manifest"
+while IFS=' ' read -r _key src; do
+    case "$src" in
+        *.dll|*.exe|*.xml|*.mdb)
+            ln -sf "$src" "$RUNDIR/$(basename "$src")"
+            ;;
+    esac
+done < "$MANIFEST"
+
+case "$PROFILE_MODE" in
+    sample)
+        # sample=real: wall-clock SIGPROF sampling, low overhead, good for hot-path discovery
+        PROFILE_OPTS="log:output=$PROFILE_OUT,sample=real"
+        ;;
+    calls)
+        # calls + alloc: exact call counts and allocation tracking; high overhead
+        PROFILE_OPTS="log:output=$PROFILE_OUT,calls,alloc"
+        ;;
+    *)
+        echo "Unknown PROFILE_MODE '$PROFILE_MODE'. Use 'sample' or 'calls'." >&2
+        exit 1
+        ;;
+esac
+
+echo "==> Profile output: $PROFILE_OUT"
+echo "==> Mode: $PROFILE_MODE"
+echo "==> Run a benchmark in another terminal:"
+echo "      tools/profiling/benchmark.py        (RPC throughput)"
+echo "      tools/profiling/stream-benchmark.py (streaming throughput)"
+echo "==> Press Ctrl-C to stop the server and generate the report."
+echo ""
+
+cd "$RUNDIR"
+echo "TestServer.exe $@"
+/usr/bin/mono --profile="$PROFILE_OPTS" TestServer.exe "$@" || true
+
+echo ""
+echo "==> Generating profile report..."
+mprof-report "$PROFILE_OUT"

--- a/tools/profiling/stream-benchmark.py
+++ b/tools/profiling/stream-benchmark.py
@@ -1,0 +1,237 @@
+#!/usr/bin/env python3
+"""
+Benchmark streaming RPC throughput for the kRPC TestServer hot path.
+
+Measures server-side stream update rate and client-side read overhead
+across different numbers of concurrent streams.
+
+The server runs at 60 FPS, so the maximum possible stream update rate
+is ~60 StreamUpdate messages/second regardless of the number of streams.
+Each message bundles all changed results for a tick into one payload.
+
+Usage:
+    tools/profiling/stream-benchmark.py [--rpc-port PORT] [--measure-secs N]
+
+Typical workflow:
+    # Terminal 1: start the profiled server
+    tools/profiling/run-profiled.sh -- --rpc-port=50000 --stream-port=50001
+
+    # Terminal 2: run the stream benchmark
+    tools/profiling/stream-benchmark.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import threading
+import time
+
+import krpc
+
+WARMUP_SECS = 2.0
+
+
+def bench_update_rate(
+    label: str,
+    conn: krpc.client.Client,
+    num_streams: int,
+    measure_secs: float,
+) -> float:
+    """
+    Add num_streams changing streams and count StreamUpdate messages/sec.
+
+    Each stream tracks counter(id='sN'), which increments every evaluation,
+    so the value always changes and the server always sends an update each tick.
+    All N results are bundled in one StreamUpdate message per server tick.
+
+    Returns StreamUpdate messages/sec.
+    """
+    ts = conn.test_service
+
+    count = 0
+    lock = threading.Lock()
+
+    def on_update() -> None:
+        nonlocal count
+        with lock:
+            count += 1
+
+    # Use distinct counter IDs so each becomes a separate stream on the server.
+    streams = [conn.add_stream(ts.counter, id=f"sb{i}") for i in range(num_streams)]
+    conn.add_stream_update_callback(on_update)
+    for s in streams:
+        s.start(wait=False)
+
+    # Warmup — let the EMA on the server stabilise before measuring.
+    time.sleep(WARMUP_SECS)
+    with lock:
+        count = 0
+
+    t0 = time.perf_counter()
+    time.sleep(measure_secs)
+    elapsed = time.perf_counter() - t0
+
+    with lock:
+        n = count
+
+    conn.remove_stream_update_callback(on_update)
+    for s in streams:
+        s.remove()
+
+    ups = n / elapsed
+    us = elapsed / n * 1e6 if n > 0 else float("inf")
+    print(f"  {label:<45s}  {ups:>6.1f} updates/s  {us:>7.1f} µs/update  ({n:,} total)")
+    return ups
+
+
+def bench_server_time(
+    label: str,
+    conn: krpc.client.Client,
+    num_streams: int,
+    measure_secs: float,
+) -> None:
+    """
+    Add num_streams *static* streams and report the server's
+    time_per_stream_update after the measurement window.
+
+    Static streams use float_to_string(3.14) — the value never changes so
+    the server evaluates the procedure but sends no updates.  This isolates
+    the cost of procedure execution + change-detection from serialisation.
+    """
+    ts = conn.test_service
+
+    streams = [conn.add_stream(ts.float_to_string, 3.14) for _ in range(num_streams)]
+    for s in streams:
+        s.start(wait=False)
+
+    time.sleep(WARMUP_SECS)
+
+    # Accumulate server-reported time_per_stream_update over the window.
+    samples: list[float] = []
+    t_end = time.perf_counter() + measure_secs
+    while time.perf_counter() < t_end:
+        samples.append(conn.krpc.get_status().time_per_stream_update)
+        time.sleep(0.1)
+
+    for s in streams:
+        s.remove()
+
+    if samples:
+        avg_us = sum(samples) / len(samples) * 1e6
+        print(f"  {label:<45s}  server time_per_stream_update: {avg_us:>6.1f} µs/tick")
+    else:
+        print(f"  {label:<45s}  (no samples)")
+
+
+def bench_poll_rate(
+    label: str,
+    conn: krpc.client.Client,
+    num_streams: int,
+    iterations: int,
+) -> None:
+    """
+    Read cached stream values in a tight loop; measures client-side overhead.
+
+    This does not stress the server beyond whatever update rate it already runs
+    at — it only measures how fast the Python client can read the most-recently-
+    cached value for a stream (lock + attribute access).
+    """
+    ts = conn.test_service
+
+    streams = [conn.add_stream(ts.counter, id=f"pr{i}") for i in range(num_streams)]
+    for s in streams:
+        s.start(wait=True)
+
+    # Warmup
+    for _ in range(min(1000, iterations // 10)):
+        for s in streams:
+            s()
+
+    total = 0
+    reads_per_iter = num_streams
+    iters_needed = iterations // reads_per_iter
+    t0 = time.perf_counter()
+    for _ in range(iters_needed):
+        for s in streams:
+            s()
+        total += reads_per_iter
+    elapsed = time.perf_counter() - t0
+
+    for s in streams:
+        s.remove()
+
+    rps = total / elapsed
+    us = elapsed / total * 1e6
+    print(f"  {label:<45s}  {rps:>10.0f} reads/s  {us:>6.2f} µs/read")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="kRPC TestServer streaming benchmark")
+    parser.add_argument("--rpc-port", type=int, default=50000)
+    parser.add_argument("--stream-port", type=int, default=50001)
+    parser.add_argument(
+        "--measure-secs",
+        type=float,
+        default=10.0,
+        help="Seconds per update-rate benchmark (default: 10)",
+    )
+    parser.add_argument(
+        "--iterations",
+        type=int,
+        default=100_000,
+        help="Total cached-value reads for the poll benchmark (default: 100000)",
+    )
+    args = parser.parse_args()
+
+    print(f"Connecting to TestServer on port {args.rpc_port}...")
+    try:
+        conn = krpc.connect(
+            name="stream-benchmark",
+            address="127.0.0.1",
+            rpc_port=args.rpc_port,
+            stream_port=args.stream_port,
+        )
+    except Exception as e:
+        print(f"Failed to connect: {e}", file=sys.stderr)
+        print("Is the TestServer running?", file=sys.stderr)
+        sys.exit(1)
+
+    n = args.measure_secs
+
+    # ------------------------------------------------------------------ #
+    # Section 1: stream update rate (StreamUpdate messages/sec)           #
+    # Server is the bottleneck here; this exercises the full stream path: #
+    #   evaluate procedures → detect changes → serialise → send           #
+    # ------------------------------------------------------------------ #
+    print(f"\nStream update rate ({n:.0f}s per run):\n")
+    for num in [1, 8, 32, 128, 256, 512]:
+        s = "stream" if num == 1 else "streams"
+        bench_update_rate(f"{num} changing {s}", conn, num, n)
+
+    # ------------------------------------------------------------------ #
+    # Section 2: server time per tick with static streams (no sends)      #
+    # Procedure is evaluated every tick but value never changes, so the   #
+    # server skips serialisation. Isolates evaluation + change-check cost.#
+    # ------------------------------------------------------------------ #
+    print(f"\nServer time per tick — static streams ({n:.0f}s per run):\n")
+    bench_server_time("0 streams (baseline)", conn, 0, n)
+    for num in [1, 16, 256, 512]:
+        s = "stream" if num == 1 else "streams"
+        bench_server_time(f"{num} static {s}", conn, num, n)
+
+    # ------------------------------------------------------------------ #
+    # Section 3: client-side cached-read rate                             #
+    # Pure Python overhead of calling stream() to read the cached value.  #
+    # ------------------------------------------------------------------ #
+    print(f"\nClient-side cached read rate:\n")
+    for num in [1, 16, 256, 512]:
+        s = "stream" if num == 1 else "streams"
+        bench_poll_rate(f"{num} {s}", conn, num, args.iterations)
+
+    conn.close()
+    print("\nDone.")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/profiling/stress-test.py
+++ b/tools/profiling/stress-test.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+"""
+Continuous RPC stress-test against the kRPC in-game server.
+
+Hammers a set of lightweight RPCs in a tight loop until stopped with Ctrl-C.
+Watch RPC/s on the kRPC in-game window; this script also prints a local count
+every few seconds so you can cross-check.
+
+Usage:
+    tools/profiling/stress-test.py [--host HOST] [--rpc-port PORT] [--stream-port PORT]
+
+The script adapts to the current game state:
+  - Space Center / any scene: calls basic RPCs (ut, game scene, paused)
+  - Flight scene with active vessel: also calls vessel and flight RPCs
+If the game state changes (scene switch, vessel loss), the RPC set is rebuilt
+automatically without restarting the script.
+"""
+from __future__ import annotations
+
+import argparse
+import signal
+import sys
+import time
+from typing import Callable
+
+import krpc
+from krpc.error import RPCError
+
+
+REPORT_INTERVAL = 2.0  # seconds between local RPC/s prints
+
+
+def build_rpc_list(conn: krpc.client.Client) -> tuple[list[Callable[[], object]], str]:
+    """
+    Probe the current game state and return (callables, description).
+    Never raises — skips any RPC that errors during probing.
+    """
+    rpcs: list[Callable[[], object]] = []
+    labels: list[str] = []
+
+    kr = conn.krpc
+    sc = conn.space_center
+
+    # Always available
+    rpcs.append(kr.get_status)
+    labels.append("krpc.get_status")
+
+    rpcs.append(lambda: kr.current_game_scene)
+    labels.append("krpc.current_game_scene")
+
+    rpcs.append(lambda: kr.paused)
+    labels.append("krpc.paused")
+
+    # Space-center-level properties (available outside main menu)
+    try:
+        _ = sc.ut
+        rpcs.append(lambda: sc.ut)
+        labels.append("space_center.ut")
+
+        rpcs.append(lambda: sc.warp_factor)
+        labels.append("space_center.warp_factor")
+
+        rpcs.append(lambda: sc.warp_mode)
+        labels.append("space_center.warp_mode")
+    except RPCError:
+        pass
+
+    # Active vessel (flight scene)
+    vessel = None
+    try:
+        vessel = sc.active_vessel
+    except RPCError:
+        pass
+
+    if vessel is not None:
+        try:
+            _ = vessel.name
+            rpcs.append(lambda: vessel.name)          # type: ignore[union-attr]
+            labels.append("vessel.name")
+
+            rpcs.append(lambda: vessel.met)           # type: ignore[union-attr]
+            labels.append("vessel.met")
+
+            rpcs.append(lambda: vessel.mass)          # type: ignore[union-attr]
+            labels.append("vessel.mass")
+
+            rpcs.append(lambda: vessel.situation)     # type: ignore[union-attr]
+            labels.append("vessel.situation")
+        except RPCError:
+            vessel = None
+
+    if vessel is not None:
+        try:
+            flight = vessel.flight()
+            rpcs.append(lambda: flight.mean_altitude)
+            labels.append("flight.mean_altitude")
+
+            rpcs.append(lambda: flight.surface_altitude)
+            labels.append("flight.surface_altitude")
+
+            rpcs.append(lambda: flight.speed)
+            labels.append("flight.speed")
+
+            rpcs.append(lambda: flight.velocity)
+            labels.append("flight.velocity")
+        except RPCError:
+            pass
+
+    desc = f"{len(rpcs)} RPCs: [{', '.join(labels)}]"
+    return rpcs, desc
+
+
+def stress_loop(conn: krpc.client.Client) -> None:
+    rpcs, desc = build_rpc_list(conn)
+    print(f"RPC set: {desc}")
+    print("Running — Ctrl-C to stop.\n")
+
+    total = 0
+    total_at_last_report = 0
+    errors = 0
+    t_report = time.perf_counter()
+
+    while True:
+        for fn in rpcs:
+            try:
+                fn()
+                total += 1
+            except RPCError:
+                errors += 1
+                # Game state changed — rebuild the RPC list
+                try:
+                    rpcs, desc = build_rpc_list(conn)
+                    print(f"\nRPC set changed: {desc}")
+                except Exception:
+                    raise  # propagate connection errors
+
+        now = time.perf_counter()
+        if now - t_report >= REPORT_INTERVAL:
+            elapsed = now - t_report
+            rps = (total - total_at_last_report) / elapsed
+            total_at_last_report = total
+            t_report = now
+            label = f"{rps:>9,.0f} RPC/s"
+            if errors:
+                label += f"  ({errors} errors since start)"
+            print(f"\r{label}", end="", flush=True)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Continuous RPC stress-test for the kRPC in-game server"
+    )
+    parser.add_argument("--host", default="127.0.0.1",
+                        help="kRPC server host (default: 127.0.0.1)")
+    parser.add_argument("--rpc-port", type=int, default=50000,
+                        help="RPC port (default: 50000)")
+    parser.add_argument("--stream-port", type=int, default=50001,
+                        help="Stream port (default: 50001)")
+    args = parser.parse_args()
+
+    # Clean exit on Ctrl-C without a traceback
+    signal.signal(signal.SIGINT, lambda *_: sys.exit(0))
+
+    print(f"Connecting to kRPC server at {args.host}:{args.rpc_port} ...")
+    try:
+        conn = krpc.connect(
+            name="stress-test",
+            address=args.host,
+            rpc_port=args.rpc_port,
+            stream_port=args.stream_port,
+        )
+    except Exception as exc:
+        print(f"Failed to connect: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    print(f"Connected (server version {conn.krpc.get_status().version}).\n")
+
+    try:
+        stress_loop(conn)
+    except (ConnectionResetError, OSError) as exc:
+        print(f"\nConnection lost: {exc}", file=sys.stderr)
+        sys.exit(1)
+    finally:
+        conn.close()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Reduce RPC call overhead and stream updates through a series of targeted hot-path improvements.

### RPC call path
- **Replace `MethodInfo.Invoke` with compiled expression-tree delegates** — eliminates reflection overhead on every RPC call; delegates are compiled once and cached per procedure
- **Pre-allocate shared RPC argument buffers** — avoids per-call heap allocation when unpacking procedure arguments
- **Cache `ProcedureSignature` on `ProcedureCall`** — removes a second dictionary lookup on every RPC dispatch
- **Replace `ContainsKey` + `[]` double lookups with `TryGetValue`** in `ObjectStore` and `Services` — halves dictionary probe count on the hot path
- **Set `TCP_NODELAY` on connections** — reduces round-trip latency by disabling Nagle buffering

### Stream update path
- **Avoid LINQ and interface-dispatch overhead** in the per-tick stream update loop — removes unnecessary allocations
- **Reuse `ProcedureResult` instance per stream** — avoids allocating a new object each tick
- **Cache `StreamUpdate` and `Schema.KRPC.StreamResult` objects per client** — avoids per-tick allocation
- **Replace `Schema.KRPC.StreamUpdate` with a `List`-backed `IMessage`** — avoids array reallocation on every tick

### Bug fix
- **Fix stream RPCs Executed counter not incrementing** — Stream RPCs Executed and Stream RPC Rate were always showing 0 in the info window

### Profiling & benchmarking tools (`tools/profiling/`)
- `benchmark.py` — measures RPC call throughput (calls/sec) against a running TestServer instance
- `stream-benchmark.py` — measures stream update throughput (updates/sec)
- `stress-test.py` — sustained load test to surface GC pauses and memory pressure under continuous RPC + stream traffic
- `run-profiled.sh` — launches TestServer under the Mono log profiler and collects allocation and call-graph data

## Benchmark results

Tested on Mono 6.8, loopback TCP, 100000 calls per benchmark.

### RPC throughput

| Benchmark | Before | After | Δ |
|-----------|--------|-------|---|
| `int32_to_string(42)` | 37 219 /s | 38 204 /s | +2.6 % |
| `float_to_string(3.14)` | 38 081 /s | 39 853 /s | +4.7 % |
| `enum_return()` | 44 031 /s | 45 967 /s | +4.4 % |
| `counter()` | 33 469 /s | 35 836 /s | +7.1 % |
| `string_property get` | 46 886 /s | 47 555 /s | +1.4 % |
| `string_property set` | 43 950 /s | 45 759 /s | +4.1 % |
| `object.get_value()` | 38 462 /s | 40 054 /s | +4.1 % |
| `object.int_property get` | 38 304 /s | 40 900 /s | +6.8 % |
| `object.int_property set` | 38 218 /s | 40 147 /s | +5.0 % |

**~4–7 % throughput improvement** across all call types.

### Heap allocations eliminated per RPC call

Measured with the Mono allocation profiler (`--profile=log:alloc,nodefaults`) over ~909 000 RPC calls.

| Type | Before | After | Change |
|------|--------|-------|--------|
| `System.Object[]` (argument boxing for `MethodInfo.Invoke`) | ~1.0 / call | 0 | **−1 per call** |
| `System.Reflection.RuntimeParameterInfo[]` (reflection parameter metadata) | ~0.4 / call | 0 | **−0.4 per call** |

**~1.5 fewer heap allocations per RPC call.** The remaining allocations (protobuf messages, continuations) are inherent to the request/response path and were not targeted by this PR.

### Stream update path — allocations eliminated per tick

Code changes verified by inspection (stream tick rate is capped at 60 fps so throughput improvement is not directly measurable):

  | Before (per stream per tick) | After |
  |------------------------------|-------|
  | 1 × `ProcedureResult` (new each tick) | reused — cached on `ProcedureCallStream` |
  | 1 × `Schema.KRPC.StreamResult` (new each tick) | reused — cached per stream |
  | 1 × `Schema.KRPC.StreamUpdate` / `StreamUpdate` list (new each tick) | reused — `List`-backed, reset and reused per tick |
  | 1 × LINQ `SelectListIterator` in stream dispatch loop | removed — replaced with direct `for` loop |

