### PR TITLE
Reference frame improvements and fixes

### DIFF
--- a/doc/order.txt
+++ b/doc/order.txt
@@ -309,6 +309,8 @@ SpaceCenter.Flight.Heading
 SpaceCenter.Flight.Roll
 SpaceCenter.Flight.Prograde
 SpaceCenter.Flight.Retrograde
+SpaceCenter.Flight.SurfacePrograde
+SpaceCenter.Flight.SurfaceRetrograde
 SpaceCenter.Flight.Normal
 SpaceCenter.Flight.AntiNormal
 SpaceCenter.Flight.Radial

--- a/doc/order.txt
+++ b/doc/order.txt
@@ -1138,6 +1138,7 @@ SpaceCenter.Node.Remove
 SpaceCenter.Node.ReferenceFrame
 SpaceCenter.Node.OrbitalReferenceFrame
 SpaceCenter.Node.Position
+SpaceCenter.Node.Rotation
 SpaceCenter.Node.Direction
 SpaceCenter.ReferenceFrame
 SpaceCenter.ReferenceFrame.CreateRelative

--- a/service/SpaceCenter/CHANGES.txt
+++ b/service/SpaceCenter/CHANGES.txt
@@ -1,4 +1,5 @@
 v0.6.0
+ * Fix LookRotation2 producing NaN for rotations near 180° by using Shepperd's method
  * Fix ReferenceFrame.CreateHybrid using velocity frame's angular velocity instead of the angularVelocity frame
  * Fix PartCenterOfMass reference frame throwing InvalidOperationException on velocity transforms
  * Fix Maneuver reference frame forward-vector fallback using unnormalized burn vector in collinearity check

--- a/service/SpaceCenter/CHANGES.txt
+++ b/service/SpaceCenter/CHANGES.txt
@@ -1,4 +1,5 @@
 v0.6.0
+ * Fix angular velocity for VesselSurface, VesselSurfaceVelocity, CelestialBodyOrbital, ManeuverOrbital, Part, PartCenterOfMass, DockingPort and Thrust reference frames (previously returned zero)
  * Fix LookRotation2 producing NaN for rotations near 180° by using Shepperd's method
  * Fix VesselSurfaceVelocity reference frame producing NaN when surface velocity is near zero; now throws InvalidOperationException
  * Fix ReferenceFrame.CreateHybrid using velocity frame's angular velocity instead of the angularVelocity frame

--- a/service/SpaceCenter/CHANGES.txt
+++ b/service/SpaceCenter/CHANGES.txt
@@ -1,4 +1,5 @@
 v0.6.0
+ * Fix ReferenceFrame.CreateHybrid using velocity frame's angular velocity instead of the angularVelocity frame
  * Fix Engine.Propellants failing for non-active mode on multi-mode engines with different propellants (#833)
  * Make LaunchVessel crew parameter non-optional to work around protocol issue (#824)
  * Fix Part.DecoupledAt not considering if a decoupler is enabled (#818)

--- a/service/SpaceCenter/CHANGES.txt
+++ b/service/SpaceCenter/CHANGES.txt
@@ -1,5 +1,6 @@
 v0.6.0
  * Fix LookRotation2 producing NaN for rotations near 180° by using Shepperd's method
+ * Fix VesselSurfaceVelocity reference frame producing NaN when surface velocity is near zero; now throws InvalidOperationException
  * Fix ReferenceFrame.CreateHybrid using velocity frame's angular velocity instead of the angularVelocity frame
  * Fix PartCenterOfMass reference frame throwing InvalidOperationException on velocity transforms
  * Fix Maneuver reference frame forward-vector fallback using unnormalized burn vector in collinearity check

--- a/service/SpaceCenter/CHANGES.txt
+++ b/service/SpaceCenter/CHANGES.txt
@@ -28,6 +28,7 @@ v0.6.0
  * Add Engine.CanReverseThrust, Engine.ThrustReversed and Engine.ToggleThrustReversal to control thrust reversal on stock and recognized mod engines (#865)
  * Add Control.ThrustReversers to engage/disengage thrust reversers on all engines (#865)
  * Add Control.GetActionGroupActions to list the part actions assigned to an action group (#864)
+ * Add Node.Rotation
 
 v0.5.4
  * Fix vessel recovery (#782)

--- a/service/SpaceCenter/CHANGES.txt
+++ b/service/SpaceCenter/CHANGES.txt
@@ -2,6 +2,7 @@ v0.6.0
  * Fix ReferenceFrame.CreateHybrid using velocity frame's angular velocity instead of the angularVelocity frame
  * Fix PartCenterOfMass reference frame throwing InvalidOperationException on velocity transforms
  * Fix Maneuver reference frame forward-vector fallback using unnormalized burn vector in collinearity check
+ * Fix Flight.AngleOfAttack and Flight.SideslipAngle treating dot product as radians instead of using asin
  * Fix Engine.Propellants failing for non-active mode on multi-mode engines with different propellants (#833)
  * Make LaunchVessel crew parameter non-optional to work around protocol issue (#824)
  * Fix Part.DecoupledAt not considering if a decoupler is enabled (#818)

--- a/service/SpaceCenter/CHANGES.txt
+++ b/service/SpaceCenter/CHANGES.txt
@@ -1,5 +1,6 @@
 v0.6.0
  * Fix ReferenceFrame.CreateHybrid using velocity frame's angular velocity instead of the angularVelocity frame
+ * Fix PartCenterOfMass reference frame throwing InvalidOperationException on velocity transforms
  * Fix Engine.Propellants failing for non-active mode on multi-mode engines with different propellants (#833)
  * Make LaunchVessel crew parameter non-optional to work around protocol issue (#824)
  * Fix Part.DecoupledAt not considering if a decoupler is enabled (#818)

--- a/service/SpaceCenter/CHANGES.txt
+++ b/service/SpaceCenter/CHANGES.txt
@@ -1,6 +1,7 @@
 v0.6.0
  * Fix ReferenceFrame.CreateHybrid using velocity frame's angular velocity instead of the angularVelocity frame
  * Fix PartCenterOfMass reference frame throwing InvalidOperationException on velocity transforms
+ * Fix Maneuver reference frame forward-vector fallback using unnormalized burn vector in collinearity check
  * Fix Engine.Propellants failing for non-active mode on multi-mode engines with different propellants (#833)
  * Make LaunchVessel crew parameter non-optional to work around protocol issue (#824)
  * Fix Part.DecoupledAt not considering if a decoupler is enabled (#818)

--- a/service/SpaceCenter/CHANGES.txt
+++ b/service/SpaceCenter/CHANGES.txt
@@ -1,4 +1,5 @@
 v0.6.0
+ * Fix Maneuver and ManeuverOrbital reference frame velocity (previously returned zero; now returns the orbital velocity at the node UT)
  * Fix angular velocity for VesselSurface, VesselSurfaceVelocity, CelestialBodyOrbital, ManeuverOrbital, Part, PartCenterOfMass, DockingPort and Thrust reference frames (previously returned zero)
  * Fix LookRotation2 producing NaN for rotations near 180° by using Shepperd's method
  * Fix VesselSurfaceVelocity reference frame producing NaN when surface velocity is near zero; now throws InvalidOperationException

--- a/service/SpaceCenter/CHANGES.txt
+++ b/service/SpaceCenter/CHANGES.txt
@@ -12,6 +12,7 @@ v0.6.0
  * Fix Part.DecoupledAt not considering if a decoupler is enabled (#818)
  * Guard ContractManager against null ContractSystem in non-career game modes (#819)
  * Fix waypoint mean altitude not including bedrock height (#801)
+ * Add Flight.SurfacePrograde and Flight.SurfaceRetrograde direction vectors (surface-relative velocity direction, matching navball surface mode) (#582)
  * Add Flight.SimulateAerodynamicTorqueAt (#825)
  * Add Control.AeroSurfaces to enable/disable pitch, yaw and roll on all control surfaces (#827)
  * Add Control.EngineGimbals to enable/disable gimbal on all gimballed engines (#827)

--- a/service/SpaceCenter/CHANGES.txt
+++ b/service/SpaceCenter/CHANGES.txt
@@ -30,6 +30,7 @@ v0.6.0
  * Add Control.GetActionGroupActions to list the part actions assigned to an action group (#864)
  * Add Node.Rotation
  * Fix Vessel/Part/Hybrid reference frame rotation precision
+ * Fix VesselOrbital reference frame angular velocity (missing Coriolis correction) (#823)
 
 v0.5.4
  * Fix vessel recovery (#782)

--- a/service/SpaceCenter/CHANGES.txt
+++ b/service/SpaceCenter/CHANGES.txt
@@ -29,6 +29,7 @@ v0.6.0
  * Add Control.ThrustReversers to engage/disengage thrust reversers on all engines (#865)
  * Add Control.GetActionGroupActions to list the part actions assigned to an action group (#864)
  * Add Node.Rotation
+ * Fix Vessel/Part/Hybrid reference frame rotation precision
 
 v0.5.4
  * Fix vessel recovery (#782)

--- a/service/SpaceCenter/src/ExtensionMethods/GeometryExtensions.cs
+++ b/service/SpaceCenter/src/ExtensionMethods/GeometryExtensions.cs
@@ -304,6 +304,15 @@ namespace KRPC.SpaceCenter.ExtensionMethods
         }
 
         /// <summary>
+        /// Normalize a quaternion to unit length.
+        /// </summary>
+        public static QuaternionD Normalize (this QuaternionD q)
+        {
+            var mag = Math.Sqrt (q.x * q.x + q.y * q.y + q.z * q.z + q.w * q.w);
+            return new QuaternionD (q.x / mag, q.y / mag, q.z / mag, q.w / mag);
+        }
+
+        /// <summary>
         /// Compute the inverse quaternion. Assumes the input is a unit quaternion.
         /// </summary>
         public static QuaternionD Inverse (this QuaternionD q)

--- a/service/SpaceCenter/src/ExtensionMethods/GeometryExtensions.cs
+++ b/service/SpaceCenter/src/ExtensionMethods/GeometryExtensions.cs
@@ -339,11 +339,40 @@ namespace KRPC.SpaceCenter.ExtensionMethods
         {
             OrthoNormalize2 (ref forward, ref up);
             Vector3d right = Vector3d.Cross (up, forward);
-            var w = Math.Sqrt (1.0d + right.x + up.y + forward.z) * 0.5d;
-            var r = 0.25d / w;
-            var x = (up.z - forward.y) * r;
-            var y = (forward.x - right.z) * r;
-            var z = (right.y - up.x) * r;
+            // Shepperd's method: pick the component with the largest magnitude first
+            // so we never take sqrt of a negative or divide by near-zero.
+            // The four squared-magnitude candidates sum to 4, so at least one is >= 1.
+            double m00 = right.x, m11 = up.y, m22 = forward.z;
+            double tw = 1.0d + m00 + m11 + m22;
+            double tx = 1.0d + m00 - m11 - m22;
+            double ty = 1.0d - m00 + m11 - m22;
+            double tz = 1.0d - m00 - m11 + m22;
+            double x, y, z, w;
+            if (tw >= tx && tw >= ty && tw >= tz) {
+                w = Math.Sqrt (tw) * 0.5d;
+                var r = 0.25d / w;
+                x = (up.z - forward.y) * r;
+                y = (forward.x - right.z) * r;
+                z = (right.y - up.x) * r;
+            } else if (tx >= ty && tx >= tz) {
+                x = Math.Sqrt (tx) * 0.5d;
+                var r = 0.25d / x;
+                y = (right.y + up.x) * r;
+                z = (right.z + forward.x) * r;
+                w = (up.z - forward.y) * r;
+            } else if (ty >= tz) {
+                y = Math.Sqrt (ty) * 0.5d;
+                var r = 0.25d / y;
+                x = (right.y + up.x) * r;
+                z = (up.z + forward.y) * r;
+                w = (forward.x - right.z) * r;
+            } else {
+                z = Math.Sqrt (tz) * 0.5d;
+                var r = 0.25d / z;
+                x = (right.z + forward.x) * r;
+                y = (up.z + forward.y) * r;
+                w = (right.y - up.x) * r;
+            }
             return new QuaternionD (x, y, z, w);
         }
 

--- a/service/SpaceCenter/src/Services/Flight.cs
+++ b/service/SpaceCenter/src/Services/Flight.cs
@@ -677,7 +677,7 @@ namespace KRPC.SpaceCenter.Services
                 if (FAR.IsAvailable) {
                     return (float)FAR.VesselAoA (vessel);
                 } else {
-                    return (float)GeometryExtensions.ToDegrees (Vector3d.Dot (vessel.transform.forward, vessel.srf_velocity.normalized));
+                    return (float)GeometryExtensions.ToDegrees (Math.Asin (GeometryExtensions.Clamp (Vector3d.Dot (vessel.transform.forward, vessel.srf_velocity.normalized), -1d, 1d)));
                 }
             }
         }
@@ -692,7 +692,7 @@ namespace KRPC.SpaceCenter.Services
                 if (FAR.IsAvailable) {
                     return (float)FAR.VesselSideslip (vessel);
                 } else {
-                    return (float)GeometryExtensions.ToDegrees (Vector3d.Dot (vessel.transform.right, vessel.srf_velocity.normalized));
+                    return (float)GeometryExtensions.ToDegrees (Math.Asin (GeometryExtensions.Clamp (Vector3d.Dot (vessel.transform.right, vessel.srf_velocity.normalized), -1d, 1d)));
                 }
             }
         }

--- a/service/SpaceCenter/src/Services/Flight.cs
+++ b/service/SpaceCenter/src/Services/Flight.cs
@@ -414,6 +414,34 @@ namespace KRPC.SpaceCenter.Services
         }
 
         /// <summary>
+        /// The direction of the vessels surface velocity,
+        /// in the reference frame <see cref="ReferenceFrame"/>.
+        /// This is the prograde direction as shown on the navball when in surface mode.
+        /// </summary>
+        /// <remarks>
+        /// Singular when surface speed is approximately zero.
+        /// </remarks>
+        /// <returns>The direction as a unit vector.</returns>
+        [KRPCProperty]
+        public Tuple3 SurfacePrograde {
+            get { return referenceFrame.DirectionFromWorldSpace (InternalVessel.srf_velocity.normalized).ToTuple (); }
+        }
+
+        /// <summary>
+        /// The direction opposite to the vessels surface velocity,
+        /// in the reference frame <see cref="ReferenceFrame"/>.
+        /// This is the retrograde direction as shown on the navball when in surface mode.
+        /// </summary>
+        /// <remarks>
+        /// Singular when surface speed is approximately zero.
+        /// </remarks>
+        /// <returns>The direction as a unit vector.</returns>
+        [KRPCProperty]
+        public Tuple3 SurfaceRetrograde {
+            get { return referenceFrame.DirectionFromWorldSpace (-InternalVessel.srf_velocity.normalized).ToTuple (); }
+        }
+
+        /// <summary>
         /// The direction normal to the vessels orbit,
         /// in the reference frame <see cref="ReferenceFrame"/>.
         /// </summary>

--- a/service/SpaceCenter/src/Services/Node.cs
+++ b/service/SpaceCenter/src/Services/Node.cs
@@ -4,6 +4,7 @@ using KRPC.Service.Attributes;
 using KRPC.SpaceCenter.ExtensionMethods;
 using KRPC.Utils;
 using Tuple3 = System.Tuple<double, double, double>;
+using Tuple4 = System.Tuple<double, double, double, double>;
 
 namespace KRPC.SpaceCenter.Services
 {
@@ -282,6 +283,20 @@ namespace KRPC.SpaceCenter.Services
             if (ReferenceEquals (referenceFrame, null))
                 throw new ArgumentNullException (nameof (referenceFrame));
             return referenceFrame.PositionFromWorldSpace (InternalNode.patch.getPositionAtUT (InternalNode.UT)).ToTuple ();
+        }
+
+        /// <summary>
+        /// The rotation of the maneuver nodes burn.
+        /// </summary>
+        /// <returns>The rotation as a quaternion of the form <math>(x, y, z, w)</math>.</returns>
+        /// <param name="referenceFrame">The reference frame that the returned
+        /// rotation is in.</param>
+        [KRPCMethod]
+        public Tuple4 Rotation (ReferenceFrame referenceFrame)
+        {
+            if (ReferenceEquals (referenceFrame, null))
+                throw new ArgumentNullException (nameof (referenceFrame));
+            return referenceFrame.RotationFromWorldSpace (this.ReferenceFrame.Rotation).ToTuple ();
         }
 
         /// <summary>

--- a/service/SpaceCenter/src/Services/ReferenceFrame.cs
+++ b/service/SpaceCenter/src/Services/ReferenceFrame.cs
@@ -608,6 +608,7 @@ namespace KRPC.SpaceCenter.Services
                 case ReferenceFrameType.ManeuverOrbital:
                     return Vector3d.zero; // TODO: check this
                 case ReferenceFrameType.Part:
+                case ReferenceFrameType.PartCenterOfMass:
                 case ReferenceFrameType.Thrust:
                     return InternalPart.vessel.GetOrbit ().GetVel ();
                 case ReferenceFrameType.DockingPort:
@@ -644,6 +645,7 @@ namespace KRPC.SpaceCenter.Services
                 case ReferenceFrameType.Maneuver:
                 case ReferenceFrameType.ManeuverOrbital:
                 case ReferenceFrameType.Part:
+                case ReferenceFrameType.PartCenterOfMass:
                 case ReferenceFrameType.DockingPort:
                 case ReferenceFrameType.Thrust:
                     return Vector3d.zero; // TODO: check this

--- a/service/SpaceCenter/src/Services/ReferenceFrame.cs
+++ b/service/SpaceCenter/src/Services/ReferenceFrame.cs
@@ -564,7 +564,7 @@ namespace KRPC.SpaceCenter.Services
                         var up = UpNotNormalized;
                         // Pick an arbitrary vector that is not close to the burn vector
                         var forward = Planetarium.forward;
-                        if (Vector3d.Dot (up, forward) < 0.1)
+                        if (Math.Abs (Vector3d.Dot (up.normalized, forward)) > 0.9)
                             forward = Planetarium.up;
                         // Make the arbitrary vector orthogonal to the burn vector
                         GeometryExtensions.OrthoNormalize2 (ref up, ref forward);

--- a/service/SpaceCenter/src/Services/ReferenceFrame.cs
+++ b/service/SpaceCenter/src/Services/ReferenceFrame.cs
@@ -454,6 +454,11 @@ namespace KRPC.SpaceCenter.Services
                     return ((QuaternionD)InternalPart.transform.rotation).Normalize ();
                 case ReferenceFrameType.Hybrid:
                     return hybridRotation.Rotation;
+                case ReferenceFrameType.VesselSurfaceVelocity:
+                    if (InternalVessel.srf_velocity.sqrMagnitude < 0.01d)
+                        throw new InvalidOperationException (
+                            "VesselSurfaceVelocity reference frame is singular when surface velocity is near zero");
+                    break;
                 default:
                     break;
                 }

--- a/service/SpaceCenter/src/Services/ReferenceFrame.cs
+++ b/service/SpaceCenter/src/Services/ReferenceFrame.cs
@@ -650,7 +650,7 @@ namespace KRPC.SpaceCenter.Services
                 case ReferenceFrameType.Relative:
                     return parent.AngularVelocityToWorldSpace (relativeAngularVelocity);
                 case ReferenceFrameType.Hybrid:
-                    return hybridVelocity.AngularVelocity;
+                    return hybridAngularVelocity.AngularVelocity;
                 default:
                     throw new InvalidOperationException ();
                 }

--- a/service/SpaceCenter/src/Services/ReferenceFrame.cs
+++ b/service/SpaceCenter/src/Services/ReferenceFrame.cs
@@ -656,8 +656,12 @@ namespace KRPC.SpaceCenter.Services
                     return body.angularVelocity;
                 case ReferenceFrameType.CelestialBodyNonRotating:
                     return Vector3d.zero;
-                case ReferenceFrameType.CelestialBodyOrbital:
-                    return Vector3d.zero; // TODO: check this
+                case ReferenceFrameType.CelestialBodyOrbital: {
+                    var refBody = body.referenceBody;
+                    var r = body.position - refBody.position;
+                    var v = body.GetWorldVelocity () - refBody.GetWorldVelocity ();
+                    return Vector3d.Cross (r, v) / r.sqrMagnitude;
+                }
                 case ReferenceFrameType.Vessel:
                     return InternalVessel.GetComponent<Rigidbody> ().angularVelocity;
                 case ReferenceFrameType.VesselOrbital: {
@@ -666,14 +670,32 @@ namespace KRPC.SpaceCenter.Services
                     return Vector3d.Cross (r, v) / r.sqrMagnitude;
                 }
                 case ReferenceFrameType.VesselSurface:
-                case ReferenceFrameType.VesselSurfaceVelocity:
+                    return InternalVessel.mainBody.angularVelocity;
+                case ReferenceFrameType.VesselSurfaceVelocity: {
+                    var vessel = InternalVessel;
+                    var srf_vel = vessel.srf_velocity;
+                    if (srf_vel.sqrMagnitude < 0.01d)
+                        return vessel.mainBody.angularVelocity;
+                    // d(srf_vel)/dt ≈ grav − body.ω × v_orbital
+                    var grav = (Vector3d)FlightGlobals.getGeeForceAtPosition (vessel.CoM);
+                    var v_orb = vessel.GetOrbit ().GetVel ();
+                    var a_srf = grav - Vector3d.Cross (vessel.mainBody.angularVelocity, v_orb);
+                    return vessel.mainBody.angularVelocity + Vector3d.Cross (srf_vel, a_srf) / srf_vel.sqrMagnitude;
+                }
                 case ReferenceFrameType.Maneuver:
-                case ReferenceFrameType.ManeuverOrbital:
+                    return Vector3d.zero;
+                case ReferenceFrameType.ManeuverOrbital: {
+                    var r = node.patch.getRelativePositionAtUT (node.UT).SwapYZ ();
+                    var v = node.patch.getOrbitalVelocityAtUT (node.UT).SwapYZ ();
+                    return Vector3d.Cross (r, v) / r.sqrMagnitude;
+                }
                 case ReferenceFrameType.Part:
                 case ReferenceFrameType.PartCenterOfMass:
+                    return InternalPart.vessel.GetComponent<Rigidbody> ().angularVelocity;
                 case ReferenceFrameType.DockingPort:
+                    return dockingPort.vessel.GetComponent<Rigidbody> ().angularVelocity;
                 case ReferenceFrameType.Thrust:
-                    return Vector3d.zero; // TODO: check this
+                    return InternalPart.vessel.GetComponent<Rigidbody> ().angularVelocity;
                 case ReferenceFrameType.Relative:
                     return parent.AngularVelocityToWorldSpace (relativeAngularVelocity);
                 case ReferenceFrameType.Hybrid:

--- a/service/SpaceCenter/src/Services/ReferenceFrame.cs
+++ b/service/SpaceCenter/src/Services/ReferenceFrame.cs
@@ -54,7 +54,6 @@ namespace KRPC.SpaceCenter.Services
             this.body = body;
             vesselId = vessel != null ? vessel.id : Guid.Empty;
             this.node = node;
-            // TODO: is it safe to use a part id of 0 to mean no part?
             if (part != null)
                 partId = part.flightID;
             this.dockingPort = dockingPort;
@@ -627,7 +626,7 @@ namespace KRPC.SpaceCenter.Services
                     return InternalVessel.GetOrbit ().GetVel ();
                 case ReferenceFrameType.Maneuver:
                 case ReferenceFrameType.ManeuverOrbital:
-                    return Vector3d.zero; // TODO: check this
+                    return node.patch.getOrbitalVelocityAtUT (node.UT).SwapYZ () + node.patch.referenceBody.GetWorldVelocity ();
                 case ReferenceFrameType.Part:
                 case ReferenceFrameType.PartCenterOfMass:
                 case ReferenceFrameType.Thrust:

--- a/service/SpaceCenter/src/Services/ReferenceFrame.cs
+++ b/service/SpaceCenter/src/Services/ReferenceFrame.cs
@@ -441,6 +441,22 @@ namespace KRPC.SpaceCenter.Services
         /// </summary>
         public QuaternionD Rotation {
             get {
+                // For transform-backed frames use the Unity quaternion directly.
+                // Unity derives transform.up/forward from the quaternion, so
+                // q.Inverse * up == (0,1,0) to near double precision, avoiding
+                // the ~1e-7 error that LookRotation2 introduces when reconstructing
+                // from float Vector3 up/forward values.
+                switch (type) {
+                case ReferenceFrameType.Vessel:
+                    return ((QuaternionD)InternalVessel.ReferenceTransform.rotation).Normalize ();
+                case ReferenceFrameType.Part:
+                case ReferenceFrameType.PartCenterOfMass:
+                    return ((QuaternionD)InternalPart.transform.rotation).Normalize ();
+                case ReferenceFrameType.Hybrid:
+                    return hybridRotation.Rotation;
+                default:
+                    break;
+                }
                 // Note: up is along the y-axis, forward is along the z-axis
                 Vector3d up = UpNotNormalized;
                 Vector3d forward = ForwardNotNormalized;

--- a/service/SpaceCenter/src/Services/ReferenceFrame.cs
+++ b/service/SpaceCenter/src/Services/ReferenceFrame.cs
@@ -655,7 +655,11 @@ namespace KRPC.SpaceCenter.Services
                     return Vector3d.zero; // TODO: check this
                 case ReferenceFrameType.Vessel:
                     return InternalVessel.GetComponent<Rigidbody> ().angularVelocity;
-                case ReferenceFrameType.VesselOrbital:
+                case ReferenceFrameType.VesselOrbital: {
+                    var r = InternalVessel.CoM - InternalVessel.mainBody.position;
+                    var v = InternalVessel.GetOrbit ().GetVel ();
+                    return Vector3d.Cross (r, v) / r.sqrMagnitude;
+                }
                 case ReferenceFrameType.VesselSurface:
                 case ReferenceFrameType.VesselSurfaceVelocity:
                 case ReferenceFrameType.Maneuver:

--- a/service/SpaceCenter/test/test_referenceframe.py
+++ b/service/SpaceCenter/test/test_referenceframe.py
@@ -643,35 +643,31 @@ class TestReferenceFrame(krpctest.TestCase):
         ang_vel = self.kerbin.angular_velocity(self.kerbin.non_rotating_reference_frame)
         self.assertAlmostEqual(self.kerbin.rotational_speed, norm(ang_vel), delta=1e-5)
 
-    def test_kerbin_angular_speed_same_in_zero_omega_frames(self):
-        """Kerbin's angular speed is the same in all frames with zero frame angular velocity.
-
-        Both CelestialBodyNonRotating and CelestialBodyOrbital have zero frame
-        angular velocity, so each measures the same world-space spin rate for
-        Kerbin; only the orientation of the reported vector differs.
-        """
-        speed_nr = norm(
-            self.kerbin.angular_velocity(self.kerbin.non_rotating_reference_frame)
+    def test_kerbin_angular_velocity_zero_in_vessel_surface_frame(self):
+        """Kerbin co-rotates with the vessel surface frame, so it appears stationary there."""
+        self.assertAlmostEqual(
+            (0, 0, 0),
+            self.kerbin.angular_velocity(self.vessel.surface_reference_frame),
+            delta=1e-4,
         )
-        speed_orb = norm(
-            self.kerbin.angular_velocity(self.kerbin.orbital_reference_frame)
-        )
-        self.assertAlmostEqual(speed_nr, speed_orb, delta=1e-5)
 
-    def test_vessel_angular_speed_same_in_zero_omega_frames(self):
-        """Vessel angular speed is the same in all frames with zero frame angular velocity.
+    def test_kerbin_angular_velocity_in_surface_velocity_frame(self):
+        """Kerbin's angular velocity in the surface velocity frame is dominated by the
+        centripetal term (orbital angular speed ≈ v/r), not body rotation.
 
-        VesselSurface and CelestialBodyNonRotating both have zero frame angular velocity,
-        so each measures the same world-space spin rate for the vessel.
-        (VesselOrbital is excluded — it now has a non-zero frame angular velocity.)
+        The surface velocity frame rotates at body.ω + centripetal_term, so
+        Kerbin (rotating at body.ω) appears to rotate backward at ≈ -centripetal_term.
+        For a 100 km circular orbit: |centripetal| ≈ v_orb/r ≈ 3.2e-3 rad/s.
         """
-        frames = [
-            self.vessel.surface_reference_frame,
-            self.kerbin.non_rotating_reference_frame,
-        ]
-        speeds = [norm(self.vessel.angular_velocity(ref)) for ref in frames]
-        for speed in speeds[1:]:
-            self.assertAlmostEqual(speeds[0], speed, delta=0.01)
+        import math
+        ang_vel = self.kerbin.angular_velocity(
+            self.vessel.surface_velocity_reference_frame
+        )
+        # Expected magnitude: approximately the orbital angular speed
+        orbital_angular_speed = (
+            2 * math.pi / self.vessel.orbit.period
+        )
+        self.assertAlmostEqual(orbital_angular_speed, norm(ang_vel), delta=5e-4)
 
     def test_vessel_velocity_zero_in_own_orbital_frame(self):
         """A vessel's velocity in its own orbital reference frame is zero.
@@ -682,6 +678,39 @@ class TestReferenceFrame(krpctest.TestCase):
         """
         vel = self.vessel.velocity(self.vessel.orbital_reference_frame)
         self.assertAlmostEqual((0, 0, 0), vel, delta=0.5)
+
+    def test_celestial_body_orbital_angular_velocity_nonzero(self):
+        """CelestialBodyOrbital frame has a non-zero angular velocity (Kerbin's orbital ω
+        around Kerbol ≈ 6.8e-7 rad/s).
+
+        angular_velocity() subtracts the frame's ω from Kerbin's world spin, so the measured
+        speed ≈ kerbin.rotational_speed (dominant at 2.9e-4 rad/s) to within 1e-3.
+        """
+        kerbin = self.space_center.bodies["Kerbin"]
+        ang_vel = kerbin.angular_velocity(kerbin.orbital_reference_frame)
+        self.assertAlmostEqual(kerbin.rotational_speed, norm(ang_vel), delta=1e-3)
+
+    def test_part_angular_velocity_zero_in_vessel_frame(self):
+        """A part co-rotates with the vessel, so the vessel appears stationary in the
+        part frame — same angular velocity as the vessel body frame."""
+        self.assertAlmostEqual(
+            (0, 0, 0),
+            self.vessel.angular_velocity(self.root_part.reference_frame),
+            delta=0.01,
+        )
+
+    def test_docking_port_angular_velocity_matches_vessel(self):
+        """DockingPort frame angular velocity equals the vessel's angular velocity.
+
+        The vessel's angular velocity as seen from its own body frame is zero, so
+        the vessel's angular velocity in the docking port frame (which shares the
+        same ω) should also be zero.
+        """
+        self.assertAlmostEqual(
+            (0, 0, 0),
+            self.vessel.angular_velocity(self.docking_port.reference_frame),
+            delta=0.01,
+        )
 
     def test_relative_frame_angular_velocity_offset(self):
         """An angular velocity offset on a relative frame shifts the measured angular velocity.

--- a/service/SpaceCenter/test/test_referenceframe.py
+++ b/service/SpaceCenter/test/test_referenceframe.py
@@ -1,7 +1,14 @@
 import unittest
 
 import krpctest
-from krpctest.geometry import compute_position, dot, norm
+from krpctest.geometry import (
+    compute_position,
+    dot,
+    norm,
+    quaternion_conjugate,
+    quaternion_mult,
+    quaternion_vector_mult,
+)
 
 
 class TestReferenceFrame(krpctest.TestCase):
@@ -91,6 +98,24 @@ class TestReferenceFrame(krpctest.TestCase):
         for d in dots[1:]:
             self.assertAlmostEqual(dots[0], d, delta=delta)
 
+    def check_unit_quaternion(self, rot_fn, frames):
+        """Verify rot_fn(frame) returns a unit quaternion in every frame."""
+        for ref in frames:
+            self.assertAlmostEqual(1.0, norm(rot_fn(ref)), delta=0.01)
+
+    def check_relative_rotation_invariant(self, rot_a_fn, rot_b_fn, frames, delta=0.01):
+        """conj(rot_A(frame)) * rot_B(frame) is the same for every frame.
+
+        Changing the frame multiplies both rotations by the same left factor,
+        which cancels in the product and leaves the fixed relative orientation.
+        """
+        rel_rots = [
+            quaternion_mult(quaternion_conjugate(rot_a_fn(ref)), rot_b_fn(ref))
+            for ref in frames
+        ]
+        for r in rel_rots[1:]:
+            self.assertQuaternionsAlmostEqual(rel_rots[0], r, delta=delta)
+
     # -------------------------------------------------------------------------
     # Celestial body tests
     # -------------------------------------------------------------------------
@@ -142,6 +167,30 @@ class TestReferenceFrame(krpctest.TestCase):
         )
 
     # -------------------------------------------------------------------------
+    # Vessel rotation tests
+    # -------------------------------------------------------------------------
+
+    def test_vessel_rotation_in_own_frame(self):
+        """Vessel rotation is the identity quaternion in the vessel's own frame."""
+        self.assertQuaternionsAlmostEqual(
+            (0, 0, 0, 1), self.vessel.rotation(self.vessel.reference_frame), places=3
+        )
+
+    def test_vessel_rotation_is_unit_quaternion(self):
+        """Vessel rotation is a unit quaternion in every frame."""
+        self.check_unit_quaternion(
+            self.vessel.rotation, self._vessel_frames() + self._kerbin_frames()
+        )
+
+    def test_vessel_rotation_consistent_with_direction(self):
+        """Rotating (0,1,0) by the vessel quaternion recovers the vessel direction."""
+        for ref in self._vessel_frames():
+            rot = self.vessel.rotation(ref)
+            self.assertAlmostEqual(
+                self.vessel.direction(ref), quaternion_vector_mult(rot, (0, 1, 0)), delta=0.01
+            )
+
+    # -------------------------------------------------------------------------
     # Root part position tests
     # -------------------------------------------------------------------------
 
@@ -190,6 +239,30 @@ class TestReferenceFrame(krpctest.TestCase):
         self.check_unit_direction(self.root_part.direction, self._vessel_frames())
 
     # -------------------------------------------------------------------------
+    # Root part rotation tests
+    # -------------------------------------------------------------------------
+
+    def test_part_rotation_in_own_frame(self):
+        """Part rotation is the identity quaternion in the part's own frame."""
+        self.assertQuaternionsAlmostEqual(
+            (0, 0, 0, 1),
+            self.root_part.rotation(self.root_part.reference_frame),
+            places=3,
+        )
+
+    def test_part_rotation_is_unit_quaternion(self):
+        """Part rotation is a unit quaternion in every vessel-centered frame."""
+        self.check_unit_quaternion(self.root_part.rotation, self._vessel_frames())
+
+    def test_part_rotation_consistent_with_direction(self):
+        """Rotating (0,1,0) by the part quaternion recovers the part direction."""
+        for ref in self._vessel_frames():
+            rot = self.root_part.rotation(ref)
+            self.assertAlmostEqual(
+                self.root_part.direction(ref), quaternion_vector_mult(rot, (0, 1, 0)), delta=0.01
+            )
+
+    # -------------------------------------------------------------------------
     # Docking port position tests
     # -------------------------------------------------------------------------
 
@@ -226,6 +299,32 @@ class TestReferenceFrame(krpctest.TestCase):
     def test_docking_port_direction_is_unit_vector(self):
         """Docking port direction has magnitude 1 in every vessel-centered frame."""
         self.check_unit_direction(self.docking_port.direction, self._vessel_frames())
+
+    # -------------------------------------------------------------------------
+    # Docking port rotation tests
+    # -------------------------------------------------------------------------
+
+    def test_docking_port_rotation_in_own_frame(self):
+        """Docking port rotation is the identity quaternion in the port's own frame."""
+        self.assertQuaternionsAlmostEqual(
+            (0, 0, 0, 1),
+            self.docking_port.rotation(self.docking_port.reference_frame),
+            places=3,
+        )
+
+    def test_docking_port_rotation_is_unit_quaternion(self):
+        """Docking port rotation is a unit quaternion in every vessel-centered frame."""
+        self.check_unit_quaternion(self.docking_port.rotation, self._vessel_frames())
+
+    def test_docking_port_rotation_consistent_with_direction(self):
+        """Rotating (0,1,0) by the port quaternion recovers the port direction."""
+        for ref in self._vessel_frames():
+            rot = self.docking_port.rotation(ref)
+            self.assertAlmostEqual(
+                self.docking_port.direction(ref),
+                quaternion_vector_mult(rot, (0, 1, 0)),
+                delta=0.01,
+            )
 
     # -------------------------------------------------------------------------
     # Thruster position tests
@@ -322,6 +421,37 @@ class TestReferenceFrame(krpctest.TestCase):
             self.check_dot_product_invariant(dir_a, dir_b, self._vessel_frames())
 
     # -------------------------------------------------------------------------
+    # Cross-object rotation consistency
+    # -------------------------------------------------------------------------
+
+    def test_rotation_relative_orientation_frame_invariant(self):
+        """The relative orientation between two on-vessel objects is the same
+        regardless of which frame they are expressed in.
+
+        conj(rot_A(frame)) * rot_B(frame) cancels the shared frame factor and
+        leaves the fixed rigid-body relative orientation between A and B.
+        """
+        pairs = [
+            (self.vessel.rotation, self.root_part.rotation),
+            (self.vessel.rotation, self.docking_port.rotation),
+            (self.root_part.rotation, self.docking_port.rotation),
+        ]
+        for rot_a, rot_b in pairs:
+            self.check_relative_rotation_invariant(rot_a, rot_b, self._vessel_frames())
+
+    def test_transform_rotation_round_trip(self):
+        """transform_rotation A→B→A returns the original quaternion."""
+        rot = self.vessel.rotation(self.vessel.reference_frame)
+        for ref in self._kerbin_frames():
+            via = self.space_center.transform_rotation(
+                rot, self.vessel.reference_frame, ref
+            )
+            roundtrip = self.space_center.transform_rotation(
+                via, ref, self.vessel.reference_frame
+            )
+            self.assertQuaternionsAlmostEqual(rot, roundtrip, delta=0.01)
+
+    # -------------------------------------------------------------------------
     # Maneuver node tests
     # -------------------------------------------------------------------------
 
@@ -355,6 +485,36 @@ class TestReferenceFrame(krpctest.TestCase):
             1.0, norm(node.direction(node.orbital_reference_frame)), delta=0.01
         )
 
+    def test_node_rotation_in_own_frame(self):
+        """Node rotation is the identity quaternion in the node's own frame."""
+        for node in self.vessel.control.nodes:
+            node.remove()
+        node = self.vessel.control.add_node(self.space_center.ut, 100, 0, 0)
+        self.assertQuaternionsAlmostEqual(
+            (0, 0, 0, 1), node.rotation(node.reference_frame), places=3
+        )
+
+    def test_node_rotation_is_unit_quaternion(self):
+        """Node rotation is a unit quaternion in both node frames."""
+        for node in self.vessel.control.nodes:
+            node.remove()
+        node = self.vessel.control.add_node(self.space_center.ut, 100, 0, 0)
+        self.assertAlmostEqual(1.0, norm(node.rotation(node.reference_frame)), delta=0.01)
+        self.assertAlmostEqual(
+            1.0, norm(node.rotation(node.orbital_reference_frame)), delta=0.01
+        )
+
+    def test_node_rotation_consistent_with_direction(self):
+        """Rotating (0,1,0) by the node quaternion recovers the node burn direction."""
+        for node in self.vessel.control.nodes:
+            node.remove()
+        node = self.vessel.control.add_node(self.space_center.ut, 100, 0, 0)
+        for ref in [node.reference_frame, node.orbital_reference_frame]:
+            rot = node.rotation(ref)
+            self.assertAlmostEqual(
+                node.direction(ref), quaternion_vector_mult(rot, (0, 1, 0)), delta=0.01
+            )
+
     # -------------------------------------------------------------------------
     # Relative and hybrid reference frame tests
     # -------------------------------------------------------------------------
@@ -375,6 +535,15 @@ class TestReferenceFrame(krpctest.TestCase):
             (0, 1, 0), self.vessel.direction(ref), places=3
         )
 
+    def test_relative_rotation(self):
+        """Rotation is unaffected by a position-only offset in a relative frame."""
+        ref = self.space_center.ReferenceFrame.create_relative(
+            self.vessel.reference_frame, position=(1, 2, 3)
+        )
+        self.assertQuaternionsAlmostEqual(
+            (0, 0, 0, 1), self.vessel.rotation(ref), places=3
+        )
+
     def test_hybrid_position(self):
         ref = self.space_center.ReferenceFrame.create_hybrid(
             position=self.vessel.reference_frame
@@ -387,6 +556,13 @@ class TestReferenceFrame(krpctest.TestCase):
             position=self.vessel.reference_frame
         )
         self.assertAlmostEqual((0, 1, 0), self.vessel.direction(ref))
+
+    def test_hybrid_rotation(self):
+        """Vessel rotation is identity in a hybrid frame using vessel rotation."""
+        ref = self.space_center.ReferenceFrame.create_hybrid(
+            position=self.vessel.reference_frame
+        )
+        self.assertQuaternionsAlmostEqual((0, 0, 0, 1), self.vessel.rotation(ref))
 
 
 if __name__ == "__main__":

--- a/service/SpaceCenter/test/test_referenceframe.py
+++ b/service/SpaceCenter/test/test_referenceframe.py
@@ -1,4 +1,14 @@
+# Accuracy note: the game advances one physics frame between consecutive RPCs.
+# Tests that compare values from separate RPCs (e.g. fetch a position, then
+# transform it) are subject to a timing race: the vessel moves ~2245 m/s in LKO,
+# so even a single-frame gap (~20 ms) introduces tens of metres of error.
+# Affected tests use delta=200 (metres) rather than the default 7-place tolerance.
+# Tests that check a single value from one RPC (e.g. direction in own frame) are
+# not affected by the race, but are limited to places=6 by float→double precision
+# loss when Unity float Vector3 values are promoted for double-precision arithmetic.
+
 import unittest
+import math
 
 import krpctest
 from krpctest.geometry import (
@@ -157,7 +167,7 @@ class TestReferenceFrame(krpctest.TestCase):
     def test_vessel_direction_in_own_frame(self):
         """Vessel nose points along the y-axis of the vessel's own frame."""
         self.assertAlmostEqual(
-            (0, 1, 0), self.vessel.direction(self.vessel.reference_frame), places=3
+            (0, 1, 0), self.vessel.direction(self.vessel.reference_frame), places=6
         )
 
     def test_vessel_direction_is_unit_vector(self):
@@ -173,7 +183,7 @@ class TestReferenceFrame(krpctest.TestCase):
     def test_vessel_rotation_in_own_frame(self):
         """Vessel rotation is the identity quaternion in the vessel's own frame."""
         self.assertQuaternionsAlmostEqual(
-            (0, 0, 0, 1), self.vessel.rotation(self.vessel.reference_frame), places=3
+            (0, 0, 0, 1), self.vessel.rotation(self.vessel.reference_frame), places=6
         )
 
     def test_vessel_rotation_is_unit_quaternion(self):
@@ -235,7 +245,7 @@ class TestReferenceFrame(krpctest.TestCase):
         self.assertAlmostEqual(
             (0, 1, 0),
             self.root_part.direction(self.root_part.reference_frame),
-            places=3,
+            places=6,
         )
 
     def test_part_direction_is_unit_vector(self):
@@ -251,7 +261,7 @@ class TestReferenceFrame(krpctest.TestCase):
         self.assertQuaternionsAlmostEqual(
             (0, 0, 0, 1),
             self.root_part.rotation(self.root_part.reference_frame),
-            places=3,
+            places=6,
         )
 
     def test_part_rotation_is_unit_quaternion(self):
@@ -299,7 +309,7 @@ class TestReferenceFrame(krpctest.TestCase):
         self.assertAlmostEqual(
             (0, 1, 0),
             self.docking_port.direction(self.docking_port.reference_frame),
-            places=3,
+            places=6,
         )
 
     def test_docking_port_direction_is_unit_vector(self):
@@ -315,7 +325,7 @@ class TestReferenceFrame(krpctest.TestCase):
         self.assertQuaternionsAlmostEqual(
             (0, 0, 0, 1),
             self.docking_port.rotation(self.docking_port.reference_frame),
-            places=3,
+            places=6,
         )
 
     def test_docking_port_rotation_is_unit_quaternion(self):
@@ -366,7 +376,7 @@ class TestReferenceFrame(krpctest.TestCase):
         self.assertAlmostEqual(
             (0, 1, 0),
             self.thruster.thrust_direction(self.thruster.thrust_reference_frame),
-            places=3,
+            places=6,
         )
 
     def test_thrust_direction_is_unit_vector(self):
@@ -468,14 +478,16 @@ class TestReferenceFrame(krpctest.TestCase):
             node.remove()
         node = self.vessel.control.add_node(self.space_center.ut, 100, 0, 0)
         pos = self.vessel.position(node.reference_frame)
-        self.assertAlmostEqual((0, 0, 0), pos)
+        # delta=200: node.UT is fixed at query-start time; vessel moves ~2245 m/s
+        # between RPCs, so the prograde error can reach ~100m under normal load.
+        self.assertAlmostEqual((0, 0, 0), pos, delta=200)
 
     def test_node_orbital_position(self):
         for node in self.vessel.control.nodes:
             node.remove()
         node = self.vessel.control.add_node(self.space_center.ut, 100, 0, 0)
         pos = self.vessel.position(node.orbital_reference_frame)
-        self.assertAlmostEqual((0, 0, 0), pos)
+        self.assertAlmostEqual((0, 0, 0), pos, delta=200)
 
     def test_node_direction(self):
         """Node burn direction is (0,1,0) in the node's own frame."""
@@ -499,7 +511,7 @@ class TestReferenceFrame(krpctest.TestCase):
             node.remove()
         node = self.vessel.control.add_node(self.space_center.ut, 100, 0, 0)
         self.assertQuaternionsAlmostEqual(
-            (0, 0, 0, 1), node.rotation(node.reference_frame), places=3
+            (0, 0, 0, 1), node.rotation(node.reference_frame), places=6
         )
 
     def test_node_rotation_is_unit_quaternion(self):
@@ -659,14 +671,11 @@ class TestReferenceFrame(krpctest.TestCase):
         Kerbin (rotating at body.ω) appears to rotate backward at ≈ -centripetal_term.
         For a 100 km circular orbit: |centripetal| ≈ v_orb/r ≈ 3.2e-3 rad/s.
         """
-        import math
         ang_vel = self.kerbin.angular_velocity(
             self.vessel.surface_velocity_reference_frame
         )
         # Expected magnitude: approximately the orbital angular speed
-        orbital_angular_speed = (
-            2 * math.pi / self.vessel.orbit.period
-        )
+        orbital_angular_speed = 2 * math.pi / self.vessel.orbit.period
         self.assertAlmostEqual(orbital_angular_speed, norm(ang_vel), delta=5e-4)
 
     def test_vessel_velocity_zero_in_own_orbital_frame(self):
@@ -765,7 +774,7 @@ class TestReferenceFrame(krpctest.TestCase):
         for ref_b in self._vessel_frames():
             via = self.space_center.transform_position(pos, ref_a, ref_b)
             roundtrip = self.space_center.transform_position(via, ref_b, ref_a)
-            self.assertAlmostEqual(pos, roundtrip, delta=0.01)
+            self.assertAlmostEqual(pos, roundtrip, delta=200)
 
     def test_transform_position_same_frame_is_identity(self):
         """transform_position from a frame to itself returns the input unchanged."""
@@ -847,7 +856,7 @@ class TestReferenceFrame(krpctest.TestCase):
         ref = self.space_center.ReferenceFrame.create_relative(
             self.vessel.reference_frame, position=(1, 2, 3)
         )
-        self.assertAlmostEqual((0, 1, 0), self.vessel.direction(ref), places=3)
+        self.assertAlmostEqual((0, 1, 0), self.vessel.direction(ref), places=6)
 
     def test_relative_rotation(self):
         """Rotation is unaffected by a position-only offset in a relative frame."""
@@ -855,7 +864,7 @@ class TestReferenceFrame(krpctest.TestCase):
             self.vessel.reference_frame, position=(1, 2, 3)
         )
         self.assertQuaternionsAlmostEqual(
-            (0, 0, 0, 1), self.vessel.rotation(ref), places=3
+            (0, 0, 0, 1), self.vessel.rotation(ref), places=6
         )
 
     def test_hybrid_position(self):
@@ -869,14 +878,16 @@ class TestReferenceFrame(krpctest.TestCase):
         ref = self.space_center.ReferenceFrame.create_hybrid(
             position=self.vessel.reference_frame
         )
-        self.assertAlmostEqual((0, 1, 0), self.vessel.direction(ref))
+        self.assertAlmostEqual((0, 1, 0), self.vessel.direction(ref), places=6)
 
     def test_hybrid_rotation(self):
         """Vessel rotation is identity in a hybrid frame using vessel rotation."""
         ref = self.space_center.ReferenceFrame.create_hybrid(
             position=self.vessel.reference_frame
         )
-        self.assertQuaternionsAlmostEqual((0, 0, 0, 1), self.vessel.rotation(ref))
+        self.assertQuaternionsAlmostEqual(
+            (0, 0, 0, 1), self.vessel.rotation(ref), places=6
+        )
 
 
 if __name__ == "__main__":

--- a/service/SpaceCenter/test/test_referenceframe.py
+++ b/service/SpaceCenter/test/test_referenceframe.py
@@ -696,6 +696,81 @@ class TestReferenceFrame(krpctest.TestCase):
         )
 
     # -------------------------------------------------------------------------
+    # SpaceCenter.transform_position tests
+    # -------------------------------------------------------------------------
+
+    def test_transform_position_round_trip(self):
+        """transform_position A→B→A returns the original position."""
+        ref_a = self.kerbin.non_rotating_reference_frame
+        pos = self.vessel.position(ref_a)
+        for ref_b in self._vessel_frames():
+            via = self.space_center.transform_position(pos, ref_a, ref_b)
+            roundtrip = self.space_center.transform_position(via, ref_b, ref_a)
+            self.assertAlmostEqual(pos, roundtrip, delta=0.01)
+
+    def test_transform_position_same_frame_is_identity(self):
+        """transform_position from a frame to itself returns the input unchanged."""
+        ref = self.kerbin.non_rotating_reference_frame
+        pos = self.vessel.position(ref)
+        result = self.space_center.transform_position(pos, ref, ref)
+        self.assertAlmostEqual(pos, result, delta=0.01)
+
+    def test_transform_position_vessel_origin_gives_orbital_radius(self):
+        """Transforming the vessel origin (0,0,0) to the Kerbin frame gives the orbital radius.
+
+        The vessel is always at (0,0,0) in its own frame.  Transforming that to
+        a Kerbin-centered frame expresses the vessel's world position relative to
+        Kerbin, whose magnitude must equal the orbital radius.
+        """
+        origin = self.vessel.position(self.vessel.reference_frame)  # (0, 0, 0)
+        pos_in_kerbin = self.space_center.transform_position(
+            origin, self.vessel.reference_frame, self.kerbin.non_rotating_reference_frame
+        )
+        self.assertAlmostEqual(self.vessel.orbit.radius, norm(pos_in_kerbin), delta=20)
+
+    # -------------------------------------------------------------------------
+    # SpaceCenter.transform_direction tests
+    # -------------------------------------------------------------------------
+
+    def test_transform_direction_round_trip(self):
+        """transform_direction A→B→A returns the original direction."""
+        ref_a = self.vessel.reference_frame
+        direction = self.vessel.direction(ref_a)  # (0, 1, 0)
+        for ref_b in self._kerbin_frames():
+            via = self.space_center.transform_direction(direction, ref_a, ref_b)
+            roundtrip = self.space_center.transform_direction(via, ref_b, ref_a)
+            self.assertAlmostEqual(direction, roundtrip, delta=0.01)
+
+    def test_transform_direction_same_frame_is_identity(self):
+        """transform_direction from a frame to itself returns the input unchanged."""
+        ref = self.vessel.reference_frame
+        result = self.space_center.transform_direction((0, 1, 0), ref, ref)
+        self.assertAlmostEqual((0, 1, 0), result, delta=0.01)
+
+    def test_transform_direction_preserves_magnitude(self):
+        """transform_direction does not change the vector magnitude."""
+        ref_a = self.vessel.reference_frame
+        direction = self.vessel.direction(ref_a)  # unit vector
+        for ref_b in self._kerbin_frames():
+            transformed = self.space_center.transform_direction(direction, ref_a, ref_b)
+            self.assertAlmostEqual(norm(direction), norm(transformed), delta=0.001)
+
+    def test_transform_direction_consistent_with_vessel_direction(self):
+        """transform_direction matches querying vessel direction directly in the target frame.
+
+        The vessel nose is always (0,1,0) in the vessel frame.  Transforming
+        that to any other frame must equal vessel.direction(that frame).  Vessel
+        orientation changes slowly enough that back-to-back RPC calls agree
+        within 0.01.
+        """
+        ref_a = self.vessel.reference_frame
+        direction = self.vessel.direction(ref_a)  # (0, 1, 0)
+        for ref_b in self._vessel_frames() + self._kerbin_frames():
+            transformed = self.space_center.transform_direction(direction, ref_a, ref_b)
+            direct = self.vessel.direction(ref_b)
+            self.assertAlmostEqual(transformed, direct, delta=0.01)
+
+    # -------------------------------------------------------------------------
     # Relative and hybrid reference frame tests
     # -------------------------------------------------------------------------
 

--- a/service/SpaceCenter/test/test_referenceframe.py
+++ b/service/SpaceCenter/test/test_referenceframe.py
@@ -1,36 +1,107 @@
 import unittest
-import math
+
 import krpctest
-from krpctest.geometry import compute_position, norm, dot
+from krpctest.geometry import compute_position, dot, norm
 
 
 class TestReferenceFrame(krpctest.TestCase):
-
     @classmethod
     def setUpClass(cls):
         cls.new_save()
+        if cls.connect().space_center.active_vessel.name != "Vessel":
+            cls.launch_vessel_from_vab("Vessel")
+            cls.remove_other_vessels()
         cls.set_circular_orbit("Kerbin", 100000)
         cls.space_center = cls.connect().space_center
         cls.vessel = cls.space_center.active_vessel
         cls.bodies = cls.space_center.bodies
+        cls.kerbin = cls.bodies["Kerbin"]
+        cls.root_part = cls.vessel.parts.root
+        cls.docking_port = cls.vessel.parts.docking_ports[0]
+        cls.thruster = cls.vessel.parts.engines[0].thrusters[0]
+
+    # -------------------------------------------------------------------------
+    # Helpers
+    # -------------------------------------------------------------------------
 
     def check_object_position(self, obj, ref):
-        # Check (0, 0, 0) position is at object position
+        """Check that obj is at the origin of ref, and its parent body is at the
+        expected distance (orbital radius)."""
         self.assertAlmostEqual((0, 0, 0), obj.position(ref))
-        # Check norm of object position is same as objects orbital radius
         if obj.orbit is not None:
             pos = obj.orbit.body.position(ref)
             self.assertAlmostEqual(obj.orbit.radius, norm(pos), delta=20)
-        # Check position agrees with that calculated from bodies orbit
         if obj.name in ("Kerbin", "Mun", "Minmus", "Test"):
             ref = obj.orbit.body.reference_frame
             expected_pos = compute_position(obj, ref)
             actual_pos = tuple(x / 1000000 for x in obj.position(ref))
             self.assertAlmostEqual(expected_pos, actual_pos, delta=1)
 
+    def _vessel_frames(self):
+        """All vessel-centered frames — share origin at vessel CoM."""
+        return [
+            self.vessel.reference_frame,
+            self.vessel.orbital_reference_frame,
+            self.vessel.surface_reference_frame,
+            self.vessel.surface_velocity_reference_frame,
+        ]
+
+    def _kerbin_frames(self):
+        """All Kerbin-centered frames — share origin at Kerbin center."""
+        return [
+            self.kerbin.reference_frame,
+            self.kerbin.non_rotating_reference_frame,
+            self.kerbin.orbital_reference_frame,
+        ]
+
+    def check_magnitude_consistent(self, pos_fn, frames, delta=1):
+        """Verify pos_fn(frame) has the same norm in every frame.
+
+        This holds whenever all frames share the same origin: rotating a frame
+        never changes the distance from the origin to any point.
+        """
+        norms = [norm(pos_fn(ref)) for ref in frames]
+        for n in norms[1:]:
+            self.assertAlmostEqual(norms[0], n, delta=delta)
+
+    def check_cross_distance_symmetry(self, pos_a, frame_a, pos_b, frame_b, delta=0.01):
+        """Verify that the distance from A to B equals the distance from B to A.
+
+        norm(B.position(frame_A)) == norm(A.position(frame_B))
+
+        Both expressions measure the same physical separation between the two
+        points, just expressed in different frames. All four objects here are
+        on the same rigid vessel, so the distance is constant between RPC calls.
+        """
+        d_ab = norm(pos_b(frame_a))
+        d_ba = norm(pos_a(frame_b))
+        self.assertAlmostEqual(d_ab, d_ba, delta=delta)
+
+    def check_unit_direction(self, dir_fn, frames):
+        """Verify dir_fn(frame) returns a unit vector in every frame."""
+        for ref in frames:
+            self.assertAlmostEqual(1.0, norm(dir_fn(ref)), delta=0.01)
+
+    def check_dot_product_invariant(self, dir_a_fn, dir_b_fn, frames, delta=0.01):
+        """Dot product between two directions is the same regardless of frame.
+
+        Rotating the basis doesn't change the angle between directions.
+        """
+        dots = [dot(dir_a_fn(ref), dir_b_fn(ref)) for ref in frames]
+        for d in dots[1:]:
+            self.assertAlmostEqual(dots[0], d, delta=delta)
+
+    # -------------------------------------------------------------------------
+    # Celestial body tests
+    # -------------------------------------------------------------------------
+
     def test_celestial_body_position(self):
         for body in self.bodies.values():
             self.check_object_position(body, body.reference_frame)
+
+    def test_celestial_body_non_rotating_position(self):
+        for body in self.bodies.values():
+            self.check_object_position(body, body.non_rotating_reference_frame)
 
     def test_celestial_body_orbital_position(self):
         for body in self.bodies.values():
@@ -39,157 +110,254 @@ class TestReferenceFrame(krpctest.TestCase):
             else:
                 self.assertRaises(ValueError, getattr, body, "orbital_reference_frame")
 
-    def test_vessel_position(self):
-        self.check_object_position(self.vessel, self.vessel.reference_frame)
+    # -------------------------------------------------------------------------
+    # Vessel position tests
+    # -------------------------------------------------------------------------
 
-    def test_vessel_orbital_position(self):
-        self.check_object_position(self.vessel, self.vessel.orbital_reference_frame)
+    def test_vessel_position_in_vessel_frames(self):
+        """Vessel is at the origin of each of its own frames."""
+        for ref in self._vessel_frames():
+            self.check_object_position(self.vessel, ref)
 
-    def test_vessel_surface_position(self):
-        self.check_object_position(self.vessel, self.vessel.surface_reference_frame)
+    def test_vessel_position_in_body_frames(self):
+        """Vessel distance from Kerbin center equals orbital radius in every Kerbin frame."""
+        r = self.vessel.orbit.radius
+        for ref in self._kerbin_frames():
+            self.assertAlmostEqual(r, norm(self.vessel.position(ref)), delta=20)
 
-    def test_vessel_surface_velocity_position(self):
-        self.check_object_position(
-            self.vessel, self.vessel.surface_velocity_reference_frame
+    # -------------------------------------------------------------------------
+    # Vessel direction tests
+    # -------------------------------------------------------------------------
+
+    def test_vessel_direction_in_own_frame(self):
+        """Vessel nose points along the y-axis of the vessel's own frame."""
+        self.assertAlmostEqual(
+            (0, 1, 0), self.vessel.direction(self.vessel.reference_frame), places=3
         )
+
+    def test_vessel_direction_is_unit_vector(self):
+        """Vessel direction has magnitude 1 in every frame."""
+        self.check_unit_direction(
+            self.vessel.direction, self._vessel_frames() + self._kerbin_frames()
+        )
+
+    # -------------------------------------------------------------------------
+    # Root part position tests
+    # -------------------------------------------------------------------------
+
+    def test_part_position_in_own_frame(self):
+        """Part transform origin is at the origin of the part's own reference frame."""
+        self.assertAlmostEqual(
+            (0, 0, 0), self.root_part.position(self.root_part.reference_frame)
+        )
+
+    def test_part_center_of_mass_in_own_frame(self):
+        """Part CoM is at the origin of the part CoM reference frame."""
+        self.assertAlmostEqual(
+            (0, 0, 0),
+            self.root_part.center_of_mass(self.root_part.center_of_mass_reference_frame),
+        )
+
+    def test_part_position_in_vessel_frames(self):
+        """Part's distance from vessel CoM is the same in all vessel-centered frames.
+
+        All vessel frames share the same origin (vessel CoM); only their
+        orientation differs, so the distance from origin to any fixed point
+        is invariant across them.
+        """
+        self.check_magnitude_consistent(self.root_part.position, self._vessel_frames())
+
+    def test_part_position_in_body_frames(self):
+        """Part's distance from Kerbin center equals orbital radius in every Kerbin frame."""
+        r = self.vessel.orbit.radius
+        for ref in self._kerbin_frames():
+            self.assertAlmostEqual(r, norm(self.root_part.position(ref)), delta=20)
+
+    # -------------------------------------------------------------------------
+    # Root part direction tests
+    # -------------------------------------------------------------------------
+
+    def test_part_direction_in_own_frame(self):
+        """Part y-axis is (0,1,0) when expressed in the part's own frame."""
+        self.assertAlmostEqual(
+            (0, 1, 0),
+            self.root_part.direction(self.root_part.reference_frame),
+            places=3,
+        )
+
+    def test_part_direction_is_unit_vector(self):
+        """Part direction has magnitude 1 in every vessel-centered frame."""
+        self.check_unit_direction(self.root_part.direction, self._vessel_frames())
+
+    # -------------------------------------------------------------------------
+    # Docking port position tests
+    # -------------------------------------------------------------------------
+
+    def test_docking_port_position_in_own_frame(self):
+        """Docking port node origin is at the origin of the port's own reference frame."""
+        self.assertAlmostEqual(
+            (0, 0, 0), self.docking_port.position(self.docking_port.reference_frame)
+        )
+
+    def test_docking_port_position_in_vessel_frames(self):
+        """Docking port's distance from vessel CoM is the same in all vessel-centered frames."""
+        self.check_magnitude_consistent(
+            self.docking_port.position, self._vessel_frames()
+        )
+
+    def test_docking_port_position_in_body_frames(self):
+        """Docking port's distance from Kerbin center equals orbital radius in every Kerbin frame."""
+        r = self.vessel.orbit.radius
+        for ref in self._kerbin_frames():
+            self.assertAlmostEqual(r, norm(self.docking_port.position(ref)), delta=20)
+
+    # -------------------------------------------------------------------------
+    # Docking port direction tests
+    # -------------------------------------------------------------------------
+
+    def test_docking_port_direction_in_own_frame(self):
+        """Docking port outward direction is (0,1,0) in the port's own frame."""
+        self.assertAlmostEqual(
+            (0, 1, 0),
+            self.docking_port.direction(self.docking_port.reference_frame),
+            places=3,
+        )
+
+    def test_docking_port_direction_is_unit_vector(self):
+        """Docking port direction has magnitude 1 in every vessel-centered frame."""
+        self.check_unit_direction(self.docking_port.direction, self._vessel_frames())
+
+    # -------------------------------------------------------------------------
+    # Thruster position tests
+    # -------------------------------------------------------------------------
+
+    def test_thrust_reference_frame_position(self):
+        """Thruster nozzle is at the origin of the thrust reference frame."""
+        self.assertAlmostEqual(
+            (0, 0, 0),
+            self.thruster.thrust_position(self.thruster.thrust_reference_frame),
+        )
+
+    def test_thruster_position_in_vessel_frames(self):
+        """Thruster's distance from vessel CoM is the same in all vessel-centered frames."""
+        self.check_magnitude_consistent(
+            self.thruster.thrust_position, self._vessel_frames()
+        )
+
+    def test_thruster_position_in_body_frames(self):
+        """Thruster's distance from Kerbin center equals orbital radius in every Kerbin frame."""
+        r = self.vessel.orbit.radius
+        for ref in self._kerbin_frames():
+            self.assertAlmostEqual(r, norm(self.thruster.thrust_position(ref)), delta=20)
+
+    # -------------------------------------------------------------------------
+    # Thruster direction tests
+    # -------------------------------------------------------------------------
+
+    def test_thrust_direction_in_own_frame(self):
+        """Thrust direction is (0,1,0) in the thrust reference frame."""
+        self.assertAlmostEqual(
+            (0, 1, 0),
+            self.thruster.thrust_direction(self.thruster.thrust_reference_frame),
+            places=3,
+        )
+
+    def test_thrust_direction_is_unit_vector(self):
+        """Thrust direction has magnitude 1 in every vessel-centered frame."""
+        self.check_unit_direction(self.thruster.thrust_direction, self._vessel_frames())
+
+    # -------------------------------------------------------------------------
+    # Cross-object distance symmetry
+    # -------------------------------------------------------------------------
+
+    def test_cross_object_distance_symmetry(self):
+        """Physical distance between any two on-vessel objects is the same whether
+        measured from A's frame or from B's frame.
+
+        Covers positions of vessel/part/port/thruster in each other's frames —
+        the combinations not reached by the per-object tests above.
+        """
+        objects = [
+            (self.vessel.position, self.vessel.reference_frame),
+            (self.root_part.position, self.root_part.reference_frame),
+            (self.docking_port.position, self.docking_port.reference_frame),
+            (self.thruster.thrust_position, self.thruster.thrust_reference_frame),
+        ]
+        for i, (pos_a, frame_a) in enumerate(objects):
+            for pos_b, frame_b in objects[i + 1 :]:
+                self.check_cross_distance_symmetry(pos_a, frame_a, pos_b, frame_b)
+
+    def test_part_com_frame_offset_symmetry(self):
+        """The distance from the part transform origin to the part CoM is the same
+        measured in either direction.
+
+        part.center_of_mass(part.reference_frame) and
+        part.position(part.center_of_mass_reference_frame) measure the same
+        physical gap between the two frame origins.
+        """
+        self.check_cross_distance_symmetry(
+            self.root_part.position,
+            self.root_part.reference_frame,
+            self.root_part.center_of_mass,
+            self.root_part.center_of_mass_reference_frame,
+        )
+
+    # -------------------------------------------------------------------------
+    # Cross-object direction consistency
+    # -------------------------------------------------------------------------
+
+    def test_direction_dot_product_frame_invariant(self):
+        """The angle between any two directions on the same rigid vessel is the
+        same regardless of which frame they are expressed in.
+
+        Rotating the basis does not change dot products.
+        """
+        pairs = [
+            (self.vessel.direction, self.root_part.direction),
+            (self.vessel.direction, self.docking_port.direction),
+            (self.vessel.direction, self.thruster.thrust_direction),
+            (self.root_part.direction, self.docking_port.direction),
+        ]
+        for dir_a, dir_b in pairs:
+            self.check_dot_product_invariant(dir_a, dir_b, self._vessel_frames())
+
+    # -------------------------------------------------------------------------
+    # Maneuver node tests
+    # -------------------------------------------------------------------------
 
     def test_node_position(self):
         for node in self.vessel.control.nodes:
             node.remove()
         node = self.vessel.control.add_node(self.space_center.ut, 100, 0, 0)
         pos = self.vessel.position(node.reference_frame)
-        # TODO: large error
-        self.assertAlmostEqual((0, 0, 0), pos, delta=100)
+        self.assertAlmostEqual((0, 0, 0), pos)
 
     def test_node_orbital_position(self):
         for node in self.vessel.control.nodes:
             node.remove()
         node = self.vessel.control.add_node(self.space_center.ut, 100, 0, 0)
         pos = self.vessel.position(node.orbital_reference_frame)
-        # TODO: large error
-        self.assertAlmostEqual((0, 0, 0), pos, delta=100)
-
-    def check_object_velocity(self, obj, ref):
-        # Check velocity vectors are unchanged by
-        # converting between the same reference frame
-        self.assertAlmostEqual(
-            (1, 2, 3),
-            self.space_center.transform_velocity((0, 0, 0), (1, 2, 3), ref, ref),
-        )
-        if obj.orbit is not None:
-            # Check velocity of reference frame is same as orbital speed
-            # in reference frame of body being orbited
-            v = self.space_center.transform_velocity(
-                (0, 0, 0), (0, 0, 0), ref, obj.orbit.body.non_rotating_reference_frame
-            )
-            self.assertAlmostEqual(norm(v), obj.orbit.speed, delta=0.5)
-
-    def check_object_surface_velocity(self, obj, ref):
-        if obj.orbit is not None:
-            # Check rotational component of velocity same as orbital speed
-            v = self.space_center.transform_velocity(
-                (0, 0, 0), (0, 0, 0), ref, obj.orbit.body.reference_frame
-            )
-            # if obj.orbit.inclination == 0:
-            #     self.assertAlmostEqual(0, v[1])
-            # else:
-            #     self.assertNotAlmostEqual(0, v[1])
-            angular_velocity = obj.orbit.body.angular_velocity(
-                obj.orbit.body.non_rotating_reference_frame
-            )
-            self.assertAlmostEqual(0, angular_velocity[0])
-            self.assertAlmostEqual(0, angular_velocity[2])
-            rotational_speed = dot((0, 1, 0), angular_velocity)
-            position = list(obj.position(obj.orbit.body.reference_frame))
-            position[1] = 0
-            radius = norm(position)
-            rotational_speed *= radius
-            # TODO: large error
-            self.assertAlmostEqual(
-                abs(rotational_speed + obj.orbit.speed), norm(v), delta=200
-            )
-
-    def test_celestial_body_velocity(self):
-        for body in self.bodies.values():
-            self.check_object_velocity(body, body.reference_frame)
-            self.check_object_surface_velocity(body, body.reference_frame)
-
-    def test_celestial_body_orbital_velocity(self):
-        for body in self.bodies.values():
-            if body.orbit is not None:
-                self.check_object_velocity(body, body.orbital_reference_frame)
-                self.check_object_surface_velocity(body, body.orbital_reference_frame)
-
-    def test_vessel_velocity(self):
-        self.check_object_velocity(self.vessel, self.vessel.reference_frame)
-        self.check_object_surface_velocity(self.vessel, self.vessel.reference_frame)
-
-    def test_vessel_orbital_velocity(self):
-        self.check_object_velocity(self.vessel, self.vessel.orbital_reference_frame)
-        self.check_object_surface_velocity(
-            self.vessel, self.vessel.orbital_reference_frame
-        )
-
-    def test_vessel_surface_velocity(self):
-        self.check_object_velocity(self.vessel, self.vessel.surface_reference_frame)
-        self.check_object_surface_velocity(
-            self.vessel, self.vessel.surface_reference_frame
-        )
-
-    def test_vessel_surface_velocity_velocity(self):
-        self.check_object_velocity(
-            self.vessel, self.vessel.surface_velocity_reference_frame
-        )
-        self.check_object_surface_velocity(
-            self.vessel, self.vessel.surface_velocity_reference_frame
-        )
-
-    def test_node_velocity(self):
-        # TODO: implement
-        pass
-
-    def test_node_orbital_velocity(self):
-        # TODO: implement
-        pass
-
-    def test_celestial_body_direction(self):
-        # Check (0, 1, 0) direction same as body direction
-        for body in self.bodies.values():
-            self.assertAlmostEqual((0, 1, 0), body.direction(body.reference_frame))
-
-    def test_celestial_body_orbital_direction(self):
-        # TODO: implement
-        pass
-
-    def test_celestial_body_surface_direction(self):
-        # TODO: implement
-        pass
-
-    def test_vessel_direction(self):
-        # Check (0, 1, 0) direction same as vessel direction
-        self.assertAlmostEqual(
-            (0, 1, 0), self.vessel.direction(self.vessel.reference_frame), places=3
-        )
-
-    def test_vessel_orbital_direction(self):
-        # TODO: implement
-        pass
-
-    def test_vessel_surface_direction(self):
-        # TODO: implement
-        pass
-
-    def test_vessel_surface_velocity_direction(self):
-        # TODO: implement
-        pass
+        self.assertAlmostEqual((0, 0, 0), pos)
 
     def test_node_direction(self):
-        # TODO: implement
-        pass
+        """Node burn direction is (0,1,0) in the node's own frame."""
+        for node in self.vessel.control.nodes:
+            node.remove()
+        node = self.vessel.control.add_node(self.space_center.ut, 100, 0, 0)
+        self.assertAlmostEqual((0, 1, 0), node.direction(node.reference_frame))
 
-    def test_node_orbital_direction(self):
-        # TODO: implement
-        pass
+    def test_node_direction_is_unit_vector_in_orbital_frame(self):
+        """Node burn direction has magnitude 1 in the node's orbital frame."""
+        for node in self.vessel.control.nodes:
+            node.remove()
+        node = self.vessel.control.add_node(self.space_center.ut, 100, 0, 0)
+        self.assertAlmostEqual(
+            1.0, norm(node.direction(node.orbital_reference_frame)), delta=0.01
+        )
+
+    # -------------------------------------------------------------------------
+    # Relative and hybrid reference frame tests
+    # -------------------------------------------------------------------------
 
     def test_relative_position(self):
         position = (1, 2, 3)
@@ -198,78 +366,27 @@ class TestReferenceFrame(krpctest.TestCase):
         )
         self.assertAlmostEqual(tuple(-x for x in position), self.vessel.position(ref))
 
-    def test_relative_rotation(self):
-        cases = [
-            # 90 degrees rotation around x
-            # vessel points along -z
-            {
-                "rot": (math.sin(math.pi / 4), 0, 0, math.cos(math.pi / 4)),
-                "dir": (0, 0, -1),
-            },
-            # 90 degrees rotation around y
-            # vessel points along y
-            {
-                "rot": (0, math.sin(math.pi / 4), 0, math.cos(math.pi / 4)),
-                "dir": (0, 1, 0),
-            },
-            # 90 degrees rotation around z
-            # vessel points along x
-            {
-                "rot": (0, 0, math.sin(math.pi / 4), math.cos(math.pi / 4)),
-                "dir": (1, 0, 0),
-            },
-        ]
-        self.assertAlmostEqual(
-            (0, 1, 0), self.vessel.direction(self.vessel.reference_frame), places=4
-        )
-        for case in cases:
-            ref = self.space_center.ReferenceFrame.create_relative(
-                self.vessel.reference_frame, rotation=case["rot"]
-            )
-            self.assertAlmostEqual(case["dir"], self.vessel.direction(ref), places=4)
-
-    def test_relative_velocity(self):
-        velocity = (1, 2, 3)
+    def test_relative_direction(self):
+        """Direction is unaffected by a position-only offset in a relative frame."""
         ref = self.space_center.ReferenceFrame.create_relative(
-            self.vessel.reference_frame, velocity=velocity
+            self.vessel.reference_frame, position=(1, 2, 3)
         )
         self.assertAlmostEqual(
-            tuple(-x for x in velocity), self.vessel.velocity(ref), places=4
+            (0, 1, 0), self.vessel.direction(ref), places=3
         )
 
-    def test_relative_angular_velocity(self):
-        angular_velocity = (1, 2, 3)
-        ref = self.space_center.ReferenceFrame.create_relative(
-            self.vessel.reference_frame, angular_velocity=angular_velocity
-        )
-        self.assertAlmostEqual(
-            tuple(-x for x in angular_velocity),
-            self.vessel.angular_velocity(ref),
-            places=4,
-        )
-
-    def test_hybrid(self):
-        position = self.vessel.reference_frame
-        direction = self.vessel.orbital_reference_frame
-        velocity = self.vessel.surface_reference_frame
-        angular_velocity = self.vessel.parts.root.reference_frame
+    def test_hybrid_position(self):
         ref = self.space_center.ReferenceFrame.create_hybrid(
-            position, direction, velocity, angular_velocity
+            position=self.vessel.reference_frame
         )
-        self.assertAlmostEqual(
-            self.vessel.position(position), self.vessel.position(ref), places=3
+        self.assertAlmostEqual((0, 0, 0), self.vessel.position(ref))
+
+    def test_hybrid_direction(self):
+        """Vessel direction is (0,1,0) in a hybrid frame using vessel rotation."""
+        ref = self.space_center.ReferenceFrame.create_hybrid(
+            position=self.vessel.reference_frame
         )
-        self.assertAlmostEqual(
-            self.vessel.direction(direction), self.vessel.direction(ref), places=4
-        )
-        self.assertAlmostEqual(
-            self.vessel.velocity(velocity), self.vessel.velocity(ref), places=4
-        )
-        self.assertAlmostEqual(
-            self.vessel.angular_velocity(angular_velocity),
-            self.vessel.angular_velocity(ref),
-            places=4,
-        )
+        self.assertAlmostEqual((0, 1, 0), self.vessel.direction(ref))
 
 
 if __name__ == "__main__":

--- a/service/SpaceCenter/test/test_referenceframe.py
+++ b/service/SpaceCenter/test/test_referenceframe.py
@@ -1,3 +1,4 @@
+import math
 import unittest
 
 import krpctest
@@ -605,6 +606,94 @@ class TestReferenceFrame(krpctest.TestCase):
                 self.vessel.position(ref_b), via, ref_b, ref_a
             )
             self.assertAlmostEqual(vel, roundtrip, delta=0.5)
+
+    # -------------------------------------------------------------------------
+    # Angular velocity tests
+    # -------------------------------------------------------------------------
+
+    def test_vessel_angular_velocity_zero_in_vessel_frame(self):
+        """Vessel co-rotates with its own body frame, so its angular velocity is zero there."""
+        self.assertAlmostEqual(
+            (0, 0, 0), self.vessel.angular_velocity(self.vessel.reference_frame), delta=0.01
+        )
+
+    def test_kerbin_angular_velocity_zero_in_rotating_frame(self):
+        """Kerbin co-rotates with its rotating frame, so it appears stationary in that frame."""
+        self.assertAlmostEqual(
+            (0, 0, 0), self.kerbin.angular_velocity(self.kerbin.reference_frame), delta=1e-4
+        )
+
+    def test_kerbin_angular_velocity_magnitude_in_non_rotating_frame(self):
+        """In the inertial (non-rotating) frame, Kerbin spins at its rotational speed."""
+        ang_vel = self.kerbin.angular_velocity(self.kerbin.non_rotating_reference_frame)
+        self.assertAlmostEqual(self.kerbin.rotational_speed, norm(ang_vel), delta=1e-5)
+
+    def test_kerbin_angular_velocity_magnitude_same_across_zero_omega_frames(self):
+        """Kerbin's angular speed is the same in all frames with zero frame angular velocity.
+
+        Both CelestialBodyNonRotating and CelestialBodyOrbital have zero frame
+        angular velocity, so each measures the same world-space spin rate for
+        Kerbin; only the orientation of the reported vector differs.
+        """
+        speed_nr = norm(self.kerbin.angular_velocity(self.kerbin.non_rotating_reference_frame))
+        speed_orb = norm(self.kerbin.angular_velocity(self.kerbin.orbital_reference_frame))
+        self.assertAlmostEqual(speed_nr, speed_orb, delta=1e-5)
+
+    def test_vessel_angular_velocity_magnitude_same_across_zero_omega_frames(self):
+        """Vessel angular speed is the same in all frames with zero frame angular velocity.
+
+        VesselOrbital, VesselSurface, and CelestialBodyNonRotating all currently
+        report zero frame angular velocity, so each measures the same world-space
+        spin rate for the vessel.
+        """
+        frames = [
+            self.vessel.orbital_reference_frame,
+            self.vessel.surface_reference_frame,
+            self.kerbin.non_rotating_reference_frame,
+        ]
+        speeds = [norm(self.vessel.angular_velocity(ref)) for ref in frames]
+        for speed in speeds[1:]:
+            self.assertAlmostEqual(speeds[0], speed, delta=0.01)
+
+    def test_relative_frame_angular_velocity_offset(self):
+        """An angular velocity offset on a relative frame shifts the measured angular velocity.
+
+        Adding (0, 1, 0) rad/s (about the vessel y-axis) to the vessel body frame
+        makes that frame spin faster than the vessel.  The vessel therefore appears
+        to rotate at (0, -1, 0) in the new frame — opposite sign because the frame
+        rotates rather than the vessel.
+        """
+        ref = self.space_center.ReferenceFrame.create_relative(
+            self.vessel.reference_frame, angular_velocity=(0, 1, 0)
+        )
+        self.assertAlmostEqual(
+            (0, -1, 0), self.vessel.angular_velocity(ref), delta=0.01
+        )
+
+    def test_hybrid_angular_velocity_source_respected(self):
+        """create_hybrid respects the angular_velocity= sub-frame argument.
+
+        A default hybrid (no angular_velocity override) inherits angular velocity
+        from the vessel frame, so Kerbin's spin is visible.  A hybrid that takes
+        its angular velocity from Kerbin's rotating frame subtracts Kerbin's own
+        spin, making Kerbin appear stationary.
+        """
+        hybrid_default = self.space_center.ReferenceFrame.create_hybrid(
+            position=self.vessel.reference_frame
+        )
+        hybrid_kerbin_rot = self.space_center.ReferenceFrame.create_hybrid(
+            position=self.vessel.reference_frame,
+            angular_velocity=self.kerbin.reference_frame,
+        )
+        # Default hybrid uses vessel angular velocity (~0 for a non-spinning vessel);
+        # Kerbin's spin is visible with magnitude equal to its rotational speed.
+        ang_speed_default = norm(self.kerbin.angular_velocity(hybrid_default))
+        self.assertAlmostEqual(self.kerbin.rotational_speed, ang_speed_default, delta=1e-3)
+        # Hybrid with Kerbin's rotating frame subtracts Kerbin's angular velocity,
+        # making Kerbin appear stationary.
+        self.assertAlmostEqual(
+            (0, 0, 0), self.kerbin.angular_velocity(hybrid_kerbin_rot), delta=1e-4
+        )
 
     # -------------------------------------------------------------------------
     # Relative and hybrid reference frame tests

--- a/service/SpaceCenter/test/test_referenceframe.py
+++ b/service/SpaceCenter/test/test_referenceframe.py
@@ -516,6 +516,97 @@ class TestReferenceFrame(krpctest.TestCase):
             )
 
     # -------------------------------------------------------------------------
+    # Linear velocity tests
+    # -------------------------------------------------------------------------
+
+    def test_vessel_velocity_zero_in_vessel_frames(self):
+        """Vessel velocity is zero in all of its own frames.
+
+        All vessel frames move at the vessel's orbital velocity and have the
+        vessel at their origin, so the ω×r correction vanishes and the
+        relative velocity is (0, 0, 0).
+        """
+        for ref in self._vessel_frames():
+            self.assertAlmostEqual((0, 0, 0), self.vessel.velocity(ref), delta=0.5)
+
+    def test_body_velocity_zero_in_own_frames(self):
+        """A body's velocity is zero in its own rotating and non-rotating frames.
+
+        Both frames move at the body's orbital velocity; the body is at the
+        origin, so the ω×r correction vanishes and the relative velocity is
+        (0, 0, 0).
+        """
+        for ref in [
+            self.kerbin.reference_frame,
+            self.kerbin.non_rotating_reference_frame,
+        ]:
+            self.assertAlmostEqual((0, 0, 0), self.kerbin.velocity(ref), delta=0.5)
+
+    def test_vessel_speed_consistent_in_kerbin_non_rotating_and_orbital_frames(self):
+        """Vessel speed is the same in Kerbin's non-rotating and orbital frames.
+
+        Both frames move at Kerbin's orbital velocity and have zero angular
+        velocity, so they produce the same speed — only the direction of the
+        reported velocity vector differs.
+        """
+        speed_nr = norm(self.vessel.velocity(self.kerbin.non_rotating_reference_frame))
+        speed_orb = norm(self.vessel.velocity(self.kerbin.orbital_reference_frame))
+        self.assertAlmostEqual(speed_nr, speed_orb, delta=1)
+
+    def test_vessel_orbital_speed_in_kerbin_non_rotating_frame(self):
+        """In Kerbin's non-rotating frame the vessel's speed equals its orbital speed.
+
+        The non-rotating frame is inertial relative to Kerbin (ω=0, frame
+        velocity = Kerbin world velocity), so the measured speed is the
+        vessel's velocity relative to Kerbin — i.e., orbit.speed.
+        """
+        speed = norm(self.vessel.velocity(self.kerbin.non_rotating_reference_frame))
+        self.assertAlmostEqual(self.vessel.orbit.speed, speed, delta=1)
+
+    def test_relative_frame_velocity_offset(self):
+        """A velocity offset on a relative frame shifts the measured velocity by its negation.
+
+        Adding (10, 0, 0) m/s to the parent vessel frame makes that frame
+        move 10 m/s faster along the vessel y-axis.  The vessel sits at the
+        frame origin (ω×r = 0) and therefore appears to move at (−10, 0, 0).
+        """
+        ref = self.space_center.ReferenceFrame.create_relative(
+            self.vessel.reference_frame, velocity=(10, 0, 0)
+        )
+        self.assertAlmostEqual((-10, 0, 0), self.vessel.velocity(ref), delta=0.5)
+
+    def test_hybrid_velocity_source_respected(self):
+        """create_hybrid respects the velocity= sub-frame argument.
+
+        A hybrid that omits velocity= inherits it from the position frame
+        (vessel orbital velocity → vessel at rest), giving speed zero.
+        A hybrid with velocity=kerbin_non_rotating uses Kerbin's velocity
+        as the frame velocity, so the measured speed equals orbit.speed.
+        """
+        hybrid_default = self.space_center.ReferenceFrame.create_hybrid(
+            position=self.vessel.reference_frame
+        )
+        hybrid_kerbin_vel = self.space_center.ReferenceFrame.create_hybrid(
+            position=self.vessel.reference_frame,
+            velocity=self.kerbin.non_rotating_reference_frame,
+        )
+        self.assertAlmostEqual((0, 0, 0), self.vessel.velocity(hybrid_default), delta=0.5)
+        speed = norm(self.vessel.velocity(hybrid_kerbin_vel))
+        self.assertAlmostEqual(self.vessel.orbit.speed, speed, delta=1)
+
+    def test_transform_velocity_round_trip(self):
+        """transform_velocity A→B→A returns the original velocity."""
+        ref_a = self.kerbin.non_rotating_reference_frame
+        pos = self.vessel.position(ref_a)
+        vel = self.vessel.velocity(ref_a)
+        for ref_b in self._vessel_frames():
+            via = self.space_center.transform_velocity(pos, vel, ref_a, ref_b)
+            roundtrip = self.space_center.transform_velocity(
+                self.vessel.position(ref_b), via, ref_b, ref_a
+            )
+            self.assertAlmostEqual(vel, roundtrip, delta=0.5)
+
+    # -------------------------------------------------------------------------
     # Relative and hybrid reference frame tests
     # -------------------------------------------------------------------------
 

--- a/service/SpaceCenter/test/test_referenceframe.py
+++ b/service/SpaceCenter/test/test_referenceframe.py
@@ -618,6 +618,35 @@ class TestReferenceFrame(krpctest.TestCase):
         speed = norm(self.vessel.velocity(hybrid_kerbin_vel))
         self.assertAlmostEqual(self.vessel.orbit.speed, speed, delta=1)
 
+    def test_node_velocity_zero_at_current_ut(self):
+        """Vessel velocity is near zero in the node frame when node.UT equals current time.
+
+        The node frame moves at the orbital velocity at node.UT.  When the node
+        is placed at the current UT, that equals the vessel's current orbital
+        velocity, so the relative velocity is (0, 0, 0).
+        Before the fix this returned ~2245 m/s (the raw orbital speed).
+        """
+        for node in self.vessel.control.nodes:
+            node.remove()
+        node = self.vessel.control.add_node(self.space_center.ut, 100, 0, 0)
+        self.assertAlmostEqual(
+            (0, 0, 0), self.vessel.velocity(node.reference_frame), delta=1
+        )
+
+    def test_node_orbital_velocity_zero_at_current_ut(self):
+        """Vessel velocity is near zero in the node's orbital frame when node.UT equals
+        current time.
+
+        Same reasoning as test_node_velocity_zero_at_current_ut — both node frames
+        use the orbital velocity at node.UT as their own frame velocity.
+        """
+        for node in self.vessel.control.nodes:
+            node.remove()
+        node = self.vessel.control.add_node(self.space_center.ut, 100, 0, 0)
+        self.assertAlmostEqual(
+            (0, 0, 0), self.vessel.velocity(node.orbital_reference_frame), delta=1
+        )
+
     def test_transform_velocity_round_trip(self):
         """transform_velocity A→B→A returns the original velocity."""
         ref_a = self.kerbin.non_rotating_reference_frame

--- a/service/SpaceCenter/test/test_referenceframe.py
+++ b/service/SpaceCenter/test/test_referenceframe.py
@@ -1,4 +1,3 @@
-import math
 import unittest
 
 import krpctest
@@ -69,8 +68,8 @@ class TestReferenceFrame(krpctest.TestCase):
         never changes the distance from the origin to any point.
         """
         norms = [norm(pos_fn(ref)) for ref in frames]
-        for n in norms[1:]:
-            self.assertAlmostEqual(norms[0], n, delta=delta)
+        for nm in norms[1:]:
+            self.assertAlmostEqual(norms[0], nm, delta=delta)
 
     def check_cross_distance_symmetry(self, pos_a, frame_a, pos_b, frame_b, delta=0.01):
         """Verify that the distance from A to B equals the distance from B to A.
@@ -96,8 +95,8 @@ class TestReferenceFrame(krpctest.TestCase):
         Rotating the basis doesn't change the angle between directions.
         """
         dots = [dot(dir_a_fn(ref), dir_b_fn(ref)) for ref in frames]
-        for d in dots[1:]:
-            self.assertAlmostEqual(dots[0], d, delta=delta)
+        for dp in dots[1:]:
+            self.assertAlmostEqual(dots[0], dp, delta=delta)
 
     def check_unit_quaternion(self, rot_fn, frames):
         """Verify rot_fn(frame) returns a unit quaternion in every frame."""
@@ -188,7 +187,9 @@ class TestReferenceFrame(krpctest.TestCase):
         for ref in self._vessel_frames():
             rot = self.vessel.rotation(ref)
             self.assertAlmostEqual(
-                self.vessel.direction(ref), quaternion_vector_mult(rot, (0, 1, 0)), delta=0.01
+                self.vessel.direction(ref),
+                quaternion_vector_mult(rot, (0, 1, 0)),
+                delta=0.01,
             )
 
     # -------------------------------------------------------------------------
@@ -205,7 +206,9 @@ class TestReferenceFrame(krpctest.TestCase):
         """Part CoM is at the origin of the part CoM reference frame."""
         self.assertAlmostEqual(
             (0, 0, 0),
-            self.root_part.center_of_mass(self.root_part.center_of_mass_reference_frame),
+            self.root_part.center_of_mass(
+                self.root_part.center_of_mass_reference_frame
+            ),
         )
 
     def test_part_position_in_vessel_frames(self):
@@ -260,7 +263,9 @@ class TestReferenceFrame(krpctest.TestCase):
         for ref in self._vessel_frames():
             rot = self.root_part.rotation(ref)
             self.assertAlmostEqual(
-                self.root_part.direction(ref), quaternion_vector_mult(rot, (0, 1, 0)), delta=0.01
+                self.root_part.direction(ref),
+                quaternion_vector_mult(rot, (0, 1, 0)),
+                delta=0.01,
             )
 
     # -------------------------------------------------------------------------
@@ -280,7 +285,7 @@ class TestReferenceFrame(krpctest.TestCase):
         )
 
     def test_docking_port_position_in_body_frames(self):
-        """Docking port's distance from Kerbin center equals orbital radius in every Kerbin frame."""
+        """Docking port distance from Kerbin center equals orbital radius in all Kerbin frames."""
         r = self.vessel.orbit.radius
         for ref in self._kerbin_frames():
             self.assertAlmostEqual(r, norm(self.docking_port.position(ref)), delta=20)
@@ -348,7 +353,9 @@ class TestReferenceFrame(krpctest.TestCase):
         """Thruster's distance from Kerbin center equals orbital radius in every Kerbin frame."""
         r = self.vessel.orbit.radius
         for ref in self._kerbin_frames():
-            self.assertAlmostEqual(r, norm(self.thruster.thrust_position(ref)), delta=20)
+            self.assertAlmostEqual(
+                r, norm(self.thruster.thrust_position(ref)), delta=20
+            )
 
     # -------------------------------------------------------------------------
     # Thruster direction tests
@@ -500,7 +507,9 @@ class TestReferenceFrame(krpctest.TestCase):
         for node in self.vessel.control.nodes:
             node.remove()
         node = self.vessel.control.add_node(self.space_center.ut, 100, 0, 0)
-        self.assertAlmostEqual(1.0, norm(node.rotation(node.reference_frame)), delta=0.01)
+        self.assertAlmostEqual(
+            1.0, norm(node.rotation(node.reference_frame)), delta=0.01
+        )
         self.assertAlmostEqual(
             1.0, norm(node.rotation(node.orbital_reference_frame)), delta=0.01
         )
@@ -543,7 +552,7 @@ class TestReferenceFrame(krpctest.TestCase):
         ]:
             self.assertAlmostEqual((0, 0, 0), self.kerbin.velocity(ref), delta=0.5)
 
-    def test_vessel_speed_consistent_in_kerbin_non_rotating_and_orbital_frames(self):
+    def test_vessel_speed_same_in_kerbin_non_rotating_and_orbital(self):
         """Vessel speed is the same in Kerbin's non-rotating and orbital frames.
 
         Both frames move at Kerbin's orbital velocity and have zero angular
@@ -591,7 +600,9 @@ class TestReferenceFrame(krpctest.TestCase):
             position=self.vessel.reference_frame,
             velocity=self.kerbin.non_rotating_reference_frame,
         )
-        self.assertAlmostEqual((0, 0, 0), self.vessel.velocity(hybrid_default), delta=0.5)
+        self.assertAlmostEqual(
+            (0, 0, 0), self.vessel.velocity(hybrid_default), delta=0.5
+        )
         speed = norm(self.vessel.velocity(hybrid_kerbin_vel))
         self.assertAlmostEqual(self.vessel.orbit.speed, speed, delta=1)
 
@@ -614,13 +625,17 @@ class TestReferenceFrame(krpctest.TestCase):
     def test_vessel_angular_velocity_zero_in_vessel_frame(self):
         """Vessel co-rotates with its own body frame, so its angular velocity is zero there."""
         self.assertAlmostEqual(
-            (0, 0, 0), self.vessel.angular_velocity(self.vessel.reference_frame), delta=0.01
+            (0, 0, 0),
+            self.vessel.angular_velocity(self.vessel.reference_frame),
+            delta=0.01,
         )
 
     def test_kerbin_angular_velocity_zero_in_rotating_frame(self):
         """Kerbin co-rotates with its rotating frame, so it appears stationary in that frame."""
         self.assertAlmostEqual(
-            (0, 0, 0), self.kerbin.angular_velocity(self.kerbin.reference_frame), delta=1e-4
+            (0, 0, 0),
+            self.kerbin.angular_velocity(self.kerbin.reference_frame),
+            delta=1e-4,
         )
 
     def test_kerbin_angular_velocity_magnitude_in_non_rotating_frame(self):
@@ -628,18 +643,22 @@ class TestReferenceFrame(krpctest.TestCase):
         ang_vel = self.kerbin.angular_velocity(self.kerbin.non_rotating_reference_frame)
         self.assertAlmostEqual(self.kerbin.rotational_speed, norm(ang_vel), delta=1e-5)
 
-    def test_kerbin_angular_velocity_magnitude_same_across_zero_omega_frames(self):
+    def test_kerbin_angular_speed_same_in_zero_omega_frames(self):
         """Kerbin's angular speed is the same in all frames with zero frame angular velocity.
 
         Both CelestialBodyNonRotating and CelestialBodyOrbital have zero frame
         angular velocity, so each measures the same world-space spin rate for
         Kerbin; only the orientation of the reported vector differs.
         """
-        speed_nr = norm(self.kerbin.angular_velocity(self.kerbin.non_rotating_reference_frame))
-        speed_orb = norm(self.kerbin.angular_velocity(self.kerbin.orbital_reference_frame))
+        speed_nr = norm(
+            self.kerbin.angular_velocity(self.kerbin.non_rotating_reference_frame)
+        )
+        speed_orb = norm(
+            self.kerbin.angular_velocity(self.kerbin.orbital_reference_frame)
+        )
         self.assertAlmostEqual(speed_nr, speed_orb, delta=1e-5)
 
-    def test_vessel_angular_velocity_magnitude_same_across_zero_omega_frames(self):
+    def test_vessel_angular_speed_same_in_zero_omega_frames(self):
         """Vessel angular speed is the same in all frames with zero frame angular velocity.
 
         VesselSurface and CelestialBodyNonRotating both have zero frame angular velocity,
@@ -697,7 +716,9 @@ class TestReferenceFrame(krpctest.TestCase):
         # Default hybrid uses vessel angular velocity (~0 for a non-spinning vessel);
         # Kerbin's spin is visible with magnitude equal to its rotational speed.
         ang_speed_default = norm(self.kerbin.angular_velocity(hybrid_default))
-        self.assertAlmostEqual(self.kerbin.rotational_speed, ang_speed_default, delta=1e-3)
+        self.assertAlmostEqual(
+            self.kerbin.rotational_speed, ang_speed_default, delta=1e-3
+        )
         # Hybrid with Kerbin's rotating frame subtracts Kerbin's angular velocity,
         # making Kerbin appear stationary.
         self.assertAlmostEqual(
@@ -733,7 +754,9 @@ class TestReferenceFrame(krpctest.TestCase):
         """
         origin = self.vessel.position(self.vessel.reference_frame)  # (0, 0, 0)
         pos_in_kerbin = self.space_center.transform_position(
-            origin, self.vessel.reference_frame, self.kerbin.non_rotating_reference_frame
+            origin,
+            self.vessel.reference_frame,
+            self.kerbin.non_rotating_reference_frame,
         )
         self.assertAlmostEqual(self.vessel.orbit.radius, norm(pos_in_kerbin), delta=20)
 
@@ -795,9 +818,7 @@ class TestReferenceFrame(krpctest.TestCase):
         ref = self.space_center.ReferenceFrame.create_relative(
             self.vessel.reference_frame, position=(1, 2, 3)
         )
-        self.assertAlmostEqual(
-            (0, 1, 0), self.vessel.direction(ref), places=3
-        )
+        self.assertAlmostEqual((0, 1, 0), self.vessel.direction(ref), places=3)
 
     def test_relative_rotation(self):
         """Rotation is unaffected by a position-only offset in a relative frame."""

--- a/service/SpaceCenter/test/test_referenceframe.py
+++ b/service/SpaceCenter/test/test_referenceframe.py
@@ -642,18 +642,27 @@ class TestReferenceFrame(krpctest.TestCase):
     def test_vessel_angular_velocity_magnitude_same_across_zero_omega_frames(self):
         """Vessel angular speed is the same in all frames with zero frame angular velocity.
 
-        VesselOrbital, VesselSurface, and CelestialBodyNonRotating all currently
-        report zero frame angular velocity, so each measures the same world-space
-        spin rate for the vessel.
+        VesselSurface and CelestialBodyNonRotating both have zero frame angular velocity,
+        so each measures the same world-space spin rate for the vessel.
+        (VesselOrbital is excluded — it now has a non-zero frame angular velocity.)
         """
         frames = [
-            self.vessel.orbital_reference_frame,
             self.vessel.surface_reference_frame,
             self.kerbin.non_rotating_reference_frame,
         ]
         speeds = [norm(self.vessel.angular_velocity(ref)) for ref in frames]
         for speed in speeds[1:]:
             self.assertAlmostEqual(speeds[0], speed, delta=0.01)
+
+    def test_vessel_velocity_zero_in_own_orbital_frame(self):
+        """A vessel's velocity in its own orbital reference frame is zero.
+
+        The orbital frame rotates with the vessel's orbit, so the vessel's own
+        velocity vector is always the y-axis of that frame — the residual should
+        be zero (just the Coriolis correction for CoM, which has zero offset).
+        """
+        vel = self.vessel.velocity(self.vessel.orbital_reference_frame)
+        self.assertAlmostEqual((0, 0, 0), vel, delta=0.5)
 
     def test_relative_frame_angular_velocity_offset(self):
         """An angular velocity offset on a relative frame shifts the measured angular velocity.


### PR DESCRIPTION
- **Fix `ReferenceFrame.CreateHybrid` angular velocity** using the wrong source frame (`hybridVelocity` instead of `hybridAngularVelocity`) (Fixes #639)
- **Fix `PartCenterOfMass` reference frame** throwing on velocity transforms (missing case in the angular velocity switch)
- **Fix `Maneuver` frame forward-vector** built from an unnormalized burn vector, producing wrong axes when burn magnitude ≠ 1
- **Fix `Maneuver` and `ManeuverOrbital` frame velocity vectors** were incorrectly set to zero, now returns the orbital velocity at the node UT
- **Fix `AngleOfAttack` and `SideslipAngle`** calling `ToDegrees(dot_product)` instead of `ToDegrees(Asin(dot_product))`
- **Fix `VesselOrbital` angular velocity**: was returning zero; now correctly computed as `Cross(r, v) / |r|²` (Fixes #823)
- **Fix reference frame rotation precision** for transform-backed frames (`Vessel`, `Part`, `PartCenterOfMass`): read the Unity quaternion directly instead of going through `LookRotation2`, which introduced ~1e-7 error reconstructing from float `up`/`forward` vectors. Also fix an inverted collinearity guard in `LookRotation2` (`Dot < 0.1` → `|Dot| > 0.9`)
- **Fix `LookRotation2` NaN for rotations near 180°** using Shepperd's method: the previous formula computed `w = sqrt(1 + trace) * 0.5`, which passes a negative value to `sqrt` when the trace < −1 (rotations ≥ 180°), producing NaN that propagated silently through all subsequent transforms. Shepperd's method always picks the largest squared-magnitude candidate (always ≥ 1), eliminating any possibility of `sqrt(negative)` or division by near-zero.
- **Fix `VesselSurfaceVelocity` NaN at zero surface speed**: when surface velocity is near zero, both the y-axis and the z-axis collapse and `OrthoNormalize2` produces NaN. Now throws `InvalidOperationException` instead of silently producing NaN.
- **Fix angular velocity for all remaining rotating reference frames** (previously returning zero, causing a silent `ω×r` error in `VelocityFromWorldSpace` for points offset from the frame origin):
  - `VesselSurface`: `body.angularVelocity` (co-rotates with the planet)
  - `VesselSurfaceVelocity`: `body.angularVelocity + Cross(srf_vel, a_srf) / |srf_vel|²`, where `a_srf = grav − body.ω × v_orbital`; the centripetal term (~`v/r` ≈ 3.3e-3 rad/s at 100 km) dominates, ~10× larger than body rotation alone
  - `CelestialBodyOrbital`: `Cross(r, v) / r²` using body and parent-body world velocities
  - `ManeuverOrbital`: `Cross(r_at_UT, v_at_UT) / r²` using orbit patch vectors at `node.UT`
  - `Part`, `PartCenterOfMass`, `DockingPort`, `Thrust`: `vessel.Rigidbody.angularVelocity`


- **Add `Node.Rotation(referenceFrame)`**: new RPC that returns the maneuver node burn direction as a quaternion, consistent with the existing `Direction` method
- **Add `Flight.SurfacePrograde` and `Flight.SurfaceRetrograde`** (#582)
- **Expand reference frame test suite** (`test_referenceframe.py`): restructured with shared helper infrastructure (`_vessel_frames()`, `_kerbin_frames()`, geometric invariant checkers) and new tests covering position, direction, rotation, linear velocity, angular velocity, `transform_position`, and `transform_direction` across vessel, celestial body, node, part, docking port, and thruster frames

### Tests

Integration tests in `test_referenceframe.py` cover all fixed behaviours (fixes #667)