### PR TITLE
Fix CelestialBody.Rotation returning a spurious pole rotation before a flight scene loads

### DIFF
--- a/service/SpaceCenter/CHANGES.txt
+++ b/service/SpaceCenter/CHANGES.txt
@@ -38,6 +38,7 @@ v0.6.0
  * Fix VesselOrbital reference frame angular velocity (missing Coriolis correction) (#823)
  * Fix Vessel.AvailableTorque due to sign inconsistency in KSP's ITorqueProvider implementations (#525)
  * Fix AutoPilot.Error to return the absolute value of the normalized angle (#893)
+ * Fix CelestialBody.Rotation returning incorrect values before a flight scene loads (#890)
 
 v0.5.4
  * Fix vessel recovery (#782)

--- a/service/SpaceCenter/src/Services/CelestialBody.cs
+++ b/service/SpaceCenter/src/Services/CelestialBody.cs
@@ -566,13 +566,7 @@ namespace KRPC.SpaceCenter.Services
         {
             if (ReferenceEquals (referenceFrame, null))
                 throw new ArgumentNullException (nameof (referenceFrame));
-            // Use the body's own (body-fixed) reference frame as the canonical source of the body's
-            // world-space orientation. This guarantees Rotation(body.ReferenceFrame) is the identity
-            // quaternion regardless of scene/physics state. The previous hand-rolled basis
-            // (Vector3.up + GetRelSurfacePosition) could desync from bodyTransform in the azimuth,
-            // producing a large spurious rotation about the pole.
-            var rotation = ReferenceFrame.Object (InternalBody).Rotation;
-            return referenceFrame.RotationFromWorldSpace (rotation).ToTuple ();
+            return referenceFrame.RotationFromWorldSpace (ReferenceFrame.Object (InternalBody).Rotation).ToTuple ();
         }
 
         /// <summary>

--- a/service/SpaceCenter/src/Services/CelestialBody.cs
+++ b/service/SpaceCenter/src/Services/CelestialBody.cs
@@ -566,11 +566,12 @@ namespace KRPC.SpaceCenter.Services
         {
             if (ReferenceEquals (referenceFrame, null))
                 throw new ArgumentNullException (nameof (referenceFrame));
-            var up = Vector3.up;
-            var right = InternalBody.GetRelSurfacePosition (0, 0, 1).normalized;
-            var forward = Vector3.Cross (right, up);
-            Vector3.OrthoNormalize (ref forward, ref up);
-            var rotation = Quaternion.LookRotation (forward, up);
+            // Use the body's own (body-fixed) reference frame as the canonical source of the body's
+            // world-space orientation. This guarantees Rotation(body.ReferenceFrame) is the identity
+            // quaternion regardless of scene/physics state. The previous hand-rolled basis
+            // (Vector3.up + GetRelSurfacePosition) could desync from bodyTransform in the azimuth,
+            // producing a large spurious rotation about the pole.
+            var rotation = ReferenceFrame.Object (InternalBody).Rotation;
             return referenceFrame.RotationFromWorldSpace (rotation).ToTuple ();
         }
 


### PR DESCRIPTION
Closes #884.

## Problem
`body.rotation(body.reference_frame)` should be the identity quaternion `(0, 0, 0, 1)` (a frame
has zero rotation relative to itself) but from a cold start (in the Space Center, before any
flight scene loads) it returns a non-identity quaternion with a spurious rotation about the body's
polar (Y) axis (e.g. `(0.0, 0.478, 0.0, 0.878)`, ~57°). After a vessel is loaded into flight once,
the same query returns the correct identity.

## Root cause
`Rotation()` built the body's world-space orientation from a hand-rolled basis
(`Vector3.up` + `GetRelSurfacePosition(0, 0, 1)`). Before a flight scene runs, that basis can
desync from the body's actual `bodyTransform` in azimuth, producing the spurious pole rotation.

## Fix
Use the body's own (body-fixed) reference frame as the canonical source of its world-space
orientation: `ReferenceFrame.Object(InternalBody).Rotation`. This makes `Rotation(body.ReferenceFrame)`
the identity regardless of scene/physics state, and keeps it consistent with how other
body-relative rotations are derived.

## Verification
Build the SpaceCenter service, then from a cold start in the Space Center (no flight scene yet)
run the repro script from #884. Every body now reports the identity quaternion.