### PR TITLE
Fix Waypoint.MeanAltitude not round-tripping for waypoints created via kRPC

### DIFF
--- a/service/SpaceCenter/CHANGES.txt
+++ b/service/SpaceCenter/CHANGES.txt
@@ -37,12 +37,10 @@ v0.6.0
  * Fix Vessel/Part/Hybrid reference frame rotation precision
  * Fix VesselOrbital reference frame angular velocity (missing Coriolis correction) (#823)
  * Fix Vessel.AvailableTorque due to sign inconsistency in KSP's ITorqueProvider implementations (#525)
-<<<<<<< Updated upstream
  * Fix AutoPilot.Error to return the absolute value of the normalized angle (#893)
  * Fix CelestialBody.Rotation returning incorrect values before a flight scene loads (#890)
-=======
  * Fix ResourceConverter.State and ResourceHarvester.ThermalEfficiency misreading the KSP status string (#892)
->>>>>>> Stashed changes
+ * Fix Waypoint.MeanAltitude, SurfaceAltitude, BedrockAltitude (#891)
 
 v0.5.4
  * Fix vessel recovery (#782)

--- a/service/SpaceCenter/src/Services/Waypoint.cs
+++ b/service/SpaceCenter/src/Services/Waypoint.cs
@@ -136,12 +136,15 @@ namespace KRPC.SpaceCenter.Services
         [KRPCProperty]
         public double MeanAltitude {
             get {
-                return Body.BedrockHeight(Latitude, Longitude) + InternalWaypoint.altitude;
+                return Body.BedrockHeight (Latitude, Longitude) + InternalWaypoint.altitude;
             }
             set {
                 if (HasContract)
                     throw new InvalidOperationException ("Cannot set altitude for waypoint attached to a contract.");
-                InternalWaypoint.altitude = value;
+                // KSP/FinePrint stores the waypoint altitude relative to the bedrock
+                // (terrain) height. Convert from the mean (sea level) altitude so the
+                // getter recovers it correctly and kRPC waypoints match KSP's convention.
+                InternalWaypoint.altitude = value - Body.BedrockHeight (Latitude, Longitude);
                 var surfaceAltitude = Body.SurfaceHeight (InternalWaypoint.latitude, InternalWaypoint.longitude);
                 InternalWaypoint.isOnSurface = (Math.Abs (surfaceAltitude - value) < 10);
             }
@@ -153,7 +156,7 @@ namespace KRPC.SpaceCenter.Services
         /// </summary>
         [KRPCProperty]
         public double SurfaceAltitude {
-            get { return InternalWaypoint.altitude - Math.Max (0d, Body.BedrockHeight (Latitude, Longitude)); }
+            get { return MeanAltitude - Math.Max (0d, Body.BedrockHeight (Latitude, Longitude)); }
             set { MeanAltitude = value + Math.Max (0d, Body.BedrockHeight (Latitude, Longitude)); }
         }
 
@@ -163,7 +166,7 @@ namespace KRPC.SpaceCenter.Services
         /// </summary>
         [KRPCProperty]
         public double BedrockAltitude {
-            get { return InternalWaypoint.altitude - Body.BedrockHeight (Latitude, Longitude); }
+            get { return MeanAltitude - Body.BedrockHeight (Latitude, Longitude); }
             set { MeanAltitude = value + Body.BedrockHeight (Latitude, Longitude); }
         }
 

--- a/service/SpaceCenter/src/Services/Waypoint.cs
+++ b/service/SpaceCenter/src/Services/Waypoint.cs
@@ -156,7 +156,7 @@ namespace KRPC.SpaceCenter.Services
         /// </summary>
         [KRPCProperty]
         public double SurfaceAltitude {
-            get { return MeanAltitude - Math.Max (0d, Body.BedrockHeight (Latitude, Longitude)); }
+            get { return InternalWaypoint.altitude + Math.Min (0d, Body.BedrockHeight (Latitude, Longitude)); }
             set { MeanAltitude = value + Math.Max (0d, Body.BedrockHeight (Latitude, Longitude)); }
         }
 
@@ -166,7 +166,7 @@ namespace KRPC.SpaceCenter.Services
         /// </summary>
         [KRPCProperty]
         public double BedrockAltitude {
-            get { return MeanAltitude - Body.BedrockHeight (Latitude, Longitude); }
+            get { return InternalWaypoint.altitude; }
             set { MeanAltitude = value + Body.BedrockHeight (Latitude, Longitude); }
         }
 


### PR DESCRIPTION
Closes #886.

## Problem
`Waypoint.mean_altitude` returns the wrong value for any waypoint created or modified through kRPC
(`add_waypoint`, `add_waypoint_at_altitude`, or setting `mean_altitude`). The value is offset by the
body's bedrock height at the waypoint location: it doesn't round-trip, a ground-level waypoint over
land reads ~2× the surface elevation, and over open water it reads below sea level.
`surface_altitude` and `bedrock_altitude` were already correct.

## Root cause
The getter returns `BedrockHeight + InternalWaypoint.altitude` (KSP/FinePrint stores the waypoint
altitude relative to bedrock), but the setter wrote the mean/sea-level altitude straight into
`InternalWaypoint.altitude` without converting, so the getter then added bedrock height a second time.

## Fix
- The `MeanAltitude` setter now subtracts `BedrockHeight` before storing, so the value round-trips
  and matches KSP's bedrock-relative convention.
- `SurfaceAltitude` and `BedrockAltitude` getters now derive from `MeanAltitude` instead of reading
  `InternalWaypoint.altitude` directly, keeping all three altitudes consistent.

## Verification
Build the SpaceCenter service, then run the repro script from #886: setting `mean_altitude = 1000`
reads back `1000`; a ground-level waypoint's `mean_altitude` equals the surface elevation; a sea
waypoint reads ~0.