### PR TITLE
Fix ResourceConverter.State and ResourceHarvester.ThermalEfficiency misreading the KSP status string

### DIFF
--- a/service/SpaceCenter/CHANGES.txt
+++ b/service/SpaceCenter/CHANGES.txt
@@ -37,8 +37,12 @@ v0.6.0
  * Fix Vessel/Part/Hybrid reference frame rotation precision
  * Fix VesselOrbital reference frame angular velocity (missing Coriolis correction) (#823)
  * Fix Vessel.AvailableTorque due to sign inconsistency in KSP's ITorqueProvider implementations (#525)
+<<<<<<< Updated upstream
  * Fix AutoPilot.Error to return the absolute value of the normalized angle (#893)
  * Fix CelestialBody.Rotation returning incorrect values before a flight scene loads (#890)
+=======
+ * Fix ResourceConverter.State and ResourceHarvester.ThermalEfficiency misreading the KSP status string (#892)
+>>>>>>> Stashed changes
 
 v0.5.4
  * Fix vessel recovery (#782)

--- a/service/SpaceCenter/src/Services/Parts/ResourceConverter.cs
+++ b/service/SpaceCenter/src/Services/Parts/ResourceConverter.cs
@@ -130,7 +130,7 @@ namespace KRPC.SpaceCenter.Services.Parts
             var status = converter.status;
             if (status == null)
                 return ResourceConverterState.Unknown;
-            else if (status.Contains ("missing") || status.Contains ("nsufficient"))
+            else if (status.Contains ("missing") || status.IndexOf("insufficient", StringComparison.OrdinalIgnoreCase) >= 0)
                 return ResourceConverterState.MissingResource;
             else if (status.Contains ("full"))
                 return ResourceConverterState.StorageFull;

--- a/service/SpaceCenter/src/Services/Parts/ResourceConverter.cs
+++ b/service/SpaceCenter/src/Services/Parts/ResourceConverter.cs
@@ -119,21 +119,25 @@ namespace KRPC.SpaceCenter.Services.Parts
         public ResourceConverterState State (int index)
         {
             CheckConverterExists (index);
-            var status = converters [index].status;
+            var converter = converters [index];
+            // Use IsActivated for the active/idle distinction rather than matching
+            // the localized "Inactive" status string. A running converter reports
+            // either "<x>% load" (while thermally throttled) or "Operational" (at
+            // full capacity), so anything active that isn't reporting a problem is
+            // treated as running.
+            if (!converter.IsActivated)
+                return ResourceConverterState.Idle;
+            var status = converter.status;
             if (status == null)
                 return ResourceConverterState.Unknown;
-            else if (status.Contains ("load"))
-                return ResourceConverterState.Running;
-            else if (status.Contains ("Inactive"))
-                return ResourceConverterState.Idle;
-            else if (status.Contains ("missing"))
+            else if (status.Contains ("missing") || status.Contains ("nsufficient"))
                 return ResourceConverterState.MissingResource;
             else if (status.Contains ("full"))
                 return ResourceConverterState.StorageFull;
             else if (status.Contains ("cap"))
                 return ResourceConverterState.Capacity;
             else
-                return ResourceConverterState.Unknown;
+                return ResourceConverterState.Running;
         }
 
         /// <summary>

--- a/service/SpaceCenter/src/Services/Parts/ResourceHarvester.cs
+++ b/service/SpaceCenter/src/Services/Parts/ResourceHarvester.cs
@@ -66,7 +66,10 @@ namespace KRPC.SpaceCenter.Services.Parts
             get {
                 if (harvester.IsActivated)
                     return ResourceHarvesterState.Active;
-                else if (animator.ActiveAnimation.isPlaying)
+                // ActiveAnimation can be null/destroyed (e.g. while the vessel is
+                // packed); guard it so the state can still be reported.
+                var animation = animator.ActiveAnimation;
+                if (animation != null && animation.isPlaying)
                     return animator.isDeployed ? ResourceHarvesterState.Deploying : ResourceHarvesterState.Retracting;
                 else if (animator.isDeployed)
                     return ResourceHarvesterState.Deployed;
@@ -128,10 +131,13 @@ namespace KRPC.SpaceCenter.Services.Parts
             get {
                 if (!Active)
                     return 0;
-                var status = harvester.status;
-                if (!status.Contains ("load"))
-                    return 0;
-                return GetFloatValue (status);
+                // Evaluate the thermal efficiency curve at the current core
+                // temperature, matching ResourceConverter.ThermalEfficiency. The
+                // harvester's "status" string is not used: a drill never reports a
+                // "<x>% load" status, and its "Ore rate" readout is only populated
+                // while the part's right-click window is open.
+                var temp = Convert.ToSingle (harvester.GetCoreTemperature ());
+                return harvester.ThermalEfficiency.Evaluate (temp);
             }
         }
 


### PR DESCRIPTION
Closes #888.
Closes #887 (duplicate of #888, same root cause and fix for the harvester half).

Both properties derived their value by substring-matching the localized KSP `status` display
string, and both broke because the substrings don't cover what KSP actually emits.

## ResourceConverter.State
A running converter reports `"<x>% load"` while thermally throttled (warming up) but `"Operational"`
once at full capacity. The old code mapped `"load"` → `Running` with no case for `"Operational"`, so
`State` flipped from `Running` to `Unknown` exactly when the converter was running best.

**Fix:** drive the active/idle distinction off `ModuleResourceConverter.IsActivated` (not the
localized `"Inactive"` string), and treat any active converter not reporting a problem
(`missing`/`insufficient`/`full`/capacity) as `Running`, covering both `"<x>% load"` and
`"Operational"`.

## ResourceHarvester.ThermalEfficiency
Harvesters never emit a `"<x>% load"` status (they report `"Operational"`, `"no ground contact"`,
`"insufficient abundance"`, …), so the `"load"`-gated parse never matched and the property always
returned `0` for an active drill. The same `status.Contains(...)` path also risked a
`NullReferenceException` when `status` was null.

**Fix:** compute it from the thermal-efficiency curve at the core temperature (`ThermalEfficiency.Evaluate(GetCoreTemperature())`) exactly as `ResourceConverter.ThermalEfficiency`
already does, instead of parsing the status string. Also guards `ResourceHarvester.Active` against a
null/destroyed `ActiveAnimation` (e.g. while the vessel is packed) so the state can still be reported.

## Verification
Build the SpaceCenter service, then:
- **Converter:** run an ISRU and poll `state(0)` as the core heats; it stays `running` through both
  `"<x>% load"` and `"Operational"` (repro in #888).
- **Harvester:** land a drill on Ore, activate it, and read `thermal_efficiency`; it now climbs with
  core temperature instead of returning `0` (repro in #887/#888).