### PR TITLE
TestingTools: CLI auto-load of saves/craft and a Quit endpoint

### DIFF
--- a/service/SpaceCenter/src/Services/SpaceCenter.cs
+++ b/service/SpaceCenter/src/Services/SpaceCenter.cs
@@ -385,6 +385,45 @@ namespace KRPC.SpaceCenter.Services
         }
 
         /// <summary>
+        /// Outcome of <see cref="LaunchVesselCoroutine"/>. Carries the failure reason, if any,
+        /// so the caller decides how to report it. The coroutine itself does not log.
+        /// </summary>
+        internal sealed class LaunchResult
+        {
+            public string Error { get; set; }
+        }
+
+        internal static System.Collections.IEnumerator LaunchVesselCoroutine (
+            string craftDirectory, string name, string launchSite, IList<string> crew,
+            LaunchResult result, bool recover = true, string flagUrl = "")
+        {
+            LaunchConfig config = null;
+            try {
+                CloseDialogs();
+                config = new LaunchConfig(craftDirectory, name, launchSite, recover, crew, flagUrl);
+                config.RunPreFlightChecks();
+            } catch (Exception e) {
+                result.Error = "pre-flight preparation failed: " + e.Message;
+            }
+            if (result.Error != null)
+                yield break;
+
+            while (!config.preFlightChecksComplete && config.error == null)
+                yield return null;
+
+            if (config.error != null) {
+                result.Error = config.error;
+                yield break;
+            }
+
+            try {
+                LaunchConfiguredVessel(config);
+            } catch (Exception e) {
+                result.Error = "launch failed: " + e.Message;
+            }
+        }
+
+        /// <summary>
         /// Wait until pre-flight checks for new vessel are complete.
         /// </summary>
         /// <param name="config">Config.</param>
@@ -394,6 +433,12 @@ namespace KRPC.SpaceCenter.Services
                 throw new InvalidOperationException(config.error);
             if (!config.preFlightChecksComplete)
                 throw new YieldException<Action>(() => WaitForVesselPreFlightChecks(config));
+            LaunchConfiguredVessel(config);
+            throw new YieldException<Action>(() => WaitForVesselSwitch(0));
+        }
+
+        static void LaunchConfiguredVessel(LaunchConfig config)
+        {
             // Check launch site clear
             var vesselsToRecover = ShipConstruction.FindVesselsLandedAt(HighLogic.CurrentGame.flightState, config.LaunchSite);
             if (vesselsToRecover.Any()) {
@@ -405,7 +450,6 @@ namespace KRPC.SpaceCenter.Services
             }
             // Do the actual launch - passed pre-flight checks, and launch site is clear.
             FlightDriver.StartWithNewLaunch(config.Path, config.FlagUrl, config.LaunchSite, config.manifest);
-            throw new YieldException<Action>(() => WaitForVesselSwitch(0));
         }
 
         /// <summary>

--- a/tools/TestingTools/BUILD.bazel
+++ b/tools/TestingTools/BUILD.bazel
@@ -1,7 +1,7 @@
 load("//:config.bzl", "assembly_version", "author")
 load("//tools/build:csharp.bzl", "csharp_assembly_info", "csharp_library")
 
-srcs = glob(["**/*.cs"]) + [":AssemblyInfo"]
+srcs = glob(["src/**/*.cs"]) + [":AssemblyInfo"]
 
 deps = [
     "//core:KRPC.Core",

--- a/tools/TestingTools/README.md
+++ b/tools/TestingTools/README.md
@@ -1,0 +1,120 @@
+# TestingTools
+
+TestingTools is a development-only kRPC add-on installed by `tools/install.sh`.
+It is used by service tests and local KSP runs; it is not included in the release
+zip.
+
+## Auto-load CLI arguments
+
+The add-on auto-loads a save when KSP reaches the main menu. With no command-line
+arguments, it preserves the historical behavior:
+
+```sh
+tools/run-ksp.sh
+```
+
+This loads `saves/default/persistent.sfs` and switches to the first vessel that is
+not a `SpaceObject`.
+
+The standard runners forward all arguments to KSP, so the auto-load behavior can
+be configured through `tools/run-ksp.sh` or `tools/run-ksp-remote.sh`:
+
+```sh
+tools/run-ksp.sh \
+  --krpc-auto-load-game=krpctest \
+  --krpc-auto-load-save=persistent \
+  --krpc-auto-load-craft=Parts \
+  --krpc-auto-load-craft-directory=VAB \
+  --krpc-auto-load-craft-fixture-dir="$PWD/service/SpaceCenter/test/craft"
+```
+
+Supported arguments:
+
+| Argument | Default | Description |
+| --- | --- | --- |
+| `--krpc-auto-load-game=<folder>` | `default` | Save folder under `saves/`. |
+| `--krpc-auto-load-save=<name>` | `persistent` | Save file name without `.sfs`. |
+| `--krpc-auto-load-vessel=<index>` | first non-`SpaceObject` | Vessel index to focus after loading the save. Ignored when craft launch is requested. |
+| `--krpc-auto-load-craft=<name>` | none | Craft to launch after loading the save. Accepts `Parts` or `Parts.craft`. |
+| `--krpc-auto-load-craft-directory=VAB\|SPH` | inferred | KSP craft directory and launch facility. `VAB` uses `Ships/VAB`; `SPH` uses `Ships/SPH`. |
+| `--krpc-auto-load-craft-fixture-dir=<path>` | none | Source directory of fixture `.craft` files to stage into the save. When omitted, the craft is loaded from the save's own `Ships` directory. |
+| `--krpc-auto-load-launch-site=<site>` | by craft directory | Launch site passed to KSP, for example `LaunchPad` or `Runway`. |
+
+Craft launch takes precedence over vessel switching. If `--krpc-auto-load-craft`
+is provided, TestingTools launches that craft from Space Center, staging it from a
+fixture directory first when `--krpc-auto-load-craft-fixture-dir` is given.
+
+## Craft launch
+
+Craft launch resolves the craft in one of two ways:
+
+- **Staged from a fixture directory.** When `--krpc-auto-load-craft-fixture-dir`
+  is given and contains `<craft>.craft`, TestingTools copies it (and
+  `<craft>.loadmeta`, when present) into `saves/<game>/Ships/<craft-directory>/`
+  before launching. This mirrors `krpctest.TestCase.launch_vessel_from_vab`.
+- **Loaded from the save.** Otherwise, the craft is launched directly from
+  `saves/<game>/Ships/<craft-directory>/` and must already exist there, having
+  been built in the editor or staged by a previous run. This is also the fallback
+  when the craft is not found in the fixture directory.
+
+Launch uses kRPC's internal SpaceCenter launch helper, after the same pre-flight
+checks as the `LaunchVessel` RPC.
+
+`--krpc-auto-load-craft-fixture-dir` is the source directory for fixture craft
+files. It is not the KSP craft directory. Use
+`--krpc-auto-load-craft-directory=VAB` or `SPH` to choose where the craft is
+staged and which editor facility KSP uses for launch checks. Relative fixture
+paths are resolved by the KSP process; with `tools/run-ksp.sh`, that means
+relative to `KSP_DIR`, not the repository root.
+
+Default inference:
+
+| Inputs | Resolved craft directory | Resolved launch site |
+| --- | --- | --- |
+| no craft directory, no launch site | `VAB` | `LaunchPad` |
+| `--krpc-auto-load-launch-site=Runway` | `SPH` | `Runway` |
+| `--krpc-auto-load-craft-directory=VAB` | `VAB` | `LaunchPad` |
+| `--krpc-auto-load-craft-directory=SPH` | `SPH` | `Runway` |
+
+Examples:
+
+```sh
+# Stage the Parts fixture from the repo into the save, then launch it.
+tools/run-ksp.sh \
+  --krpc-auto-load-game=krpctest \
+  --krpc-auto-load-save=persistent \
+  --krpc-auto-load-craft=Parts \
+  --krpc-auto-load-craft-fixture-dir="$PWD/service/SpaceCenter/test/craft"
+```
+
+```sh
+# Launch a craft already saved under saves/krpctest/Ships/VAB.
+tools/run-ksp.sh \
+  --krpc-auto-load-game=krpctest \
+  --krpc-auto-load-save=persistent \
+  --krpc-auto-load-craft=Parts
+```
+
+```sh
+# Stage a spaceplane fixture and launch it from the SPH/Runway.
+tools/run-ksp.sh \
+  --krpc-auto-load-game=krpctest \
+  --krpc-auto-load-save=persistent \
+  --krpc-auto-load-craft=Spaceplane \
+  --krpc-auto-load-craft-directory=SPH \
+  --krpc-auto-load-craft-fixture-dir="$PWD/service/SpaceCenter/test/craft"
+```
+
+## Vessel switching
+
+To load a save and switch to a specific existing vessel:
+
+```sh
+tools/run-ksp.sh \
+  --krpc-auto-load-game=krpctest \
+  --krpc-auto-load-save=persistent \
+  --krpc-auto-load-vessel=0
+```
+
+If the requested vessel index is invalid, TestingTools logs a warning and falls
+back to the first non-`SpaceObject` vessel.

--- a/tools/TestingTools/README.md
+++ b/tools/TestingTools/README.md
@@ -60,6 +60,11 @@ Craft launch resolves the craft in one of two ways:
 Launch uses kRPC's internal SpaceCenter launch helper, after the same pre-flight
 checks as the `LaunchVessel` RPC.
 
+If the craft cannot be staged or found, TestingTools logs a warning and still
+loads the save into the Space Center without launching a craft. This keeps KSP
+out of the main menu so a test client can connect and fail with a real assertion
+rather than a connection timeout.
+
 `--krpc-auto-load-craft-fixture-dir` is the source directory for fixture craft
 files. It is not the KSP craft directory. Use
 `--krpc-auto-load-craft-directory=VAB` or `SPH` to choose where the craft is

--- a/tools/TestingTools/src/AutoLoadGame.cs
+++ b/tools/TestingTools/src/AutoLoadGame.cs
@@ -26,6 +26,7 @@
  */
 
 using System;
+using System.IO;
 using SaveUpgradePipeline;
 using UnityEngine;
 
@@ -34,27 +35,31 @@ namespace TestingTools
     /// <summary>
     /// Addon that automatically loads a save when the game starts
     /// </summary>
-    [KSPAddon (KSPAddon.Startup.MainMenu, false)]
+    [KSPAddon(KSPAddon.Startup.MainMenu, false)]
     public sealed class AutoLoadGame : MonoBehaviour
     {
         /// <summary>
         /// Name of the game to load.
         /// </summary>
         public static string Game {
-            get { return "default"; }
+            get { return Options.Game; }
         }
 
         /// <summary>
         /// Name of the save file to load.
         /// </summary>
         public static string Save {
-            get { return "persistent"; }
+            get { return Options.Save; }
         }
 
         /// <summary>
         /// Whether the game has been loaded.
         /// </summary>
         public static bool Loaded { get; private set; }
+
+        static TestingToolsOptions Options {
+            get { return TestingToolsOptions.Instance; }
+        }
 
         /// <summary>
         /// Initialize the addon.
@@ -64,19 +69,27 @@ namespace TestingTools
             GameEvents.onLevelWasLoadedGUIReady.Add(OnLevelWasLoaded);
         }
 
+        /// <summary>
+        /// Destroy the addon.
+        /// </summary>
+        public void OnDestroy()
+        {
+            GameEvents.onLevelWasLoadedGUIReady.Remove(OnLevelWasLoaded);
+        }
+
         void OnLevelWasLoaded(GameScenes scene)
         {
             if (scene == GameScenes.MAINMENU)
                 StartCoroutine(CallbackUtil.DelayedCallback(15, LoadGame));
         }
 
-        static void LoadGame ()
+        static void LoadGame()
         {
             if (Loaded)
                 return;
             Loaded = true;
 
-            Console.WriteLine("[kRPC testing tools]: Loading game \"" + Game + "\"");
+            Console.WriteLine("[kRPC testing tools]: Loading game \"" + Game + "\" save \"" + Save + "\"");
             var gameObj = GamePersistence.LoadSFSFile(Save, Game);
             if (gameObj == null) {
                 Console.WriteLine("[kRPC testing tools]: Failed to load game, got null when loading sfs file");
@@ -102,25 +115,130 @@ namespace TestingTools
                 return;
             }
 
-            // Find the vessel to switch to
-            bool foundVessel = false;
-            int vesselIdx = 0;
-            foreach (var vessel in HighLogic.CurrentGame.flightState.protoVessels) {
-               if (vessel.vesselType != VesselType.SpaceObject) {
-                   foundVessel = true;
-                   break;
-                }
-                vesselIdx++;}
-            if (!foundVessel) {
-                Console.WriteLine("[kRPC testing tools]: Failed to find vessel to switch to");
-                return;
-            }
-            AutoSwitchVessel.Vessel = vesselIdx;
-
             // Load the game
             HighLogic.CurrentGame.startScene = GameScenes.SPACECENTER;
             HighLogic.SaveFolder = Game;
+
+            if (Options.HasCraft) {
+                if (!PrepareCraftLaunch(Options))
+                    return;
+                AutoSwitchVessel.SetCraftLaunch(
+                    Options.Craft, Options.CraftDirectory, Options.LaunchSite);
+            } else {
+                var vesselIdx = FindVesselToSwitchTo(Options);
+                if (vesselIdx < 0) {
+                    Console.WriteLine("[kRPC testing tools]: Failed to find vessel to switch to");
+                    return;
+                }
+                AutoSwitchVessel.Vessel = vesselIdx;
+            }
+
             HighLogic.CurrentGame.Start();
+        }
+
+        static int FindVesselToSwitchTo(TestingToolsOptions options)
+        {
+            var vessels = HighLogic.CurrentGame.flightState.protoVessels;
+            if (options.Vessel.HasValue) {
+                var vesselIdx = options.Vessel.Value;
+                if (vesselIdx >= 0 && vesselIdx < vessels.Count) {
+                    Console.WriteLine("[kRPC testing tools]: Switching to vessel index " + vesselIdx);
+                    return vesselIdx;
+                }
+                Console.WriteLine(
+                    "[kRPC testing tools]: Vessel index " + vesselIdx +
+                    " is out of range; falling back to the first non-space-object vessel");
+            }
+
+            for (int i = 0; i < vessels.Count; i++) {
+                if (vessels [i].vesselType != VesselType.SpaceObject)
+                    return i;
+            }
+            return -1;
+        }
+
+        static bool PrepareCraftLaunch(TestingToolsOptions options)
+        {
+            var craftName = options.Craft;
+            var targetDirectory = Path.Combine(
+                KSPUtil.ApplicationRootPath, "saves", Game, "Ships", options.CraftDirectory);
+            var targetCraft = Path.Combine(targetDirectory, craftName + ".craft");
+            var sourceCraft = FindCraftSource(options);
+
+            if (sourceCraft == null) {
+                if (File.Exists(targetCraft)) {
+                    Console.WriteLine(
+                        "[kRPC testing tools]: Launching already-staged " +
+                        options.CraftDirectory + " craft \"" + craftName + "\"");
+                    return true;
+                }
+                Console.WriteLine(
+                    "[kRPC testing tools]: Failed to find craft \"" + craftName +
+                    "\" in save Ships/" + options.CraftDirectory +
+                    " (pass --krpc-auto-load-craft-fixture-dir to stage one from elsewhere)");
+                return false;
+            }
+
+            try {
+                Directory.CreateDirectory(targetDirectory);
+                CopyFileIfDifferent(sourceCraft, targetCraft);
+
+                var sourceLoadMeta = Path.ChangeExtension(sourceCraft, ".loadmeta");
+                if (File.Exists(sourceLoadMeta)) {
+                    var targetLoadMeta = Path.Combine(targetDirectory, craftName + ".loadmeta");
+                    CopyFileIfDifferent(sourceLoadMeta, targetLoadMeta);
+                }
+
+                Console.WriteLine(
+                    "[kRPC testing tools]: Staged " + options.CraftDirectory +
+                    " craft \"" + craftName + "\" from " + sourceCraft);
+                return true;
+            } catch (Exception e) {
+                Console.WriteLine(
+                    "[kRPC testing tools]: Failed to stage craft \"" + craftName + "\": " + e);
+                return false;
+            }
+        }
+
+        static string FindCraftSource(TestingToolsOptions options)
+        {
+            // Without an explicit fixture directory, the craft is expected to be
+            // already staged in the save's Ships directory; PrepareCraftLaunch
+            // handles that case when this returns null.
+            if (string.IsNullOrEmpty(options.CraftFixtureDirectory))
+                return null;
+
+            var source = FindCraftInDirectory(options.CraftFixtureDirectory, options.Craft);
+            if (source == null)
+                Console.WriteLine(
+                    "[kRPC testing tools]: Craft \"" + options.Craft +
+                    "\" was not found in fixture directory " + options.CraftFixtureDirectory);
+            return source;
+        }
+
+        static string FindCraftInDirectory(string directory, string craftName)
+        {
+            try {
+                var path = Path.Combine(directory, craftName + ".craft");
+                return File.Exists(path) ? path : null;
+            } catch (Exception) {
+                return null;
+            }
+        }
+
+        static void CopyFileIfDifferent(string source, string target)
+        {
+            if (PathsEqual(source, target))
+                return;
+            File.Copy(source, target, true);
+        }
+
+        static bool PathsEqual(string first, string second)
+        {
+            return string.Equals(
+                Path.GetFullPath(first).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar),
+                Path.GetFullPath(second).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar),
+                StringComparison.OrdinalIgnoreCase);
         }
     }
 }

--- a/tools/TestingTools/src/AutoLoadGame.cs
+++ b/tools/TestingTools/src/AutoLoadGame.cs
@@ -66,7 +66,7 @@ namespace TestingTools
         /// </summary>
         public void Awake()
         {
-            GameEvents.onLevelWasLoadedGUIReady.Add(OnLevelWasLoaded);
+            GameEvents.onLevelWasLoadedGUIReady.Add(OnGUIReady);
         }
 
         /// <summary>
@@ -74,10 +74,15 @@ namespace TestingTools
         /// </summary>
         public void OnDestroy()
         {
-            GameEvents.onLevelWasLoadedGUIReady.Remove(OnLevelWasLoaded);
+            GameEvents.onLevelWasLoadedGUIReady.Remove(OnGUIReady);
         }
 
-        void OnLevelWasLoaded(GameScenes scene)
+        // Named OnGUIReady rather than OnLevelWasLoaded to avoid colliding with
+        // Unity's deprecated OnLevelWasLoaded(int) magic message. The collision is
+        // harmless (the handler is invoked via the GameEvents delegate, not Unity's
+        // message dispatch) but logs a spurious "message parameter has to be of
+        // type: int" error on every run.
+        void OnGUIReady(GameScenes scene)
         {
             if (scene == GameScenes.MAINMENU)
                 StartCoroutine(CallbackUtil.DelayedCallback(15, LoadGame));
@@ -89,31 +94,33 @@ namespace TestingTools
                 return;
             Loaded = true;
 
-            Console.WriteLine("[kRPC testing tools]: Loading game \"" + Game + "\" save \"" + Save + "\"");
+            Debug.Log("[kRPC testing tools]: Loading game \"" + Game + "\" save \"" + Save + "\"");
             var gameObj = GamePersistence.LoadSFSFile(Save, Game);
             if (gameObj == null) {
-                Console.WriteLine("[kRPC testing tools]: Failed to load game, got null when loading sfs file");
+                Debug.LogWarning("[kRPC testing tools]: Failed to load game, got null when loading sfs file");
                 return;
             }
             KSPUpgradePipeline.Process(gameObj, Game, LoadContext.SFS, OnLoadDialogPipelineFinished, OnLoadDialogPipelineError);
         }
 
         static void OnLoadDialogPipelineError(KSPUpgradePipeline.UpgradeFailOption opt, ConfigNode node) {
-            Console.WriteLine("[kRPC testing tools]: KSPUpgradePipeline failed " + opt.ToString() + " " + node);
+            Debug.LogError("[kRPC testing tools]: KSPUpgradePipeline failed " + opt.ToString() + " " + node);
         }
-                           
+
         static void OnLoadDialogPipelineFinished(ConfigNode node)
         {
             // Load game cfg
             HighLogic.CurrentGame = GamePersistence.LoadGameCfg(node, Game, true, false);
             if (HighLogic.CurrentGame == null) {
-                Console.WriteLine("[kRPC testing tools]: Failed to load game, got null when loading game cfg");
+                Debug.LogWarning("[kRPC testing tools]: Failed to load game, got null when loading game cfg");
                 return;
             }
-            if (GamePersistence.UpdateScenarioModules(HighLogic.CurrentGame)) {
-                Console.WriteLine("[kRPC testing tools]: Failed to load game, scenario update required");
-                return;
-            }
+            // Ensure the loaded save has every scenario module the current install
+            // expects. Loading a clean save into a modded install commonly adds
+            // modules and makes this return true; that is normal, not a failure, so
+            // the return value is ignored, matching KSP's own MainMenu load flow.
+            // (Treating true as an error here left the game stuck at the main menu.)
+            GamePersistence.UpdateScenarioModules(HighLogic.CurrentGame);
 
             // Load the game
             HighLogic.CurrentGame.startScene = GameScenes.SPACECENTER;
@@ -127,7 +134,7 @@ namespace TestingTools
             } else {
                 var vesselIdx = FindVesselToSwitchTo(Options);
                 if (vesselIdx < 0) {
-                    Console.WriteLine("[kRPC testing tools]: Failed to find vessel to switch to");
+                    Debug.LogWarning("[kRPC testing tools]: Failed to find vessel to switch to");
                     return;
                 }
                 AutoSwitchVessel.Vessel = vesselIdx;
@@ -142,10 +149,10 @@ namespace TestingTools
             if (options.Vessel.HasValue) {
                 var vesselIdx = options.Vessel.Value;
                 if (vesselIdx >= 0 && vesselIdx < vessels.Count) {
-                    Console.WriteLine("[kRPC testing tools]: Switching to vessel index " + vesselIdx);
+                    Debug.Log("[kRPC testing tools]: Switching to vessel index " + vesselIdx);
                     return vesselIdx;
                 }
-                Console.WriteLine(
+                Debug.LogWarning(
                     "[kRPC testing tools]: Vessel index " + vesselIdx +
                     " is out of range; falling back to the first non-space-object vessel");
             }
@@ -167,12 +174,12 @@ namespace TestingTools
 
             if (sourceCraft == null) {
                 if (File.Exists(targetCraft)) {
-                    Console.WriteLine(
+                    Debug.Log(
                         "[kRPC testing tools]: Launching already-staged " +
                         options.CraftDirectory + " craft \"" + craftName + "\"");
                     return true;
                 }
-                Console.WriteLine(
+                Debug.LogWarning(
                     "[kRPC testing tools]: Failed to find craft \"" + craftName +
                     "\" in save Ships/" + options.CraftDirectory +
                     " (pass --krpc-auto-load-craft-fixture-dir to stage one from elsewhere)");
@@ -189,12 +196,12 @@ namespace TestingTools
                     CopyFileIfDifferent(sourceLoadMeta, targetLoadMeta);
                 }
 
-                Console.WriteLine(
+                Debug.Log(
                     "[kRPC testing tools]: Staged " + options.CraftDirectory +
                     " craft \"" + craftName + "\" from " + sourceCraft);
                 return true;
             } catch (Exception e) {
-                Console.WriteLine(
+                Debug.LogError(
                     "[kRPC testing tools]: Failed to stage craft \"" + craftName + "\": " + e);
                 return false;
             }
@@ -210,7 +217,7 @@ namespace TestingTools
 
             var source = FindCraftInDirectory(options.CraftFixtureDirectory, options.Craft);
             if (source == null)
-                Console.WriteLine(
+                Debug.LogWarning(
                     "[kRPC testing tools]: Craft \"" + options.Craft +
                     "\" was not found in fixture directory " + options.CraftFixtureDirectory);
             return source;

--- a/tools/TestingTools/src/AutoLoadGame.cs
+++ b/tools/TestingTools/src/AutoLoadGame.cs
@@ -127,10 +127,17 @@ namespace TestingTools
             HighLogic.SaveFolder = Game;
 
             if (Options.HasCraft) {
-                if (!PrepareCraftLaunch(Options))
-                    return;
-                AutoSwitchVessel.SetCraftLaunch(
-                    Options.Craft, Options.CraftDirectory, Options.LaunchSite);
+                // Still start into the Space Center if staging fails, rather than
+                // leaving KSP stuck at the main menu. PrepareCraftLaunch has already
+                // logged why; loading the save anyway lets a test client connect and
+                // fail with a real assertion instead of a connection timeout.
+                if (PrepareCraftLaunch(Options))
+                    AutoSwitchVessel.SetCraftLaunch(
+                        Options.Craft, Options.CraftDirectory, Options.LaunchSite);
+                else
+                    Debug.LogWarning(
+                        "[kRPC testing tools]: Loading into the Space Center without " +
+                        "launching a craft");
             } else {
                 var vesselIdx = FindVesselToSwitchTo(Options);
                 if (vesselIdx < 0) {

--- a/tools/TestingTools/src/AutoSwitchVessel.cs
+++ b/tools/TestingTools/src/AutoSwitchVessel.cs
@@ -25,7 +25,6 @@
  * SOFTWARE.
  */
 
-using System;
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
@@ -67,7 +66,7 @@ namespace TestingTools
         /// </summary>
         public void Awake()
         {
-            GameEvents.onLevelWasLoadedGUIReady.Add(OnLevelWasLoaded);
+            GameEvents.onLevelWasLoadedGUIReady.Add(OnGUIReady);
         }
 
         /// <summary>
@@ -75,10 +74,13 @@ namespace TestingTools
         /// </summary>
         public void OnDestroy()
         {
-            GameEvents.onLevelWasLoadedGUIReady.Remove(OnLevelWasLoaded);
+            GameEvents.onLevelWasLoadedGUIReady.Remove(OnGUIReady);
         }
 
-        void OnLevelWasLoaded(GameScenes scene)
+        // Named OnGUIReady rather than OnLevelWasLoaded to avoid colliding with
+        // Unity's deprecated OnLevelWasLoaded(int) magic message, which would
+        // otherwise log a spurious type error on every run.
+        void OnGUIReady(GameScenes scene)
         {
             if (scene != GameScenes.SPACECENTER)
                 return;
@@ -100,7 +102,7 @@ namespace TestingTools
             launchSite = "LaunchPad";
             if (string.IsNullOrEmpty(name))
                 return;
-            Console.WriteLine(
+            Debug.Log(
                 "[kRPC testing tools]: Launching " + directory +
                 " craft \"" + name + "\" at " + site);
             StartCoroutine(LaunchCraftCoroutine(name, directory, site));
@@ -112,13 +114,13 @@ namespace TestingTools
             yield return KRPC.SpaceCenter.Services.SpaceCenter.LaunchVesselCoroutine(
                 directory, name, site, new List<string>(), result);
             if (!string.IsNullOrEmpty(result.Error))
-                Console.WriteLine(
+                Debug.LogError(
                     "[kRPC testing tools]: Failed to launch craft \"" + name + "\": " + result.Error);
         }
 
         static void SwitchVessel()
         {
-            Console.WriteLine("[kRPC testing tools]: Switching to active vessel");
+            Debug.Log("[kRPC testing tools]: Switching to active vessel");
             FlightDriver.StartAndFocusVessel(AutoLoadGame.Save, Vessel);
             Vessel = -1;
         }

--- a/tools/TestingTools/src/AutoSwitchVessel.cs
+++ b/tools/TestingTools/src/AutoSwitchVessel.cs
@@ -26,6 +26,8 @@
  */
 
 using System;
+using System.Collections;
+using System.Collections.Generic;
 using UnityEngine;
 
 namespace TestingTools
@@ -45,6 +47,20 @@ namespace TestingTools
         }
 
         static int vessel = -1;
+        static string craft;
+        static string craftDirectory = "VAB";
+        static string launchSite = "LaunchPad";
+
+        /// <summary>
+        /// Set the craft to launch after the save has loaded.
+        /// </summary>
+        public static void SetCraftLaunch(string name, string directory, string site)
+        {
+            craft = name;
+            craftDirectory = string.IsNullOrEmpty(directory) ? "VAB" : directory;
+            launchSite = string.IsNullOrEmpty(site) ? "LaunchPad" : site;
+            vessel = -1;
+        }
 
         /// <summary>
         /// Initialize the addon.
@@ -54,10 +70,50 @@ namespace TestingTools
             GameEvents.onLevelWasLoadedGUIReady.Add(OnLevelWasLoaded);
         }
 
+        /// <summary>
+        /// Destroy the addon.
+        /// </summary>
+        public void OnDestroy()
+        {
+            GameEvents.onLevelWasLoadedGUIReady.Remove(OnLevelWasLoaded);
+        }
+
         void OnLevelWasLoaded(GameScenes scene)
         {
-            if (scene == GameScenes.SPACECENTER && Vessel >= 0)
+            if (scene != GameScenes.SPACECENTER)
+                return;
+            if (!string.IsNullOrEmpty(craft))
+                StartCoroutine(CallbackUtil.DelayedCallback(15, LaunchCraft));
+            else if (Vessel >= 0)
                 StartCoroutine(CallbackUtil.DelayedCallback(15, SwitchVessel));
+        }
+
+        void LaunchCraft()
+        {
+            // Snapshot and clear the request up front so a repeated scene load
+            // cannot launch the same craft twice.
+            var name = craft;
+            var directory = craftDirectory;
+            var site = launchSite;
+            craft = null;
+            craftDirectory = "VAB";
+            launchSite = "LaunchPad";
+            if (string.IsNullOrEmpty(name))
+                return;
+            Console.WriteLine(
+                "[kRPC testing tools]: Launching " + directory +
+                " craft \"" + name + "\" at " + site);
+            StartCoroutine(LaunchCraftCoroutine(name, directory, site));
+        }
+
+        static IEnumerator LaunchCraftCoroutine(string name, string directory, string site)
+        {
+            var result = new KRPC.SpaceCenter.Services.SpaceCenter.LaunchResult();
+            yield return KRPC.SpaceCenter.Services.SpaceCenter.LaunchVesselCoroutine(
+                directory, name, site, new List<string>(), result);
+            if (!string.IsNullOrEmpty(result.Error))
+                Console.WriteLine(
+                    "[kRPC testing tools]: Failed to launch craft \"" + name + "\": " + result.Error);
         }
 
         static void SwitchVessel()

--- a/tools/TestingTools/src/TestingTools.cs
+++ b/tools/TestingTools/src/TestingTools.cs
@@ -27,6 +27,17 @@ namespace TestingTools
         }
 
         /// <summary>
+        /// Quit the game, closing Kerbal Space Program and returning to the desktop.
+        /// Works from any scene, including in-flight, and skips the confirmation dialog
+        /// that the main-menu quit button normally shows.
+        /// </summary>
+        [KRPCProcedure]
+        public static void Quit ()
+        {
+            Application.Quit ();
+        }
+
+        /// <summary>
         /// Load an existing save game.
         /// </summary>
         [KRPCProcedure]

--- a/tools/TestingTools/src/TestingTools.csproj
+++ b/tools/TestingTools/src/TestingTools.csproj
@@ -52,5 +52,6 @@
     <Compile Include="AutoSwitchVessel.cs" />
     <Compile Include="OrbitTools.cs" />
     <Compile Include="TestingTools.cs" />
+    <Compile Include="TestingToolsOptions.cs" />
   </ItemGroup>
 </Project>

--- a/tools/TestingTools/src/TestingToolsOptions.cs
+++ b/tools/TestingTools/src/TestingToolsOptions.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using UnityEngine;
 
 namespace TestingTools
 {
@@ -77,7 +78,7 @@ namespace TestingTools
                 Vessel = vessel;
                 return;
             }
-            Console.WriteLine("[kRPC testing tools]: Ignoring invalid vessel index '" + value + "'");
+            Debug.LogWarning("[kRPC testing tools]: Ignoring invalid vessel index '" + value + "'");
         }
 
         void ParseCraftDirectory(string value)
@@ -88,7 +89,7 @@ namespace TestingTools
                 craftDirectorySpecified = true;
                 return;
             }
-            Console.WriteLine("[kRPC testing tools]: Ignoring invalid craft directory '" + value + "'");
+            Debug.LogWarning("[kRPC testing tools]: Ignoring invalid craft directory '" + value + "'");
         }
 
         void ResolveCraftDefaults()

--- a/tools/TestingTools/src/TestingToolsOptions.cs
+++ b/tools/TestingTools/src/TestingToolsOptions.cs
@@ -1,0 +1,128 @@
+using System;
+using System.IO;
+
+namespace TestingTools
+{
+    sealed class TestingToolsOptions
+    {
+        const string GameArgument = "--krpc-auto-load-game=";
+        const string SaveArgument = "--krpc-auto-load-save=";
+        const string VesselArgument = "--krpc-auto-load-vessel=";
+        const string CraftArgument = "--krpc-auto-load-craft=";
+        const string CraftDirectoryArgument = "--krpc-auto-load-craft-directory=";
+        const string CraftFixtureDirectoryArgument = "--krpc-auto-load-craft-fixture-dir=";
+        const string LaunchSiteArgument = "--krpc-auto-load-launch-site=";
+
+        static TestingToolsOptions instance;
+
+        TestingToolsOptions()
+        {
+            Game = "default";
+            Save = "persistent";
+        }
+
+        public static TestingToolsOptions Instance {
+            get {
+                if (instance == null)
+                    instance = Parse(Environment.GetCommandLineArgs());
+                return instance;
+            }
+        }
+
+        public string Game { get; private set; }
+        public string Save { get; private set; }
+        public int? Vessel { get; private set; }
+        public string Craft { get; private set; }
+        public string CraftDirectory { get; private set; }
+        public string CraftFixtureDirectory { get; private set; }
+        public string LaunchSite { get; private set; }
+
+        bool craftDirectorySpecified;
+        bool launchSiteSpecified;
+
+        public bool HasCraft {
+            get { return !string.IsNullOrEmpty(Craft); }
+        }
+
+        static TestingToolsOptions Parse(string[] args)
+        {
+            var options = new TestingToolsOptions();
+            foreach (var arg in args) {
+                string value;
+                if (TryGetArgumentValue(arg, GameArgument, out value))
+                    options.Game = value;
+                else if (TryGetArgumentValue(arg, SaveArgument, out value))
+                    options.Save = value;
+                else if (TryGetArgumentValue(arg, VesselArgument, out value))
+                    options.ParseVessel(value);
+                else if (TryGetArgumentValue(arg, CraftArgument, out value))
+                    options.Craft = NormalizeCraftName(value);
+                else if (TryGetArgumentValue(arg, CraftDirectoryArgument, out value))
+                    options.ParseCraftDirectory(value);
+                else if (TryGetArgumentValue(arg, CraftFixtureDirectoryArgument, out value))
+                    options.CraftFixtureDirectory = value;
+                else if (TryGetArgumentValue(arg, LaunchSiteArgument, out value)) {
+                    options.LaunchSite = value;
+                    options.launchSiteSpecified = true;
+                }
+            }
+            options.ResolveCraftDefaults();
+            return options;
+        }
+
+        void ParseVessel(string value)
+        {
+            int vessel;
+            if (int.TryParse(value, out vessel) && vessel >= 0) {
+                Vessel = vessel;
+                return;
+            }
+            Console.WriteLine("[kRPC testing tools]: Ignoring invalid vessel index '" + value + "'");
+        }
+
+        void ParseCraftDirectory(string value)
+        {
+            value = value.ToUpperInvariant();
+            if (value == "VAB" || value == "SPH") {
+                CraftDirectory = value;
+                craftDirectorySpecified = true;
+                return;
+            }
+            Console.WriteLine("[kRPC testing tools]: Ignoring invalid craft directory '" + value + "'");
+        }
+
+        void ResolveCraftDefaults()
+        {
+            if (!craftDirectorySpecified)
+                CraftDirectory = string.Equals(LaunchSite, "Runway", StringComparison.OrdinalIgnoreCase) ? "SPH" : "VAB";
+            if (!launchSiteSpecified)
+                LaunchSite = CraftDirectory == "SPH" ? "Runway" : "LaunchPad";
+        }
+
+        static bool TryGetArgumentValue(string arg, string prefix, out string value)
+        {
+            value = null;
+            if (!arg.StartsWith(prefix, StringComparison.Ordinal))
+                return false;
+            value = TrimQuotes(arg.Substring(prefix.Length).Trim());
+            return !string.IsNullOrEmpty(value);
+        }
+
+        static string NormalizeCraftName(string value)
+        {
+            value = TrimQuotes(value.Trim());
+            if (value.EndsWith(".craft", StringComparison.OrdinalIgnoreCase))
+                value = value.Substring(0, value.Length - ".craft".Length);
+            return Path.GetFileName(value);
+        }
+
+        static string TrimQuotes(string value)
+        {
+            if (value.Length >= 2 &&
+                ((value [0] == '"' && value [value.Length - 1] == '"') ||
+                 (value [0] == '\'' && value [value.Length - 1] == '\'')))
+                return value.Substring(1, value.Length - 2);
+            return value;
+        }
+    }
+}

--- a/tools/TestingTools/src/TestingToolsOptions.cs
+++ b/tools/TestingTools/src/TestingToolsOptions.cs
@@ -111,7 +111,6 @@ namespace TestingTools
 
         static string NormalizeCraftName(string value)
         {
-            value = TrimQuotes(value.Trim());
             if (value.EndsWith(".craft", StringComparison.OrdinalIgnoreCase))
                 value = value.Substring(0, value.Length - ".craft".Length);
             return Path.GetFileName(value);

--- a/tools/krpctest/README.txt
+++ b/tools/krpctest/README.txt
@@ -1,1 +1,4 @@
-Utilities for running service tests for kRPC
+Utilities for running service tests for kRPC.
+
+For KSP startup flags that load test saves, switch vessels, or launch craft
+before a test client connects, see tools/TestingTools/README.md.

--- a/tools/run-ksp-remote.sh
+++ b/tools/run-ksp-remote.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -e
 tools/install.sh
-DISPLAY=:0 $KSP_DIR/KSP.x86 &
+DISPLAY=:0 $KSP_DIR/KSP.x86 "$@" &
 trap 'kill $(jobs -p)' EXIT
 tail -f "$HOME/.config/unity3d/Squad/Kerbal Space Program/Player.log"

--- a/tools/run-ksp.sh
+++ b/tools/run-ksp.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 tools/install.sh
-(cd "${KSP_DIR:-lib/ksp}"; ./KSP.x86_64) &
+(cd "${KSP_DIR:-lib/ksp}"; ./KSP.x86_64 "$@") &
 trap 'kill $(jobs -p)' EXIT
 sleep 3
 tail -f "$KSP_DIR/KSP.log" | grep -i krpc


### PR DESCRIPTION
Adds development-only TestingTools support for launching KSP straight into a known state and shutting it down over RPC, so test and benchmark runs can be fully unattended.

- **Auto-load on startup** via CLI args forwarded by `run-ksp.sh`: load a given save folder/name, then either switch to a vessel by index or stage and launch a fixture craft (e.g. `--krpc-auto-load-game=krpctest --krpc-auto-load-craft=Parts`). See `tools/TestingTools/README.md`.
- **`Quit` endpoint** (`conn.testing_tools.quit()`) that closes KSP from any scene via `Application.Quit()`, replacing the need to force-kill the process.
- Supporting `SpaceCenter` launch helper used by the auto-switch addon.

Together these let a script boot KSP into a specific craft/save, run its checks, and quit, with no manual menu clicks or process management, which is handy for automating integration tests and performance benchmarks.

Also fixes the auto-load aborting at the main menu when `UpdateScenarioModules` adds modules (normal when loading a clean save into a modded install), and routes the addon's diagnostics through `Debug.Log` so failures show up in `KSP.log`.
