### PR TITLE
Fix available torque; add reaction wheel limiter

### DIFF
--- a/doc/order.txt
+++ b/doc/order.txt
@@ -947,6 +947,7 @@ SpaceCenter.ReactionWheel.Active
 SpaceCenter.ReactionWheel.Broken
 SpaceCenter.ReactionWheel.AvailableTorque
 SpaceCenter.ReactionWheel.MaxTorque
+SpaceCenter.ReactionWheel.AuthorityLimiter
 SpaceCenter.ResourceConverter
 SpaceCenter.ResourceConverter.Part
 SpaceCenter.ResourceConverter.Count

--- a/service/SpaceCenter/CHANGES.txt
+++ b/service/SpaceCenter/CHANGES.txt
@@ -41,6 +41,10 @@ v0.6.0
  * Fix CelestialBody.Rotation returning incorrect values before a flight scene loads (#890)
  * Fix ResourceConverter.State and ResourceHarvester.ThermalEfficiency misreading the KSP status string (#892)
  * Fix Waypoint.MeanAltitude, SurfaceAltitude, BedrockAltitude (#891)
+ * Add ReactionWheel.AuthorityLimiter (#909)
+ * Fix RCS force and torque vector calculations using max thrust rather than available thrust (#909)
+ * Fix RCS.MaxTorque documentation error - it considers thrust limit set to 100% (#909)
+ * Fix ReactionWheel.AvailableTorque not considering authority limiter setting (#909)
 
 v0.5.4
  * Fix vessel recovery (#782)

--- a/service/SpaceCenter/src/Services/Parts/ControlSurface.cs
+++ b/service/SpaceCenter/src/Services/Parts/ControlSurface.cs
@@ -130,7 +130,12 @@ namespace KRPC.SpaceCenter.Services.Parts
         }
 
         internal TupleV3 AvailableTorqueVectors {
-            get { return controlSurface.GetPotentialTorque (); }
+            get {
+                // GetPotentialTorque already applies the authority limiter (via
+                // ModuleControlSurface.GetPotentialLift, which scales the deflection by
+                // authorityLimiter * 0.01), so no further scaling is needed here.
+                return controlSurface.GetPotentialTorque ();
+            }
         }
     }
 }

--- a/service/SpaceCenter/src/Services/Parts/Engine.cs
+++ b/service/SpaceCenter/src/Services/Parts/Engine.cs
@@ -579,6 +579,9 @@ namespace KRPC.SpaceCenter.Services.Parts
             get {
                 if (!Active || !Gimballed)
                     return ITorqueProviderExtensions.zero;
+                // GetPotentialTorque already applies the gimbal limiter (via
+                // ModuleGimbal.GimbalRotation, which scales the deflection by
+                // gimbalLimiter * 0.01), so no further scaling is needed here.
                 var torque = gimbal.GetPotentialTorque ();
                 // Note: GetPotentialTorque returns negative torques with incorrect sign
                 return new TupleV3 (torque.Item1, -torque.Item2);

--- a/service/SpaceCenter/src/Services/Parts/RCS.cs
+++ b/service/SpaceCenter/src/Services/Parts/RCS.cs
@@ -186,7 +186,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         private TupleV3 GetTorqueVectors()
         {
             var frame = Part.Vessel.ReferenceFrame;
-            var thrust = MaxThrust;
+            var thrust = AvailableThrust;
             double torqueX = 0;
             double torqueXn = 0;
             double torqueY = 0;
@@ -228,7 +228,9 @@ namespace KRPC.SpaceCenter.Services.Parts
         private TupleV3 GetForceVectors ()
         {
             var frame = Part.Vessel.ReferenceFrame;
-            var thrust = MaxThrust;
+            // Thrust-limited (and fuel-gated) thrust, so available force reflects the thrust limiter
+            // (consistent with GetTorqueVectors).
+            var thrust = AvailableThrust;
             var force = Vector3d.zero;
             var forceN = Vector3d.zero;
             foreach (var thruster in Thrusters) {

--- a/service/SpaceCenter/src/Services/Parts/RCS.cs
+++ b/service/SpaceCenter/src/Services/Parts/RCS.cs
@@ -280,9 +280,8 @@ namespace KRPC.SpaceCenter.Services.Parts
 
         /// <summary>
         /// The maximum amount of thrust that can be produced by the RCS thrusters when active,
-        /// in Newtons.
-        /// Takes the thrusters current <see cref="ThrustLimit"/> and atmospheric conditions
-        /// into account.
+        /// in Newtons, with the <see cref="ThrustLimit"/> set to 100%.
+        /// Takes atmospheric conditions into account.
         /// </summary>
         [KRPCProperty]
         public float MaxThrust {

--- a/service/SpaceCenter/src/Services/Parts/ReactionWheel.cs
+++ b/service/SpaceCenter/src/Services/Parts/ReactionWheel.cs
@@ -78,6 +78,16 @@ namespace KRPC.SpaceCenter.Services.Parts
         }
 
         /// <summary>
+        /// The authority limiter for the reaction wheel, as a percentage of maximum torque.
+        /// A value between 0 and 1.
+        /// </summary>
+        [KRPCProperty]
+        public float AuthorityLimiter {
+            get { return reactionWheel.authorityLimiter / 100f; }
+            set { reactionWheel.authorityLimiter = (value * 100f).Clamp (0f, 100f); }
+        }
+
+        /// <summary>
         /// The available torque, in Newton meters, that can be produced by this reaction wheel,
         /// in the positive and negative pitch, roll and yaw axes of the vessel. These axes
         /// correspond to the coordinate axes of the <see cref="Vessel.ReferenceFrame"/>.

--- a/service/SpaceCenter/src/Services/Parts/ReactionWheel.cs
+++ b/service/SpaceCenter/src/Services/Parts/ReactionWheel.cs
@@ -112,9 +112,12 @@ namespace KRPC.SpaceCenter.Services.Parts
             get {
                 if (!Active || Broken)
                     return ITorqueProviderExtensions.zero;
+                // Note: GetPotentialTorque returns the base torque without applying the
+                // wheel's authority limiter
                 var torque = reactionWheel.GetPotentialTorque ();
+                var scale = reactionWheel.authorityLimiter / 100.0;
                 // Note: GetPotentialTorque returns negative torques with incorrect sign
-                return new TupleV3 (torque.Item1, -torque.Item2);
+                return new TupleV3 (torque.Item1 * scale, -torque.Item2 * scale);
             }
         }
 

--- a/service/SpaceCenter/test/test_parts_control_surface.py
+++ b/service/SpaceCenter/test/test_parts_control_surface.py
@@ -101,6 +101,10 @@ class TestPartsControlSurface(krpctest.TestCase):
         self.assertAlmostEqual(0.2, self.winglet.surface_area)
 
     def test_available_torque(self):
+        # TODO: verify that authority_limiter scales available_torque proportionally
+        # (mirrors test_authority_limiter in test_parts_reaction_wheel.py). This
+        # requires the vessel to be in motion — GetPotentialTorque() returns zero
+        # at rest with no airspeed, so the scaling cannot be exercised here.
         self.assertAlmostEqual((0, 0, 0), self.ctrlsrf.available_torque[0], places=3)
         self.assertAlmostEqual((0, 0, 0), self.winglet.available_torque[1], places=3)
 

--- a/service/SpaceCenter/test/test_parts_engine.py
+++ b/service/SpaceCenter/test/test_parts_engine.py
@@ -1,9 +1,9 @@
 import unittest
+
 import krpctest
 
 
 class EngineTestBase:
-
     # Keyed by language-independent internal part name (part.name); the inline
     # comment is the English title (part.title) for readability.
     engine_data = {
@@ -126,7 +126,6 @@ class EngineTestBase:
 
 
 class EngineTest(EngineTestBase):
-
     def thrust_delta(self, data):
         """Absolute tolerance, in Newtons, for thrust comparisons.
 
@@ -248,7 +247,6 @@ class EngineTest(EngineTestBase):
 
 
 class TestPartsEngine(krpctest.TestCase, EngineTestBase):
-
     @classmethod
     def setUpClass(cls):
         cls.new_save()
@@ -344,6 +342,25 @@ class TestPartsEngine(krpctest.TestCase, EngineTestBase):
         engine.gimbal_locked = False
         self.assertEqual(1, engine.gimbal_limit)
 
+        self.set_throttle(engine, 1)
+        engine.gimbal_limit = 1
+        torque_full = engine.available_torque
+        engine.gimbal_limit = 0.5
+        torque_half = engine.available_torque
+        for axis in range(3):
+            self.assertAlmostEqual(
+                torque_full[0][axis] * 0.5,
+                torque_half[0][axis],
+                delta=max(1, abs(torque_full[0][axis]) * 0.01),
+            )
+            self.assertAlmostEqual(
+                torque_full[1][axis] * 0.5,
+                torque_half[1][axis],
+                delta=max(1, abs(torque_full[1][axis]) * 0.01),
+            )
+        self.set_idle(engine)
+        engine.gimbal_limit = 1
+
     def test_no_thrust_reverser(self):
         engine = self.get_engine("liquidEngine")  # LV-T30 "Reliant"
         self.assertFalse(engine.can_reverse_thrust)
@@ -353,7 +370,6 @@ class TestPartsEngine(krpctest.TestCase, EngineTestBase):
 
 
 class TestPartsEngineMSL(krpctest.TestCase, EngineTest):
-
     @classmethod
     def setUpClass(cls):
         cls.new_save()
@@ -401,7 +417,6 @@ class TestPartsEngineMSL(krpctest.TestCase, EngineTest):
 
 
 class TestPartsEngineVacuum(krpctest.TestCase, EngineTest):
-
     @classmethod
     def setUpClass(cls):
         cls.new_save()
@@ -441,7 +456,6 @@ class TestPartsEngineVacuum(krpctest.TestCase, EngineTest):
 
 
 class TestPartsEngineReverser(krpctest.TestCase, EngineTestBase):
-
     @classmethod
     def setUpClass(cls):
         cls.new_save()

--- a/service/SpaceCenter/test/test_parts_rcs.py
+++ b/service/SpaceCenter/test/test_parts_rcs.py
@@ -91,6 +91,12 @@ class RCSTest(RCSTestBase):
         self.assertAlmostEqual(data["max_thrust"], rcs.max_thrust, delta=1)
         self.assertEqual(data["max_vac_thrust"], rcs.max_vacuum_thrust)
         self.assertAlmostEqual(0.25, rcs.thrust_limit)
+        self.assert_torque_almost_equal(
+            tuple(x * 0.25 for x in data["pos_torque"]), rcs.available_torque[0]
+        )
+        self.assert_torque_almost_equal(
+            tuple(x * 0.25 for x in data["neg_torque"]), rcs.available_torque[1]
+        )
 
         rcs.thrust_limit = 1
 

--- a/service/SpaceCenter/test/test_parts_reaction_wheel.py
+++ b/service/SpaceCenter/test/test_parts_reaction_wheel.py
@@ -1,9 +1,9 @@
 import unittest
+
 import krpctest
 
 
 class TestPartsReactionWheel(krpctest.TestCase):
-
     @classmethod
     def setUpClass(cls):
         cls.new_save()
@@ -37,6 +37,27 @@ class TestPartsReactionWheel(krpctest.TestCase):
         self.assertEqual(pos_torque, self.wheel.max_torque[0])
         self.assertEqual(pos_torque, self.wheel.available_torque[0])
         self.assertEqual(neg_torque, self.wheel.max_torque[1])
+        self.assertEqual(neg_torque, self.wheel.available_torque[1])
+
+    def test_authority_limiter(self):
+        pos_torque = (30000, 30000, 30000)
+        neg_torque = tuple(-x for x in pos_torque)
+        self.assertAlmostEqual(1.0, self.wheel.authority_limiter, places=4)
+        self.assertEqual(pos_torque, self.wheel.available_torque[0])
+        self.assertEqual(neg_torque, self.wheel.available_torque[1])
+        self.wheel.authority_limiter = 0.5
+        self.assertAlmostEqual(0.5, self.wheel.authority_limiter, places=4)
+        self.assertEqual(pos_torque, self.wheel.max_torque[0])
+        self.assertEqual(neg_torque, self.wheel.max_torque[1])
+        self.assertAlmostEqual(15000, self.wheel.available_torque[0][0], places=0)
+        self.assertAlmostEqual(15000, self.wheel.available_torque[0][1], places=0)
+        self.assertAlmostEqual(15000, self.wheel.available_torque[0][2], places=0)
+        self.assertAlmostEqual(-15000, self.wheel.available_torque[1][0], places=0)
+        self.assertAlmostEqual(-15000, self.wheel.available_torque[1][1], places=0)
+        self.assertAlmostEqual(-15000, self.wheel.available_torque[1][2], places=0)
+        self.wheel.authority_limiter = 1.0
+        self.assertAlmostEqual(1.0, self.wheel.authority_limiter, places=4)
+        self.assertEqual(pos_torque, self.wheel.available_torque[0])
         self.assertEqual(neg_torque, self.wheel.available_torque[1])
 
     def test_control(self):


### PR DESCRIPTION
 * Add ReactionWheel.AuthorityLimiter
 * Fix RCS force and torque vector calculations using max thrust rather than available thrust
 * Fix RCS.MaxTorque documentation error - it considers thrust limit set to 100%
 * Fix ReactionWheel.AvailableTorque not considering authority limiter setting