### PR TITLE
TestingTools: make auto-load and vessel focus opt-in

### DIFF
--- a/Development-Guide.md
+++ b/Development-Guide.md
@@ -231,9 +231,10 @@ running. To run these tests:
  * First run `tools/install.sh`
    This script builds kRPC and the `TestingTools` DLL, and installs them into the GameData directory
    of the copy of KSP found at `lib/ksp`.
- * Then run KSP (in `lib/ksp`), or run `tools/run-ksp.sh` to load up the game automatically.
- * When the game loads, `TestingTools` will automatically load up a save game and place you in the
-   flight scene.
+ * Then run KSP (in `lib/ksp`). Pass an auto-load argument so `TestingTools` loads a save and puts
+   you in-game at the Space Center, for example `tools/run-ksp.sh --krpc-auto-load-game=default`.
+   With no auto-load arguments KSP stays at the main menu. See `tools/TestingTools/README.md` for
+   the full set of arguments.
  * Install the python client package, the krpctest package. This can be done using:
    ```
    bazel build //client/python //tools/krpctest

--- a/tools/TestingTools/README.md
+++ b/tools/TestingTools/README.md
@@ -6,15 +6,26 @@ zip.
 
 ## Auto-load CLI arguments
 
-The add-on auto-loads a save when KSP reaches the main menu. With no command-line
-arguments, it preserves the historical behavior:
+The add-on auto-loads a save when KSP reaches the main menu, but only when at
+least one `--krpc-auto-load-*` argument is supplied. With no such arguments it
+does nothing and KSP stays at the main menu:
 
 ```sh
+# No auto-load arguments: KSP stays at the main menu.
 tools/run-ksp.sh
 ```
 
-This loads `saves/default/persistent.sfs` and switches to the first vessel that is
-not a `SpaceObject`.
+To load `saves/default/persistent.sfs` into the Space Center, request it
+explicitly:
+
+```sh
+tools/run-ksp.sh --krpc-auto-load-game=default
+```
+
+Loading a save does not focus a vessel on its own: add `--krpc-auto-load-vessel`
+to switch to an existing vessel, or `--krpc-auto-load-craft` to launch a craft.
+When a load is requested, any argument left out uses its default from the table
+below.
 
 The standard runners forward all arguments to KSP, so the auto-load behavior can
 be configured through `tools/run-ksp.sh` or `tools/run-ksp-remote.sh`:
@@ -34,7 +45,7 @@ Supported arguments:
 | --- | --- | --- |
 | `--krpc-auto-load-game=<folder>` | `default` | Save folder under `saves/`. |
 | `--krpc-auto-load-save=<name>` | `persistent` | Save file name without `.sfs`. |
-| `--krpc-auto-load-vessel=<index>` | first non-`SpaceObject` | Vessel index to focus after loading the save. Ignored when craft launch is requested. |
+| `--krpc-auto-load-vessel=<index>` | none | Vessel index to focus after loading the save. When omitted, no vessel is focused and the save loads into the Space Center. An out-of-range index falls back to the first non-`SpaceObject` vessel. Ignored when craft launch is requested. |
 | `--krpc-auto-load-craft=<name>` | none | Craft to launch after loading the save. Accepts `Parts` or `Parts.craft`. |
 | `--krpc-auto-load-craft-directory=VAB\|SPH` | inferred | KSP craft directory and launch facility. `VAB` uses `Ships/VAB`; `SPH` uses `Ships/SPH`. |
 | `--krpc-auto-load-craft-fixture-dir=<path>` | none | Source directory of fixture `.craft` files to stage into the save. When omitted, the craft is loaded from the save's own `Ships` directory. |

--- a/tools/TestingTools/src/AutoLoadGame.cs
+++ b/tools/TestingTools/src/AutoLoadGame.cs
@@ -84,7 +84,9 @@ namespace TestingTools
         // type: int" error on every run.
         void OnGUIReady(GameScenes scene)
         {
-            if (scene == GameScenes.MAINMENU)
+            // Only auto-load when an auto-load argument was actually supplied.
+            // With no arguments, leave KSP at the main menu.
+            if (scene == GameScenes.MAINMENU && Options.AutoLoadRequested)
                 StartCoroutine(CallbackUtil.DelayedCallback(15, LoadGame));
         }
 
@@ -138,13 +140,17 @@ namespace TestingTools
                     Debug.LogWarning(
                         "[kRPC testing tools]: Loading into the Space Center without " +
                         "launching a craft");
-            } else {
+            } else if (Options.Vessel.HasValue) {
+                // Only switch to a vessel when one was explicitly requested with
+                // --krpc-auto-load-vessel. Without it (and without a craft) the save
+                // is loaded into the Space Center and no vessel is focused.
                 var vesselIdx = FindVesselToSwitchTo(Options);
-                if (vesselIdx < 0) {
-                    Debug.LogWarning("[kRPC testing tools]: Failed to find vessel to switch to");
-                    return;
-                }
-                AutoSwitchVessel.Vessel = vesselIdx;
+                if (vesselIdx >= 0)
+                    AutoSwitchVessel.Vessel = vesselIdx;
+                else
+                    Debug.LogWarning(
+                        "[kRPC testing tools]: No vessel to switch to; loading into " +
+                        "the Space Center");
             }
 
             HighLogic.CurrentGame.Start();

--- a/tools/TestingTools/src/TestingToolsOptions.cs
+++ b/tools/TestingTools/src/TestingToolsOptions.cs
@@ -6,13 +6,17 @@ namespace TestingTools
 {
     sealed class TestingToolsOptions
     {
-        const string GameArgument = "--krpc-auto-load-game=";
-        const string SaveArgument = "--krpc-auto-load-save=";
-        const string VesselArgument = "--krpc-auto-load-vessel=";
-        const string CraftArgument = "--krpc-auto-load-craft=";
-        const string CraftDirectoryArgument = "--krpc-auto-load-craft-directory=";
-        const string CraftFixtureDirectoryArgument = "--krpc-auto-load-craft-fixture-dir=";
-        const string LaunchSiteArgument = "--krpc-auto-load-launch-site=";
+        // All auto-load arguments share this prefix. Auto-load is enabled by the
+        // presence of any argument with this prefix, so future TestingTools
+        // arguments that use a different prefix will not trigger a load.
+        const string AutoLoadPrefix = "--krpc-auto-load-";
+        const string GameArgument = AutoLoadPrefix + "game=";
+        const string SaveArgument = AutoLoadPrefix + "save=";
+        const string VesselArgument = AutoLoadPrefix + "vessel=";
+        const string CraftArgument = AutoLoadPrefix + "craft=";
+        const string CraftDirectoryArgument = AutoLoadPrefix + "craft-directory=";
+        const string CraftFixtureDirectoryArgument = AutoLoadPrefix + "craft-fixture-dir=";
+        const string LaunchSiteArgument = AutoLoadPrefix + "launch-site=";
 
         static TestingToolsOptions instance;
 
@@ -38,6 +42,12 @@ namespace TestingTools
         public string CraftFixtureDirectory { get; private set; }
         public string LaunchSite { get; private set; }
 
+        /// <summary>
+        /// Whether any auto-load argument was supplied. When false, no save is
+        /// loaded and KSP is left at the main menu.
+        /// </summary>
+        public bool AutoLoadRequested { get; private set; }
+
         bool craftDirectorySpecified;
         bool launchSiteSpecified;
 
@@ -49,6 +59,12 @@ namespace TestingTools
         {
             var options = new TestingToolsOptions();
             foreach (var arg in args) {
+                // Any auto-load argument requests a load. Keyed off the shared
+                // prefix, not the individual arguments, so unrelated TestingTools
+                // arguments added later cannot trigger a load by accident.
+                if (arg.StartsWith(AutoLoadPrefix, StringComparison.Ordinal))
+                    options.AutoLoadRequested = true;
+
                 string value;
                 if (TryGetArgumentValue(arg, GameArgument, out value))
                     options.Game = value;


### PR DESCRIPTION
Follow-up fix to [#908](https://github.com/krpc/krpc/pull/908), which added the TestingTools CLI auto-load. Two behaviors from that PR were too eager for manual and dev runs, so this makes them opt-in.

- **Auto-load only runs when requested.** Previously TestingTools auto-loaded `default/persistent` on every launch. It now loads only when at least one `--krpc-auto-load-*` argument is supplied (keyed off the shared prefix, so unrelated arguments added later can't trigger it); with none, KSP is left at the main menu.
- **Loading a save no longer focuses a vessel by default.** Use `--krpc-auto-load-vessel` to focus an existing vessel, or `--krpc-auto-load-craft` to launch a craft. Without either, the save loads into the Space Center.

Also fixes a case where a save with no switchable vessel stranded KSP at the main menu (it now loads into the Space Center), and drops a redundant `TrimQuotes` call in `NormalizeCraftName` (review comment). Docs updated: the dev/test bootstrap now uses `tools/run-ksp.sh --krpc-auto-load-game=default`.
