### PR TITLE
Fix SimulateAerodynamicForceAt over-predicting subsonic drag (#911)

### DIFF
--- a/service/SpaceCenter/CHANGES.txt
+++ b/service/SpaceCenter/CHANGES.txt
@@ -1,5 +1,4 @@
 v0.6.0
- * Fix Flight.SimulateAerodynamicForceAt overestimating drag at low altitude and subsonic speed by applying KSP's pseudo-Reynolds drag multiplier to cube drag (#911)
  * Fix Maneuver and ManeuverOrbital reference frame velocity (previously returned zero; now returns the orbital velocity at the node UT)
  * Fix angular velocity for VesselSurface, VesselSurfaceVelocity, CelestialBodyOrbital, ManeuverOrbital, Part, PartCenterOfMass, DockingPort and Thrust reference frames (previously returned zero)
  * Fix LookRotation2 producing NaN for rotations near 180° by using Shepperd's method

--- a/service/SpaceCenter/CHANGES.txt
+++ b/service/SpaceCenter/CHANGES.txt
@@ -1,4 +1,5 @@
 v0.6.0
+ * Fix Flight.SimulateAerodynamicForceAt overestimating drag at low altitude and subsonic speed by applying KSP's pseudo-Reynolds drag multiplier to cube drag (#911)
  * Fix Maneuver and ManeuverOrbital reference frame velocity (previously returned zero; now returns the orbital velocity at the node UT)
  * Fix angular velocity for VesselSurface, VesselSurfaceVelocity, CelestialBodyOrbital, ManeuverOrbital, Part, PartCenterOfMass, DockingPort and Thrust reference frames (previously returned zero)
  * Fix LookRotation2 producing NaN for rotations near 180° by using Shepperd's method

--- a/service/SpaceCenter/CHANGES.txt
+++ b/service/SpaceCenter/CHANGES.txt
@@ -45,6 +45,8 @@ v0.6.0
  * Fix RCS force and torque vector calculations using max thrust rather than available thrust (#909)
  * Fix RCS.MaxTorque documentation error - it considers thrust limit set to 100% (#909)
  * Fix ReactionWheel.AvailableTorque not considering authority limiter setting (#909)
+ * Fix Flight.SimulateAerodynamicForceAt overestimating drag at low altitude and
+   subsonic speed by applying KSP's pseudo-Reynolds drag multiplier to cube drag (#912)
 
 v0.5.4
  * Fix vessel recovery (#782)

--- a/service/SpaceCenter/src/ExtensionMethods/StockAerodynamics.cs
+++ b/service/SpaceCenter/src/ExtensionMethods/StockAerodynamics.cs
@@ -129,6 +129,13 @@ namespace KRPC.SpaceCenter.ExtensionMethods
             if (mach > 25.0)
                 mach = 25.0;
 
+            // KSP's FlightIntegrator scales cube drag by a pseudo-Reynolds factor
+            // (density times speed). See CalculateConstantsAtmosphere setting
+            // pseudoReDragMult, applied per part in CalculateDragValue. Omitting it
+            // overestimates drag at low altitude and subsonic speed (see #911).
+            var pseudoReDragMult = PhysicsGlobals.DragCurvePseudoReynolds.Evaluate(
+                (float)(rho * v_wrld_vel.magnitude));
+
             // Loop through all parts, accumulating drag and lift.
             for (int i = 0; i < _vessel.Parts.Count; ++i) {
                 // need checks on shielded components
@@ -175,7 +182,7 @@ namespace KRPC.SpaceCenter.ExtensionMethods
                             liftForce = p_drag_data.liftForce;
                         }
 
-                        var sim_dragScalar = dyn_pressure * drag * PhysicsGlobals.DragMultiplier;
+                        var sim_dragScalar = dyn_pressure * drag * PhysicsGlobals.DragMultiplier * pseudoReDragMult;
                         dragForce = -(Vector3d)sim_dragVectorDir * sim_dragScalar;
                         break;
 


### PR DESCRIPTION
Closes #911.

## Problem

`Flight.SimulateAerodynamicForceAt` (stock aero path) over-predicts drag at subsonic speeds in dense air. Compared against the live `Flight.AerodynamicForce` at the vessel's actual state and orientation, the simulated magnitude is up to ~20% high below about Mach 0.8, while matching to <0.2% supersonically.

Density and orientation are ruled out as the cause: model vs live density agree to ~1%, and the simulated and live force vectors stay parallel (angle <0.1°), so it is a pure drag-magnitude error.

## Root cause

`StockAerodynamics.SimAeroForce` (adapted from KSPTrajectories) computes cube drag as `areaDrag * DragCubeMultiplier * dynamicPressure * DragMultiplier` but omits the pseudo-Reynolds drag multiplier KSP applies. Verified against KSP's `FlightIntegrator`:

- `CalculateConstantsAtmosphere`: `pseudoReDragMult = PhysicsGlobals.DragCurvePseudoReynolds.Evaluate(density * speed)`
- applied per part: `CalculateDragValue(part) * pseudoReDragMult`, where `CalculateDragValue_Cube = DragCubes.AreaDrag * DragCubeMultiplier`

The factor is ≈1 supersonically and falls below 1 at high `density * speed` (low altitude, subsonic), so omitting it inflates low-altitude drag.

## Fix

Compute `pseudoReDragMult` once from the same density and air speed already used for dynamic pressure, and apply it to the cube/default drag scalar.

## Validation

Simulated vs live `AerodynamicForce` sampled down a steady retrograde descent on Kerbin (stock aero), before and after the change:

| Mach | before | after |
|---:|---:|---:|
| ~5.7 | 0.08% | 0.09% |
| 0.85 | 7.1% | 0.7% |
| 0.81 | 19.4% | 0.6% |
| 0.74 | 20.4% | 1.2% |
| 0.68 | 20.1% | 1.2% |

Supersonic accuracy is unchanged; the subsonic tail collapses to ~1%. The residual ~1% is the pre-existing density approximation (model density ~1% below live, which tracks the remaining force deficit), not introduced by this change.

## Scope

- Affects the stock (non-FAR) path only; the FAR path is unchanged.
- Applied to the cube/default drag model (what stock parts use); the legacy
  spherical/cylindrical/conic branches are left as-is.

## Suggested CHANGES.txt Entry

 * Fix Flight.SimulateAerodynamicForceAt overestimating drag at low altitude and subsonic speed by applying KSP's pseudo-Reynolds drag multiplier to cube drag
