### PR TITLE
Add rotation parameter to Flight.SimulateAerodynamicForceAt

### DIFF
--- a/service/SpaceCenter/CHANGES.txt
+++ b/service/SpaceCenter/CHANGES.txt
@@ -47,6 +47,11 @@ v0.6.0
  * Fix ReactionWheel.AvailableTorque not considering authority limiter setting (#909)
  * Fix Flight.SimulateAerodynamicForceAt overestimating drag at low altitude and
    subsonic speed by applying KSP's pseudo-Reynolds drag multiplier to cube drag (#912)
+ * Add a rotation parameter to Flight.SimulateAerodynamicForceAt to set the vessel
+   attitude (angle of attack and sideslip) independently of velocity. Pass the current
+   rotation for the previous behavior (#915)
+ * Fix Flight.SimulateAerodynamicForceAt returning force in kilonewtons instead of
+   newtons when FAR is installed (#915)
 
 v0.5.4
  * Fix vessel recovery (#782)

--- a/service/SpaceCenter/src/Services/Flight.cs
+++ b/service/SpaceCenter/src/Services/Flight.cs
@@ -546,20 +546,29 @@ namespace KRPC.SpaceCenter.Services
 
         /// <summary>
         /// Simulate and return the total aerodynamic forces acting on the vessel,
-        /// if it where to be traveling with the given velocity at the given position in the
-        /// atmosphere of the given celestial body.
+        /// if it were traveling with the given velocity, at the given position and
+        /// orientation, in the atmosphere of the given celestial body.
         /// </summary>
         /// <param name="body">The celestial body whose atmosphere the forces are simulated in.</param>
         /// <param name="position">The position of the vessel, in reference frame
         /// <see cref="ReferenceFrame"/>.</param>
         /// <param name="velocity">The velocity of the vessel, in reference frame
         /// <see cref="ReferenceFrame"/>.</param>
-        /// <param name="rotation">The rotation of the vessel, in reference frame
+        /// <param name="rotation">The orientation of the vessel, in reference frame
         /// <see cref="ReferenceFrame"/>, in the same form as <see cref="Vessel.Rotation"/>.
-        /// This sets the angle of attack and sideslip independently of the velocity. Pass the
-        /// vessel's current rotation to use its current orientation.</param>
-        /// <returns>A vector pointing in the direction that the force acts,
-        /// with its magnitude equal to the strength of the force in Newtons.</returns>
+        /// The angle of attack and sideslip follow from this orientation relative to the
+        /// velocity; the roll component sets the direction of any aerodynamic lift. Pass
+        /// the vessel's current rotation to evaluate the force at its current orientation.</param>
+        /// <returns>A vector pointing in the direction that the force acts, with its
+        /// magnitude equal to the strength of the force in Newtons, in reference frame
+        /// <see cref="ReferenceFrame"/>.</returns>
+        /// <remarks>
+        /// The position, velocity and rotation arguments, and the returned force, are all
+        /// expressed in reference frame <see cref="ReferenceFrame"/>. The result is the
+        /// force the vessel would experience if it were placed at that position and
+        /// orientation with the air flowing past it at that velocity; it is the force at
+        /// the requested orientation, not the force in the vessel's current orientation.
+        /// </remarks>
         [KRPCMethod]
         public Tuple3 SimulateAerodynamicForceAt(CelestialBody body, Tuple3 position, Tuple3 velocity, Tuple4 rotation)
         {

--- a/service/SpaceCenter/src/Services/Flight.cs
+++ b/service/SpaceCenter/src/Services/Flight.cs
@@ -549,25 +549,41 @@ namespace KRPC.SpaceCenter.Services
         /// if it where to be traveling with the given velocity at the given position in the
         /// atmosphere of the given celestial body.
         /// </summary>
+        /// <param name="body">The celestial body whose atmosphere the forces are simulated in.</param>
+        /// <param name="position">The position of the vessel, in reference frame
+        /// <see cref="ReferenceFrame"/>.</param>
+        /// <param name="velocity">The velocity of the vessel, in reference frame
+        /// <see cref="ReferenceFrame"/>.</param>
+        /// <param name="rotation">The rotation of the vessel, in reference frame
+        /// <see cref="ReferenceFrame"/>, in the same form as <see cref="Vessel.Rotation"/>.
+        /// This sets the angle of attack and sideslip independently of the velocity. Pass the
+        /// vessel's current rotation to use its current orientation.</param>
         /// <returns>A vector pointing in the direction that the force acts,
         /// with its magnitude equal to the strength of the force in Newtons.</returns>
         [KRPCMethod]
-        public Tuple3 SimulateAerodynamicForceAt(CelestialBody body, Tuple3 position, Tuple3 velocity)
+        public Tuple3 SimulateAerodynamicForceAt(CelestialBody body, Tuple3 position, Tuple3 velocity, Tuple4 rotation)
         {
             if (ReferenceEquals (body, null))
                 throw new ArgumentNullException (nameof (body));
             var vessel = InternalVessel;
             var worldVelocity = referenceFrame.VelocityToWorldSpace(position.ToVector(), velocity.ToVector());
             var worldPosition = referenceFrame.PositionToWorldSpace(position.ToVector());
-            Vector3 worldForce;
+            QuaternionD desiredWorld = referenceFrame.RotationToWorldSpace (rotation.ToQuaternion ());
+            QuaternionD currentWorld = vessel.ReferenceTransform.rotation;
+            var delta = desiredWorld * currentWorld.Inverse ();
+            var adjustedVelocity = delta.Inverse () * (worldVelocity - body.InternalBody.getRFrmVel(worldPosition));
+            Vector3 force;
             if (!FAR.IsAvailable) {
-                var relativeWorldVelocity = worldVelocity - body.InternalBody.getRFrmVel(worldPosition);
-                worldForce = StockAerodynamics.SimAeroForce(body.InternalBody, vessel, relativeWorldVelocity, worldPosition);
+                force = StockAerodynamics.SimAeroForce(body.InternalBody, vessel, adjustedVelocity, worldPosition);
             } else {
                 Vector3 torque;
                 var altitude = (worldPosition - body.InternalBody.position).magnitude - body.InternalBody.Radius;
-                FAR.CalculateVesselAeroForces(vessel, out worldForce, out torque, worldVelocity - body.InternalBody.getRFrmVel(worldPosition), altitude);
+                FAR.CalculateVesselAeroForces(vessel, out force, out torque, adjustedVelocity, altitude);
+                // CalculateVesselAeroForces returns kilonewtons; convert to newtons to
+                // match the stock path and this method's documented units.
+                force = force * 1000f;
             }
+            var worldForce = (Vector3)(delta * (Vector3d)force);
             return referenceFrame.DirectionFromWorldSpace(worldForce).ToTuple();
         }
 

--- a/service/SpaceCenter/test/test_flight.py
+++ b/service/SpaceCenter/test/test_flight.py
@@ -1,7 +1,16 @@
 import unittest
 import math
 import krpctest
-from krpctest.geometry import rad2deg, norm, normalize, dot, cross, vector
+from krpctest.geometry import (
+    rad2deg,
+    norm,
+    normalize,
+    dot,
+    cross,
+    vector,
+    quaternion_axis_angle,
+    quaternion_mult,
+)
 
 
 class TestFlight(krpctest.TestCase):
@@ -292,6 +301,36 @@ class TestFlightAtLaunchpad(krpctest.TestCase):
             self.assertAlmostEqual(0, flight.thrust_specific_fuel_consumption)
 
             self.assertEqual("Nominal", flight.far_status)
+
+    def test_simulate_aerodynamic_force_rotation(self):
+        # The rotation argument sets the vessel attitude the force is computed
+        # for (issue #913). A 300 m/s head-on wind (angle of attack 0 at the
+        # current attitude) gives a real force; pitching 90 degrees turns it into
+        # a broadside wind and changes the force. Works for stock and FAR (both
+        # return the force in newtons).
+        body = self.vessel.orbit.body
+        ref = body.reference_frame
+        flight = self.vessel.flight(ref)
+        position = self.vessel.position(ref)
+        nose = vector(self.vessel.direction(ref))
+        velocity = tuple(300 * nose)  # angle of attack 0 at the current attitude
+        head_on = vector(
+            flight.simulate_aerodynamic_force_at(
+                body, position, velocity, self.vessel.rotation(ref)
+            )
+        )
+        self.assertGreater(norm(head_on), 1000)  # a real force
+        axis = cross(nose, (0, 1, 0))
+        if norm(axis) < 0.1:
+            axis = cross(nose, (1, 0, 0))
+        pitched = quaternion_mult(
+            quaternion_axis_angle(normalize(axis), math.radians(90)),
+            self.vessel.rotation(ref),
+        )
+        broadside = vector(
+            flight.simulate_aerodynamic_force_at(body, position, velocity, pitched)
+        )
+        self.assertGreater(norm(broadside - head_on), 0.1 * norm(head_on))
 
     # def test_drag_coefficient(self):
     #     if not self.far:


### PR DESCRIPTION
This adds a required `rotation` parameter to `Flight.SimulateAerodynamicForceAt`, setting the vessel's attitude (angle of attack and sideslip) independently of velocity. This lets callers evaluate aerodynamic forces at arbitrary attitudes without physically reorienting the vessel. The attitude is applied by rotating the airflow into the vessel's current orientation, running the aerodynamic model, then rotating the resulting force back out, handling drag, body lift and wing lift uniformly for both the stock and FAR models.

Resolves #913.

## Behavior change

`rotation` is required (rather than optional/nullable, which runs into protocol-level issues with null for value types), so the previous 3-argument form no longer exists. To reproduce the old behavior, pass the vessel's current rotation:

```python
flight.simulate_aerodynamic_force_at(body, position, velocity, vessel.rotation(reference_frame))
```
where `reference_frame` is the frame the flight was created with.

## Additional fix

The FAR path returned force in kilonewtons rather than newtons (CalculateVesselAeroForces returns KSP units; the stock path multiplies by 1000, the FAR path did not). Fixed so both models return newtons, matching the method's documentation. Tracked as a separate CHANGES entry.

## Testing

`test_simulate_aerodynamic_force_rotation` checks for a real force at the current attitude and that a 90-degree pitch changes it. Passes under both stock and FAR.

## Suggested changelog entries

 * Add a required rotation parameter to Flight.SimulateAerodynamicForceAt to set the vessel attitude (angle of attack and sideslip) independently of velocity; pass the current rotation for the previous behavior
 * Fix Flight.SimulateAerodynamicForceAt returning force in kilonewtons instead of newtons when FAR is installed