### PR TITLE
Direct control of engine gimbals, RCS and control surfaces

### DIFF
--- a/doc/order.txt
+++ b/doc/order.txt
@@ -738,6 +738,8 @@ SpaceCenter.ControlSurface.RollEnabled
 SpaceCenter.ControlSurface.AuthorityLimiter
 SpaceCenter.ControlSurface.Inverted
 SpaceCenter.ControlSurface.Deployed
+SpaceCenter.ControlSurface.DeflectionOverride
+SpaceCenter.ControlSurface.Deflection
 SpaceCenter.ControlSurface.SurfaceArea
 SpaceCenter.ControlSurface.AvailableTorque
 SpaceCenter.Decoupler
@@ -805,6 +807,8 @@ SpaceCenter.Engine.Gimballed
 SpaceCenter.Engine.GimbalRange
 SpaceCenter.Engine.GimbalLocked
 SpaceCenter.Engine.GimbalLimit
+SpaceCenter.Engine.GimbalOverride
+SpaceCenter.Engine.GimbalActuation
 SpaceCenter.Engine.AvailableTorque
 SpaceCenter.Engine.CanReverseThrust
 SpaceCenter.Engine.ThrustReversed
@@ -928,6 +932,9 @@ SpaceCenter.RCS.RollEnabled
 SpaceCenter.RCS.ForwardEnabled
 SpaceCenter.RCS.UpEnabled
 SpaceCenter.RCS.RightEnabled
+SpaceCenter.RCS.InputOverride
+SpaceCenter.RCS.RotationOverride
+SpaceCenter.RCS.TranslationOverride
 SpaceCenter.RCS.AvailableTorque
 SpaceCenter.RCS.AvailableForce
 SpaceCenter.RCS.AvailableThrust

--- a/doc/src/dictionary.txt
+++ b/doc/src/dictionary.txt
@@ -127,6 +127,7 @@ runtime
 serialio
 serializable
 shader
+sideslip
 socat
 sph
 stderr
@@ -137,6 +138,7 @@ symlink
 targetting
 thruster
 thrusters
+toolchain
 tradeoff
 translational
 tuple
@@ -150,11 +152,10 @@ unpaused
 unserialize
 vab
 varint
+vcpkg
 ve
 vertices
 virtualenv
 waypoint
 waypoints
 websockets
-toolchain
-vcpkg

--- a/service/SpaceCenter/CHANGES.txt
+++ b/service/SpaceCenter/CHANGES.txt
@@ -52,6 +52,7 @@ v0.6.0
    rotation for the previous behavior (#915)
  * Fix Flight.SimulateAerodynamicForceAt returning force in kilonewtons instead of
    newtons when FAR is installed (#915)
+ * Add direct control of engine gimbals, RCS and control surfaces (#917)
 
 v0.5.4
  * Fix vessel recovery (#782)

--- a/service/SpaceCenter/src/ActuatorControlAddon.cs
+++ b/service/SpaceCenter/src/ActuatorControlAddon.cs
@@ -1,0 +1,449 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Expansions.Missions.Adjusters;
+using KRPC.Server;
+using KRPC.Service;
+using KRPC.SpaceCenter.ExtensionMethods;
+using UnityEngine;
+
+namespace KRPC.SpaceCenter
+{
+    /// <summary>
+    /// Addon that controls individual actuators: engine gimbals, RCS and aero control
+    /// surfaces.  It holds the override state for each actuator, keyed by the
+    /// underlying part module, and is responsible for its lifecycle: overrides are
+    /// dropped when the controlling client disconnects, when the part is destroyed, and
+    /// when the scene changes.
+    /// </summary>
+    /// <remarks>
+    /// Gimbals and RCS are overridden using KSP's own part-module "adjuster" mechanism,
+    /// which the module invokes mid-update to transform its control input just before
+    /// it is applied. The public entry point for installing an adjuster
+    /// (PartModule.AddPartModuleAdjuster) is gated behind the Making History expansion,
+    /// so instead the adjuster is added directly to the module's (private)
+    /// adjusterCache by reflection - the module's apply path iterates that list with no
+    /// such gate.
+    /// </remarks>
+    [KSPAddon (KSPAddon.Startup.Flight, false)]
+    public sealed class ActuatorControlAddon : MonoBehaviour
+    {
+        /// <summary>
+        /// Overrides a gimbal's actuation. ModuleGimbal calls this mid-FixedUpdate,
+        /// after populating the pitch/roll/yaw actuation from the cooked control input
+        /// and before running its own kinematics, so returning the stored command
+        /// overrides it cleanly.
+        /// </summary>
+        sealed class GimbalAdjuster : AdjusterGimbalBase
+        {
+            // KSP's Missions system reflects over every Adjuster subclass at load and
+            // instantiates it, so both base constructors must be present.
+            public GimbalAdjuster () { }
+            public GimbalAdjuster (Expansions.Missions.MENode node) : base (node) { }
+
+            public Vector3 Setting = Vector3.zero;
+
+            public override Vector3 ApplyControlAdjustment (Vector3 control)
+            {
+                return Setting;
+            }
+        }
+
+        /// <summary>
+        /// Overrides an RCS block's rotation and translation demand. ModuleRCS calls
+        /// these mid-Update, after rotating the cooked control input into world space
+        /// and before it is used to allocate thrust across the thrusters. The command
+        /// is stored in the vessel's control axes, so it is rotated into world space
+        /// here to match.
+        /// </summary>
+        sealed class RCSAdjuster : AdjusterRCSBase
+        {
+            public RCSAdjuster () { }
+            public RCSAdjuster (Expansions.Missions.MENode node) : base (node) { }
+
+            public ModuleRCS Module;
+            public Vector3 Rotation = Vector3.zero;
+            public Vector3 Linear = Vector3.zero;
+
+            Quaternion ToWorld ()
+            {
+                return Module != null && Module.vessel != null && Module.vessel.ReferenceTransform != null
+                    ? Module.vessel.ReferenceTransform.rotation : Quaternion.identity;
+            }
+
+            public override Vector3 ApplyInputRotationAdjustment (Vector3 inputRotation)
+            {
+                return ToWorld () * Rotation;
+            }
+
+            public override Vector3 ApplyInputLinearAdjustment (Vector3 inputLinear)
+            {
+                return ToWorld () * Linear;
+            }
+        }
+
+        /// <summary>
+        /// An override on a single actuator, tagged with the client that owns it (so it
+        /// can be released when that client disconnects).
+        /// </summary>
+        abstract class Entry
+        {
+            public IClient Client;
+        }
+
+        /// <summary>
+        /// A gimbal override, installed as an adjuster on the module. The prior active
+        /// state is saved and forced on so the module's FixedUpdate (which is skipped
+        /// when inactive) runs the adjuster.
+        /// </summary>
+        sealed class GimbalEntry : Entry
+        {
+            public GimbalAdjuster Adjuster;
+            public bool SavedGimbalActive;
+        }
+
+        /// <summary>
+        /// An RCS override, installed as an adjuster on the module.
+        /// </summary>
+        sealed class RCSEntry : Entry
+        {
+            public RCSAdjuster Adjuster;
+        }
+
+        /// <summary>
+        /// A control surface override. Control surfaces have no deflection adjuster
+        /// (the KSP adjuster only overrides actuation speed), so the override is driven
+        /// through the persistent <c>deploy</c>/<c>deployAngle</c> fields with cooked
+        /// control removed via the <c>ignore*</c> flags. The prior state is saved so it
+        /// can be restored on release.
+        /// </summary>
+        sealed class ControlSurfaceEntry : Entry
+        {
+            public float Deflection;
+            public bool SavedIgnorePitch;
+            public bool SavedIgnoreYaw;
+            public bool SavedIgnoreRoll;
+            public bool SavedDeploy;
+        }
+
+        /// <summary>
+        /// A set of actuator overrides of one kind, keyed by the part module. Owns the
+        /// shared lifecycle: installing an override on enable, releasing it on disable,
+        /// and dropping overrides whose owning client has disconnected or whose module
+        /// has been destroyed. The per-kind behaviour is supplied as delegates.
+        /// </summary>
+        sealed class OverrideRegistry<TModule, TEntry>
+            where TModule : PartModule
+            where TEntry : Entry
+        {
+            readonly IDictionary<TModule, TEntry> entries = new Dictionary<TModule, TEntry> ();
+            readonly Func<TModule, TEntry> install;
+            readonly Action<TModule, TEntry> release;
+
+            public OverrideRegistry (Func<TModule, TEntry> install, Action<TModule, TEntry> release)
+            {
+                this.install = install;
+                this.release = release;
+            }
+
+            public bool IsSet (TModule module)
+            {
+                return entries.ContainsKey (module);
+            }
+
+            /// <summary>
+            /// The override for the given module, or null if it is not being overridden.
+            /// </summary>
+            public TEntry Get (TModule module)
+            {
+                TEntry entry;
+                return entries.TryGetValue (module, out entry) ? entry : null;
+            }
+
+            /// <summary>
+            /// The override for the given module, re-tagged with the calling client, or
+            /// null if it is not being overridden. Used when changing a live override's
+            /// command.
+            /// </summary>
+            public TEntry Own (TModule module)
+            {
+                var entry = Get (module);
+                if (entry != null)
+                    entry.Client = CallContext.Client;
+                return entry;
+            }
+
+            public void Set (TModule module, bool enabled)
+            {
+                var entry = Get (module);
+                if (entry != null) {
+                    if (enabled)
+                        entry.Client = CallContext.Client;
+                    else {
+                        release (module, entry);
+                        entries.Remove (module);
+                    }
+                } else if (enabled) {
+                    entry = install (module);
+                    entry.Client = CallContext.Client;
+                    entries [module] = entry;
+                }
+            }
+
+            /// <summary>
+            /// Drop overrides whose module has been destroyed or whose client has
+            /// disconnected.
+            /// </summary>
+            public void Sweep ()
+            {
+                foreach (var module in entries.Keys.ToList ()) {
+                    var entry = entries [module];
+                    if (Destroyed (module) || Disconnected (entry.Client)) {
+                        release (module, entry);
+                        entries.Remove (module);
+                    }
+                }
+            }
+
+            public void Clear ()
+            {
+                foreach (var entry in entries)
+                    release (entry.Key, entry.Value);
+                entries.Clear ();
+            }
+        }
+
+        static readonly OverrideRegistry<ModuleGimbal, GimbalEntry> gimbals =
+            new OverrideRegistry<ModuleGimbal, GimbalEntry> (InstallGimbal, ReleaseGimbal);
+        static readonly OverrideRegistry<ModuleRCS, RCSEntry> rcs =
+            new OverrideRegistry<ModuleRCS, RCSEntry> (InstallRCS, ReleaseRCS);
+        static readonly OverrideRegistry<ModuleControlSurface, ControlSurfaceEntry> controlSurfaces =
+            new OverrideRegistry<ModuleControlSurface, ControlSurfaceEntry> (
+                InstallControlSurface, RestoreControlSurface);
+
+        // The module's adjuster list is private; AddPartModuleAdjuster (which would
+        // populate it) is gated behind the Making History expansion, so add/remove
+        // directly by reflection.
+        static readonly FieldInfo gimbalAdjusterCache =
+            typeof (ModuleGimbal).GetField ("adjusterCache", BindingFlags.NonPublic | BindingFlags.Instance);
+        static readonly FieldInfo rcsAdjusterCache =
+            typeof (ModuleRCS).GetField ("adjusterCache", BindingFlags.NonPublic | BindingFlags.Instance);
+
+        /// <summary>
+        /// Wake the addon
+        /// </summary>
+        public void Awake ()
+        {
+            Clear ();
+        }
+
+        /// <summary>
+        /// Destroy the addon
+        /// </summary>
+        public void OnDestroy ()
+        {
+            Clear ();
+        }
+
+        static void Clear ()
+        {
+            gimbals.Clear ();
+            rcs.Clear ();
+            controlSurfaces.Clear ();
+        }
+
+        /// <summary>
+        /// Drop overrides whose controlling client has disconnected or whose part module has been
+        /// destroyed, returning those actuators to normal control. The overrides themselves are
+        /// applied by the modules calling into the installed adjusters, so nothing is driven here.
+        /// </summary>
+        public void FixedUpdate ()
+        {
+            gimbals.Sweep ();
+            rcs.Sweep ();
+            controlSurfaces.Sweep ();
+        }
+
+        static bool Destroyed (UnityEngine.Object module)
+        {
+            return module == null;
+        }
+
+        static bool Disconnected (IClient client)
+        {
+            return client != null && !client.Connected;
+        }
+
+        static void CacheAdd (FieldInfo cache, PartModule module, object adjuster)
+        {
+            var list = cache?.GetValue (module) as System.Collections.IList;
+            if (list != null)
+                list.Add (adjuster);
+        }
+
+        static void CacheRemove (FieldInfo cache, PartModule module, object adjuster)
+        {
+            var list = cache?.GetValue (module) as System.Collections.IList;
+            if (list != null)
+                list.Remove (adjuster);
+        }
+
+        static GimbalEntry InstallGimbal (ModuleGimbal module)
+        {
+            var entry = new GimbalEntry {
+                Adjuster = new GimbalAdjuster (),
+                SavedGimbalActive = module.gimbalActive
+            };
+            // ModuleGimbal.FixedUpdate (which runs the adjuster) returns early when
+            // inactive, so ensure it runs.
+            module.gimbalActive = true;
+            CacheAdd (gimbalAdjusterCache, module, entry.Adjuster);
+            return entry;
+        }
+
+        static void ReleaseGimbal (ModuleGimbal module, GimbalEntry entry)
+        {
+            if (Destroyed (module))
+                return;
+            CacheRemove (gimbalAdjusterCache, module, entry.Adjuster);
+            module.gimbalActive = entry.SavedGimbalActive;
+        }
+
+        internal static bool GetGimbalOverride (ModuleGimbal module)
+        {
+            return gimbals.IsSet (module);
+        }
+
+        internal static void SetGimbalOverride (ModuleGimbal module, bool enabled)
+        {
+            gimbals.Set (module, enabled);
+        }
+
+        internal static Vector3 GetGimbalActuation (ModuleGimbal module)
+        {
+            var entry = gimbals.Get (module);
+            return entry != null ? entry.Adjuster.Setting : (Vector3)module.actuation;
+        }
+
+        internal static void SetGimbalActuation (ModuleGimbal module, Vector3 actuation)
+        {
+            var entry = gimbals.Own (module);
+            if (entry != null)
+                entry.Adjuster.Setting = actuation.Clamp (-1f, 1f);
+        }
+
+        static RCSEntry InstallRCS (ModuleRCS module)
+        {
+            var entry = new RCSEntry { Adjuster = new RCSAdjuster { Module = module } };
+            CacheAdd (rcsAdjusterCache, module, entry.Adjuster);
+            return entry;
+        }
+
+        static void ReleaseRCS (ModuleRCS module, RCSEntry entry)
+        {
+            if (!Destroyed (module))
+                CacheRemove (rcsAdjusterCache, module, entry.Adjuster);
+        }
+
+        internal static bool GetRCSOverride (ModuleRCS module)
+        {
+            return rcs.IsSet (module);
+        }
+
+        internal static void SetRCSOverride (ModuleRCS module, bool enabled)
+        {
+            rcs.Set (module, enabled);
+        }
+
+        internal static Vector3 GetRCSRotation (ModuleRCS module)
+        {
+            var entry = rcs.Get (module);
+            return entry != null ? entry.Adjuster.Rotation : Vector3.zero;
+        }
+
+        internal static void SetRCSRotation (ModuleRCS module, Vector3 rotation)
+        {
+            var entry = rcs.Own (module);
+            if (entry != null)
+                entry.Adjuster.Rotation = rotation.Clamp (-1f, 1f);
+        }
+
+        internal static Vector3 GetRCSTranslation (ModuleRCS module)
+        {
+            var entry = rcs.Get (module);
+            return entry != null ? entry.Adjuster.Linear : Vector3.zero;
+        }
+
+        internal static void SetRCSTranslation (ModuleRCS module, Vector3 translation)
+        {
+            var entry = rcs.Own (module);
+            if (entry != null)
+                entry.Adjuster.Linear = translation.Clamp (-1f, 1f);
+        }
+
+        static ControlSurfaceEntry InstallControlSurface (ModuleControlSurface module)
+        {
+            var entry = new ControlSurfaceEntry {
+                Deflection = 0f,
+                SavedIgnorePitch = module.ignorePitch,
+                SavedIgnoreYaw = module.ignoreYaw,
+                SavedIgnoreRoll = module.ignoreRoll,
+                SavedDeploy = module.deploy
+            };
+            // Remove the cooked-control contribution and drive the surface through the
+            // deploy offset, which the module applies persistently every frame.
+            module.ignorePitch = true;
+            module.ignoreYaw = true;
+            module.ignoreRoll = true;
+            module.deploy = true;
+            ApplyControlSurfaceDeflection (module, entry);
+            return entry;
+        }
+
+        static void RestoreControlSurface (ModuleControlSurface module, ControlSurfaceEntry entry)
+        {
+            if (Destroyed (module))
+                return;
+            module.ignorePitch = entry.SavedIgnorePitch;
+            module.ignoreYaw = entry.SavedIgnoreYaw;
+            module.ignoreRoll = entry.SavedIgnoreRoll;
+            module.deploy = entry.SavedDeploy;
+        }
+
+        static void ApplyControlSurfaceDeflection (ModuleControlSurface module, ControlSurfaceEntry entry)
+        {
+            // Map the normalized command onto the module's deploy angle limits (min,
+            // max). The exact mapping/sign may need in-game calibration.
+            var limits = module.deployAngleLimits;
+            module.deployAngle = entry.Deflection >= 0f
+                ? entry.Deflection * limits.y
+                : entry.Deflection * -limits.x;
+        }
+
+        internal static bool GetControlSurfaceOverride (ModuleControlSurface module)
+        {
+            return controlSurfaces.IsSet (module);
+        }
+
+        internal static void SetControlSurfaceOverride (ModuleControlSurface module, bool enabled)
+        {
+            controlSurfaces.Set (module, enabled);
+        }
+
+        internal static float GetControlSurfaceDeflection (ModuleControlSurface module)
+        {
+            var entry = controlSurfaces.Get (module);
+            return entry != null ? entry.Deflection : 0f;
+        }
+
+        internal static void SetControlSurfaceDeflection (ModuleControlSurface module, float deflection)
+        {
+            var entry = controlSurfaces.Own (module);
+            if (entry != null) {
+                entry.Deflection = Mathf.Clamp (deflection, -1f, 1f);
+                ApplyControlSurfaceDeflection (module, entry);
+            }
+        }
+    }
+}

--- a/service/SpaceCenter/src/KRPC.SpaceCenter.csproj
+++ b/service/SpaceCenter/src/KRPC.SpaceCenter.csproj
@@ -80,6 +80,7 @@
     <Compile Include="ExtensionMethods\VesselControlStateExtensions.cs" />
     <Compile Include="ExtensionMethods\VesselSituationExtensions.cs" />
     <Compile Include="ExtensionMethods\VesselTypeExtensions.cs" />
+    <Compile Include="ActuatorControlAddon.cs" />
     <Compile Include="ExternalAPIAddon.cs" />
     <Compile Include="ExternalAPI\AGX.cs" />
     <Compile Include="ExternalAPI\FAR.cs" />

--- a/service/SpaceCenter/src/Services/Parts/ControlSurface.cs
+++ b/service/SpaceCenter/src/Services/Parts/ControlSurface.cs
@@ -112,6 +112,29 @@ namespace KRPC.SpaceCenter.Services.Parts
         }
 
         /// <summary>
+        /// Whether the control surface deflection is being set directly, bypassing the vessel's
+        /// normal flight control. When enabled, the surface holds the deflection set by
+        /// <see cref="Deflection"/> instead of responding to pitch, yaw and roll control inputs.
+        /// The prior state is restored when the override is released, when the
+        /// controlling client disconnects, or when the vessel changes.
+        /// </summary>
+        [KRPCProperty]
+        public bool DeflectionOverride {
+            get { return ActuatorControlAddon.GetControlSurfaceOverride (controlSurface); }
+            set { ActuatorControlAddon.SetControlSurfaceOverride (controlSurface, value); }
+        }
+
+        /// <summary>
+        /// The deflection command applied when <see cref="DeflectionOverride"/> is enabled, as a
+        /// value between -1 and 1, mapped onto the surface's deploy angle range.
+        /// </summary>
+        [KRPCProperty]
+        public float Deflection {
+            get { return ActuatorControlAddon.GetControlSurfaceDeflection (controlSurface); }
+            set { ActuatorControlAddon.SetControlSurfaceDeflection (controlSurface, value); }
+        }
+
+        /// <summary>
         /// Surface area of the control surface in <math>m^2</math>.
         /// </summary>
         [KRPCProperty]

--- a/service/SpaceCenter/src/Services/Parts/Engine.cs
+++ b/service/SpaceCenter/src/Services/Parts/Engine.cs
@@ -5,6 +5,7 @@ using KRPC.Service.Attributes;
 using KRPC.SpaceCenter.ExtensionMethods;
 using KRPC.Utils;
 using UnityEngine;
+using Tuple3 = System.Tuple<double, double, double>;
 using TupleV3 = System.Tuple<Vector3d, Vector3d>;
 using TupleT3 = System.Tuple<System.Tuple<double, double, double>, System.Tuple<double, double, double>>;
 
@@ -561,6 +562,44 @@ namespace KRPC.SpaceCenter.Services.Parts
             set {
                 CheckGimballed ();
                 gimbal.gimbalLimiter = (value * 100f).Clamp (0f, 100f);
+            }
+        }
+
+        /// <summary>
+        /// Whether the gimbal is being controlled directly, bypassing the vessel's normal
+        /// flight controls. When enabled, the gimbal deflection is set by
+        /// <see cref="GimbalActuation"/> instead of the normal control inputs.
+        /// The override is automatically released if the controlling client disconnects or the
+        /// vessel changes. Has no effect if the engine is not gimballed.
+        /// </summary>
+        [KRPCProperty]
+        public bool GimbalOverride {
+            get {
+                CheckGimballed ();
+                return ActuatorControlAddon.GetGimbalOverride (gimbal);
+            }
+            set {
+                CheckGimballed ();
+                ActuatorControlAddon.SetGimbalOverride (gimbal, value);
+            }
+        }
+
+        /// <summary>
+        /// The gimbal actuation command applied when <see cref="GimbalOverride"/> is enabled, in
+        /// the pitch, roll and yaw axes. Each component is a normalized control input between -1
+        /// and 1. The physical deflection is scaled by <see cref="GimbalRange"/>
+        /// and <see cref="GimbalLimit"/>. When the gimbal is not being overridden,
+        /// returns the current actuation.
+        /// </summary>
+        [KRPCProperty]
+        public Tuple3 GimbalActuation {
+            get {
+                CheckGimballed ();
+                return ActuatorControlAddon.GetGimbalActuation (gimbal).ToTuple ();
+            }
+            set {
+                CheckGimballed ();
+                ActuatorControlAddon.SetGimbalActuation (gimbal, value.ToVector ());
             }
         }
 

--- a/service/SpaceCenter/src/Services/Parts/RCS.cs
+++ b/service/SpaceCenter/src/Services/Parts/RCS.cs
@@ -142,6 +142,40 @@ namespace KRPC.SpaceCenter.Services.Parts
         }
 
         /// <summary>
+        /// Whether the RCS control is being set directly, bypassing the vessel's
+        /// normal flight controls. When enabled, the rotation and translation demand is set by
+        /// <see cref="RotationOverride"/> and <see cref="TranslationOverride"/> instead of the
+        /// normal control inputs. The override is automatically released if the
+        /// controlling client disconnects or the vessel changes.
+        /// </summary>
+        [KRPCProperty]
+        public bool InputOverride {
+            get { return ActuatorControlAddon.GetRCSOverride (rcs); }
+            set { ActuatorControlAddon.SetRCSOverride (rcs, value); }
+        }
+
+        /// <summary>
+        /// The rotation demand applied when <see cref="InputOverride"/> is enabled, in the pitch,
+        /// roll and yaw axes. Each component is a normalized control input between -1 and 1.
+        /// </summary>
+        [KRPCProperty]
+        public Tuple3 RotationOverride {
+            get { return ActuatorControlAddon.GetRCSRotation (rcs).ToTuple (); }
+            set { ActuatorControlAddon.SetRCSRotation (rcs, value.ToVector ()); }
+        }
+
+        /// <summary>
+        /// The translation demand applied when <see cref="InputOverride"/> is enabled, in the
+        /// right, up and forward axes. Each component is a normalized control input between -1
+        /// and 1.
+        /// </summary>
+        [KRPCProperty]
+        public Tuple3 TranslationOverride {
+            get { return ActuatorControlAddon.GetRCSTranslation (rcs).ToTuple (); }
+            set { ActuatorControlAddon.SetRCSTranslation (rcs, value.ToVector ()); }
+        }
+
+        /// <summary>
         /// The available torque, in Newton meters, that can be produced by this RCS,
         /// in the positive and negative pitch, roll and yaw axes of the vessel. These axes
         /// correspond to the coordinate axes of the <see cref="Vessel.ReferenceFrame"/>.

--- a/service/SpaceCenter/test/test_parts_control_surface.py
+++ b/service/SpaceCenter/test/test_parts_control_surface.py
@@ -96,6 +96,37 @@ class TestPartsControlSurface(krpctest.TestCase):
         self.wait()
         self.assertFalse(self.ctrlsrf.deployed)
 
+    def test_deflection_override(self):
+        cs = self.ctrlsrf
+        self.assertFalse(cs.deflection_override)
+        self.assertAlmostEqual(0, cs.deflection)
+        # Enabling the override removes cooked control and deploys the surface
+        cs.deflection_override = True
+        self.wait()
+        self.assertTrue(cs.deflection_override)
+        self.assertFalse(cs.pitch_enabled)
+        self.assertFalse(cs.yaw_enabled)
+        self.assertFalse(cs.roll_enabled)
+        self.assertTrue(cs.deployed)
+        # The deflection command round-trips and clamps to [-1, 1]
+        for deflection in (1, -1, 0.5, 0):
+            cs.deflection = deflection
+            self.assertAlmostEqual(deflection, cs.deflection)
+        cs.deflection = 5
+        self.assertAlmostEqual(1, cs.deflection)
+        cs.deflection = -5
+        self.assertAlmostEqual(-1, cs.deflection)
+        # Disabling restores the prior control-surface state (the axis baseline
+        # and deploy state set up in setUpClass)
+        cs.deflection_override = False
+        self.wait()
+        self.assertFalse(cs.deflection_override)
+        self.assertAlmostEqual(0, cs.deflection)
+        self.assertFalse(cs.pitch_enabled)
+        self.assertTrue(cs.yaw_enabled)
+        self.assertFalse(cs.roll_enabled)
+        self.assertFalse(cs.deployed)
+
     def test_surface_area(self):
         self.assertAlmostEqual(1, self.ctrlsrf.surface_area)
         self.assertAlmostEqual(0.2, self.winglet.surface_area)

--- a/service/SpaceCenter/test/test_parts_engine.py
+++ b/service/SpaceCenter/test/test_parts_engine.py
@@ -1,6 +1,7 @@
 import unittest
 
 import krpctest
+from krpctest.geometry import angle_between, dot, norm
 
 
 class EngineTestBase:
@@ -361,6 +362,57 @@ class TestPartsEngine(krpctest.TestCase, EngineTestBase):
         self.set_idle(engine)
         engine.gimbal_limit = 1
 
+    def test_gimbal_override(self):
+        engine = self.get_engine("liquidEngine2")  # LV-T45 "Swivel"
+        thruster = engine.thrusters[0]
+        ref = self.vessel.reference_frame
+        self.assertTrue(engine.gimballed)
+        self.assertFalse(engine.gimbal_override)
+
+        engine.gimbal_override = True
+        self.wait()
+        self.assertTrue(engine.gimbal_override)
+
+        # The actuation command round-trips and clamps to [-1, 1]
+        for actuation in ((1, 0, 0), (0, -1, 0), (0.5, 0.25, -0.75), (0, 0, 0)):
+            engine.gimbal_actuation = actuation
+            self.assertAlmostEqual(actuation, engine.gimbal_actuation)
+        engine.gimbal_actuation = (5, -5, 0)
+        self.assertAlmostEqual((1, -1, 0), engine.gimbal_actuation)
+
+        # The override physically vectors the thrust. A zero command leaves the
+        # thrust along the un-gimballed direction; a full pitch command deflects
+        # it by about the gimbal range, and opposite commands deflect to
+        # opposite sides. initial_thrust_direction gives the un-gimballed
+        # reference regardless of the current override.
+        neutral = thruster.initial_thrust_direction(ref)
+        engine.gimbal_actuation = (0, 0, 0)
+        self.wait(0.5)
+        self.assertLess(angle_between(thruster.thrust_direction(ref), neutral), 0.5)
+        engine.gimbal_actuation = (1, 0, 0)
+        self.wait(0.5)
+        pitch_pos = thruster.thrust_direction(ref)
+        engine.gimbal_actuation = (-1, 0, 0)
+        self.wait(0.5)
+        pitch_neg = thruster.thrust_direction(ref)
+        self.assertGreater(angle_between(pitch_pos, neutral), 2)
+        self.assertGreater(angle_between(pitch_neg, neutral), 2)
+        self.assertGreater(angle_between(pitch_pos, pitch_neg), 4)
+
+        # Disabling releases the override
+        engine.gimbal_actuation = (0, 0, 0)
+        engine.gimbal_override = False
+        self.wait()
+        self.assertFalse(engine.gimbal_override)
+
+    def test_gimbal_override_not_gimballed(self):
+        engine = self.get_engine("liquidEngine")  # LV-T30 "Reliant"
+        self.assertFalse(engine.gimballed)
+        self.assertRaises(RuntimeError, getattr, engine, "gimbal_override")
+        self.assertRaises(RuntimeError, setattr, engine, "gimbal_override", True)
+        self.assertRaises(RuntimeError, getattr, engine, "gimbal_actuation")
+        self.assertRaises(RuntimeError, setattr, engine, "gimbal_actuation", (0, 0, 0))
+
     def test_no_thrust_reverser(self):
         engine = self.get_engine("liquidEngine")  # LV-T30 "Reliant"
         self.assertFalse(engine.can_reverse_thrust)
@@ -498,6 +550,64 @@ class TestPartsEngineReverser(krpctest.TestCase, EngineTestBase):
         control.thrust_reversers = False
         self.wait(2)
         self.assertFalse(control.thrust_reversers)
+
+
+class TestGimbalOverrideAttitude(krpctest.TestCase):
+    """The gimbal override actually flies the vessel. Uses the "Vessel" craft,
+    whose single gimballed engine thrusts through the centre of mass, so a
+    gimbal deflection produces a clean torque about the centre of mass."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.new_save()
+        cls.launch_vessel_from_vab("Vessel")
+        cls.remove_other_vessels()
+        cls.set_circular_orbit("Kerbin", 250000)
+        cls.vessel = cls.connect().space_center.active_vessel
+
+    def get_gimballed_engine(self):
+        for part in self.vessel.parts.all:
+            if part.engine is not None and part.engine.gimballed:
+                return part.engine
+        self.fail("the vessel has no gimballed engine")
+
+    def test_gimbal_override_attitude(self):
+        engine = self.get_gimballed_engine()
+        vessel = self.vessel
+        body_frame = vessel.orbit.body.non_rotating_reference_frame
+
+        def angular_speed():
+            return norm(vessel.angular_velocity(body_frame))
+
+        # Fire the engine with the given pitch gimbal command from rest, and
+        # return the angular velocity it induces. Start from the same still pose
+        # each time, so the induced spins are directly comparable.
+        def spin_from(pitch):
+            self.set_pitch_heading_roll(0, 90, 0)
+            engine.gimbal_actuation = (pitch, 0, 0)
+            vessel.control.throttle = 1
+            engine.active = True
+            self.wait_until(
+                lambda: angular_speed() > 0.05,
+                timeout=20,
+                message="the gimbal override to rotate the vessel",
+            )
+            spin = vessel.angular_velocity(body_frame)
+            engine.active = False
+            vessel.control.throttle = 0
+            engine.gimbal_actuation = (0, 0, 0)
+            return spin
+
+        vessel.control.sas = False
+        engine.gimbal_override = True
+
+        spin_positive = spin_from(1)
+        spin_negative = spin_from(-1)
+
+        engine.gimbal_override = False
+
+        # Opposite gimbal deflections rotate the vessel in opposite directions.
+        self.assertLess(dot(spin_positive, spin_negative), 0)
 
 
 if __name__ == "__main__":

--- a/service/SpaceCenter/test/test_parts_rcs.py
+++ b/service/SpaceCenter/test/test_parts_rcs.py
@@ -1,5 +1,6 @@
 import unittest
 import krpctest
+from krpctest.geometry import distance, norm
 
 
 class RCSTestBase:
@@ -183,6 +184,35 @@ class TestPartsRCS(krpctest.TestCase, RCSTestBase):
             for prop2 in props:
                 self.assertTrue(getattr(rcs, prop2))
 
+    def test_input_override(self):
+        rcs = self.get_rcs("RCSBlock.v2")
+        self.assertFalse(rcs.input_override)
+        # The getters return zero when the override is not active
+        self.assertAlmostEqual((0, 0, 0), rcs.rotation_override)
+        self.assertAlmostEqual((0, 0, 0), rcs.translation_override)
+
+        rcs.input_override = True
+        self.wait()
+        self.assertTrue(rcs.input_override)
+
+        # The rotation and translation demands round-trip
+        for rotation in ((1, 0, 0), (0, -0.5, 0.5), (0, 0, 0)):
+            rcs.rotation_override = rotation
+            self.assertAlmostEqual(rotation, rcs.rotation_override)
+        for translation in ((0, 1, 0), (-0.5, 0, 0.25), (0, 0, 0)):
+            rcs.translation_override = translation
+            self.assertAlmostEqual(translation, rcs.translation_override)
+        # Commands are clamped to [-1, 1]
+        rcs.rotation_override = (2, -2, 0)
+        self.assertAlmostEqual((1, -1, 0), rcs.rotation_override)
+
+        # Disabling releases the override
+        rcs.input_override = False
+        self.wait()
+        self.assertFalse(rcs.input_override)
+        self.assertAlmostEqual((0, 0, 0), rcs.rotation_override)
+        self.assertAlmostEqual((0, 0, 0), rcs.translation_override)
+
     def test_has_fuel(self):
         rcs = self.get_rcs("RCSBlock.v2")
         self.assertTrue(rcs.has_fuel)
@@ -276,6 +306,48 @@ class TestPartsRCSVacuum(krpctest.TestCase, RCSTest):
                 "neg_torque": (0, 0, -6931),
             },
         )
+
+    def test_input_override_attitude(self):
+        """The override actually flies the vessel: a rotation demand spins it and
+        a translation demand accelerates it, both burning monopropellant."""
+        rcs = self.get_rcs("RCSBlock.v2")
+        vessel = self.vessel
+        body_frame = vessel.orbit.body.non_rotating_reference_frame
+
+        def angular_speed():
+            return norm(vessel.angular_velocity(body_frame))
+
+        vessel.control.sas = False
+        vessel.control.rcs = True
+        rcs.enabled = True
+
+        # A rotation demand spins the vessel up and consumes monopropellant.
+        self.set_pitch_heading_roll(0, 90, 0)  # start still
+        mono_before = vessel.resources.amount("MonoPropellant")
+        rcs.input_override = True
+        rcs.rotation_override = (0, 0, 1)  # yaw
+        self.wait_until(
+            lambda: angular_speed() > 0.1,
+            timeout=20,
+            message="the RCS override to rotate the vessel",
+        )
+        self.assertLess(vessel.resources.amount("MonoPropellant"), mono_before)
+        rcs.rotation_override = (0, 0, 0)
+        rcs.input_override = False
+
+        # A translation demand changes the orbital velocity.
+        self.set_pitch_heading_roll(0, 90, 0)  # start still
+        velocity_before = vessel.velocity(body_frame)
+        rcs.input_override = True
+        rcs.translation_override = (0, 0, 1)  # forward
+        self.wait_until(
+            lambda: distance(vessel.velocity(body_frame), velocity_before) > 1,
+            timeout=20,
+            message="the RCS override to accelerate the vessel",
+        )
+        rcs.translation_override = (0, 0, 0)
+        rcs.input_override = False
+        self.set_pitch_heading_roll(0, 90, 0)  # leave the vessel at rest
 
 
 if __name__ == "__main__":

--- a/tools/TestingTools/src/TestingTools.cs
+++ b/tools/TestingTools/src/TestingTools.cs
@@ -129,11 +129,15 @@ namespace TestingTools
         {
             Vessel internalVessel = vessel == null ? FlightGlobals.ActiveVessel : vessel.InternalVessel;
             internalVessel.SetRotation (ZeroRotation);
-            // SetRotation only reorients the part transforms; it leaves each
-            // rigidbody's angular velocity untouched, so without SAS the vessel
-            // keeps tumbling from the new attitude. Explicitly remove the
-            // rotational motion: make every part move with the common center of
-            // mass velocity and zero spin, so the assembly translates rigidly.
+            ZeroAngularVelocity (internalVessel);
+        }
+
+        // Remove the rotational motion of a vessel without changing its attitude. SetRotation only
+        // reorients the part transforms; it leaves each rigidbody's angular velocity untouched, so
+        // without SAS the vessel keeps tumbling from the new attitude. Make every part move with the
+        // common centre-of-mass velocity and zero spin, so the assembly translates rigidly.
+        static void ZeroAngularVelocity (Vessel internalVessel)
+        {
             if (!internalVessel.loaded)
                 return;
             var momentum = Vector3.zero;
@@ -155,6 +159,28 @@ namespace TestingTools
                 rb.velocity = comVelocity;
                 rb.angularVelocity = Vector3.zero;
             }
+        }
+
+        /// <summary>
+        /// Set the absolute attitude of the given vessel (default: the active vessel) to the given
+        /// pitch, heading and roll (degrees) in the given reference frame (default: the vessel's
+        /// surface reference frame), and zero its rotational velocity. Lets a test start from a
+        /// fixed, still pose without first flying the autopilot there. The angles match those
+        /// reported by the vessel's Flight pitch/heading/roll.
+        /// </summary>
+        [KRPCProcedure]
+        public static void SetPitchHeadingRoll (
+            double pitch, double heading, double roll,
+            KRPC.SpaceCenter.Services.ReferenceFrame referenceFrame = null,
+            KRPC.SpaceCenter.Services.Vessel vessel = null)
+        {
+            var serviceVessel = vessel ?? new KRPC.SpaceCenter.Services.Vessel (FlightGlobals.ActiveVessel);
+            var internalVessel = serviceVessel.InternalVessel;
+            var frame = referenceFrame ?? serviceVessel.SurfaceReferenceFrame;
+            var inFrame = KRPC.SpaceCenter.ExtensionMethods.GeometryExtensions.QuaternionFromPitchHeadingRoll (
+                new Vector3d (pitch, heading, roll));
+            internalVessel.SetRotation ((Quaternion)frame.RotationToWorldSpace (inFrame));
+            ZeroAngularVelocity (internalVessel);
         }
 
         /// <summary>

--- a/tools/krpctest/krpctest/__init__.py
+++ b/tools/krpctest/krpctest/__init__.py
@@ -118,6 +118,12 @@ class TestCase(unittest.TestCase):
         cls.connect().testing_tools.set_landed(body, latitude, longitude, altitude)
 
     @classmethod
+    def set_pitch_heading_roll(cls, pitch, heading, roll):
+        """Point the active vessel at the given pitch, heading and roll (degrees)
+        in its surface reference frame, and zero its rotational velocity."""
+        cls.connect().testing_tools.set_pitch_heading_roll(pitch, heading, roll)
+
+    @classmethod
     def wait(cls, timeout=0.1):
         time.sleep(timeout)
 

--- a/tools/krpctest/krpctest/geometry.py
+++ b/tools/krpctest/krpctest/geometry.py
@@ -19,6 +19,15 @@ def dot(u, v):
     return sum(x * y for x, y in zip(u, v))
 
 
+def distance(u, v):
+    return norm(tuple(a - b for a, b in zip(u, v)))
+
+
+def angle_between(u, v):
+    """Angle in degrees between two vectors."""
+    return rad2deg(math.acos(max(-1.0, min(1.0, dot(normalize(u), normalize(v))))))
+
+
 def cross(u, v):
     return (
         u[1] * v[2] - u[2] * v[1],


### PR DESCRIPTION
Let's a client command individual flight-control actuators directly, bypassing the vessel's normal control:
 * Engine.GimbalOverride / GimbalActuation - set an engine's gimbal deflection as a normalized pitch/roll/yaw command.
 * RCS.InputOverride / RotationOverride / TranslationOverride - set an RCS block's rotation and translation demand.
 * ControlSurface.DeflectionOverride / Deflection - hold an aero control surface at a fixed deflection.

Each override is enabled per part and released automatically when the controlling client disconnects, the part is destroyed, or the scene changes.

Gimbals and RCS are driven through KSP's own part-module adjuster mechanism, so the module still runs its usual gimbal kinematics / thrust allocation / fuel use. The public installer (PartModule.AddPartModuleAdjuster) is gated behind the Making History expansion, so the adjuster is instead added directly to the module's private adjusterCache by reflection.

Control surfaces have no deflection adjuster, so they are driven through the persistent deploy/deployAngle fields with cooked control removed via the ignore flags.

Closes #827