### PR TITLE
UI improvements

### DIFF
--- a/doc/src/internals.rst
+++ b/doc/src/internals.rst
@@ -28,10 +28,10 @@ resulting tradeoff between RPC throughput and game FPS:
    high RPC throughput, this is a good option to use.
 
 2. **Maximum time per update**. When one RPC per update is not enabled, this
-   setting controls the maximum amount of time (in nanoseconds) that kRPC will
+   setting controls the maximum amount of time (in microseconds) that kRPC will
    spend executing RPCs per FixedUpdate.  Setting this to a high value, for
-   example 20000 ns, will allow the server to process many RPCs at the expense
-   of the game's framerate. A low value, for example 1000 ns, won't allow the
+   example 20000 us, will allow the server to process many RPCs at the expense
+   of the game's framerate. A low value, for example 1000 us, won't allow the
    server to execute many RPCs per update, but will allow the game to run at a
    much higher framerate.
 

--- a/server/CHANGES.txt
+++ b/server/CHANGES.txt
@@ -3,6 +3,8 @@ v0.6.0
  * Fix Logger to write to both KSP.log and Player.log (#780)
  * Improve RPC and stream update performance (#879)
  * Fix Stream RPCs Executed and Stream RPC Rate always showing 0 in the info window (#879)
+ * Improve the server window UI
+ * Fix incorrect unit shown for "max. time per update" and "receive timeout" - they are microseconds, not nanoseconds
 
 v0.5.4
  * Fix memory leaks when switching game scene (#779)

--- a/server/src/UI/EditServer.cs
+++ b/server/src/UI/EditServer.cs
@@ -19,6 +19,7 @@ namespace KRPC.UI
         const int portNameMaxLength = 255;
         const int baudRateMaxLength = 16;
         const int dataBitsMaxLength = 1;
+        const float labelWidth = 90f;
         const string protocolLabelText = "Protocol:";
         const string addressLabelText = "Address:";
         const string rpcPortLabelText = "RPC port:";
@@ -87,17 +88,24 @@ namespace KRPC.UI
             name = GUILayout.TextField (name, nameMaxLength, window.stretchyTextFieldStyle);
         }
 
+        // A fixed-width field label, so every field in the form starts at the same
+        // column and the (stretchy) fields all end up the same width.
+        void DrawFieldLabel (string text)
+        {
+            GUILayout.Label (text, window.labelStyle, GUILayout.Width (labelWidth * GameSettings.UI_SCALE));
+        }
+
         public void Draw ()
         {
             GUILayout.BeginHorizontal ();
-            GUILayout.Label (protocolLabelText, window.labelStyle);
+            DrawFieldLabel (protocolLabelText);
             protocol = (Protocol)GUILayoutExtensions.ComboBox (protocolComboId, (int)protocol, availableProtocols, window.buttonStyle, window.comboOptionsStyle, window.comboOptionStyle);
             GUILayout.EndHorizontal ();
 
             if (protocol == Protocol.ProtocolBuffersOverTCP ||
                 protocol == Protocol.ProtocolBuffersOverWebsockets) {
                 GUILayout.BeginHorizontal();
-                GUILayout.Label(addressLabelText, window.labelStyle);
+                DrawFieldLabel (addressLabelText);
                 if (!settings.ContainsKey("address"))
                     settings["address"] = IPAddress.Loopback.ToString();
                 var address = settings["address"];
@@ -134,20 +142,20 @@ namespace KRPC.UI
                 GUILayout.EndHorizontal();
 
                 GUILayout.BeginHorizontal();
-                GUILayout.Label(rpcPortLabelText, window.labelStyle);
+                DrawFieldLabel (rpcPortLabelText);
                 if (!settings.ContainsKey("rpc_port"))
                     settings["rpc_port"] = "50000";
                 settings["rpc_port"] = GUILayoutExtensions.FilterDigits (
-                    GUILayoutExtensions.ValidatedTextField (settings["rpc_port"], portMaxLength, window.longTextFieldStyle,
+                    GUILayoutExtensions.ValidatedTextField (settings["rpc_port"], portMaxLength, window.stretchyTextFieldStyle,
                         ValidPort (settings["rpc_port"]), window.errorColor));
                 GUILayout.EndHorizontal();
 
                 GUILayout.BeginHorizontal();
-                GUILayout.Label(streamPortLabelText, window.labelStyle);
+                DrawFieldLabel (streamPortLabelText);
                 if (!settings.ContainsKey("stream_port"))
                     settings["stream_port"] = "50000";
                 settings["stream_port"] = GUILayoutExtensions.FilterDigits (
-                    GUILayoutExtensions.ValidatedTextField (settings["stream_port"], portMaxLength, window.longTextFieldStyle,
+                    GUILayoutExtensions.ValidatedTextField (settings["stream_port"], portMaxLength, window.stretchyTextFieldStyle,
                         ValidPort (settings["stream_port"]), window.errorColor));
                 GUILayout.EndHorizontal();
             } else {
@@ -157,34 +165,34 @@ namespace KRPC.UI
                     settings["data_bits"] = "8";
 
                 GUILayout.BeginHorizontal();
-                GUILayout.Label(portLabelText, window.labelStyle);
+                DrawFieldLabel (portLabelText);
                 if (!settings.ContainsKey("port"))
                     settings["port"] = new KRPC.IO.Ports.SerialPort ().PortName;
                 settings["port"] = GUILayoutExtensions.ValidatedTextField (
-                    settings["port"], portNameMaxLength, window.longTextFieldStyle,
+                    settings["port"], portNameMaxLength, window.stretchyTextFieldStyle,
                     settings["port"].Length > 0, window.errorColor);
                 GUILayout.EndHorizontal();
 
                 GUILayout.BeginHorizontal();
-                GUILayout.Label(baudRateLabelText, window.labelStyle);
+                DrawFieldLabel (baudRateLabelText);
                 if (!settings.ContainsKey("baud_rate"))
                     settings["baud_rate"] = "9600";
                 settings["baud_rate"] = GUILayoutExtensions.FilterDigits (
-                    GUILayoutExtensions.ValidatedTextField (settings["baud_rate"], baudRateMaxLength, window.longTextFieldStyle,
+                    GUILayoutExtensions.ValidatedTextField (settings["baud_rate"], baudRateMaxLength, window.stretchyTextFieldStyle,
                         ValidBaudRate (settings["baud_rate"]), window.errorColor));
                 GUILayout.EndHorizontal();
 
                 GUILayout.BeginHorizontal();
-                GUILayout.Label(dataBitsLabelText, window.labelStyle);
+                DrawFieldLabel (dataBitsLabelText);
                 if (!settings.ContainsKey("data_bits"))
                     settings["data_bits"] = "8";
                 settings["data_bits"] = GUILayoutExtensions.FilterDigits (
-                    GUILayoutExtensions.ValidatedTextField (settings["data_bits"], dataBitsMaxLength, window.longTextFieldStyle,
+                    GUILayoutExtensions.ValidatedTextField (settings["data_bits"], dataBitsMaxLength, window.stretchyTextFieldStyle,
                         ValidDataBits (settings["data_bits"]), window.errorColor));
                 GUILayout.EndHorizontal();
 
                 GUILayout.BeginHorizontal();
-                GUILayout.Label(parityLabelText, window.labelStyle);
+                DrawFieldLabel (parityLabelText);
                 if (!settings.ContainsKey("parity"))
                     settings["parity"] = "None";
                 settings["parity"] = parityOptions [GUILayoutExtensions.ComboBox (
@@ -193,7 +201,7 @@ namespace KRPC.UI
                 GUILayout.EndHorizontal();
 
                 GUILayout.BeginHorizontal();
-                GUILayout.Label(stopBitsLabelText, window.labelStyle);
+                DrawFieldLabel (stopBitsLabelText);
                 if (!settings.ContainsKey("stop_bits"))
                     settings["stop_bits"] = "One";
                 settings["stop_bits"] = stopBitsOptions [GUILayoutExtensions.ComboBox (

--- a/server/src/UI/EditServer.cs
+++ b/server/src/UI/EditServer.cs
@@ -56,6 +56,14 @@ namespace KRPC.UI
         bool manualAddress;
         List<string> availableAddresses;
 
+        // Unique identifiers for the combo boxes, so that they do not collide with
+        // the combo boxes of other servers being edited at the same time. These must
+        // be stable across frames, so they cannot be constructed inline in Draw ().
+        readonly object protocolComboId = new object ();
+        readonly object addressComboId = new object ();
+        readonly object parityComboId = new object ();
+        readonly object stopBitsComboId = new object ();
+
         public EditServer (MainWindow mainWindow, Configuration.Server server)
         {
             window = mainWindow;
@@ -83,7 +91,7 @@ namespace KRPC.UI
         {
             GUILayout.BeginHorizontal ();
             GUILayout.Label (protocolLabelText, window.labelStyle);
-            protocol = (Protocol)GUILayoutExtensions.ComboBox ("protocol", (int)protocol, availableProtocols, window.buttonStyle, window.comboOptionsStyle, window.comboOptionStyle);
+            protocol = (Protocol)GUILayoutExtensions.ComboBox (protocolComboId, (int)protocol, availableProtocols, window.buttonStyle, window.comboOptionsStyle, window.comboOptionStyle);
             GUILayout.EndHorizontal ();
 
             if (protocol == Protocol.ProtocolBuffersOverTCP ||
@@ -104,7 +112,7 @@ namespace KRPC.UI
                 else
                     addressSelected = availableAddresses.Count - 1;
                 // Display the combo box
-                addressSelected = GUILayoutExtensions.ComboBox("address", addressSelected, availableAddresses, window.buttonStyle, window.comboOptionsStyle, window.comboOptionStyle);
+                addressSelected = GUILayoutExtensions.ComboBox(addressComboId, addressSelected, availableAddresses, window.buttonStyle, window.comboOptionsStyle, window.comboOptionStyle);
                 // Get the address from the combo box selection
                 if (addressSelected == 0) {
                     address = IPAddress.Loopback.ToString();
@@ -117,7 +125,9 @@ namespace KRPC.UI
                     manualAddress = false;
                 } else {
                     // Display a text field when "Manual" is selected
-                    address = GUILayout.TextField(address, addressMaxLength, window.stretchyTextFieldStyle);
+                    address = GUILayoutExtensions.FilterDigitsAndPeriods (
+                        GUILayoutExtensions.ValidatedTextField (address, addressMaxLength, window.stretchyTextFieldStyle,
+                            ValidAddress (address), window.errorColor));
                     manualAddress = true;
                 }
                 settings["address"] = address;
@@ -127,14 +137,18 @@ namespace KRPC.UI
                 GUILayout.Label(rpcPortLabelText, window.labelStyle);
                 if (!settings.ContainsKey("rpc_port"))
                     settings["rpc_port"] = "50000";
-                settings["rpc_port"] = GUILayout.TextField(settings["rpc_port"], portMaxLength, window.longTextFieldStyle);
+                settings["rpc_port"] = GUILayoutExtensions.FilterDigits (
+                    GUILayoutExtensions.ValidatedTextField (settings["rpc_port"], portMaxLength, window.longTextFieldStyle,
+                        ValidPort (settings["rpc_port"]), window.errorColor));
                 GUILayout.EndHorizontal();
 
                 GUILayout.BeginHorizontal();
                 GUILayout.Label(streamPortLabelText, window.labelStyle);
                 if (!settings.ContainsKey("stream_port"))
                     settings["stream_port"] = "50000";
-                settings["stream_port"] = GUILayout.TextField(settings["stream_port"], portMaxLength, window.longTextFieldStyle);
+                settings["stream_port"] = GUILayoutExtensions.FilterDigits (
+                    GUILayoutExtensions.ValidatedTextField (settings["stream_port"], portMaxLength, window.longTextFieldStyle,
+                        ValidPort (settings["stream_port"]), window.errorColor));
                 GUILayout.EndHorizontal();
             } else {
                 if (!settings.ContainsKey("baud_rate"))
@@ -146,24 +160,27 @@ namespace KRPC.UI
                 GUILayout.Label(portLabelText, window.labelStyle);
                 if (!settings.ContainsKey("port"))
                     settings["port"] = new KRPC.IO.Ports.SerialPort ().PortName;
-                settings["port"] = GUILayout.TextField(
-                    settings["port"], portNameMaxLength, window.longTextFieldStyle);
+                settings["port"] = GUILayoutExtensions.ValidatedTextField (
+                    settings["port"], portNameMaxLength, window.longTextFieldStyle,
+                    settings["port"].Length > 0, window.errorColor);
                 GUILayout.EndHorizontal();
 
                 GUILayout.BeginHorizontal();
                 GUILayout.Label(baudRateLabelText, window.labelStyle);
                 if (!settings.ContainsKey("baud_rate"))
                     settings["baud_rate"] = "9600";
-                settings["baud_rate"] = GUILayout.TextField(
-                    settings["baud_rate"], baudRateMaxLength, window.longTextFieldStyle);
+                settings["baud_rate"] = GUILayoutExtensions.FilterDigits (
+                    GUILayoutExtensions.ValidatedTextField (settings["baud_rate"], baudRateMaxLength, window.longTextFieldStyle,
+                        ValidBaudRate (settings["baud_rate"]), window.errorColor));
                 GUILayout.EndHorizontal();
 
                 GUILayout.BeginHorizontal();
                 GUILayout.Label(dataBitsLabelText, window.labelStyle);
                 if (!settings.ContainsKey("data_bits"))
                     settings["data_bits"] = "8";
-                settings["data_bits"] = GUILayout.TextField(
-                    settings["data_bits"], dataBitsMaxLength, window.longTextFieldStyle);
+                settings["data_bits"] = GUILayoutExtensions.FilterDigits (
+                    GUILayoutExtensions.ValidatedTextField (settings["data_bits"], dataBitsMaxLength, window.longTextFieldStyle,
+                        ValidDataBits (settings["data_bits"]), window.errorColor));
                 GUILayout.EndHorizontal();
 
                 GUILayout.BeginHorizontal();
@@ -171,7 +188,7 @@ namespace KRPC.UI
                 if (!settings.ContainsKey("parity"))
                     settings["parity"] = "None";
                 settings["parity"] = parityOptions [GUILayoutExtensions.ComboBox (
-                        "parity", parityOptions.IndexOf(settings["parity"]), parityOptions,
+                        parityComboId, parityOptions.IndexOf(settings["parity"]), parityOptions,
                         window.buttonStyle, window.comboOptionsStyle, window.comboOptionStyle)];
                 GUILayout.EndHorizontal();
 
@@ -180,10 +197,34 @@ namespace KRPC.UI
                 if (!settings.ContainsKey("stop_bits"))
                     settings["stop_bits"] = "One";
                 settings["stop_bits"] = stopBitsOptions [GUILayoutExtensions.ComboBox (
-                        "stop_bits", stopBitsOptions.IndexOf(settings["stop_bits"]), stopBitsOptions,
+                        stopBitsComboId, stopBitsOptions.IndexOf(settings["stop_bits"]), stopBitsOptions,
                         window.buttonStyle, window.comboOptionsStyle, window.comboOptionStyle)];
                 GUILayout.EndHorizontal();
             }
+        }
+
+        static bool ValidAddress (string value)
+        {
+            IPAddress address;
+            return IPAddress.TryParse (value, out address);
+        }
+
+        static bool ValidPort (string value)
+        {
+            ushort port;
+            return ushort.TryParse (value, out port);
+        }
+
+        static bool ValidBaudRate (string value)
+        {
+            uint baudRate;
+            return uint.TryParse (value, out baudRate);
+        }
+
+        static bool ValidDataBits (string value)
+        {
+            ushort dataBits;
+            return ushort.TryParse (value, out dataBits) && dataBits >= 5 && dataBits <= 8;
         }
 
         public Configuration.Server Save ()
@@ -193,30 +234,19 @@ namespace KRPC.UI
             if (protocol == Protocol.ProtocolBuffersOverTCP ||
                 protocol == Protocol.ProtocolBuffersOverWebsockets)
             {
-                IPAddress ipAddress;
-                ushort rpcPortInt;
-                ushort streamPortInt;
-                bool validAddress = IPAddress.TryParse(settings["address"], out ipAddress);
-                bool validRPCPort = ushort.TryParse(settings["rpc_port"], out rpcPortInt);
-                bool validStreamPort = ushort.TryParse(settings["stream_port"], out streamPortInt);
-                if (!validAddress)
+                if (!ValidAddress (settings["address"]))
                     window.Errors.Add(invalidAddressText);
-                if (!validRPCPort)
+                if (!ValidPort (settings["rpc_port"]))
                     window.Errors.Add(invalidRPCPortText);
-                if (!validStreamPort)
+                if (!ValidPort (settings["stream_port"]))
                     window.Errors.Add(invalidStreamPortText);
                 allowedKeys = new List<string> { "address", "rpc_port", "stream_port" };
             } else {
-                uint baudRateInt;
-                ushort dataBitsInt;
-                bool validPort = (settings["port"].Length > 0);
-                bool validBaudRate = uint.TryParse(settings["baud_rate"], out baudRateInt);
-                bool validDataBits = ushort.TryParse(settings["data_bits"], out dataBitsInt);
-                if (!validPort)
+                if (settings["port"].Length == 0)
                     window.Errors.Add(invalidPortNameText);
-                if (!validBaudRate)
+                if (!ValidBaudRate (settings["baud_rate"]))
                     window.Errors.Add(invalidBaudRateText);
-                if (!validDataBits)
+                if (!ValidDataBits (settings["data_bits"]))
                     window.Errors.Add(invalidDataBitsText);
                 allowedKeys = new List<string> {
                     "port", "baud_rate", "data_bits", "parity", "stop_bits" };

--- a/server/src/UI/EditServer.cs
+++ b/server/src/UI/EditServer.cs
@@ -84,7 +84,7 @@ namespace KRPC.UI
 
         public void DrawName ()
         {
-            name = GUILayout.TextField (name, nameMaxLength, window.longTextFieldStyle);
+            name = GUILayout.TextField (name, nameMaxLength, window.stretchyTextFieldStyle);
         }
 
         public void Draw ()

--- a/server/src/UI/GUILayoutExtensions.cs
+++ b/server/src/UI/GUILayoutExtensions.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 using UnityEngine;
 
 namespace KRPC.UI
@@ -9,6 +10,48 @@ namespace KRPC.UI
         public static void Init (GameObject gameObject)
         {
             ComboBoxWindow.MainInit (gameObject);
+        }
+
+        /// <summary>
+        /// A text field that is tinted with the given colour when its current value is not valid.
+        /// </summary>
+        public static string ValidatedTextField (string value, int maxLength, GUIStyle style, bool valid, Color invalidColor)
+        {
+            var oldBackgroundColor = GUI.backgroundColor;
+            var oldContentColor = GUI.contentColor;
+            if (!valid) {
+                GUI.backgroundColor = invalidColor;
+                GUI.contentColor = invalidColor;
+            }
+            var result = GUILayout.TextField (value, maxLength, style);
+            GUI.backgroundColor = oldBackgroundColor;
+            GUI.contentColor = oldContentColor;
+            return result;
+        }
+
+        /// <summary>
+        /// Strip any character that is not a digit.
+        /// </summary>
+        public static string FilterDigits (string value)
+        {
+            return Filter (value, false);
+        }
+
+        /// <summary>
+        /// Strip any character that is not a digit or a period.
+        /// </summary>
+        public static string FilterDigitsAndPeriods (string value)
+        {
+            return Filter (value, true);
+        }
+
+        static string Filter (string value, bool allowPeriod)
+        {
+            var result = new StringBuilder (value.Length);
+            foreach (char c in value)
+                if ((c >= '0' && c <= '9') || (allowPeriod && c == '.'))
+                    result.Append (c);
+            return result.ToString ();
         }
 
         public static void Destroy ()
@@ -89,11 +132,19 @@ namespace KRPC.UI
         public static GUIStyle ComboOptionStyle ()
         {
             var style = new GUIStyle (Skin.DefaultSkin.label);
-            style.hover.textColor = Color.yellow;
+            // Highlighting of the hovered option is handled manually in
+            // ComboBoxWindow.Draw via GUI.contentColor. Neutralise the built-in
+            // interactive states so they never recolour (or, in the case of the skin's
+            // default hover colour, hide) the text based on the stale hover position.
+            style.hover.textColor = style.normal.textColor;
+            style.active.textColor = style.normal.textColor;
+            style.onHover.textColor = style.normal.textColor;
+            style.onActive.textColor = style.normal.textColor;
             var texture = new Texture2D (1, 1);
             texture.SetPixel (0, 0, new Color (0, 0, 0, 0));
             texture.Apply ();
             style.hover.background = texture;
+            style.active.background = texture;
             return style;
         }
 
@@ -151,6 +202,10 @@ namespace KRPC.UI
 
             bool stalePosition;
 
+            // Screen positions of the drawn options, used to highlight the one under
+            // the mouse (see Draw).
+            readonly List<Rect> optionRects = new List<Rect> ();
+
             public static void MainInit (GameObject gameObject)
             {
                 Instance = gameObject.AddComponent<ComboBoxWindow> ();
@@ -180,12 +235,34 @@ namespace KRPC.UI
 
             protected override void Draw (bool needRescale)
             {
-                if (Options != null) {
-                    int selectedOption = GUILayout.SelectionGrid (-1, Options.ToArray (), 1, OptionStyle);
-                    if (selectedOption >= 0) {
-                        SelectedOption = selectedOption;
-                    }
+                if (Options == null)
+                    return;
+
+                // Highlight the option under the mouse using the live pointer position
+                // (Input.mousePosition) rather than the built-in hover state, which is
+                // driven by Event.current.mousePosition. In the KSP runtime the latter is
+                // only refreshed when an input event is processed, so the built-in
+                // highlight freezes between mouse movements (the classic "wiggle the mouse
+                // to update it" behaviour). The options do not move once the window is
+                // shown, so hit-testing against the rects captured on the last repaint is
+                // exact. Position is the window's top-left in screen space; Input.mousePosition
+                // is bottom-left origin, hence the y flip.
+                var mouse = new Vector2 (
+                    Input.mousePosition.x - Position.x,
+                    Screen.height - Input.mousePosition.y - Position.y);
+
+                while (optionRects.Count < Options.Count)
+                    optionRects.Add (new Rect ());
+
+                var contentColor = GUI.contentColor;
+                for (int i = 0; i < Options.Count; i++) {
+                    GUI.contentColor = optionRects [i].Contains (mouse) ? Color.yellow : contentColor;
+                    if (GUILayout.Button (Options [i], OptionStyle))
+                        SelectedOption = i;
+                    if (Event.current.type == EventType.Repaint)
+                        optionRects [i] = GUILayoutUtility.GetLastRect ();
                 }
+                GUI.contentColor = contentColor;
             }
 
             public void Show (object caller, IList<string> options, GUIStyle windowStyle, GUIStyle optionStyle)
@@ -196,6 +273,7 @@ namespace KRPC.UI
                 SelectedOption = -1;
                 Options = options;
                 OptionStyle = optionStyle;
+                optionRects.Clear ();
                 stalePosition = true;
                 GUI.BringWindowToFront (Id);
             }

--- a/server/src/UI/GUILayoutExtensions.cs
+++ b/server/src/UI/GUILayoutExtensions.cs
@@ -132,10 +132,13 @@ namespace KRPC.UI
         public static GUIStyle ComboOptionStyle ()
         {
             var style = new GUIStyle (Skin.DefaultSkin.label);
-            // Highlighting of the hovered option is handled manually in
-            // ComboBoxWindow.Draw via GUI.contentColor. Neutralise the built-in
-            // interactive states so they never recolour (or, in the case of the skin's
-            // default hover colour, hide) the text based on the stale hover position.
+            // Highlighting of the hovered option (a grey background and lighter text)
+            // is handled manually in ComboBoxWindow.Draw. Give the text a known base
+            // colour so the manual GUI.contentColor tint is predictable, and neutralise
+            // the built-in interactive states so they never recolour (or, in the case
+            // of the skin's default hover colour, hide) the text based on the stale
+            // hover position.
+            style.normal.textColor = Color.white;
             style.hover.textColor = style.normal.textColor;
             style.active.textColor = style.normal.textColor;
             style.onHover.textColor = style.normal.textColor;
@@ -206,6 +209,11 @@ namespace KRPC.UI
             // the mouse (see Draw).
             readonly List<Rect> optionRects = new List<Rect> ();
 
+            // Grey background drawn behind the hovered option.
+            Texture2D hoverBackground;
+            static readonly Color hoverTextColor = Color.white;
+            static readonly Color normalTextColor = new Color (0.8f, 0.8f, 0.8f);
+
             public static void MainInit (GameObject gameObject)
             {
                 Instance = gameObject.AddComponent<ComboBoxWindow> ();
@@ -231,6 +239,9 @@ namespace KRPC.UI
                 Style.border.top = Style.border.bottom;
                 Style.padding.top = Style.padding.bottom;
                 stalePosition = true;
+                hoverBackground = new Texture2D (1, 1);
+                hoverBackground.SetPixel (0, 0, new Color (0.5f, 0.5f, 0.5f, 0.4f));
+                hoverBackground.Apply ();
             }
 
             protected override void Draw (bool needRescale)
@@ -256,7 +267,12 @@ namespace KRPC.UI
 
                 var contentColor = GUI.contentColor;
                 for (int i = 0; i < Options.Count; i++) {
-                    GUI.contentColor = optionRects [i].Contains (mouse) ? Color.yellow : contentColor;
+                    bool hover = optionRects [i].Contains (mouse);
+                    // Draw the grey highlight behind the hovered option, using the rect
+                    // captured on the previous repaint (the options do not move).
+                    if (hover && Event.current.type == EventType.Repaint)
+                        GUI.DrawTexture (optionRects [i], hoverBackground);
+                    GUI.contentColor = hover ? hoverTextColor : normalTextColor;
                     if (GUILayout.Button (Options [i], OptionStyle))
                         SelectedOption = i;
                     if (Event.current.type == EventType.Repaint)

--- a/server/src/UI/GUILayoutExtensions.cs
+++ b/server/src/UI/GUILayoutExtensions.cs
@@ -155,8 +155,9 @@ namespace KRPC.UI
 
         public static int ComboBox (object caller, int selectedItem, IList<string> entries, GUIStyle buttonStyle, GUIStyle optionsStyle, GUIStyle optionStyle)
         {
-            // Main button
-            if (GUILayout.Button (entries [selectedItem], buttonStyle)) {
+            // Main button. Expand to fill the row so combo boxes line up with the
+            // (stretchy) text fields in the edit-server form.
+            if (GUILayout.Button (entries [selectedItem], buttonStyle, GUILayout.ExpandWidth (true))) {
                 if (ComboBoxWindow.Instance.Caller != caller || !ComboBoxWindow.Instance.Visible) {
                     ComboBoxWindow.Instance.Show (caller, entries, optionsStyle, optionStyle);
                 } else if (ComboBoxWindow.Instance.Caller == caller && ComboBoxWindow.Instance.Visible) {

--- a/server/src/UI/GUILayoutExtensions.cs
+++ b/server/src/UI/GUILayoutExtensions.cs
@@ -156,8 +156,14 @@ namespace KRPC.UI
         public static int ComboBox (object caller, int selectedItem, IList<string> entries, GUIStyle buttonStyle, GUIStyle optionsStyle, GUIStyle optionStyle)
         {
             // Main button. Expand to fill the row so combo boxes line up with the
-            // (stretchy) text fields in the edit-server form.
-            if (GUILayout.Button (entries [selectedItem], buttonStyle, GUILayout.ExpandWidth (true))) {
+            // (stretchy) text fields in the edit-server form, and left-align the label
+            // to match the left-aligned drop-down items. buttonStyle is shared with the
+            // action buttons, so its alignment is restored immediately after.
+            var oldAlignment = buttonStyle.alignment;
+            buttonStyle.alignment = TextAnchor.MiddleLeft;
+            var clicked = GUILayout.Button (entries [selectedItem], buttonStyle, GUILayout.ExpandWidth (true));
+            buttonStyle.alignment = oldAlignment;
+            if (clicked) {
                 if (ComboBoxWindow.Instance.Caller != caller || !ComboBoxWindow.Instance.Visible) {
                     ComboBoxWindow.Instance.Show (caller, entries, optionsStyle, optionStyle);
                 } else if (ComboBoxWindow.Instance.Caller == caller && ComboBoxWindow.Instance.Visible) {

--- a/server/src/UI/InfoWindow.cs
+++ b/server/src/UI/InfoWindow.cs
@@ -152,10 +152,10 @@ namespace KRPC.UI
         {
             string[] suffix = { "B", "KB", "MB", "GB", "TB", "PB", "EB" };
             if (bytes == 0)
-                return "0" + suffix [0];
+                return "0 " + suffix [0];
             int place = Convert.ToInt32 (Math.Floor (Math.Log (bytes, 1024)));
             double num = Math.Round (bytes / Math.Pow (1024, place), 1);
-            return num + suffix [place];
+            return num + " " + suffix [place];
         }
     }
 }

--- a/server/src/UI/InfoWindow.cs
+++ b/server/src/UI/InfoWindow.cs
@@ -121,9 +121,9 @@ namespace KRPC.UI
             DrawInfo (rpcsExecutedText, core.RPCsExecuted.ToString ());
             DrawInfo (rpcRateText, Math.Round (core.RPCRate) + " RPC/s");
             DrawInfo (rpcExecutionMode, config.OneRPCPerUpdate ? singleRPCModeText : (config.AdaptiveRateControl ? adaptiveModeText : staticModeText));
-            DrawInfo (maxTimePerUpdateText, config.OneRPCPerUpdate ? notApplicableText : config.MaxTimePerUpdate + " ns");
+            DrawInfo (maxTimePerUpdateText, config.OneRPCPerUpdate ? notApplicableText : config.MaxTimePerUpdate + " us");
             DrawInfo (rpcReceiveModeText, config.BlockingRecv ? blockingModeText : nonBlockingModeText);
-            DrawInfo (recvTimeoutText, config.BlockingRecv ? config.RecvTimeout + " ns" : notApplicableText);
+            DrawInfo (recvTimeoutText, config.BlockingRecv ? config.RecvTimeout + " us" : notApplicableText);
             DrawInfo (timePerRPCUpdateText, string.Format ("{0:F5} s", core.TimePerRPCUpdate));
             DrawInfo (pollTimePerRPCUpdateText, string.Format ("{0:F5} s", core.PollTimePerRPCUpdate));
             DrawInfo (execTimePerRPCUpdateText, string.Format ("{0:F5} s", core.ExecTimePerRPCUpdate));

--- a/server/src/UI/MainWindow.cs
+++ b/server/src/UI/MainWindow.cs
@@ -193,7 +193,7 @@ namespace KRPC.UI
 
             var servers = core.Servers.ToList();
             foreach (var server in servers) {
-                DrawServer(server, servers.Count == 1);
+                DrawServer(server);
                 GUILayoutExtensions.Separator(separatorStyle);
             }
 
@@ -228,24 +228,22 @@ namespace KRPC.UI
             GUI.enabled = true;
         }
 
-        void DrawServer (Server.Server server, bool forceExpanded = false)
+        void DrawServer (Server.Server server)
         {
             var running = server.Running;
             var editingServer = editServers.ContainsKey (server.Id);
-            var expanded = forceExpanded || expandServers.Contains (server.Id);
+            var expanded = expandServers.Contains (server.Id);
 
             GUILayout.BeginHorizontal ();
-            if (!forceExpanded) {
-                var icons = Icons.Instance;
-                if (GUILayout.Button(new GUIContent(expanded ? icons.ButtonCollapse : icons.ButtonExpand, expanded ? "Collapse" : "Expand"),
-                        expandStyle, GUILayout.MaxWidth(20), GUILayout.MaxHeight(20))) {
-                    if (expanded)
-                        expandServers.Remove(server.Id);
-                    else
-                        expandServers.Add(server.Id);
-                    expanded = !expanded;
-                    Resized = true;
-                }
+            var icons = Icons.Instance;
+            if (GUILayout.Button(new GUIContent(expanded ? icons.ButtonCollapse : icons.ButtonExpand, expanded ? "Collapse" : "Expand"),
+                    expandStyle, GUILayout.MaxWidth(20), GUILayout.MaxHeight(20))) {
+                if (expanded)
+                    expandServers.Remove(server.Id);
+                else
+                    expandServers.Add(server.Id);
+                expanded = !expanded;
+                Resized = true;
             }
             GUILayoutExtensions.Light (running, lightStyle);
             if (!editingServer)

--- a/server/src/UI/MainWindow.cs
+++ b/server/src/UI/MainWindow.cs
@@ -238,8 +238,16 @@ namespace KRPC.UI
 
             GUILayout.BeginHorizontal ();
             var icons = Icons.Instance;
+            // Vertically centre the expand/collapse arrow in the row; it is shorter
+            // than the activity light and name and would otherwise sit at the top.
+            // A fixed top space (rather than ExpandHeight + FlexibleSpace) is used so
+            // the column cannot grab the window's spare height and push the arrow onto
+            // its own line.
+            GUILayout.BeginVertical (GUILayout.Width (20));
+            GUILayout.Space (Mathf.Max (0f, (Style.lineHeight - 16f) / 2f));
             GUILayout.Label (new GUIContent (expanded ? icons.ButtonCollapse : icons.ButtonExpand, expanded ? "Collapse" : "Expand"),
                 expandStyle, GUILayout.MaxWidth (20), GUILayout.MaxHeight (20));
+            GUILayout.EndVertical ();
             GUILayoutExtensions.Light (running, lightStyle);
             if (!editingServer)
                 GUILayout.Label (server.Name, labelStyle);

--- a/server/src/UI/MainWindow.cs
+++ b/server/src/UI/MainWindow.cs
@@ -34,7 +34,7 @@ namespace KRPC.UI
         string maxTimePerUpdate;
         string recvTimeout;
         // Style settings
-        readonly Color errorColor = Color.yellow;
+        internal readonly Color errorColor = Color.yellow;
         internal GUIStyle labelStyle, stretchyLabelStyle, fixedLabelStyle, textFieldStyle, longTextFieldStyle, stretchyTextFieldStyle,
             buttonStyle, toggleStyle, expandStyle, separatorStyle, lightStyle, errorLabelStyle, comboOptionsStyle, comboOptionStyle;
         const float windowWidth = 288f;
@@ -43,8 +43,8 @@ namespace KRPC.UI
         const float fixedLabelWidth = 160f;
         const float indentWidth = 15f;
         float scaledIndentWidth;
-        const int maxTimePerUpdateMaxLength = 5;
-        const int recvTimeoutMaxLength = 5;
+        const int maxTimePerUpdateMaxLength = 20;
+        const int recvTimeoutMaxLength = 20;
         // Text strings
         const string advancedModeText = "Show advanced settings";
         const string startAllServersText = "Start server";
@@ -73,9 +73,8 @@ namespace KRPC.UI
         const string adaptiveRateControlText = "Adaptive rate control";
         const string blockingRecvText = "Blocking receives";
         const string recvTimeoutText = "Receive timeout";
+        const string microsecondsUnitText = "us";
         const string debugLoggingText = "Debug logging";
-        const string invalidMaxTimePerUpdateText = "Max. time per update must be an integer";
-        const string invalidRecvTimeoutText = "Receive timeout must be an integer";
         const string showInfoWindowText = "Show info";
 
         protected override void Init ()
@@ -473,12 +472,17 @@ namespace KRPC.UI
         void DrawMaxTimePerUpdate ()
         {
             GUILayout.Label (maxTimePerUpdateText, fixedLabelStyle);
-            var newMaxTimePerUpdate = GUILayout.TextField (maxTimePerUpdate, maxTimePerUpdateMaxLength, longTextFieldStyle);
+            uint value;
+            bool valid = uint.TryParse (maxTimePerUpdate, out value);
+            var newMaxTimePerUpdate = GUILayoutExtensions.FilterDigits (
+                GUILayoutExtensions.ValidatedTextField (maxTimePerUpdate, maxTimePerUpdateMaxLength, longTextFieldStyle, valid, errorColor));
+            GUILayout.Label (microsecondsUnitText, labelStyle);
             if (newMaxTimePerUpdate != maxTimePerUpdate) {
-                uint value = config.Configuration.MaxTimePerUpdate;
-                uint.TryParse (newMaxTimePerUpdate, out value);
-                config.Configuration.MaxTimePerUpdate = value;
-                config.Save ();
+                maxTimePerUpdate = newMaxTimePerUpdate;
+                if (uint.TryParse (maxTimePerUpdate, out value)) {
+                    config.Configuration.MaxTimePerUpdate = value;
+                    config.Save ();
+                }
             }
         }
 
@@ -503,12 +507,17 @@ namespace KRPC.UI
         void DrawRecvTimeout ()
         {
             GUILayout.Label (recvTimeoutText, fixedLabelStyle);
-            var newRecvTimeout = GUILayout.TextField (recvTimeout, recvTimeoutMaxLength, longTextFieldStyle);
+            uint value;
+            bool valid = uint.TryParse (recvTimeout, out value);
+            var newRecvTimeout = GUILayoutExtensions.FilterDigits (
+                GUILayoutExtensions.ValidatedTextField (recvTimeout, recvTimeoutMaxLength, longTextFieldStyle, valid, errorColor));
+            GUILayout.Label (microsecondsUnitText, labelStyle);
             if (newRecvTimeout != recvTimeout) {
-                uint value = config.Configuration.RecvTimeout;
-                uint.TryParse (newRecvTimeout, out value);
-                config.Configuration.RecvTimeout = value;
-                config.Save ();
+                recvTimeout = newRecvTimeout;
+                if (uint.TryParse (recvTimeout, out value)) {
+                    config.Configuration.RecvTimeout = value;
+                    config.Save ();
+                }
             }
         }
 

--- a/server/src/UI/MainWindow.cs
+++ b/server/src/UI/MainWindow.cs
@@ -236,21 +236,27 @@ namespace KRPC.UI
 
             GUILayout.BeginHorizontal ();
             var icons = Icons.Instance;
-            if (GUILayout.Button(new GUIContent(expanded ? icons.ButtonCollapse : icons.ButtonExpand, expanded ? "Collapse" : "Expand"),
-                    expandStyle, GUILayout.MaxWidth(20), GUILayout.MaxHeight(20))) {
-                if (expanded)
-                    expandServers.Remove(server.Id);
-                else
-                    expandServers.Add(server.Id);
-                expanded = !expanded;
-                Resized = true;
-            }
+            GUILayout.Label (new GUIContent (expanded ? icons.ButtonCollapse : icons.ButtonExpand, expanded ? "Collapse" : "Expand"),
+                expandStyle, GUILayout.MaxWidth (20), GUILayout.MaxHeight (20));
             GUILayoutExtensions.Light (running, lightStyle);
             if (!editingServer)
                 GUILayout.Label (server.Name, labelStyle);
             else
                 editServers [server.Id].DrawName ();
             GUILayout.EndHorizontal ();
+
+            // Expand/collapse when the header row (icon, activity light and name) is
+            // clicked. Skipped while editing, where the row holds the name text field.
+            if (!editingServer && Event.current.type == EventType.MouseDown &&
+                GUILayoutUtility.GetLastRect ().Contains (Event.current.mousePosition)) {
+                if (expanded)
+                    expandServers.Remove (server.Id);
+                else
+                    expandServers.Add (server.Id);
+                expanded = !expanded;
+                Resized = true;
+                Event.current.Use ();
+            }
 
             if (editingServer) {
                 editServers [server.Id].Draw ();

--- a/server/src/UI/MainWindow.cs
+++ b/server/src/UI/MainWindow.cs
@@ -64,6 +64,7 @@ namespace KRPC.UI
         internal const string protobufOverSerialIOText = "Protobuf over SerialIO";
         const string unknownClientNameText = "<unknown>";
         const string noClientsConnectedText = "No clients connected";
+        const string serverNotRunningText = "Server not running";
         const string advancedServerOptionsText = "Show advanced settings";
         const string autoStartServerText = "Auto-start server";
         const string autoAcceptConnectionsText = "Auto-accept new clients";
@@ -377,7 +378,7 @@ namespace KRPC.UI
                 }
             } else {
                 GUILayout.BeginHorizontal ();
-                GUILayout.Label (noClientsConnectedText, labelStyle);
+                GUILayout.Label (server.Running ? noClientsConnectedText : serverNotRunningText, labelStyle);
                 GUILayout.EndHorizontal ();
             }
         }

--- a/server/src/UI/MainWindow.cs
+++ b/server/src/UI/MainWindow.cs
@@ -41,6 +41,7 @@ namespace KRPC.UI
         const float textFieldWidth = 45f;
         const float longTextFieldWidth = 80f;
         const float fixedLabelWidth = 160f;
+        const float serverInfoLabelWidth = 110f;
         const float indentWidth = 15f;
         float scaledIndentWidth;
         const int maxTimePerUpdateMaxLength = 20;
@@ -57,7 +58,7 @@ namespace KRPC.UI
         const string saveServerText = "Save";
         const string serverOnlineText = "Server online";
         const string serverOfflineText = "Server offline";
-        const string protocolText = "Protocol:";
+        const string protocolText = "Protocol";
         internal const string protobufOverTcpText = "Protobuf over TCP";
         internal const string protobufOverWebSocketsText = "Protobuf over WebSockets";
         internal const string protobufOverSerialIOText = "Protobuf over SerialIO";
@@ -268,10 +269,9 @@ namespace KRPC.UI
                     protocol = protobufOverWebSocketsText;
                 else
                     protocol = protobufOverSerialIOText;
-                GUILayout.Label (protocolText + protocol, labelStyle);
-                foreach (var line in server.Address.Split ('\n'))
-                    GUILayout.Label (line, labelStyle);
-                GUILayout.Label (server.Info, labelStyle);
+                DrawServerInfoRow (protocolText, protocol);
+                DrawServerInfoLines (server.Address);
+                DrawServerInfoLines (server.Info);
                 DrawClients (server);
             }
 
@@ -311,6 +311,38 @@ namespace KRPC.UI
             }
             GUI.enabled = true;
             GUILayout.EndHorizontal ();
+        }
+
+        // Draw a name/value row with an aligned name column, for the server details
+        // "table". Matches the style of the info window.
+        void DrawServerInfoRow (string name, string value)
+        {
+            GUILayout.BeginHorizontal ();
+            GUILayout.Label (name, labelStyle, GUILayout.Width (serverInfoLabelWidth * GameSettings.UI_SCALE));
+            GUILayout.Label (value, stretchyLabelStyle);
+            GUILayout.EndHorizontal ();
+        }
+
+        // Split a multi-line server detail string (e.g. Address or Info) into name/value
+        // rows, splitting each line on its "name = value" or "name: value" separator.
+        // Lines with no separator are shown in the value column.
+        void DrawServerInfoLines (string text)
+        {
+            foreach (var line in text.Split ('\n')) {
+                var trimmed = line.Trim ();
+                if (trimmed.Length == 0)
+                    continue;
+                var separator = trimmed.IndexOf (" = ", StringComparison.Ordinal);
+                var separatorLength = 3;
+                if (separator < 0) {
+                    separator = trimmed.IndexOf (": ", StringComparison.Ordinal);
+                    separatorLength = 2;
+                }
+                if (separator >= 0)
+                    DrawServerInfoRow (trimmed.Substring (0, separator), trimmed.Substring (separator + separatorLength));
+                else
+                    DrawServerInfoRow (string.Empty, trimmed);
+            }
         }
 
         void DrawClients (IServer server)


### PR DESCRIPTION
Reworks the in-game server settings/info UI, fixing several latent bugs and improving the layout.

### Bug fixes
- **Wrong units on two settings.** "Max. time per update" and "Receive timeout" are microseconds internally (`MicrosecondsToTicks`) but were labelled "ns" in the Info window and internals docs — off by 1000×. The editable fields showed no unit at all. Corrected to microseconds/`us` everywhere.
- **Broken text-field editing.** The max-time and receive-timeout backing strings were only initialised in `Init()` and never updated while editing, so every repaint fed the stale string back into the `TextField` — backspace only moved the cursor. Now writes edited text back and pushes to config only on a successful parse.
- **Combo box collisions.** Combo boxes were identified by interned string literals compared by reference, so all servers being edited at once shared one identifier — operating one server's protocol dropdown edited a different server, and the shared position cache made dropdowns jump. Each `EditServer` instance now gets its own stable identifier per combo box.
- **Frozen combo box hover.** Option highlighting relied on `Event.current.mousePosition`, which KSP only refreshes on input events, so the highlight froze between movements. Options are now drawn manually and highlighted using the live `Input.mousePosition`.

### Validation & hardening
- New `GUILayoutExtensions.ValidatedTextField` helper: restricts input to valid characters and tints the field yellow when the value doesn't parse.
- Applied to all numeric fields — max time per update, receive timeout, manual IP, RPC/stream ports, serial baud rate and data bits.
- Enforces the documented 5–8 range for serial data bits in `EditServer.Save()` (previously only checked it was an integer). Raised the char cap on the max-time/receive-timeout fields from 5 to 20.

### Layout / polish
- Collapsible per-server details, toggled by clicking the header row, laid out as an aligned table.
- Uniform-width edit-server form fields; server name field fills the width when editing.
- Restyled combo box hover highlight; left-aligned combo box button label; vertically centred the expand/collapse arrow.
- "Server not running" instead of "No clients connected" when stopped.
- Space between value and units in Info window data rows.
