### PR TITLE
Fix reference frame velocity at non-equatorial latitudes

### DIFF
--- a/service/SpaceCenter/CHANGES.txt
+++ b/service/SpaceCenter/CHANGES.txt
@@ -53,6 +53,7 @@ v0.6.0
  * Fix Flight.SimulateAerodynamicForceAt returning force in kilonewtons instead of
    newtons when FAR is installed (#915)
  * Add direct control of engine gimbals, RCS and control surfaces (#917)
+ * Fix reference frame velocity being incorrect at non-equatorial latitudes (#454)
 
 v0.5.4
  * Fix vessel recovery (#782)

--- a/service/SpaceCenter/src/Services/ReferenceFrame.cs
+++ b/service/SpaceCenter/src/Services/ReferenceFrame.cs
@@ -711,13 +711,8 @@ namespace KRPC.SpaceCenter.Services
         /// </summary>
         public Vector3d AngularVelocityAt (Vector3d position)
         {
-            var angularVelocity = AngularVelocity;
-            var axis = angularVelocity.normalized;
-            var plane_position = Vector3d.Exclude (axis, position);
-            var radius = plane_position.magnitude;
-            var plane_direction = plane_position.normalized;
-            var direction = Vector3d.Cross (axis, plane_direction);
-            return direction * angularVelocity.magnitude * radius;
+            var angularVelocity = Rotation.Inverse () * AngularVelocity;
+            return Vector3d.Cross (angularVelocity, position);
         }
 
         /// <summary>

--- a/service/SpaceCenter/test/test_referenceframe.py
+++ b/service/SpaceCenter/test/test_referenceframe.py
@@ -7,17 +7,19 @@
 # not affected by the race, but are limited to places=6 by float→double precision
 # loss when Unity float Vector3 values are promoted for double-precision arithmetic.
 
-import unittest
 import math
+import unittest
 
 import krpctest
 from krpctest.geometry import (
     compute_position,
+    cross,
     dot,
     norm,
     quaternion_conjugate,
     quaternion_mult,
     quaternion_vector_mult,
+    vector,
 )
 
 
@@ -25,10 +27,10 @@ class TestReferenceFrame(krpctest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.new_save()
-        if cls.connect().space_center.active_vessel.name != "Vessel":
+        active_vessel = cls.connect().space_center.active_vessel
+        if active_vessel is None or active_vessel.name != "Vessel":
             cls.launch_vessel_from_vab("Vessel")
             cls.remove_other_vessels()
-        cls.set_circular_orbit("Kerbin", 100000)
         cls.space_center = cls.connect().space_center
         cls.vessel = cls.space_center.active_vessel
         cls.bodies = cls.space_center.bodies
@@ -36,6 +38,9 @@ class TestReferenceFrame(krpctest.TestCase):
         cls.root_part = cls.vessel.parts.root
         cls.docking_port = cls.vessel.parts.docking_ports[0]
         cls.thruster = cls.vessel.parts.engines[0].thrusters[0]
+
+    def setup(self):
+        self.set_circular_orbit("Kerbin", 100000)
 
     # -------------------------------------------------------------------------
     # Helpers
@@ -617,6 +622,63 @@ class TestReferenceFrame(krpctest.TestCase):
         )
         speed = norm(self.vessel.velocity(hybrid_kerbin_vel))
         self.assertAlmostEqual(self.vessel.orbit.speed, speed, delta=1)
+
+    def _expected_surface_speed(self):
+        """Surface speed computed independently of ReferenceFrame's velocity
+        machinery: orbital velocity minus the co-rotation velocity ω×r, all in
+        Kerbin's inertial (non-rotating) frame.  This is the ground truth the
+        rotating-frame surface velocity must reproduce."""
+        nonrot = self.kerbin.non_rotating_reference_frame
+        v = vector(self.vessel.velocity(nonrot))  # orbital velocity rel. Kerbin
+        r = vector(self.vessel.position(nonrot))  # position rel. Kerbin centre
+        w = vector(self.kerbin.angular_velocity(nonrot))  # Kerbin spin vector
+        return norm(v - cross(w, r))
+
+    def test_surface_speed_matches_manual_off_equator(self):
+        """Surface speed in the body-rotating frame and in the body-position +
+        surface-rotation hybrid (the frame the reference-frames tutorial builds)
+        both equal the independently computed orbital − ω×r speed, at ~45°
+        latitude in an inclined orbit.
+
+        Regression test for #454: the ω×r correction in AngularVelocityAt used
+        to combine a world-space angular velocity with a frame-space position,
+        which is only valid at the equator.  Off the equator it produced a
+        surface velocity error of ~52 m/s.
+        """
+        # Inclination 45°, observed a quarter orbit past the ascending node
+        # (mean anomaly π/2) so the vessel sits near its peak latitude.
+        self.set_orbit("Kerbin", 700000, 0, 45, 0, 0, math.pi / 2, 0)
+        expected = self._expected_surface_speed()
+        hybrid = self.space_center.ReferenceFrame.create_hybrid(
+            position=self.kerbin.reference_frame,
+            rotation=self.vessel.surface_reference_frame,
+        )
+        self.assertAlmostEqual(
+            expected, norm(self.vessel.velocity(self.kerbin.reference_frame)), delta=1
+        )
+        self.assertAlmostEqual(expected, norm(self.vessel.velocity(hybrid)), delta=1)
+
+    def test_hybrid_rotation_preserves_speed_off_equator(self):
+        """The rotation sub-frame only changes the basis the velocity is
+        expressed in, never its magnitude.  In an inclined orbit, observed at
+        ~45° latitude, the vessel's surface speed must therefore be identical
+        whether measured in Kerbin's rotating frame or in a hybrid that swaps in
+        the vessel surface rotation (same position/velocity/angular-velocity
+        sub-frames — only the rotation differs).
+
+        Before the #454 fix the buggy ω×r correction was rotation-frame
+        dependent, so the two speeds diverged away from the equator.
+        """
+        # Inclination 45°, observed a quarter orbit past the ascending node
+        # (mean anomaly π/2) so the vessel sits near its peak latitude.
+        self.set_orbit("Kerbin", 700000, 0, 45, 0, 0, math.pi / 2, 0)
+        hybrid = self.space_center.ReferenceFrame.create_hybrid(
+            position=self.kerbin.reference_frame,
+            rotation=self.vessel.surface_reference_frame,
+        )
+        speed_body = norm(self.vessel.velocity(self.kerbin.reference_frame))
+        speed_hybrid = norm(self.vessel.velocity(hybrid))
+        self.assertAlmostEqual(speed_body, speed_hybrid, delta=1)
 
     def test_node_velocity_zero_at_current_ut(self):
         """Vessel velocity is near zero in the node frame when node.UT equals current time.

--- a/service/SpaceCenter/test/test_referenceframe.py
+++ b/service/SpaceCenter/test/test_referenceframe.py
@@ -38,9 +38,7 @@ class TestReferenceFrame(krpctest.TestCase):
         cls.root_part = cls.vessel.parts.root
         cls.docking_port = cls.vessel.parts.docking_ports[0]
         cls.thruster = cls.vessel.parts.engines[0].thrusters[0]
-
-    def setup(self):
-        self.set_circular_orbit("Kerbin", 100000)
+        cls.set_circular_orbit("Kerbin", 100000)
 
     # -------------------------------------------------------------------------
     # Helpers
@@ -647,6 +645,7 @@ class TestReferenceFrame(krpctest.TestCase):
         """
         # Inclination 45°, observed a quarter orbit past the ascending node
         # (mean anomaly π/2) so the vessel sits near its peak latitude.
+        self.addCleanup(self.set_circular_orbit, "Kerbin", 100000)
         self.set_orbit("Kerbin", 700000, 0, 45, 0, 0, math.pi / 2, 0)
         expected = self._expected_surface_speed()
         hybrid = self.space_center.ReferenceFrame.create_hybrid(
@@ -671,6 +670,7 @@ class TestReferenceFrame(krpctest.TestCase):
         """
         # Inclination 45°, observed a quarter orbit past the ascending node
         # (mean anomaly π/2) so the vessel sits near its peak latitude.
+        self.addCleanup(self.set_circular_orbit, "Kerbin", 100000)
         self.set_orbit("Kerbin", 700000, 0, 45, 0, 0, math.pi / 2, 0)
         hybrid = self.space_center.ReferenceFrame.create_hybrid(
             position=self.kerbin.reference_frame,


### PR DESCRIPTION
AngularVelocityAt computed the ω×r correction with mismatched bases: AngularVelocity is a world-space vector, but the position passed by VelocityFromWorldSpace / VelocityToWorldSpace is in frame space. Crossing a world-space axis with a frame-space position is only valid when the position has no component along the spin axis, i.e. at the equator; off-equator both the radius and direction are corrupted, giving a latitude-dependent surface velocity error (~52 m/s at ~45°). This affected any rotating frame (CelestialBody, VesselSurface, and hybrids built from them), and went unnoticed because every reference-frame/flight velocity test used an equatorial orbit.

Rotate the angular velocity into frame space before the cross product, which also collapses the hand-rolled Exclude/normalize sequence to a single Vector3d.Cross. Reduces to the previous behaviour at the equator.

Fixes #454
