### PR TITLE
Fix ResourceHarvester.ExtractionRate returning 0 headless

### DIFF
--- a/service/SpaceCenter/CHANGES.txt
+++ b/service/SpaceCenter/CHANGES.txt
@@ -54,6 +54,7 @@ v0.6.0
    newtons when FAR is installed (#915)
  * Add direct control of engine gimbals, RCS and control surfaces (#917)
  * Fix reference frame velocity being incorrect at non-equatorial latitudes (#454)
+ * Fix ResourceHarvester.ExtractionRate returning 0 when part action window is not open (#889)
 
 v0.5.4
  * Fix vessel recovery (#782)

--- a/service/SpaceCenter/src/Services/Parts/ResourceHarvester.cs
+++ b/service/SpaceCenter/src/Services/Parts/ResourceHarvester.cs
@@ -1,5 +1,5 @@
 using System;
-using System.Text.RegularExpressions;
+using System.Reflection;
 using KRPC.Service.Attributes;
 using KRPC.SpaceCenter.ExtensionMethods;
 using KRPC.Utils;
@@ -111,6 +111,9 @@ namespace KRPC.SpaceCenter.Services.Parts
             }
         }
 
+        static readonly FieldInfo resFlowField =
+            typeof (ModuleResourceHarvester).GetField ("_resFlow", BindingFlags.NonPublic | BindingFlags.Instance);
+
         /// <summary>
         /// The rate at which the drill is extracting ore, in units per second.
         /// </summary>
@@ -119,7 +122,7 @@ namespace KRPC.SpaceCenter.Services.Parts
             get {
                 if (!Active)
                     return 0;
-                return GetFloatValue (harvester.ResourceStatus);
+                return Convert.ToSingle (resFlowField.GetValue (harvester));
             }
         }
 
@@ -155,19 +158,6 @@ namespace KRPC.SpaceCenter.Services.Parts
         [KRPCProperty]
         public float OptimumCoreTemperature {
             get { return (float)harvester.GetGoalTemperature (); }
-        }
-
-        static readonly Regex numberRegex = new Regex (@"(\d+(\.\d+)?)");
-
-        static float GetFloatValue (string value)
-        {
-            Match match = numberRegex.Match (value);
-            if (!match.Success)
-                return 0;
-            float result;
-            if (!float.TryParse (match.Groups [1].Value, out result))
-                return 0;
-            return result;
         }
     }
 }

--- a/service/SpaceCenter/test/test_parts_resource_harvester.py
+++ b/service/SpaceCenter/test/test_parts_resource_harvester.py
@@ -25,6 +25,7 @@ class TestPartsResourceHarvester(krpctest.TestCase):
 
     def check_inactive_properties(self):
         self.assertEqual(0, self.drill.thermal_efficiency)
+        self.assertEqual(0, self.drill.extraction_rate)
         self.assertGreater(self.drill.core_temperature, 0)
         self.assertEqual(500, self.drill.optimum_core_temperature)
 
@@ -57,9 +58,8 @@ class TestPartsResourceHarvester(krpctest.TestCase):
         self.assertEqual(self.state.active, self.drill.state)
         self.assertTrue(self.drill.deployed)
         self.assertTrue(self.drill.active)
-        # extraction_rate reads a PAW-gated KSP field ("n/a" headless), so verify
-        # the drill is mining by checking the Ore amount increases instead.
         self.assertGreater(self.vessel.resources.amount("Ore"), ore_before)
+        self.assertGreater(self.drill.extraction_rate, 0)
         self.assertGreater(self.drill.thermal_efficiency, 0)
         self.assertLess(self.drill.thermal_efficiency, 1)
         self.assertGreater(self.drill.core_temperature, 0)
@@ -126,13 +126,12 @@ class TestPartsResourceHarvester(krpctest.TestCase):
         self.wait(3)
 
         self.assertTrue(self.control.resource_harvesters_active)
-        # extraction_rate reads a PAW-gated KSP field ("n/a" headless), so verify
-        # the drills are mining by checking the Ore amount increases instead.
         self.assertGreater(self.vessel.resources.amount("Ore"), ore_before)
         for drill in self.drills:
             self.assertEqual(self.state.active, drill.state)
             self.assertTrue(drill.deployed)
             self.assertTrue(drill.active)
+            self.assertGreater(drill.extraction_rate, 0)
             self.assertGreater(drill.thermal_efficiency, 0)
             self.assertLess(drill.thermal_efficiency, 1)
             self.assertGreater(drill.core_temperature, 0)


### PR DESCRIPTION
ExtractionRate parsed harvester.ResourceStatus (the "Ore rate" display string), which KSP only refreshes in PostUpdateCleanup while the part's right-click window is open. With no PAW open the field stays at its "n/a" default and the rate parsed to 0 even while the drill was actively mining.

Read the underlying ModuleResourceHarvester._resFlow field instead. _resFlow is recomputed every physics frame in PrepareRecipe as (abundance rate * drill efficiency) and is the exact value the status string was formatting, so this is a faithful drop-in that is independent of the PAW.

Update the integration test to assert extraction_rate directly (0 while inactive, > 0 while mining) instead of working around the bug by only checking that the Ore amount rises.

Fixes #889 