### PR TITLE
Apply fuel-flow multiplier cap to air-breathing engine thrust

### DIFF
--- a/service/SpaceCenter/CHANGES.txt
+++ b/service/SpaceCenter/CHANGES.txt
@@ -56,6 +56,7 @@ v0.6.0
  * Fix reference frame velocity being incorrect at non-equatorial latitudes (#454)
  * Fix ResourceHarvester.ExtractionRate returning 0 when part action window is not open (#889)
  * Fix Sensor.Value returning zero when the part action window is not open (#883)
+ * Fix Engine.AvailableThrust and MaxThrust for air-breathing engines at supersonic speeds (#924)
 
 v0.5.4
  * Fix vessel recovery (#782)

--- a/service/SpaceCenter/src/Services/Parts/Engine.cs
+++ b/service/SpaceCenter/src/Services/Parts/Engine.cs
@@ -141,23 +141,35 @@ namespace KRPC.SpaceCenter.Services.Parts
         {
             var engine = CurrentEngine;
 
-            // Compute fuel flow multiplier
+            // Compute the fuel flow multiplier, mirroring ModuleEngines.MaxThrustOutputAtm.
+            // For air-breathing engines this scales with atmospheric density and, via the
+            // velocity curve, with Mach number.
             float flowMultiplier = 1;
-            if (engine.atmChangeFlow)
+            if (engine.atmChangeFlow) {
                 flowMultiplier = (float)(engine.part.atmDensity / 1.225d);
-            if (engine.useAtmCurve && engine.atmCurve != null)
-                flowMultiplier = engine.atmCurve.Evaluate (flowMultiplier);
-
-            // Compute velocity multiplier
-            float velocityMultiplier = 1;
+                if (engine.useAtmCurve && engine.atmCurve != null)
+                    flowMultiplier = engine.atmCurve.Evaluate (flowMultiplier);
+            }
             if (engine.useVelCurve && engine.velCurve != null)
-                velocityMultiplier = velocityMultiplier * engine.velCurve.Evaluate ((float)engine.vessel.mach);
+                flowMultiplier *= engine.velCurve.Evaluate ((float)engine.vessel.mach);
+
+            // Apply KSP's soft cap on the flow multiplier. Above flowMultCap the excess is
+            // compressed (so extra ram flow gives diminishing returns rather than growing
+            // without bound), then a lower bound is enforced. Without this the reported
+            // thrust of air-breathing engines is overstated at high Mach.
+            if (flowMultiplier > engine.flowMultCap) {
+                float excess = flowMultiplier - engine.flowMultCap;
+                flowMultiplier = engine.flowMultCap +
+                    excess / (engine.flowMultCapSharpness + excess / engine.flowMultCap);
+            }
+            if (flowMultiplier < engine.CLAMP)
+                flowMultiplier = engine.CLAMP;
 
             // Get specific impulse at the given pressure
             var specificImpulse = engine.atmosphereCurve.Evaluate ((float)pressure);
 
             // Compute thrust
-            return 1000f * Mathf.Lerp (engine.minFuelFlow, engine.maxFuelFlow, throttle) * flowMultiplier * specificImpulse * engine.g * velocityMultiplier;
+            return 1000f * Mathf.Lerp (engine.minFuelFlow, engine.maxFuelFlow, throttle) * flowMultiplier * specificImpulse * engine.g;
         }
 
         /// <summary>

--- a/service/SpaceCenter/test/test_parts_engine.py
+++ b/service/SpaceCenter/test/test_parts_engine.py
@@ -610,5 +610,73 @@ class TestGimbalOverrideAttitude(krpctest.TestCase):
         self.assertLess(dot(spin_positive, spin_negative), 0)
 
 
+class TestPartsEngineSupersonic(krpctest.TestCase, EngineTestBase):
+    """The reported thrust of an air-breathing engine must apply KSP's fuel-flow
+    multiplier cap (``flowMultCap``).
+
+    KSP soft-clamps the fuel-flow multiplier so that, above the engine's
+    ``flowMultCap``, extra ram flow yields diminishing returns rather than growing
+    without bound. The multiplier only climbs above the cap at supersonic speed, where
+    the engine's velocity curve boosts the flow -- so the ground-static engine tests
+    never exercise it. ``AvailableThrust``/``MaxThrust`` recompute the thrust
+    themselves and must apply the same clamp, otherwise they over-report thrust for a
+    fast-moving jet.
+
+    Flown with the stock Aeris 4A SSTO, whose two J-X4 "Whiplash" turbojets
+    (``turboFanEngine``, ``flowMultCap = 2``) have a velocity curve that pushes the raw
+    flow multiplier well past the cap once supersonic.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.new_save()
+        cls.launch_vessel_from_sph("Aeris 4A")
+        cls.remove_other_vessels()
+        cls.vessel = cls.connect().space_center.active_vessel
+        cls.parts = cls.vessel.parts
+
+    def test_thrust_flow_multiplier_capped_supersonic(self):
+        vessel = self.vessel
+        self.fill_all_resources()
+
+        # Place the SSTO in fast, level flight high in the atmosphere, where the
+        # Whiplash velocity curve drives the raw fuel-flow multiplier above the cap. The
+        # altitude is well within the engine's operating envelope so it sustains the
+        # supersonic cruise, and SAS holds the nose on the velocity vector.
+        vessel.control.sas = False
+        vessel.control.rcs = False
+        self.set_flight(altitude=12000, speed=700, heading=90)
+        vessel.control.throttle = 1
+        vessel.control.sas = True
+        # Stock jets must be staged before they spool up.
+        if not any(engine.active for engine in vessel.parts.engines):
+            vessel.control.activate_next_stage()
+
+        engine = self.get_engine("turboFanEngine")  # J-X4 "Whiplash"
+        flight = vessel.flight()
+
+        # Wait for the jet to reach full throttle while comfortably supersonic, so the
+        # flow multiplier is firmly above the cap.
+        self.wait_until(
+            lambda: engine.throttle > 0.98 and flight.mach > 1.8,
+            timeout=30,
+            message="the jet to spool up to full throttle while supersonic",
+        )
+        self.assertTrue(engine.has_fuel)
+
+        # KSP's actual thrust (reported via Engine.thrust as finalThrust) already
+        # applies the flowMultCap soft clamp. AvailableThrust and MaxThrust recompute
+        # the thrust and must land on the same value; before the fix they omitted the
+        # clamp and over-reported the supersonic thrust by tens of percent.
+        thrust = engine.thrust
+        self.assertGreater(thrust, 0)
+        delta = 0.05 * thrust
+        self.assertAlmostEqual(thrust, engine.available_thrust, delta=delta)
+        self.assertAlmostEqual(thrust, engine.max_thrust, delta=delta)
+
+        vessel.control.throttle = 0
+        engine.active = False
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Engine.GetThrust recomputes an engine's thrust for AvailableThrust/MaxThrust (and the ...At pressure variants), but omitted the fuel-flow multiplier cap that KSP's ModuleEngines applies. For air-breathing engines the flow multiplier climbs above the engine's flowMultCap at supersonic Mach (via the velocity curve), so the reported thrust was overstated -- e.g. ~27% high for a Whiplash turbojet flown supersonically.

Mirror ModuleEngines.MaxThrustOutputAtm: fold the velocity multiplier into the flow multiplier, then soft-cap the excess above flowMultCap (flowMultCap + excess / (flowMultCapSharpness + excess / flowMultCap)) and enforce the CLAMP lower bound. Also nest the atmCurve evaluation inside the atmChangeFlow branch to match KSP. Engines without a configured flowMultCap (rockets, nuclear, ion, SRBs) default it to float-max and are unaffected.