### PR TITLE
Fix flaky timing tests

### DIFF
--- a/client/cpp/BUILD.bazel
+++ b/client/cpp/BUILD.bazel
@@ -166,9 +166,6 @@ test_suite(
     ],
 )
 
-# size = "medium" (300s) not "small" (60s): the whole suite runs sequentially in
-# one binary and overruns the 60s cap when the machine is loaded (e.g. under a
-# parallel `bazel test //...`). See issue #540.
 client_test(
     name = "client",
     size = "medium",

--- a/client/cpp/BUILD.bazel
+++ b/client/cpp/BUILD.bazel
@@ -166,9 +166,12 @@ test_suite(
     ],
 )
 
+# size = "medium" (300s) not "small" (60s): the whole suite runs sequentially in
+# one binary and overruns the 60s cap when the machine is loaded (e.g. under a
+# parallel `bazel test //...`). See issue #540.
 client_test(
     name = "client",
-    size = "small",
+    size = "medium",
     server_executable = "//tools/TestServer",
     tags = ["requires-network"],
     test_executable = ":cpptest",

--- a/client/cpp/test/test_event.cpp
+++ b/client/cpp/test/test_event.cpp
@@ -26,7 +26,7 @@ TEST_F(test_event, test_event) {
   std::chrono::duration<double> duration = end_time - start_time;
   // Lower bound is a correctness check (the event must not fire before its
   // timer); the upper bound is a generous hang detector, kept loose so the
-  // test does not flake under parallel load. See issue #540.
+  // test does not flake under parallel load.
   ASSERT_GT(duration.count(), 0.15);
   ASSERT_LT(duration.count(), 2);
   ASSERT_TRUE(event.stream()());
@@ -166,7 +166,7 @@ TEST_F(test_event, test_custom_event) {
   // increments on every expression evaluation, so the value read back is >= 21
   // (20 at the trigger, plus this read); the exact figure depends on how many
   // more times the server evaluated the expression first, so assert the lower
-  // bound to avoid flaking under load. See issue #540.
+  // bound to avoid flaking under load.
   ASSERT_GE(test_service.counter("test_event.test_custom_event"), 21);
   event.release();
 }

--- a/client/cpp/test/test_event.cpp
+++ b/client/cpp/test/test_event.cpp
@@ -24,8 +24,11 @@ TEST_F(test_event, test_event) {
   event.wait();
   auto end_time = std::chrono::high_resolution_clock::now();
   std::chrono::duration<double> duration = end_time - start_time;
+  // Lower bound is a correctness check (the event must not fire before its
+  // timer); the upper bound is a generous hang detector, kept loose so the
+  // test does not flake under parallel load. See issue #540.
   ASSERT_GT(duration.count(), 0.15);
-  ASSERT_LT(duration.count(), 0.25);
+  ASSERT_LT(duration.count(), 2);
   ASSERT_TRUE(event.stream()());
   event.release();
 }
@@ -53,7 +56,7 @@ TEST_F(test_event, test_event_timeout_long) {
   auto end_time = std::chrono::high_resolution_clock::now();
   std::chrono::duration<double> duration = end_time - start_time;
   ASSERT_GT(duration.count(), 0.15);
-  ASSERT_LT(duration.count(), 0.25);
+  ASSERT_LT(duration.count(), 2);
   ASSERT_TRUE(event.stream()());
   event.release();
 }
@@ -70,7 +73,7 @@ TEST_F(test_event, test_event_loop) {
     ASSERT_TRUE(event.stream()());
     repeat++;
     ASSERT_GT(duration.count(), 0.2*repeat - 0.05);
-    ASSERT_LT(duration.count(), 0.2*repeat + 0.05);
+    ASSERT_LT(duration.count(), 0.2*repeat + 2);
     if (repeat == 5)
       break;
   }
@@ -89,7 +92,7 @@ TEST_F(test_event, test_event_callback) {
   auto end_time = std::chrono::high_resolution_clock::now();
   std::chrono::duration<double> duration = end_time - start_time;
   ASSERT_GT(duration.count(), 0.15);
-  ASSERT_LT(duration.count(), 0.25);
+  ASSERT_LT(duration.count(), 2);
 }
 
 TEST_F(test_event, test_event_callback_timeout) {
@@ -107,8 +110,9 @@ TEST_F(test_event, test_event_callback_timeout) {
   }
   auto end_time = std::chrono::high_resolution_clock::now();
   std::chrono::duration<double> duration = end_time - start_time;
+  // Loop breaks on its own 0.1s timeout, before the 1000ms event fires.
   ASSERT_GT(duration.count(), 0.05);
-  ASSERT_LT(duration.count(), 0.15);
+  ASSERT_LT(duration.count(), 1);
   ASSERT_TRUE(called.test_and_set());
 }
 
@@ -123,7 +127,7 @@ TEST_F(test_event, test_event_callback_loop) {
   auto end_time = std::chrono::high_resolution_clock::now();
   std::chrono::duration<double> duration = end_time - start_time;
   ASSERT_GT(duration.count(), 0.9);
-  ASSERT_LT(duration.count(), 1.1);
+  ASSERT_LT(duration.count(), 3);
   ASSERT_EQ(count, 5);
 }
 
@@ -143,7 +147,7 @@ TEST_F(test_event, test_event_remove_callback) {
   auto end_time = std::chrono::high_resolution_clock::now();
   std::chrono::duration<double> duration = end_time - start_time;
   ASSERT_GT(duration.count(), 0.15);
-  ASSERT_LT(duration.count(), 0.25);
+  ASSERT_LT(duration.count(), 2);
   ASSERT_TRUE(called2.test_and_set());
 }
 

--- a/client/cpp/test/test_event.cpp
+++ b/client/cpp/test/test_event.cpp
@@ -162,7 +162,12 @@ TEST_F(test_event, test_custom_event) {
   auto event = krpc.add_event(expr);
   event.acquire();
   event.wait();
-  ASSERT_EQ(test_service.counter("test_event.test_custom_event"), 21);
+  // The event fires when the server-side counter reaches 20. The counter
+  // increments on every expression evaluation, so the value read back is >= 21
+  // (20 at the trigger, plus this read); the exact figure depends on how many
+  // more times the server evaluated the expression first, so assert the lower
+  // bound to avoid flaking under load. See issue #540.
+  ASSERT_GE(test_service.counter("test_event.test_custom_event"), 21);
   event.release();
 }
 

--- a/client/cpp/test/test_stream.cpp
+++ b/client/cpp/test/test_stream.cpp
@@ -436,7 +436,7 @@ TEST_F(test_stream, test_rate) {
   std::chrono::duration<double> elapsed = end - start;
   // Lower bound checks the rate limit was honoured; the upper bound is a
   // generous hang detector, kept loose so the test does not flake under
-  // parallel load. See issue #540.
+  // parallel load.
   ASSERT_GT(elapsed.count(), 1.0);
   ASSERT_LT(elapsed.count(), 3.0);
   x.remove();

--- a/client/cpp/test/test_stream.cpp
+++ b/client/cpp/test/test_stream.cpp
@@ -434,8 +434,11 @@ TEST_F(test_stream, test_rate) {
   }
   auto end = std::chrono::system_clock::now();
   std::chrono::duration<double> elapsed = end - start;
+  // Lower bound checks the rate limit was honoured; the upper bound is a
+  // generous hang detector, kept loose so the test does not flake under
+  // parallel load. See issue #540.
   ASSERT_GT(elapsed.count(), 1.0);
-  ASSERT_LT(elapsed.count(), 1.2);
+  ASSERT_LT(elapsed.count(), 3.0);
   x.remove();
   ASSERT_TRUE(error.test_and_set());
   ASSERT_EQ(test_rate_value, 5);

--- a/client/csharp/BUILD.bazel
+++ b/client/csharp/BUILD.bazel
@@ -171,7 +171,8 @@ test_suite(
 
 client_test(
     name = "client",
-    size = "small",
+    # medium (300s) not small (60s): ~28s worst case under parallel load (#540)
+    size = "medium",
     server_executable = "//tools/TestServer",
     tags = [
         "local",

--- a/client/csharp/BUILD.bazel
+++ b/client/csharp/BUILD.bazel
@@ -171,7 +171,6 @@ test_suite(
 
 client_test(
     name = "client",
-    # medium (300s) not small (60s): ~28s worst case under parallel load (#540)
     size = "medium",
     server_executable = "//tools/TestServer",
     tags = [

--- a/client/csharp/test/EventTest.cs
+++ b/client/csharp/test/EventTest.cs
@@ -19,8 +19,12 @@ namespace KRPC.Client.Test
                 timer.Start ();
                 e.Wait ();
                 var time = timer.ElapsedMilliseconds;
-                Assert.Less (time, 250);
+                // Lower bound is a correctness check (the event must not fire
+                // before its timer); the upper bound is a generous hang
+                // detector, kept loose so the test does not flake under
+                // parallel load. See issue #540.
                 Assert.Greater (time, 150);
+                Assert.Less (time, 2000);
                 Assert.True (e.Stream.Get ());
             }
         }
@@ -33,8 +37,9 @@ namespace KRPC.Client.Test
                 timer.Start ();
                 e.Wait (0.1);
                 var time = timer.ElapsedMilliseconds;
-                Assert.Less (time, 150);
+                // Wait must return on its timeout, before the 200ms event fires.
                 Assert.Greater (time, 50);
+                Assert.Less (time, 200);
                 e.Wait ();
                 Assert.True (e.Stream.Get ());
             }
@@ -49,7 +54,7 @@ namespace KRPC.Client.Test
                 e.Wait (1);
                 var time = timer.ElapsedMilliseconds;
                 Assert.Greater (time, 150);
-                Assert.Less (time, 250);
+                Assert.Less (time, 2000);
                 Assert.True (e.Stream.Get ());
             }
         }
@@ -65,7 +70,7 @@ namespace KRPC.Client.Test
             called.WaitOne (1000);
             var time = timer.ElapsedMilliseconds;
             Assert.Greater (time, 150);
-            Assert.Less (time, 250);
+            Assert.Less (time, 2000);
         }
 
         [Test]
@@ -78,8 +83,9 @@ namespace KRPC.Client.Test
             e.Start ();
             called.WaitOne (100);
             var time = timer.ElapsedMilliseconds;
+            // WaitOne returns on its 100ms timeout, before the 1000ms event fires.
             Assert.Greater (time, 50);
-            Assert.Less (time, 150);
+            Assert.Less (time, 1000);
         }
 
         [Test]
@@ -94,7 +100,7 @@ namespace KRPC.Client.Test
             }
             var time = timer.ElapsedMilliseconds;
             Assert.Greater (time, 950);
-            Assert.Less (time, 1050);
+            Assert.Less (time, 3000);
             Assert.AreEqual (count, 5);
         }
 
@@ -118,7 +124,7 @@ namespace KRPC.Client.Test
             stop.WaitOne ();
             var time = timer.ElapsedMilliseconds;
             Assert.Greater (time, 150);
-            Assert.Less (time, 250);
+            Assert.Less (time, 2000);
             Assert.IsTrue (called1);
             Assert.IsFalse (called2);
         }

--- a/client/csharp/test/EventTest.cs
+++ b/client/csharp/test/EventTest.cs
@@ -22,7 +22,7 @@ namespace KRPC.Client.Test
                 // Lower bound is a correctness check (the event must not fire
                 // before its timer); the upper bound is a generous hang
                 // detector, kept loose so the test does not flake under
-                // parallel load. See issue #540.
+                // parallel load.
                 Assert.Greater (time, 150);
                 Assert.Less (time, 2000);
                 Assert.True (e.Stream.Get ());
@@ -147,7 +147,7 @@ namespace KRPC.Client.Test
                 // value read back is >= 21 (20 at the trigger, plus this read);
                 // the exact figure depends on how many more times the server
                 // evaluated the expression first, so assert the lower bound to
-                // avoid flaking under load. See issue #540.
+                // avoid flaking under load.
                 Assert.GreaterOrEqual(Connection.TestService ().Counter("TestEvent.TestCustomEvent", 1), 21);
             }
         }

--- a/client/csharp/test/EventTest.cs
+++ b/client/csharp/test/EventTest.cs
@@ -142,7 +142,13 @@ namespace KRPC.Client.Test
             var evnt = Connection.KRPC ().AddEvent(expr);
             lock (evnt.Condition) {
                 evnt.Wait();
-                Assert.AreEqual(Connection.TestService ().Counter("TestEvent.TestCustomEvent", 1), 21);
+                // The event fires when the server-side counter reaches 20. The
+                // counter increments on every expression evaluation, so the
+                // value read back is >= 21 (20 at the trigger, plus this read);
+                // the exact figure depends on how many more times the server
+                // evaluated the expression first, so assert the lower bound to
+                // avoid flaking under load. See issue #540.
+                Assert.GreaterOrEqual(Connection.TestService ().Counter("TestEvent.TestCustomEvent", 1), 21);
             }
         }
 

--- a/client/csharp/test/StreamTest.cs
+++ b/client/csharp/test/StreamTest.cs
@@ -374,7 +374,7 @@ namespace KRPC.Client.Test
             var elapsed = timer.ElapsedMilliseconds;
             // Lower bound checks the rate limit was honoured; the upper bound is
             // a generous hang detector, kept loose so the test does not flake
-            // under parallel load. See issue #540.
+            // under parallel load.
             Assert.Greater(elapsed, 1000);
             Assert.Less(elapsed, 3000);
             Assert.False(error);

--- a/client/csharp/test/StreamTest.cs
+++ b/client/csharp/test/StreamTest.cs
@@ -372,8 +372,11 @@ namespace KRPC.Client.Test
             stop.WaitOne ();
             s.Remove();
             var elapsed = timer.ElapsedMilliseconds;
+            // Lower bound checks the rate limit was honoured; the upper bound is
+            // a generous hang detector, kept loose so the test does not flake
+            // under parallel load. See issue #540.
             Assert.Greater(elapsed, 1000);
-            Assert.Less(elapsed, 1200);
+            Assert.Less(elapsed, 3000);
             Assert.False(error);
             Assert.AreEqual(value, 5);
         }

--- a/client/java/BUILD.bazel
+++ b/client/java/BUILD.bazel
@@ -95,7 +95,8 @@ test_suite(
 
 client_test(
     name = "client",
-    size = "small",
+    # medium (300s) not small (60s): ~29s worst case under parallel load (#540)
+    size = "medium",
     server_executable = "//tools/TestServer",
     tags = ["requires-network"],
     test_executable = ":testexe",

--- a/client/java/BUILD.bazel
+++ b/client/java/BUILD.bazel
@@ -95,7 +95,6 @@ test_suite(
 
 client_test(
     name = "client",
-    # medium (300s) not small (60s): ~29s worst case under parallel load (#540)
     size = "medium",
     server_executable = "//tools/TestServer",
     tags = ["requires-network"],

--- a/client/java/test/krpc/client/EventTest.java
+++ b/client/java/test/krpc/client/EventTest.java
@@ -38,10 +38,11 @@ public class EventTest {
       long startTime = System.currentTimeMillis();
       event.waitFor();
       long time = System.currentTimeMillis() - startTime;
-      System.out.println("#### time = " + time);
-      // FIXME: skipped for now, as this test is flaky
-      // assertTrue(150 < time && time < 250);
-      // assertTrue(event.getStream().get());
+      // Lower bound is a correctness check (the event must not fire before its
+      // timer); the upper bound is a generous hang detector, kept loose so the
+      // test does not flake under parallel load. See issue #540.
+      assertTrue(150 < time && time < 2000);
+      assertTrue(event.getStream().get());
     }
   }
 
@@ -53,7 +54,8 @@ public class EventTest {
       long startTime = System.currentTimeMillis();
       event.waitForWithTimeout(0.1);
       long time = System.currentTimeMillis() - startTime;
-      assertTrue(50 < time && time < 150);
+      // waitFor must return on its timeout, before the 200ms event fires.
+      assertTrue(50 < time && time < 200);
       event.waitFor();
       assertTrue(event.getStream().get());
     }
@@ -67,7 +69,7 @@ public class EventTest {
       long startTime = System.currentTimeMillis();
       event.waitForWithTimeout(1);
       long time = System.currentTimeMillis() - startTime;
-      assertTrue(150 < time && time < 250);
+      assertTrue(150 < time && time < 2000);
       assertTrue(event.getStream().get());
     }
   }
@@ -87,7 +89,7 @@ public class EventTest {
     while (!testEventCallbackCalled) {
     }
     long time = System.currentTimeMillis() - startTime;
-    assertTrue(150 < time && time < 250);
+    assertTrue(150 < time && time < 2000);
   }
 
   private volatile boolean testEventCallbackTimeoutCalled = false;
@@ -108,7 +110,8 @@ public class EventTest {
       }
     }
     long time = System.currentTimeMillis() - startTime;
-    assertTrue(50 < time && time < 150);
+    // Loop breaks on its own 100ms timeout, before the 1000ms event fires.
+    assertTrue(50 < time && time < 1000);
   }
 
   private volatile int testEventCallbackLoopCount = 0;
@@ -126,7 +129,7 @@ public class EventTest {
     while (testEventCallbackLoopCount < 5) {
     }
     long time = System.currentTimeMillis() - startTime;
-    assertTrue(950 < time && time < 1050);
+    assertTrue(950 < time && time < 3000);
     assertEquals(testEventCallbackLoopCount, 5);
   }
 
@@ -151,7 +154,7 @@ public class EventTest {
     while (!testEventRemoveCallbackCalled1) {
     }
     long time = System.currentTimeMillis() - startTime;
-    assertTrue(150 < time && time < 250);
+    assertTrue(150 < time && time < 2000);
     assertFalse(testEventRemoveCallbackCalled2);
   }
 

--- a/client/java/test/krpc/client/EventTest.java
+++ b/client/java/test/krpc/client/EventTest.java
@@ -172,7 +172,12 @@ public class EventTest {
     Event event = krpc.addEvent(expr);
     synchronized (event.getCondition()) {
       event.waitFor();
-      assertEquals(testService.counter("TestEvent.TestCustomEvent", 1), 21);
+      // The event fires when the server-side counter reaches 20. The counter
+      // increments on every expression evaluation, so the value read back is
+      // >= 21 (20 at the trigger, plus this read); the exact figure depends on
+      // how many more times the server evaluated the expression first, so
+      // assert the lower bound to avoid flaking under load. See issue #540.
+      assertTrue(testService.counter("TestEvent.TestCustomEvent", 1) >= 21);
     }
   }
 

--- a/client/java/test/krpc/client/EventTest.java
+++ b/client/java/test/krpc/client/EventTest.java
@@ -40,7 +40,7 @@ public class EventTest {
       long time = System.currentTimeMillis() - startTime;
       // Lower bound is a correctness check (the event must not fire before its
       // timer); the upper bound is a generous hang detector, kept loose so the
-      // test does not flake under parallel load. See issue #540.
+      // test does not flake under parallel load.
       assertTrue(150 < time && time < 2000);
       assertTrue(event.getStream().get());
     }

--- a/client/python/BUILD.bazel
+++ b/client/python/BUILD.bazel
@@ -191,7 +191,8 @@ py_test(
 
 py_lint_test(
     name = "lint",
-    size = "small",
+    # medium (300s) not small (60s): ~36s worst case under parallel load (#540)
+    size = "medium",
     srcs = glob(["krpc/**/*"]),
     black_exclude = "\".*(schema|services)/.+\"",
     pkg = ":python",

--- a/client/python/BUILD.bazel
+++ b/client/python/BUILD.bazel
@@ -191,7 +191,6 @@ py_test(
 
 py_lint_test(
     name = "lint",
-    # medium (300s) not small (60s): ~36s worst case under parallel load (#540)
     size = "medium",
     srcs = glob(["krpc/**/*"]),
     black_exclude = "\".*(schema|services)/.+\"",

--- a/client/python/krpc/test/test_event.py
+++ b/client/python/krpc/test/test_event.py
@@ -1,6 +1,7 @@
-import time
 import threading
+import time
 import unittest
+
 from krpc.test.servertestcase import ServerTestCase
 
 
@@ -16,7 +17,7 @@ class TestEvent(ServerTestCase, unittest.TestCase):
             event.wait()
             # Lower bound is a correctness check (event must not fire before its
             # timer); the upper bound is a generous hang detector, kept loose so
-            # the test does not flake under parallel load. See issue #540.
+            # the test does not flake under parallel load.
             self.assertGreater(time.time() - start_time, 0.15)
             self.assertLess(time.time() - start_time, 2)
             self.assertTrue(event.stream())
@@ -142,7 +143,7 @@ class TestEvent(ServerTestCase, unittest.TestCase):
             # read back here is >= 21 (20 at the trigger, plus this read); the
             # exact figure depends on how many more times the server evaluated
             # the expression before this read, so assert the lower bound rather
-            # than an exact value to avoid flaking under load. See issue #540.
+            # than an exact value to avoid flaking under load.
             self.assertGreaterEqual(
                 self.conn.test_service.counter("TestEvent.test_custom_event"), 21
             )

--- a/client/python/krpc/test/test_event.py
+++ b/client/python/krpc/test/test_event.py
@@ -14,7 +14,11 @@ class TestEvent(ServerTestCase, unittest.TestCase):
         with event.condition:
             start_time = time.time()
             event.wait()
-            self.assertAlmostEqual(time.time() - start_time, 0.2, delta=0.05)
+            # Lower bound is a correctness check (event must not fire before its
+            # timer); the upper bound is a generous hang detector, kept loose so
+            # the test does not flake under parallel load. See issue #540.
+            self.assertGreater(time.time() - start_time, 0.15)
+            self.assertLess(time.time() - start_time, 2)
             self.assertTrue(event.stream())
 
     def test_event_using_lambda(self) -> None:
@@ -22,7 +26,8 @@ class TestEvent(ServerTestCase, unittest.TestCase):
         with event.condition:
             start_time = time.time()
             event.wait()
-            self.assertAlmostEqual(time.time() - start_time, 0.2, delta=0.05)
+            self.assertGreater(time.time() - start_time, 0.15)
+            self.assertLess(time.time() - start_time, 2)
             self.assertTrue(event.stream())
 
     def test_event_timeout_short(self) -> None:
@@ -30,8 +35,9 @@ class TestEvent(ServerTestCase, unittest.TestCase):
         with event.condition:
             start_time = time.time()
             event.wait(0.1)
+            # wait() must return on its timeout, before the 200ms event fires.
+            self.assertGreater(time.time() - start_time, 0.05)
             self.assertLess(time.time() - start_time, 0.2)
-            self.assertAlmostEqual(time.time() - start_time, 0.1, delta=0.05)
             self.assertFalse(event.stream())
             event.wait()
             self.assertTrue(event.stream())
@@ -41,7 +47,8 @@ class TestEvent(ServerTestCase, unittest.TestCase):
         with event.condition:
             start_time = time.time()
             event.wait(1)
-            self.assertAlmostEqual(time.time() - start_time, 0.2, delta=0.05)
+            self.assertGreater(time.time() - start_time, 0.15)
+            self.assertLess(time.time() - start_time, 2)
             self.assertTrue(event.stream())
 
     def test_event_loop(self) -> None:
@@ -53,9 +60,8 @@ class TestEvent(ServerTestCase, unittest.TestCase):
                 event.wait()
                 self.assertTrue(event.stream())
                 repeat += 1
-                self.assertAlmostEqual(
-                    time.time() - start_time, 0.2 * repeat, delta=0.05
-                )
+                self.assertGreater(time.time() - start_time, 0.2 * repeat - 0.05)
+                self.assertLess(time.time() - start_time, 0.2 * repeat + 2)
                 if repeat == 5:
                     break
 
@@ -66,7 +72,8 @@ class TestEvent(ServerTestCase, unittest.TestCase):
         start_time = time.time()
         event.start()
         called.wait(1)
-        self.assertAlmostEqual(time.time() - start_time, 0.2, delta=0.05)
+        self.assertGreater(time.time() - start_time, 0.15)
+        self.assertLess(time.time() - start_time, 2)
         self.assertTrue(called.is_set())
 
     def test_event_callback_timeout(self) -> None:
@@ -76,7 +83,9 @@ class TestEvent(ServerTestCase, unittest.TestCase):
         start_time = time.time()
         event.start()
         called.wait(0.1)
-        self.assertAlmostEqual(time.time() - start_time, 0.1, delta=0.05)
+        # wait() must return on its timeout, before the 1000ms event fires.
+        self.assertGreater(time.time() - start_time, 0.05)
+        self.assertLess(time.time() - start_time, 1)
         self.assertFalse(called.is_set())
 
     test_event_callback_loop_count = 0
@@ -105,7 +114,8 @@ class TestEvent(ServerTestCase, unittest.TestCase):
         start_time = time.time()
         event.start()
         called1.wait(1)
-        self.assertAlmostEqual(time.time() - start_time, 0.2, delta=0.05)
+        self.assertGreater(time.time() - start_time, 0.15)
+        self.assertLess(time.time() - start_time, 2)
         self.assertTrue(called1.is_set())
         self.assertFalse(called2.is_set())
 

--- a/client/python/krpc/test/test_event.py
+++ b/client/python/krpc/test/test_event.py
@@ -137,7 +137,13 @@ class TestEvent(ServerTestCase, unittest.TestCase):
         event = self.conn.krpc.add_event(expr)
         with event.condition:
             event.wait()
-            self.assertEqual(
+            # The event fires when the server-side counter reaches 20. The
+            # counter increments on every expression evaluation, so the value
+            # read back here is >= 21 (20 at the trigger, plus this read); the
+            # exact figure depends on how many more times the server evaluated
+            # the expression before this read, so assert the lower bound rather
+            # than an exact value to avoid flaking under load. See issue #540.
+            self.assertGreaterEqual(
                 self.conn.test_service.counter("TestEvent.test_custom_event"), 21
             )
 

--- a/client/python/krpc/test/test_stream.py
+++ b/client/python/krpc/test/test_stream.py
@@ -1,6 +1,7 @@
-import unittest
 import threading
 import time
+import unittest
+
 from krpc.error import StreamError
 from krpc.test.servertestcase import ServerTestCase
 
@@ -433,7 +434,7 @@ class TestStream(ServerTestCase, unittest.TestCase):
 
         # At 5Hz, five increments take ~1s. The lower bound checks the rate
         # limit was honoured; the upper bound is a generous hang detector, kept
-        # loose so the test does not flake under parallel load. See issue #540.
+        # loose so the test does not flake under parallel load.
         self.assertGreater(elapsed, 1)
         self.assertLess(elapsed, 3)
         self.assertTrue(stop.is_set())

--- a/client/python/krpc/test/test_stream.py
+++ b/client/python/krpc/test/test_stream.py
@@ -403,35 +403,42 @@ class TestStream(ServerTestCase, unittest.TestCase):
         self.assertTrue(called1.is_set())
         self.assertFalse(called2.is_set())
 
-    # test_rate_value = 0
-    #
-    # def test_rate(self) -> None:
-    #     error = threading.Event()
-    #     stop = threading.Event()
-    #
-    #     def callback(x) -> None:
-    #         if x > 5:
-    #             stop.set()
-    #         elif self.test_rate_value+1 != x:
-    #             error.set()
-    #             stop.set()
-    #         else:
-    #             self.test_rate_value += 1
-    #
-    #     with self.conn.stream(self.conn.test_service.counter,
-    #                           'TestStream.test_rate') as x:
-    #         x.add_callback(callback)
-    #         x.rate = 5
-    #         x.start()
-    #         start = time.time()
-    #         stop.wait(3)
-    #         elapsed = time.time() - start
-    #
-    #     self.assertGreater(elapsed, 1)
-    #     self.assertLess(elapsed, 1.2)
-    #     self.assertTrue(stop.is_set())
-    #     self.assertFalse(error.is_set())
-    #     self.assertEquals(self.test_rate_value, 5)
+    test_rate_value = 0
+
+    def test_rate(self) -> None:
+        error = threading.Event()
+        stop = threading.Event()
+
+        def callback(x: int) -> None:
+            if x > 5:
+                stop.set()
+            elif self.test_rate_value + 1 != x:
+                error.set()
+                stop.set()
+            else:
+                self.test_rate_value += 1
+
+        with self.conn.stream(
+            self.conn.test_service.counter, "TestStream.test_rate"
+        ) as x:
+            x.add_callback(callback)
+            x.rate = 5
+            x.start()
+            start = time.time()
+            # The wait timeout is a generous backstop that lets the test fail
+            # cleanly (rather than hang) if updates stop arriving; it sits well
+            # above the elapsed-time upper bound asserted below.
+            stop.wait(10)
+            elapsed = time.time() - start
+
+        # At 5Hz, five increments take ~1s. The lower bound checks the rate
+        # limit was honoured; the upper bound is a generous hang detector, kept
+        # loose so the test does not flake under parallel load. See issue #540.
+        self.assertGreater(elapsed, 1)
+        self.assertLess(elapsed, 3)
+        self.assertTrue(stop.is_set())
+        self.assertFalse(error.is_set())
+        self.assertEqual(self.test_rate_value, 5)
 
 
 if __name__ == "__main__":

--- a/client/serialio/BUILD.bazel
+++ b/client/serialio/BUILD.bazel
@@ -27,7 +27,6 @@ test_suite(
 
 client_test(
     name = "iotest",
-    # medium (300s) not small (60s): ~33s worst case under parallel load (#540)
     size = "medium",
     server_executable = "//tools/TestServer",
     server_type = "serialio",
@@ -55,7 +54,6 @@ py_test(
 
 py_lint_test(
     name = "lint",
-    # medium (300s) not small (60s): ~37s worst case under parallel load (#540)
     size = "medium",
     srcs = glob(["krpcserialio/**/*"]),
     pkg = ":krpcserialio",

--- a/client/serialio/BUILD.bazel
+++ b/client/serialio/BUILD.bazel
@@ -27,7 +27,8 @@ test_suite(
 
 client_test(
     name = "iotest",
-    size = "small",
+    # medium (300s) not small (60s): ~33s worst case under parallel load (#540)
+    size = "medium",
     server_executable = "//tools/TestServer",
     server_type = "serialio",
     tags = [
@@ -54,7 +55,8 @@ py_test(
 
 py_lint_test(
     name = "lint",
-    size = "small",
+    # medium (300s) not small (60s): ~37s worst case under parallel load (#540)
+    size = "medium",
     srcs = glob(["krpcserialio/**/*"]),
     pkg = ":krpcserialio",
     pkg_name = "krpcserialio",

--- a/client/websockets/BUILD.bazel
+++ b/client/websockets/BUILD.bazel
@@ -27,7 +27,8 @@ test_suite(
 
 client_test(
     name = "wstest",
-    size = "small",
+    # medium (300s) not small (60s): ~34s worst case under parallel load (#540)
+    size = "medium",
     server_executable = "//tools/TestServer",
     server_type = "websockets",
     tags = ["requires-network"],
@@ -51,7 +52,8 @@ py_test(
 
 py_lint_test(
     name = "lint",
-    size = "small",
+    # medium (300s) not small (60s): ~39s worst case under parallel load (#540)
+    size = "medium",
     srcs = glob(["krpcwebsockets/**/*"]),
     pkg = ":krpcwebsockets",
     pkg_name = "krpcwebsockets",

--- a/client/websockets/BUILD.bazel
+++ b/client/websockets/BUILD.bazel
@@ -27,7 +27,6 @@ test_suite(
 
 client_test(
     name = "wstest",
-    # medium (300s) not small (60s): ~34s worst case under parallel load (#540)
     size = "medium",
     server_executable = "//tools/TestServer",
     server_type = "websockets",
@@ -52,7 +51,6 @@ py_test(
 
 py_lint_test(
     name = "lint",
-    # medium (300s) not small (60s): ~39s worst case under parallel load (#540)
     size = "medium",
     srcs = glob(["krpcwebsockets/**/*"]),
     pkg = ":krpcwebsockets",

--- a/service/UI/BUILD.bazel
+++ b/service/UI/BUILD.bazel
@@ -64,7 +64,8 @@ test_suite(
 
 py_lint_test(
     name = "pylint",
-    size = "small",
+    # medium (300s) not small (60s): ~29s worst case under parallel load (#540)
+    size = "medium",
     srcs = glob(["test/*.py"]),
     pylint_config = "test/pylint.rc",
     deps = [

--- a/service/UI/BUILD.bazel
+++ b/service/UI/BUILD.bazel
@@ -64,7 +64,6 @@ test_suite(
 
 py_lint_test(
     name = "pylint",
-    # medium (300s) not small (60s): ~29s worst case under parallel load (#540)
     size = "medium",
     srcs = glob(["test/*.py"]),
     pylint_config = "test/pylint.rc",

--- a/tools/krpctest/BUILD.bazel
+++ b/tools/krpctest/BUILD.bazel
@@ -37,7 +37,6 @@ deps = [
 
 py_test(
     name = "krpctesttest",
-    # medium (300s) not small (60s): ~45s worst case under parallel load (#540)
     size = "medium",
     src = ":krpctest",
     pkg = "krpctest-" + python_version,
@@ -46,7 +45,6 @@ py_test(
 
 py_lint_test(
     name = "lint",
-    # medium (300s) not small (60s): ~38s worst case under parallel load (#540)
     size = "medium",
     pkg = ":krpctest",
     pkg_name = "krpctest",

--- a/tools/krpctest/BUILD.bazel
+++ b/tools/krpctest/BUILD.bazel
@@ -37,7 +37,8 @@ deps = [
 
 py_test(
     name = "krpctesttest",
-    size = "small",
+    # medium (300s) not small (60s): ~45s worst case under parallel load (#540)
+    size = "medium",
     src = ":krpctest",
     pkg = "krpctest-" + python_version,
     deps = deps,
@@ -45,7 +46,8 @@ py_test(
 
 py_lint_test(
     name = "lint",
-    size = "small",
+    # medium (300s) not small (60s): ~38s worst case under parallel load (#540)
+    size = "medium",
     pkg = ":krpctest",
     pkg_name = "krpctest",
     pylint_config = "pylint.rc",

--- a/tools/krpctools/BUILD.bazel
+++ b/tools/krpctools/BUILD.bazel
@@ -110,7 +110,6 @@ test_suite(
 
 py_test(
     name = "krpctoolstest",
-    # medium (300s) not small (60s): ~42s worst case under parallel load (#540)
     size = "medium",
     src = ":krpctools",
     pkg = "krpctools-" + python_version,
@@ -119,7 +118,6 @@ py_test(
 
 py_lint_test(
     name = "lint",
-    # medium (300s) not small (60s): ~46s worst case under parallel load (#540)
     size = "medium",
     pkg = ":krpctools",
     pkg_name = "krpctools",

--- a/tools/krpctools/BUILD.bazel
+++ b/tools/krpctools/BUILD.bazel
@@ -110,7 +110,8 @@ test_suite(
 
 py_test(
     name = "krpctoolstest",
-    size = "small",
+    # medium (300s) not small (60s): ~42s worst case under parallel load (#540)
+    size = "medium",
     src = ":krpctools",
     pkg = "krpctools-" + python_version,
     deps = deps,
@@ -118,7 +119,8 @@ py_test(
 
 py_lint_test(
     name = "lint",
-    size = "small",
+    # medium (300s) not small (60s): ~46s worst case under parallel load (#540)
+    size = "medium",
     pkg = ":krpctools",
     pkg_name = "krpctools",
     pylint_config = "pylint.rc",


### PR DESCRIPTION
Fixes #540 

 - Loosen upper timing bounds in client event/stream tests
 - Re-enable python client stream test_rate
 - Fix TestCustomEvent flakiness
 - Increase allowed test time to "medium" from "small" for tests close to the limit 