### PR TITLE
RPC Deprecation

### DIFF
--- a/client/cnano/CHANGES.txt
+++ b/client/cnano/CHANGES.txt
@@ -9,6 +9,7 @@ v0.6.0
    (default) the system install is required; when ON FetchContent is used.
  * Add KRPC_FETCH_DEPS option to enable FetchContent for all dependencies at once
  * Add support for socket communication on Windows
+ * Mark deprecated functions with the KRPC_DEPRECATED attribute macro (#904)
 
 v0.5.2
  * The arduino compatible version of the library now uses the same "krpc_cnano/..." include directory as the version released on GitHub.

--- a/client/cnano/include/krpc_cnano/deprecated.h
+++ b/client/cnano/include/krpc_cnano/deprecated.h
@@ -1,0 +1,17 @@
+#ifndef KRPC_DEPRECATED_H
+#define KRPC_DEPRECATED_H
+
+// Marks a generated declaration as deprecated, carrying an optional reason
+// message. Expands to the compiler's deprecation attribute where available,
+// and to nothing on compilers that do not support one.
+#ifndef KRPC_DEPRECATED
+#if defined(__GNUC__) || defined(__clang__)
+#define KRPC_DEPRECATED(msg) __attribute__((deprecated(msg)))
+#elif defined(_MSC_VER)
+#define KRPC_DEPRECATED(msg) __declspec(deprecated(msg))
+#else
+#define KRPC_DEPRECATED(msg)
+#endif
+#endif
+
+#endif  // KRPC_DEPRECATED_H

--- a/client/cpp/CHANGES.txt
+++ b/client/cpp/CHANGES.txt
@@ -8,6 +8,7 @@ v0.6.0
  * CMake dependency options (KRPC_FETCH_PROTOBUF, KRPC_FETCH_ASIO, KRPC_FETCH_ABSL): when OFF
    (default) the system install is required; when ON FetchContent is used.
  * Add KRPC_FETCH_DEPS option to enable FetchContent for all dependencies at once
+ * Mark deprecated members with the [[deprecated]] attribute (#904)
 
 v0.5.2
  * Use protobuf-lite

--- a/client/csharp/CHANGES.txt
+++ b/client/csharp/CHANGES.txt
@@ -1,3 +1,6 @@
+v0.6.0
+ * Mark deprecated members with the [Obsolete] attribute (#904)
+
 v0.5.0
  * Update to protobuf v3.22.0
  * Drop support for net35

--- a/client/java/CHANGES.txt
+++ b/client/java/CHANGES.txt
@@ -3,6 +3,7 @@ v0.6.0
  * Update dependencies: junit 4.13.2, hamcrest-core 3.0, guava 33.4.8-jre, antlr4-runtime 4.13.2
  * Update checkstyle to 10.26.1, using bundled google_checks.xml
  * Fix all checkstyle violations: import ordering, typecast spacing, Javadoc, method naming (Sint32/Sint64/Uint32/Uint64)
+ * Mark deprecated members with the @Deprecated annotation and an @deprecated javadoc tag (#904)
 
 v0.5.0
  * Update to protobuf v3.22.0

--- a/client/python/CHANGES.txt
+++ b/client/python/CHANGES.txt
@@ -1,6 +1,7 @@
 v0.6.0
  * Allow calling static class methods from a class instance (#832)
  * Update to protobuf v7.35.1
+ * Emit a DeprecationWarning when calling a deprecated member, and note deprecation in docstrings (#904)
 
 v0.5.4
  * Fix streams for services without pre-generated stubs (#774)

--- a/client/python/krpc/service.py
+++ b/client/python/krpc/service.py
@@ -10,6 +10,7 @@ from typing import (
     TYPE_CHECKING,
 )
 import keyword
+import warnings
 from collections import defaultdict
 from xml.etree import ElementTree
 from krpc.types import Types, TypeBase, DynamicType, DynamicClassBase, DefaultArgument
@@ -111,6 +112,29 @@ def _construct_func(
     return cast(Callable, fn)  # type: ignore[type-arg]
 
 
+def _deprecated_doc(doc: str, reason: str) -> str:
+    """Prepend a deprecation notice to a constructed docstring"""
+    line = "Deprecated. " + reason if reason else "Deprecated."
+    return line + "\n\n" + doc if doc else line
+
+
+def _wrap_deprecated(
+    func: Callable,  # type: ignore[type-arg]
+    qualified_name: str,
+    reason: str,
+) -> Callable:  # type: ignore[type-arg]
+    """Wrap an invoker so that calling it emits a DeprecationWarning"""
+    message = qualified_name + " is deprecated"
+    if reason:
+        message += ": " + reason
+
+    def wrapper(*args: object, **kwargs: object) -> object:
+        warnings.warn(message, DeprecationWarning, stacklevel=2)
+        return func(*args, **kwargs)
+
+    return wrapper
+
+
 def _indent(lines: Iterable[str], level: int) -> List[str]:
     result = []
     for line in lines:
@@ -186,6 +210,9 @@ def _parse_documentation(xml: str) -> str:
 
 def create_service(client: Client, service: KRPC.Service) -> object:
     """Create a new service type"""
+    doc = _parse_documentation(service.documentation)
+    if service.deprecated:
+        doc = _deprecated_doc(doc, service.deprecated_reason)
     cls = cast(
         ServiceBase,
         type(
@@ -194,7 +221,7 @@ def create_service(client: Client, service: KRPC.Service) -> object:
             {
                 "_client": client,
                 "_name": service.name,
-                "__doc__": _parse_documentation(service.documentation),
+                "__doc__": doc,
             },
         ),
     )
@@ -276,23 +303,32 @@ class ServiceBase(DynamicType):
     def _add_service_class(cls, remote_cls: KRPC.Class) -> None:
         """Add a class type"""
         name = remote_cls.name
-        class_type = cls._client._types.class_type(
-            cls._name, name, _parse_documentation(remote_cls.documentation)
-        )
+        doc = _parse_documentation(remote_cls.documentation)
+        if remote_cls.deprecated:
+            doc = _deprecated_doc(doc, remote_cls.deprecated_reason)
+        class_type = cls._client._types.class_type(cls._name, name, doc)
         setattr(cls, name, class_type.python_type)
 
     @classmethod
     def _add_service_enumeration(cls, enumeration: KRPC.Enumeration) -> None:
         """Add an enum type"""
         name = enumeration.name
-        enumeration_type = cls._client._types.enumeration_type(
-            cls._name, name, _parse_documentation(enumeration.documentation)
-        )
+        doc = _parse_documentation(enumeration.documentation)
+        if enumeration.deprecated:
+            doc = _deprecated_doc(doc, enumeration.deprecated_reason)
+        enumeration_type = cls._client._types.enumeration_type(cls._name, name, doc)
+
+        def value_doc(value: KRPC.EnumerationValue) -> str:
+            vdoc = _parse_documentation(value.documentation)
+            if value.deprecated:
+                vdoc = _deprecated_doc(vdoc, value.deprecated_reason)
+            return vdoc
+
         enumeration_type.set_values(
             dict(
                 (
                     str(snake_case(x.name)),
-                    {"value": x.value, "doc": _parse_documentation(x.documentation)},
+                    {"value": x.value, "doc": value_doc(x)},
                 )
                 for x in enumeration.values
             )
@@ -303,9 +339,10 @@ class ServiceBase(DynamicType):
     def _add_service_exception(cls, exception: KRPC.Exception) -> None:
         """Add an exception type"""
         name = exception.name
-        exception_type = cls._client._types.exception_type(
-            cls._name, name, _parse_documentation(exception.documentation)
-        )
+        doc = _parse_documentation(exception.documentation)
+        if exception.deprecated:
+            doc = _deprecated_doc(doc, exception.deprecated_reason)
+        exception_type = cls._client._types.exception_type(cls._name, name, doc)
         setattr(cls, name, exception_type)
 
     @classmethod
@@ -363,9 +400,13 @@ class ServiceBase(DynamicType):
             return_type,
         )
         name = _member_name(procedure.name)
-        cls._add_class_method(
-            name, func, doc=_parse_documentation(procedure.documentation)
-        )
+        doc = _parse_documentation(procedure.documentation)
+        if procedure.deprecated:
+            func = _wrap_deprecated(
+                func, cls._name + "." + name, procedure.deprecated_reason
+            )
+            doc = _deprecated_doc(doc, procedure.deprecated_reason)
+        cls._add_class_method(name, func, doc=doc)
         cls._add_class_method("_build_call_" + name, build_call)
         cls._add_class_method("_return_type_" + name, lambda cls: return_type)
 
@@ -377,11 +418,17 @@ class ServiceBase(DynamicType):
         setter: Optional[KRPC.Procedure] = None,
     ) -> None:
         """Add a property"""
+        member_name = _member_name(name)
+        qualified_name = cls._name + "." + member_name
         doc = None
         if getter:
             doc = _parse_documentation(getter.documentation)
         elif setter:
             doc = _parse_documentation(setter.documentation)
+        if getter and getter.deprecated:
+            doc = _deprecated_doc(doc or "", getter.deprecated_reason)
+        elif setter and setter.deprecated:
+            doc = _deprecated_doc(doc or "", setter.deprecated_reason)
         getter_fn = None
         setter_fn = None
         if getter:
@@ -398,6 +445,10 @@ class ServiceBase(DynamicType):
                 [],
                 return_type,
             )
+            if getter.deprecated:
+                getter_fn = _wrap_deprecated(
+                    getter_fn, qualified_name, getter.deprecated_reason
+                )
             build_call = _construct_func(
                 cls._client._build_call,
                 cls._name,
@@ -423,7 +474,11 @@ class ServiceBase(DynamicType):
                 [None],
                 None,
             )
-        name = _member_name(name)
+            if setter.deprecated:
+                setter_fn = _wrap_deprecated(
+                    setter_fn, qualified_name, setter.deprecated_reason
+                )
+        name = member_name
         cls._add_property(name, getter_fn, setter_fn, doc=doc)
         if getter:
             cls._add_method("_build_call_" + name, build_call)
@@ -467,9 +522,15 @@ class ServiceBase(DynamicType):
             return_type,
         )
         name = _member_name(method_name)
-        class_cls._add_method(
-            name, func, doc=_parse_documentation(procedure.documentation)
-        )
+        doc = _parse_documentation(procedure.documentation)
+        if procedure.deprecated:
+            func = _wrap_deprecated(
+                func,
+                cls._name + "." + class_name + "." + name,
+                procedure.deprecated_reason,
+            )
+            doc = _deprecated_doc(doc, procedure.deprecated_reason)
+        class_cls._add_method(name, func, doc=doc)
         class_cls._add_method("_build_call_" + name, build_call)
         class_cls._add_method("_return_type_" + name, lambda self: return_type)
 
@@ -508,9 +569,15 @@ class ServiceBase(DynamicType):
             return_type,
         )
         name = _member_name(method_name)
-        class_cls._add_class_method(
-            name, func, doc=_parse_documentation(procedure.documentation)
-        )
+        doc = _parse_documentation(procedure.documentation)
+        if procedure.deprecated:
+            func = _wrap_deprecated(
+                func,
+                cls._name + "." + class_name + "." + name,
+                procedure.deprecated_reason,
+            )
+            doc = _deprecated_doc(doc, procedure.deprecated_reason)
+        class_cls._add_class_method(name, func, doc=doc)
         class_cls._add_class_method("_build_call_" + name, build_call)
         class_cls._add_class_method("_return_type_" + name, lambda cls: return_type)
 
@@ -527,11 +594,17 @@ class ServiceBase(DynamicType):
             DynamicClassBase,
             cls._client._types.class_type(cls._name, class_name).python_type,
         )
+        member_name = _member_name(property_name)
+        qualified_name = cls._name + "." + class_name + "." + member_name
         doc = None
         if getter:
             doc = _parse_documentation(getter.documentation)
         elif setter:
             doc = _parse_documentation(setter.documentation)
+        if getter and getter.deprecated:
+            doc = _deprecated_doc(doc or "", getter.deprecated_reason)
+        elif setter and setter.deprecated:
+            doc = _deprecated_doc(doc or "", setter.deprecated_reason)
         getter_fn: Optional[Callable] = None  # type: ignore[type-arg]
         setter_fn: Optional[Callable] = None  # type: ignore[type-arg]
         if getter:
@@ -551,6 +624,10 @@ class ServiceBase(DynamicType):
                 [None],
                 return_type,
             )
+            if getter.deprecated:
+                getter_fn = _wrap_deprecated(
+                    getter_fn, qualified_name, getter.deprecated_reason
+                )
             build_call = _construct_func(
                 cls._client._build_call,
                 cls._name,
@@ -576,7 +653,11 @@ class ServiceBase(DynamicType):
                 [None, None],
                 None,
             )
-        property_name = _member_name(property_name)
+            if setter.deprecated:
+                setter_fn = _wrap_deprecated(
+                    setter_fn, qualified_name, setter.deprecated_reason
+                )
+        property_name = member_name
         class_cls._add_property(property_name, getter_fn, setter_fn, doc=doc)
         if getter:
             class_cls._add_method("_build_call_" + property_name, build_call)

--- a/client/python/krpc/test/test_client.py
+++ b/client/python/krpc/test/test_client.py
@@ -1,6 +1,8 @@
 import unittest
 import socket
 import threading
+import warnings
+from typing import Callable
 import krpc
 from krpc.test.servertestcase import ServerTestCase
 
@@ -102,6 +104,41 @@ class TestClient(ServerTestCase, unittest.TestCase):
         obj = self.conn.test_service.create_test_object("bar")
         self.conn.test_service.object_property = obj
         self.assertEqual(obj, self.conn.test_service.object_property)
+
+    def assert_warns_deprecation(self, action: Callable[[], None]) -> None:
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            action()
+        self.assertTrue(
+            any(issubclass(w.category, DeprecationWarning) for w in caught),
+            "expected a DeprecationWarning to be raised",
+        )
+
+    # The runtime DeprecationWarning is a feature of the dynamically-created
+    # services, so these tests use a connection without the pre-generated stubs.
+    def test_deprecated_procedure_warns(self) -> None:
+        conn = krpc.connect(
+            name="python_client_test_dynamic",
+            address="localhost",
+            rpc_port=self.rpc_port(),
+            stream_port=self.stream_port(),
+            use_pregenerated_stubs=False,
+        )
+        try:
+            self.assert_warns_deprecation(
+                lambda: conn.test_service.deprecated_procedure(3.14159)
+            )
+            self.assert_warns_deprecation(
+                lambda: conn.test_service.deprecated_procedure_no_message(3.14159)
+            )
+            self.assert_warns_deprecation(
+                lambda: setattr(conn.test_service, "deprecated_property", "foo")
+            )
+            self.assert_warns_deprecation(
+                lambda: getattr(conn.test_service, "deprecated_property")
+            )
+        finally:
+            conn.close()
 
     def test_class_as_return_value(self) -> None:
         obj = self.conn.test_service.create_test_object("jeb")
@@ -445,6 +482,12 @@ class TestClient(ServerTestCase, unittest.TestCase):
                     "throw_argument_out_of_range_exception",
                     "on_timer",
                     "on_timer_using_lambda",
+                    "deprecated_procedure",
+                    "deprecated_procedure_no_message",
+                    "deprecated_property",
+                    "DeprecatedClass",
+                    "DeprecatedEnum",
+                    "DeprecatedException",
                 ]
             ),
             set(x for x in dir(self.conn.test_service) if not x.startswith("_")),

--- a/client/python/krpc/test/test_documentation.py
+++ b/client/python/krpc/test/test_documentation.py
@@ -1,3 +1,4 @@
+import inspect
 import unittest
 from typing import cast
 from krpc.test.servertestcase import ServerTestCase
@@ -9,8 +10,10 @@ class TestDocumentation(ServerTestCase, unittest.TestCase):
         super(TestDocumentation, cls).setUpClass()
 
     def check_doc(self, expected: str, obj: object) -> None:
+        # Normalise with cleandoc rather than strip: pre-generated stubs indent
+        # multi-line docstrings, whereas dynamically-created services do not.
         doc = cast(str, obj.__doc__)
-        self.assertEqual(expected, doc.strip())
+        self.assertEqual(expected, inspect.cleandoc(doc))
 
     def test_basic(self) -> None:
         self.check_doc("Service documentation string.", self.conn.test_service)

--- a/client/python/krpc/test/test_documentation.py
+++ b/client/python/krpc/test/test_documentation.py
@@ -39,6 +39,37 @@ class TestDocumentation(ServerTestCase, unittest.TestCase):
             "Enum ValueC documentation string.", self.conn.test_service.TestEnum.value_c
         )
 
+    def test_deprecated(self) -> None:
+        self.check_doc(
+            "Deprecated. Use FloatToString instead.\n\n"
+            "Deprecated procedure documentation string.",
+            self.conn.test_service.deprecated_procedure,
+        )
+        self.check_doc(
+            "Deprecated.\n\nDeprecated procedure with no reason documentation string.",
+            self.conn.test_service.deprecated_procedure_no_message,
+        )
+        self.check_doc(
+            "Deprecated. Use StringProperty instead.\n\n"
+            "Deprecated property documentation string.",
+            type(self.conn.test_service).deprecated_property,
+        )
+        self.check_doc(
+            "Deprecated. Use TestClass instead.\n\n"
+            "Deprecated class documentation string.",
+            self.conn.test_service.DeprecatedClass,
+        )
+        self.check_doc(
+            "Deprecated. Use CustomException instead.\n\n"
+            "Deprecated exception documentation string.",
+            self.conn.test_service.DeprecatedException,
+        )
+        self.check_doc(
+            "Deprecated. Use TestEnum instead.\n\n"
+            "Deprecated enum documentation string.",
+            self.conn.test_service.DeprecatedEnum,
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/core/CHANGES.txt
+++ b/core/CHANGES.txt
@@ -1,6 +1,7 @@
 v0.6.0
  * Add Version property to Core, set by the server plugin on startup
  * Make logger configurable in where it writes to (#780)
+ * Surface deprecated members (annotated with [Obsolete]) in the service definition and over the wire (#904)
 
 v0.5.4
  * Initial version, split off from KRPC.dll

--- a/core/src/Server/ProtocolBuffers/MessageExtensions.cs
+++ b/core/src/Server/ProtocolBuffers/MessageExtensions.cs
@@ -82,6 +82,8 @@ namespace KRPC.Server.ProtocolBuffers
             result.Enumerations.Add (service.Enumerations.Select (ToProtobufMessage));
             result.Exceptions.Add (service.Exceptions.Select (ToProtobufMessage));
             result.Documentation = service.Documentation;
+            result.Deprecated = service.Deprecated;
+            result.DeprecatedReason = service.DeprecatedReason;
             return result;
         }
 
@@ -94,6 +96,8 @@ namespace KRPC.Server.ProtocolBuffers
                 result.ReturnType = procedure.ReturnType.ToProtobufMessage ();
             result.ReturnIsNullable = procedure.ReturnIsNullable;
             result.Documentation = procedure.Documentation;
+            result.Deprecated = procedure.Deprecated;
+            result.DeprecatedReason = procedure.DeprecatedReason;
             return result;
         }
 
@@ -113,6 +117,8 @@ namespace KRPC.Server.ProtocolBuffers
             var result = new Schema.KRPC.Class ();
             result.Name = cls.Name;
             result.Documentation = cls.Documentation;
+            result.Deprecated = cls.Deprecated;
+            result.DeprecatedReason = cls.DeprecatedReason;
             return result;
         }
 
@@ -122,6 +128,8 @@ namespace KRPC.Server.ProtocolBuffers
             result.Name = enumeration.Name;
             result.Values.Add (enumeration.Values.Select (ToProtobufMessage));
             result.Documentation = enumeration.Documentation;
+            result.Deprecated = enumeration.Deprecated;
+            result.DeprecatedReason = enumeration.DeprecatedReason;
             return result;
         }
 
@@ -131,6 +139,8 @@ namespace KRPC.Server.ProtocolBuffers
             result.Name = enumerationValue.Name;
             result.Value = enumerationValue.Value;
             result.Documentation = enumerationValue.Documentation;
+            result.Deprecated = enumerationValue.Deprecated;
+            result.DeprecatedReason = enumerationValue.DeprecatedReason;
             return result;
         }
 
@@ -139,6 +149,8 @@ namespace KRPC.Server.ProtocolBuffers
             var result = new Schema.KRPC.Exception ();
             result.Name = exception.Name;
             result.Documentation = exception.Documentation;
+            result.Deprecated = exception.Deprecated;
+            result.DeprecatedReason = exception.DeprecatedReason;
             return result;
         }
 

--- a/core/src/Service/KRPC/KRPC.cs
+++ b/core/src/Service/KRPC/KRPC.cs
@@ -87,22 +87,30 @@ namespace KRPC.Service.KRPC
                     procedure.GameScene = procedureSignature.GameScene;
                     if (procedureSignature.Documentation.Length > 0)
                         procedure.Documentation = procedureSignature.Documentation;
+                    procedure.Deprecated = procedureSignature.Deprecated;
+                    procedure.DeprecatedReason = procedureSignature.DeprecatedReason;
                     service.Procedures.Add (procedure);
                 }
                 foreach (var clsSignature in serviceSignature.Classes.Values) {
                     var cls = new Class (clsSignature.Name);
                     if (clsSignature.Documentation.Length > 0)
                         cls.Documentation = clsSignature.Documentation;
+                    cls.Deprecated = clsSignature.Deprecated;
+                    cls.DeprecatedReason = clsSignature.DeprecatedReason;
                     service.Classes.Add (cls);
                 }
                 foreach (var enmSignature in serviceSignature.Enumerations.Values) {
                     var enm = new Enumeration (enmSignature.Name);
                     if (enmSignature.Documentation.Length > 0)
                         enm.Documentation = enmSignature.Documentation;
+                    enm.Deprecated = enmSignature.Deprecated;
+                    enm.DeprecatedReason = enmSignature.DeprecatedReason;
                     foreach (var enmValueSignature in enmSignature.Values) {
                         var enmValue = new EnumerationValue (enmValueSignature.Name, enmValueSignature.Value);
                         if (enmValueSignature.Documentation.Length > 0)
                             enmValue.Documentation = enmValueSignature.Documentation;
+                        enmValue.Deprecated = enmValueSignature.Deprecated;
+                        enmValue.DeprecatedReason = enmValueSignature.DeprecatedReason;
                         enm.Values.Add (enmValue);
                     }
                     service.Enumerations.Add (enm);
@@ -111,10 +119,14 @@ namespace KRPC.Service.KRPC
                     var exn = new Messages.Exception (exnSignature.Name);
                     if (exnSignature.Documentation.Length > 0)
                         exn.Documentation = exnSignature.Documentation;
+                    exn.Deprecated = exnSignature.Deprecated;
+                    exn.DeprecatedReason = exnSignature.DeprecatedReason;
                     service.Exceptions.Add (exn);
                 }
                 if (serviceSignature.Documentation.Length > 0)
                     service.Documentation = serviceSignature.Documentation;
+                service.Deprecated = serviceSignature.Deprecated;
+                service.DeprecatedReason = serviceSignature.DeprecatedReason;
                 services.ServicesList.Add (service);
             }
             return services;

--- a/core/src/Service/Messages/Class.cs
+++ b/core/src/Service/Messages/Class.cs
@@ -7,10 +7,15 @@ namespace KRPC.Service.Messages
 
         public string Documentation { get; set; }
 
+        public bool Deprecated { get; set; }
+
+        public string DeprecatedReason { get; set; }
+
         public Class (string name)
         {
             Name = name;
             Documentation = string.Empty;
+            DeprecatedReason = string.Empty;
         }
     }
 }

--- a/core/src/Service/Messages/Enumeration.cs
+++ b/core/src/Service/Messages/Enumeration.cs
@@ -11,11 +11,16 @@ namespace KRPC.Service.Messages
 
         public string Documentation { get; set; }
 
+        public bool Deprecated { get; set; }
+
+        public string DeprecatedReason { get; set; }
+
         public Enumeration (string name)
         {
             Name = name;
             Values = new List<EnumerationValue> ();
             Documentation = string.Empty;
+            DeprecatedReason = string.Empty;
         }
     }
 }

--- a/core/src/Service/Messages/EnumerationValue.cs
+++ b/core/src/Service/Messages/EnumerationValue.cs
@@ -9,11 +9,16 @@ namespace KRPC.Service.Messages
 
         public string Documentation { get; set; }
 
+        public bool Deprecated { get; set; }
+
+        public string DeprecatedReason { get; set; }
+
         public EnumerationValue (string name, int value)
         {
             Name = name;
             Value = value;
             Documentation = string.Empty;
+            DeprecatedReason = string.Empty;
         }
     }
 }

--- a/core/src/Service/Messages/Exception.cs
+++ b/core/src/Service/Messages/Exception.cs
@@ -8,10 +8,15 @@ namespace KRPC.Service.Messages
 
         public string Documentation { get; set; }
 
+        public bool Deprecated { get; set; }
+
+        public string DeprecatedReason { get; set; }
+
         public Exception (string name)
         {
             Name = name;
             Documentation = string.Empty;
+            DeprecatedReason = string.Empty;
         }
     }
 }

--- a/core/src/Service/Messages/Procedure.cs
+++ b/core/src/Service/Messages/Procedure.cs
@@ -22,11 +22,16 @@ namespace KRPC.Service.Messages
 
         public string Documentation { get; set; }
 
+        public bool Deprecated { get; set; }
+
+        public string DeprecatedReason { get; set; }
+
         public Procedure (string name)
         {
             Name = name;
             Parameters = new List<Parameter> ();
             Documentation = string.Empty;
+            DeprecatedReason = string.Empty;
         }
     }
 }

--- a/core/src/Service/Messages/Service.cs
+++ b/core/src/Service/Messages/Service.cs
@@ -17,6 +17,10 @@ namespace KRPC.Service.Messages
 
         public string Documentation { get; set; }
 
+        public bool Deprecated { get; set; }
+
+        public string DeprecatedReason { get; set; }
+
         public Service (string name)
         {
             Name = name;
@@ -25,6 +29,7 @@ namespace KRPC.Service.Messages
             Enumerations = new List<Enumeration> ();
             Exceptions = new List<Exception> ();
             Documentation = string.Empty;
+            DeprecatedReason = string.Empty;
         }
     }
 }

--- a/core/src/Service/Scanner/ClassSignature.cs
+++ b/core/src/Service/Scanner/ClassSignature.cs
@@ -26,13 +26,25 @@ namespace KRPC.Service.Scanner
         public string Documentation { get; private set; }
 
         /// <summary>
+        /// Whether the class is deprecated.
+        /// </summary>
+        public bool Deprecated { get; private set; }
+
+        /// <summary>
+        /// If the class is deprecated, the reason for its deprecation (may be empty).
+        /// </summary>
+        public string DeprecatedReason { get; private set; }
+
+        /// <summary>
         /// Create a class signature
         /// </summary>
-        public ClassSignature (string serviceName, string className, string documentation)
+        public ClassSignature (string serviceName, string className, string documentation, bool deprecated, string deprecatedReason)
         {
             Name = className;
             FullyQualifiedName = serviceName + "." + Name;
             Documentation = DocumentationUtils.ResolveCrefs (documentation);
+            Deprecated = deprecated;
+            DeprecatedReason = deprecatedReason;
         }
 
         /// <summary>
@@ -41,6 +53,10 @@ namespace KRPC.Service.Scanner
         public void GetObjectData (SerializationInfo info, StreamingContext context)
         {
             info.AddValue ("documentation", Documentation);
+            if (Deprecated) {
+                info.AddValue ("deprecated", true);
+                info.AddValue ("deprecated_reason", DeprecatedReason);
+            }
         }
     }
 }

--- a/core/src/Service/Scanner/EnumerationSignature.cs
+++ b/core/src/Service/Scanner/EnumerationSignature.cs
@@ -31,14 +31,26 @@ namespace KRPC.Service.Scanner
         public string Documentation { get; private set; }
 
         /// <summary>
+        /// Whether the enumeration is deprecated.
+        /// </summary>
+        public bool Deprecated { get; private set; }
+
+        /// <summary>
+        /// If the enumeration is deprecated, the reason for its deprecation (may be empty).
+        /// </summary>
+        public string DeprecatedReason { get; private set; }
+
+        /// <summary>
         /// Create an enumeration signature
         /// </summary>
-        public EnumerationSignature (string serviceName, string enumName, IList<EnumerationValueSignature> values, string documentation)
+        public EnumerationSignature (string serviceName, string enumName, IList<EnumerationValueSignature> values, string documentation, bool deprecated, string deprecatedReason)
         {
             Name = enumName;
             FullyQualifiedName = serviceName + "." + Name;
             Values = values;
             Documentation = DocumentationUtils.ResolveCrefs (documentation);
+            Deprecated = deprecated;
+            DeprecatedReason = deprecatedReason;
         }
 
         /// <summary>
@@ -48,6 +60,10 @@ namespace KRPC.Service.Scanner
         {
             info.AddValue ("documentation", Documentation);
             info.AddValue ("values", Values);
+            if (Deprecated) {
+                info.AddValue ("deprecated", true);
+                info.AddValue ("deprecated_reason", DeprecatedReason);
+            }
         }
     }
 }

--- a/core/src/Service/Scanner/EnumerationValueSignature.cs
+++ b/core/src/Service/Scanner/EnumerationValueSignature.cs
@@ -30,14 +30,26 @@ namespace KRPC.Service.Scanner
         public string Documentation { get; private set; }
 
         /// <summary>
+        /// Whether the enumeration value is deprecated.
+        /// </summary>
+        public bool Deprecated { get; private set; }
+
+        /// <summary>
+        /// If the enumeration value is deprecated, the reason for its deprecation (may be empty).
+        /// </summary>
+        public string DeprecatedReason { get; private set; }
+
+        /// <summary>
         /// Create a signature for an enumeration value.
         /// </summary>
-        public EnumerationValueSignature (string serviceName, string enumName, string valueName, int value, string documentation)
+        public EnumerationValueSignature (string serviceName, string enumName, string valueName, int value, string documentation, bool deprecated, string deprecatedReason)
         {
             Name = valueName;
             FullyQualifiedName = serviceName + "." + enumName + "." + Name;
             Value = value;
             Documentation = DocumentationUtils.ResolveCrefs (documentation);
+            Deprecated = deprecated;
+            DeprecatedReason = deprecatedReason;
         }
 
         /// <summary>
@@ -48,6 +60,10 @@ namespace KRPC.Service.Scanner
             info.AddValue ("name", Name);
             info.AddValue ("value", Value);
             info.AddValue ("documentation", Documentation);
+            if (Deprecated) {
+                info.AddValue ("deprecated", true);
+                info.AddValue ("deprecated_reason", DeprecatedReason);
+            }
         }
     }
 }

--- a/core/src/Service/Scanner/ExceptionSignature.cs
+++ b/core/src/Service/Scanner/ExceptionSignature.cs
@@ -26,13 +26,25 @@ namespace KRPC.Service.Scanner
         public string Documentation { get; private set; }
 
         /// <summary>
+        /// Whether the exception is deprecated.
+        /// </summary>
+        public bool Deprecated { get; private set; }
+
+        /// <summary>
+        /// If the exception is deprecated, the reason for its deprecation (may be empty).
+        /// </summary>
+        public string DeprecatedReason { get; private set; }
+
+        /// <summary>
         /// Create an exception signature
         /// </summary>
-        public ExceptionSignature (string serviceName, string className, string documentation)
+        public ExceptionSignature (string serviceName, string className, string documentation, bool deprecated, string deprecatedReason)
         {
             Name = className;
             FullyQualifiedName = serviceName + "." + Name;
             Documentation = DocumentationUtils.ResolveCrefs (documentation);
+            Deprecated = deprecated;
+            DeprecatedReason = deprecatedReason;
         }
 
         /// <summary>
@@ -41,6 +53,10 @@ namespace KRPC.Service.Scanner
         public void GetObjectData (SerializationInfo info, StreamingContext context)
         {
             info.AddValue ("documentation", Documentation);
+            if (Deprecated) {
+                info.AddValue ("deprecated", true);
+                info.AddValue ("deprecated_reason", DeprecatedReason);
+            }
         }
     }
 }

--- a/core/src/Service/Scanner/ProcedureSignature.cs
+++ b/core/src/Service/Scanner/ProcedureSignature.cs
@@ -44,6 +44,16 @@ namespace KRPC.Service.Scanner
         public GameScene GameScene { get; private set; }
 
         /// <summary>
+        /// Whether the procedure is deprecated.
+        /// </summary>
+        public bool Deprecated { get; private set; }
+
+        /// <summary>
+        /// If the procedure is deprecated, the reason for its deprecation (may be empty).
+        /// </summary>
+        public string DeprecatedReason { get; private set; }
+
+        /// <summary>
         /// The procedure's parameters.
         /// </summary>
         public IList<ParameterSignature> Parameters { get; private set; }
@@ -93,7 +103,7 @@ namespace KRPC.Service.Scanner
         /// </summary>
         public string PropertyName { get; private set; }
 
-        internal ProcedureSignature (string serviceName, string procedureName, uint id, string documentation, IProcedureHandler handler, GameScene gameScene)
+        internal ProcedureSignature (string serviceName, string procedureName, uint id, string documentation, IProcedureHandler handler, GameScene gameScene, bool deprecated, string deprecatedReason)
         {
             Name = procedureName;
             FullyQualifiedName = serviceName + "." + Name;
@@ -101,6 +111,8 @@ namespace KRPC.Service.Scanner
             Documentation = DocumentationUtils.ResolveCrefs (documentation);
             Handler = handler;
             GameScene = gameScene;
+            Deprecated = deprecated;
+            DeprecatedReason = deprecatedReason;
             Parameters = handler.Parameters.Select (x => new ParameterSignature (FullyQualifiedName, x)).ToList ();
 
             var returnType = handler.ReturnType;
@@ -158,6 +170,10 @@ namespace KRPC.Service.Scanner
             if (GameScene != GameScene.All)
                 info.AddValue ("game_scenes", GameSceneUtils.Serialize(GameScene));
             info.AddValue ("documentation", Documentation);
+            if (Deprecated) {
+                info.AddValue ("deprecated", true);
+                info.AddValue ("deprecated_reason", DeprecatedReason);
+            }
         }
     }
 }

--- a/core/src/Service/Scanner/ServiceSignature.cs
+++ b/core/src/Service/Scanner/ServiceSignature.cs
@@ -48,6 +48,16 @@ namespace KRPC.Service.Scanner
         public Dictionary<string,ExceptionSignature> Exceptions { get; private set; }
 
         /// <summary>
+        /// Whether the service is deprecated.
+        /// </summary>
+        public bool Deprecated { get; private set; }
+
+        /// <summary>
+        /// If the service is deprecated, the reason for its deprecation (may be empty).
+        /// </summary>
+        public string DeprecatedReason { get; private set; }
+
+        /// <summary>
         /// The game scene of the service, to be inherited by procedures in the service.
         /// </summary>
         GameScene gameScene;
@@ -66,6 +76,9 @@ namespace KRPC.Service.Scanner
             Procedures = new Dictionary<string, ProcedureSignature> ();
             Exceptions = new Dictionary<string, ExceptionSignature> ();
             gameScene = TypeUtils.GetServiceGameScene (type);
+            string deprecatedReason;
+            Deprecated = TypeUtils.GetDeprecated (type, out deprecatedReason);
+            DeprecatedReason = deprecatedReason;
         }
 
         /// <summary>
@@ -82,6 +95,8 @@ namespace KRPC.Service.Scanner
             Procedures = new Dictionary<string, ProcedureSignature> ();
             Exceptions = new Dictionary<string, ExceptionSignature> ();
             gameScene = GameScene.All;
+            Deprecated = false;
+            DeprecatedReason = string.Empty;
         }
 
         uint nextProcedureId = 1;
@@ -106,10 +121,13 @@ namespace KRPC.Service.Scanner
         public void AddProcedure (MethodInfo method)
         {
             TypeUtils.ValidateKRPCProcedure (method);
+            string deprecatedReason;
+            var deprecated = TypeUtils.GetDeprecated (method, out deprecatedReason);
             AddProcedure (new ProcedureSignature (
                 Name, method.Name, NextProcedureId, method.GetDocumentation (),
                 new ProcedureHandler (method, TypeUtils.GetNullable (method)),
-                TypeUtils.GetProcedureGameScene(method, gameScene)));
+                TypeUtils.GetProcedureGameScene(method, gameScene),
+                deprecated, deprecatedReason));
         }
 
         /// <summary>
@@ -129,9 +147,12 @@ namespace KRPC.Service.Scanner
         void AddPropertyProcedure (PropertyInfo property, MethodInfo method)
         {
             var handler = new ProcedureHandler (method, TypeUtils.GetNullable (property));
+            string deprecatedReason;
+            var deprecated = TypeUtils.GetPropertyDeprecated (property, method, out deprecatedReason);
             AddProcedure (new ProcedureSignature (
                 Name, method.Name, NextProcedureId, property.GetDocumentation (), handler,
-                TypeUtils.GetPropertyGameScene(property, gameScene)));
+                TypeUtils.GetPropertyGameScene(property, gameScene),
+                deprecated, deprecatedReason));
         }
 
         /// <summary>
@@ -144,7 +165,9 @@ namespace KRPC.Service.Scanner
             var name = classType.Name;
             if (Classes.ContainsKey (name))
                 throw new ServiceException ("Service " + Name + " contains duplicate classes " + name);
-            Classes [name] = new ClassSignature (Name, name, classType.GetDocumentation ());
+            string deprecatedReason;
+            var deprecated = TypeUtils.GetDeprecated (classType, out deprecatedReason);
+            Classes [name] = new ClassSignature (Name, name, classType.GetDocumentation (), deprecated, deprecatedReason);
             return name;
         }
 
@@ -160,9 +183,13 @@ namespace KRPC.Service.Scanner
                 throw new ServiceException ("Service " + Name + " contains duplicate enumerations " + name);
             var values = new List<EnumerationValueSignature> ();
             foreach (FieldInfo field in enumType.GetFields(BindingFlags.Public | BindingFlags.Static)) {
-                values.Add (new EnumerationValueSignature (Name, name, field.Name, (int)field.GetRawConstantValue (), field.GetDocumentation ()));
+                string valueDeprecatedReason;
+                var valueDeprecated = TypeUtils.GetDeprecated (field, out valueDeprecatedReason);
+                values.Add (new EnumerationValueSignature (Name, name, field.Name, (int)field.GetRawConstantValue (), field.GetDocumentation (), valueDeprecated, valueDeprecatedReason));
             }
-            Enumerations [name] = new EnumerationSignature (Name, name, values, enumType.GetDocumentation ());
+            string deprecatedReason;
+            var deprecated = TypeUtils.GetDeprecated (enumType, out deprecatedReason);
+            Enumerations [name] = new EnumerationSignature (Name, name, values, enumType.GetDocumentation (), deprecated, deprecatedReason);
             return name;
         }
 
@@ -176,7 +203,9 @@ namespace KRPC.Service.Scanner
             var name = exnType.Name;
             if (Exceptions.ContainsKey (name))
                 throw new ServiceException ("Service " + Name + " contains duplicate exceptions " + name);
-            Exceptions [name] = new ExceptionSignature (Name, name, exnType.GetDocumentation ());
+            string deprecatedReason;
+            var deprecated = TypeUtils.GetDeprecated (exnType, out deprecatedReason);
+            Exceptions [name] = new ExceptionSignature (Name, name, exnType.GetDocumentation (), deprecated, deprecatedReason);
             return name;
         }
 
@@ -192,16 +221,20 @@ namespace KRPC.Service.Scanner
             var name = method.Name;
             var id = NextProcedureId;
             var classGameScene = TypeUtils.GetClassGameScene(classType, gameScene);
+            string deprecatedReason;
+            var deprecated = TypeUtils.GetDeprecated (method, out deprecatedReason);
             if (!method.IsStatic) {
                 var handler = new ClassMethodHandler (classType, method, TypeUtils.GetNullable(method));
                 AddProcedure (new ProcedureSignature (
                     Name, cls + '_' + name, id, method.GetDocumentation (), handler,
-                    TypeUtils.GetMethodGameScene(classType, method, classGameScene)));
+                    TypeUtils.GetMethodGameScene(classType, method, classGameScene),
+                    deprecated, deprecatedReason));
             } else {
                 var handler = new ClassStaticMethodHandler (method, TypeUtils.GetNullable (method));
                 AddProcedure (new ProcedureSignature (
                     Name, cls + "_static_" + name, id, method.GetDocumentation (), handler,
-                    TypeUtils.GetMethodGameScene(classType, method, classGameScene)));
+                    TypeUtils.GetMethodGameScene(classType, method, classGameScene),
+                    deprecated, deprecatedReason));
             }
         }
 
@@ -226,9 +259,12 @@ namespace KRPC.Service.Scanner
         {
             var handler = new ClassMethodHandler (classType, method, nullable);
             var classGameScene = TypeUtils.GetClassGameScene(classType, gameScene);
+            string deprecatedReason;
+            var deprecated = TypeUtils.GetPropertyDeprecated (property, method, out deprecatedReason);
             AddProcedure (new ProcedureSignature (
                 Name, cls + '_' + method.Name, NextProcedureId, property.GetDocumentation (), handler,
-                TypeUtils.GetClassPropertyGameScene(classType, property, classGameScene)));
+                TypeUtils.GetClassPropertyGameScene(classType, property, classGameScene),
+                deprecated, deprecatedReason));
         }
 
         /// <summary>
@@ -242,6 +278,10 @@ namespace KRPC.Service.Scanner
             info.AddValue ("classes", Classes);
             info.AddValue ("enumerations", Enumerations);
             info.AddValue ("exceptions", Exceptions);
+            if (Deprecated) {
+                info.AddValue ("deprecated", true);
+                info.AddValue ("deprecated_reason", DeprecatedReason);
+            }
         }
     }
 }

--- a/core/src/Service/TypeUtils.cs
+++ b/core/src/Service/TypeUtils.cs
@@ -204,6 +204,32 @@ namespace KRPC.Service
         }
 
         /// <summary>
+        /// Get whether the given member is deprecated, i.e. annotated with the standard
+        /// [Obsolete] attribute. If it is, <paramref name="reason"/> is set to the
+        /// attribute's message (empty when none was given).
+        /// </summary>
+        public static bool GetDeprecated (ICustomAttributeProvider member, out string reason)
+        {
+            if (Reflection.HasAttribute<ObsoleteAttribute> (member)) {
+                reason = Reflection.GetAttribute<ObsoleteAttribute> (member).Message ?? string.Empty;
+                return true;
+            }
+            reason = string.Empty;
+            return false;
+        }
+
+        /// <summary>
+        /// Get whether the given property is deprecated. The [Obsolete] attribute is read
+        /// from the property itself, falling back to the given accessor method.
+        /// </summary>
+        public static bool GetPropertyDeprecated (PropertyInfo property, MethodInfo accessor, out string reason)
+        {
+            if (Reflection.HasAttribute<ObsoleteAttribute> (property))
+                return GetDeprecated (property, out reason);
+            return GetDeprecated (accessor, out reason);
+        }
+
+        /// <summary>
         /// Get the name of the service for the given KRPCClass annotated type
         /// </summary>
         public static string GetClassServiceName (Type type)

--- a/core/test/Service/KRPC/KRPCTest.cs
+++ b/core/test/Service/KRPC/KRPCTest.cs
@@ -27,7 +27,7 @@ namespace KRPC.Test.Service.KRPC
         {
             var services = global::KRPC.Service.KRPC.KRPC.GetServices ();
             Assert.IsNotNull (services);
-            Assert.AreEqual (4, services.ServicesList.Count);
+            Assert.AreEqual (5, services.ServicesList.Count);
 
             var service = services.ServicesList.First (x => x.Name == "KRPC");
             Assert.AreEqual (67, service.Procedures.Count);

--- a/core/test/Service/MessageAssert.cs
+++ b/core/test/Service/MessageAssert.cs
@@ -99,6 +99,82 @@ namespace KRPC.Test.Service
             Assert.AreEqual (documentation, enumerationValue.Documentation);
         }
 
+        public static void ValueIsDeprecated (Enumeration enumeration, int position, string reason)
+        {
+            Assert.Less (position, enumeration.Values.Count);
+            var enumerationValue = enumeration.Values [position];
+            Assert.IsTrue (enumerationValue.Deprecated);
+            Assert.AreEqual (reason, enumerationValue.DeprecatedReason);
+        }
+
+        public static void ValueIsNotDeprecated (Enumeration enumeration, int position)
+        {
+            Assert.Less (position, enumeration.Values.Count);
+            var enumerationValue = enumeration.Values [position];
+            Assert.IsFalse (enumerationValue.Deprecated);
+            Assert.AreEqual (string.Empty, enumerationValue.DeprecatedReason);
+        }
+
+        public static void IsDeprecated (Procedure procedure, string reason)
+        {
+            Assert.IsTrue (procedure.Deprecated);
+            Assert.AreEqual (reason, procedure.DeprecatedReason);
+        }
+
+        public static void IsNotDeprecated (Procedure procedure)
+        {
+            Assert.IsFalse (procedure.Deprecated);
+            Assert.AreEqual (string.Empty, procedure.DeprecatedReason);
+        }
+
+        public static void IsDeprecated (Class cls, string reason)
+        {
+            Assert.IsTrue (cls.Deprecated);
+            Assert.AreEqual (reason, cls.DeprecatedReason);
+        }
+
+        public static void IsNotDeprecated (Class cls)
+        {
+            Assert.IsFalse (cls.Deprecated);
+            Assert.AreEqual (string.Empty, cls.DeprecatedReason);
+        }
+
+        public static void IsDeprecated (Enumeration enumeration, string reason)
+        {
+            Assert.IsTrue (enumeration.Deprecated);
+            Assert.AreEqual (reason, enumeration.DeprecatedReason);
+        }
+
+        public static void IsNotDeprecated (Enumeration enumeration)
+        {
+            Assert.IsFalse (enumeration.Deprecated);
+            Assert.AreEqual (string.Empty, enumeration.DeprecatedReason);
+        }
+
+        public static void IsDeprecated (global::KRPC.Service.Messages.Exception exception, string reason)
+        {
+            Assert.IsTrue (exception.Deprecated);
+            Assert.AreEqual (reason, exception.DeprecatedReason);
+        }
+
+        public static void IsNotDeprecated (global::KRPC.Service.Messages.Exception exception)
+        {
+            Assert.IsFalse (exception.Deprecated);
+            Assert.AreEqual (string.Empty, exception.DeprecatedReason);
+        }
+
+        public static void IsDeprecated (global::KRPC.Service.Messages.Service service, string reason)
+        {
+            Assert.IsTrue (service.Deprecated);
+            Assert.AreEqual (reason, service.DeprecatedReason);
+        }
+
+        public static void IsNotDeprecated (global::KRPC.Service.Messages.Service service)
+        {
+            Assert.IsFalse (service.Deprecated);
+            Assert.AreEqual (string.Empty, service.DeprecatedReason);
+        }
+
         public static void HasDocumentation (Enumeration enumeration, string documentation)
         {
             Assert.AreEqual (documentation, enumeration.Documentation);

--- a/core/test/Service/ScannerTest.cs
+++ b/core/test/Service/ScannerTest.cs
@@ -21,9 +21,9 @@ namespace KRPC.Test.Service
         [Test]
         public void Services ()
         {
-            Assert.AreEqual (4, services.ServicesList.Count);
+            Assert.AreEqual (5, services.ServicesList.Count);
             CollectionAssert.AreEquivalent (
-                new [] { "KRPC", "TestService", "TestService2", "TestService3Name" },
+                new [] { "KRPC", "TestService", "TestService2", "TestService3Name", "TestServiceDeprecated" },
                 services.ServicesList.Select (x => x.Name).ToList ());
         }
 
@@ -31,10 +31,11 @@ namespace KRPC.Test.Service
         public void TestService ()
         {
             var service = services.ServicesList.First (x => x.Name == "TestService");
-            Assert.AreEqual (49, service.Procedures.Count);
-            Assert.AreEqual (2, service.Classes.Count);
-            Assert.AreEqual (1, service.Enumerations.Count);
+            Assert.AreEqual (53, service.Procedures.Count);
+            Assert.AreEqual (3, service.Classes.Count);
+            Assert.AreEqual (2, service.Enumerations.Count);
             Assert.AreEqual ("<doc>\n<summary>\nTest service documentation.\n</summary>\n</doc>", service.Documentation);
+            MessageAssert.IsNotDeprecated (service);
         }
 
         [Test]
@@ -55,6 +56,15 @@ namespace KRPC.Test.Service
             Assert.AreEqual (1, service.Classes.Count);
             Assert.AreEqual (0, service.Enumerations.Count);
             Assert.AreEqual (string.Empty, service.Documentation);
+            MessageAssert.IsNotDeprecated (service);
+        }
+
+        [Test]
+        public void TestServiceDeprecated ()
+        {
+            var service = services.ServicesList.First (x => x.Name == "TestServiceDeprecated");
+            Assert.AreEqual (1, service.Procedures.Count);
+            MessageAssert.IsDeprecated (service, "Use TestService instead.");
         }
 
         [Test]
@@ -68,6 +78,27 @@ namespace KRPC.Test.Service
                     MessageAssert.HasNoReturnType (proc);
                     MessageAssert.HasGameScene (proc, global::KRPC.Service.GameScene.Flight);
                     MessageAssert.HasDocumentation (proc, "<doc>\n<summary>\nProcedure with no return arguments.\n</summary>\n</doc>");
+                    MessageAssert.IsNotDeprecated (proc);
+                } else if (proc.Name == "DeprecatedProcedure") {
+                    MessageAssert.HasNoParameters (proc);
+                    MessageAssert.HasNoReturnType (proc);
+                    MessageAssert.HasGameScene (proc, global::KRPC.Service.GameScene.Flight);
+                    MessageAssert.IsDeprecated (proc, "Use ProcedureNoArgsNoReturn instead.");
+                } else if (proc.Name == "DeprecatedProcedureNoMessage") {
+                    MessageAssert.HasNoParameters (proc);
+                    MessageAssert.HasNoReturnType (proc);
+                    MessageAssert.HasGameScene (proc, global::KRPC.Service.GameScene.Flight);
+                    MessageAssert.IsDeprecated (proc, string.Empty);
+                } else if (proc.Name == "get_DeprecatedProperty") {
+                    MessageAssert.HasNoParameters (proc);
+                    MessageAssert.HasReturnType (proc, typeof(string));
+                    MessageAssert.HasGameScene (proc, global::KRPC.Service.GameScene.Flight);
+                    MessageAssert.IsDeprecated (proc, "Use PropertyWithGet instead.");
+                } else if (proc.Name == "DeprecatedClass_DeprecatedMethod") {
+                    MessageAssert.HasParameters (proc, 1);
+                    MessageAssert.HasReturnType (proc, typeof(string));
+                    MessageAssert.HasGameScene (proc, global::KRPC.Service.GameScene.Flight);
+                    MessageAssert.IsDeprecated (proc, "Use TestClass.FloatToString instead.");
                 } else if (proc.Name == "ProcedureSingleArgNoReturn") {
                     MessageAssert.HasParameters (proc, 1);
                     MessageAssert.HasParameter (proc, 0, typeof(string), "x");
@@ -365,8 +396,8 @@ namespace KRPC.Test.Service
                 }
                 foundProcedures++;
             }
-            Assert.AreEqual (49, foundProcedures);
-            Assert.AreEqual (49, service.Procedures.Count);
+            Assert.AreEqual (53, foundProcedures);
+            Assert.AreEqual (53, service.Procedures.Count);
         }
 
         [Test]
@@ -377,15 +408,19 @@ namespace KRPC.Test.Service
             foreach (var cls in service.Classes) {
                 if (cls.Name == "TestClass") {
                     MessageAssert.HasNoDocumentation (cls);
+                    MessageAssert.IsNotDeprecated (cls);
                 } else if (cls.Name == "TestTopLevelClass") {
                     MessageAssert.HasDocumentation (cls, "<doc>\n<summary>\nA class defined at the top level, but included in a service\n</summary>\n</doc>");
+                    MessageAssert.IsNotDeprecated (cls);
+                } else if (cls.Name == "DeprecatedClass") {
+                    MessageAssert.IsDeprecated (cls, "Use TestClass instead.");
                 } else {
                     Assert.Fail ();
                 }
                 foundClasses++;
             }
-            Assert.AreEqual (2, foundClasses);
-            Assert.AreEqual (2, service.Classes.Count);
+            Assert.AreEqual (3, foundClasses);
+            Assert.AreEqual (3, service.Classes.Count);
         }
 
         [Test]
@@ -400,13 +435,41 @@ namespace KRPC.Test.Service
                     MessageAssert.HasValue (enumeration, 0, "X", 0, "<doc>\n<summary>\nDocumented enum field\n</summary>\n</doc>");
                     MessageAssert.HasValue (enumeration, 1, "Y", 1);
                     MessageAssert.HasValue (enumeration, 2, "Z", 2);
+                    MessageAssert.IsNotDeprecated (enumeration);
+                    MessageAssert.ValueIsNotDeprecated (enumeration, 0);
+                } else if (enumeration.Name == "DeprecatedEnum") {
+                    MessageAssert.HasValues (enumeration, 2);
+                    MessageAssert.HasValue (enumeration, 0, "A", 0, "<doc>\n<summary>\nA value that is not deprecated.\n</summary>\n</doc>");
+                    MessageAssert.HasValue (enumeration, 1, "B", 1, "<doc>\n<summary>\nA deprecated enumeration value, annotated with a reason.\n</summary>\n</doc>");
+                    MessageAssert.IsDeprecated (enumeration, "Use TestEnum instead.");
+                    MessageAssert.ValueIsNotDeprecated (enumeration, 0);
+                    MessageAssert.ValueIsDeprecated (enumeration, 1, "Use A instead.");
                 } else {
                     Assert.Fail ();
                 }
                 foundEnumerations++;
             }
-            Assert.AreEqual (1, foundEnumerations);
-            Assert.AreEqual (1, service.Enumerations.Count);
+            Assert.AreEqual (2, foundEnumerations);
+            Assert.AreEqual (2, service.Enumerations.Count);
+        }
+
+        [Test]
+        public void TestServiceExceptions ()
+        {
+            var service = services.ServicesList.First (x => x.Name == "TestService");
+            int foundExceptions = 0;
+            foreach (var exception in service.Exceptions) {
+                if (exception.Name == "MyException") {
+                    MessageAssert.IsNotDeprecated (exception);
+                } else if (exception.Name == "DeprecatedException") {
+                    MessageAssert.IsDeprecated (exception, "Use MyException instead.");
+                } else {
+                    Assert.Fail ();
+                }
+                foundExceptions++;
+            }
+            Assert.AreEqual (2, foundExceptions);
+            Assert.AreEqual (2, service.Exceptions.Count);
         }
 
         [Test]

--- a/core/test/Service/TestService.cs
+++ b/core/test/Service/TestService.cs
@@ -350,5 +350,79 @@ namespace KRPC.Test.Service
         {
             get { return Service.PropertyAvailableInSpecifiedGameScene; }
         }
+
+        /// <summary>
+        /// A deprecated procedure, annotated with a reason.
+        /// </summary>
+        [KRPCProcedure]
+        [Obsolete ("Use ProcedureNoArgsNoReturn instead.")]
+        public static void DeprecatedProcedure ()
+        {
+        }
+
+        /// <summary>
+        /// A deprecated procedure, annotated without a reason.
+        /// </summary>
+        [KRPCProcedure]
+        [Obsolete]
+        public static void DeprecatedProcedureNoMessage ()
+        {
+        }
+
+        /// <summary>
+        /// A deprecated property, annotated with a reason.
+        /// </summary>
+        [KRPCProperty]
+        [Obsolete ("Use PropertyWithGet instead.")]
+        public static string DeprecatedProperty {
+            get { return string.Empty; }
+        }
+
+        /// <summary>
+        /// A deprecated class, annotated with a reason.
+        /// </summary>
+        [KRPCClass]
+        [Obsolete ("Use TestClass instead.")]
+        public class DeprecatedClass
+        {
+            /// <summary>
+            /// A deprecated class method, annotated with a reason.
+            /// </summary>
+            [KRPCMethod]
+            [Obsolete ("Use TestClass.FloatToString instead.")]
+            public string DeprecatedMethod ()
+            {
+                return string.Empty;
+            }
+        }
+
+        /// <summary>
+        /// A deprecated enumeration, annotated with a reason.
+        /// </summary>
+        [KRPCEnum]
+        [Serializable]
+        [Obsolete ("Use TestEnum instead.")]
+        public enum DeprecatedEnum
+        {
+            /// <summary>
+            /// A value that is not deprecated.
+            /// </summary>
+            A,
+
+            /// <summary>
+            /// A deprecated enumeration value, annotated with a reason.
+            /// </summary>
+            [Obsolete ("Use A instead.")]
+            B
+        }
+
+        /// <summary>
+        /// A deprecated exception, annotated with a reason.
+        /// </summary>
+        [KRPCException]
+        [Obsolete ("Use MyException instead.")]
+        public class DeprecatedException : Exception
+        {
+        }
     }
 }

--- a/core/test/Service/TestServiceDeprecated.cs
+++ b/core/test/Service/TestServiceDeprecated.cs
@@ -1,0 +1,19 @@
+using System;
+using KRPC.Service;
+using KRPC.Service.Attributes;
+
+namespace KRPC.Test.Service
+{
+    /// <summary>
+    /// A deprecated service, annotated with a reason.
+    /// </summary>
+    [KRPCService (GameScene = GameScene.Flight)]
+    [Obsolete ("Use TestService instead.")]
+    public static class TestServiceDeprecated
+    {
+        [KRPCProcedure]
+        public static void AProcedure ()
+        {
+        }
+    }
+}

--- a/core/test/Utils/ReflectionTest.cs
+++ b/core/test/Utils/ReflectionTest.cs
@@ -20,15 +20,15 @@ namespace KRPC.Test.Utils
         [Test]
         public void GetTypesWithAttribute ()
         {
-            Assert.AreEqual (4, Reflection.GetTypesWith<KRPCServiceAttribute> ().Count ());
-            Assert.AreEqual (5, Reflection.GetTypesWith<KRPCClassAttribute> ().Count ());
+            Assert.AreEqual (5, Reflection.GetTypesWith<KRPCServiceAttribute> ().Count ());
+            Assert.AreEqual (6, Reflection.GetTypesWith<KRPCClassAttribute> ().Count ());
             Assert.AreEqual (0, Reflection.GetTypesWith<KRPCPropertyAttribute> ().Count ());
         }
 
         [Test]
         public void GetMethodsWithAttribute ()
         {
-            Assert.AreEqual (28, Reflection.GetMethodsWith<KRPCProcedureAttribute> (typeof(TestService)).Count ());
+            Assert.AreEqual (30, Reflection.GetMethodsWith<KRPCProcedureAttribute> (typeof(TestService)).Count ());
             Assert.AreEqual (6, Reflection.GetMethodsWith<KRPCMethodAttribute> (typeof(TestService.TestClass)).Count ());
             Assert.AreEqual (0, Reflection.GetMethodsWith<KRPCProcedureAttribute> (typeof(TestService.TestClass)).Count ());
             Assert.AreEqual (0, Reflection.GetMethodsWith<KRPCProcedureAttribute> (typeof(string)).Count ());
@@ -37,7 +37,7 @@ namespace KRPC.Test.Utils
         [Test]
         public void GetPropertiesWithAttribute ()
         {
-            Assert.AreEqual (5, Reflection.GetPropertiesWith<KRPCPropertyAttribute> (typeof(TestService)).Count ());
+            Assert.AreEqual (6, Reflection.GetPropertiesWith<KRPCPropertyAttribute> (typeof(TestService)).Count ());
             Assert.AreEqual (4, Reflection.GetPropertiesWith<KRPCPropertyAttribute> (typeof(TestService.TestClass)).Count ());
             Assert.AreEqual (0, Reflection.GetPropertiesWith<KRPCPropertyAttribute> (typeof(string)).Count ());
         }

--- a/doc/src/communication-protocols/messages.rst
+++ b/doc/src/communication-protocols/messages.rst
@@ -350,6 +350,8 @@ with the format:
      repeated Enumeration enumerations = 4;
      repeated Exception exceptions = 5;
      string documentation = 6;
+     bool deprecated = 7;
+     string deprecated_reason = 8;
    }
 
 The fields are:
@@ -369,6 +371,11 @@ The fields are:
 
 * ``documentation`` - Documentation for the service, as `C# XML documentation`_.
 
+* ``deprecated`` - Whether the service is deprecated. Deprecated services remain fully functional;
+  this field is informational.
+
+* ``deprecated_reason`` - If the service is deprecated, the reason for its deprecation. May be empty.
+
 .. note:: See the :ref:`extending` documentation for more details about :csharp:attr:`KRPCClass`,
           :csharp:attr:`KRPCEnum` and :csharp:attr:`KRPCException`.
 
@@ -386,6 +393,8 @@ Details about a procedure are given by a ``Procedure`` message, with the format:
      bool return_is_nullable = 4;
      repeated GameScene game_scenes = 6;
      string documentation = 5;
+     bool deprecated = 7;
+     string deprecated_reason = 8;
    }
 
    message Parameter {
@@ -422,6 +431,12 @@ The fields are:
 
 * ``documentation`` - Documentation for the procedure, as `C# XML documentation`_.
 
+* ``deprecated`` - Whether the procedure is deprecated. Deprecated procedures remain fully
+  functional; this field is informational.
+
+* ``deprecated_reason`` - If the procedure is deprecated, the reason for its deprecation. May be
+  empty.
+
 Classes
 ^^^^^^^
 
@@ -432,6 +447,8 @@ Details about each :csharp:attr:`KRPCClass` are specified in a ``Class`` message
    message Class {
      string name = 1;
      string documentation = 2;
+     bool deprecated = 3;
+     string deprecated_reason = 4;
    }
 
 The fields are:
@@ -439,6 +456,11 @@ The fields are:
 * ``name`` - The name of the class.
 
 * ``documentation`` - Documentation for the class, as `C# XML documentation`_.
+
+* ``deprecated`` - Whether the class is deprecated. Deprecated classes remain fully functional;
+  this field is informational.
+
+* ``deprecated_reason`` - If the class is deprecated, the reason for its deprecation. May be empty.
 
 Enumerations
 ^^^^^^^^^^^^
@@ -452,12 +474,16 @@ format:
      string name = 1;
      repeated EnumerationValue values = 2;
      string documentation = 3;
+     bool deprecated = 4;
+     string deprecated_reason = 5;
    }
 
    message EnumerationValue {
      string name = 1;
      int32 value = 2;
      string documentation = 3;
+     bool deprecated = 4;
+     string deprecated_reason = 5;
    }
 
 The fields are:
@@ -473,7 +499,19 @@ The fields are:
 
   * ``documentation`` - Documentation for the enumeration value, as `C# XML documentation`_.
 
+  * ``deprecated`` - Whether the enumeration value is deprecated. Deprecated values remain fully
+    functional; this field is informational.
+
+  * ``deprecated_reason`` - If the enumeration value is deprecated, the reason for its deprecation.
+    May be empty.
+
 * ``documentation`` - Documentation for the enumeration, as `C# XML documentation`_.
+
+* ``deprecated`` - Whether the enumeration is deprecated. Deprecated enumerations remain fully
+  functional; this field is informational.
+
+* ``deprecated_reason`` - If the enumeration is deprecated, the reason for its deprecation. May be
+  empty.
 
 Exceptions
 ^^^^^^^^^^
@@ -486,6 +524,8 @@ format:
    message Exception {
      string name = 1;
      string documentation = 2;
+     bool deprecated = 3;
+     string deprecated_reason = 4;
    }
 
 The fields are:
@@ -493,6 +533,12 @@ The fields are:
 * ``name`` - The name of the exception type.
 
 * ``documentation`` - Documentation for the exception, as `C# XML documentation`_.
+
+* ``deprecated`` - Whether the exception is deprecated. Deprecated exceptions remain fully
+  functional; this field is informational.
+
+* ``deprecated_reason`` - If the exception is deprecated, the reason for its deprecation. May be
+  empty.
 
 .. _communication-protocol-procedure-names:
 

--- a/protobuf/krpc.proto
+++ b/protobuf/krpc.proto
@@ -91,6 +91,8 @@ message Service {
   repeated Enumeration enumerations = 4;
   repeated Exception exceptions = 5;
   string documentation = 6;
+  bool deprecated = 7;
+  string deprecated_reason = 8;
 }
 
 message Procedure {
@@ -100,6 +102,8 @@ message Procedure {
   bool return_is_nullable = 4;
   repeated GameScene game_scenes = 6;
   string documentation = 5;
+  bool deprecated = 7;
+  string deprecated_reason = 8;
 
   enum GameScene {
     SPACE_CENTER = 0;
@@ -121,23 +125,31 @@ message Parameter {
 message Class {
   string name = 1;
   string documentation = 2;
+  bool deprecated = 3;
+  string deprecated_reason = 4;
 }
 
 message Enumeration {
   string name = 1;
   repeated EnumerationValue values = 2;
   string documentation = 3;
+  bool deprecated = 4;
+  string deprecated_reason = 5;
 }
 
 message EnumerationValue {
   string name = 1;
   int32 value = 2;
   string documentation = 3;
+  bool deprecated = 4;
+  string deprecated_reason = 5;
 }
 
 message Exception {
   string name = 1;
   string documentation = 2;
+  bool deprecated = 3;
+  string deprecated_reason = 4;
 }
 
 message Type {

--- a/service/SpaceCenter/src/Services/CelestialBody.cs
+++ b/service/SpaceCenter/src/Services/CelestialBody.cs
@@ -117,7 +117,7 @@ namespace KRPC.SpaceCenter.Services
 
         /// <summary>
         /// The current rotation angle of the body, in radians.
-        /// A value between 0 and <math>2\pi</math>
+        /// A value between 0 and 2·pi
         /// </summary>
         [KRPCProperty]
         public double RotationAngle {
@@ -126,7 +126,7 @@ namespace KRPC.SpaceCenter.Services
 
         /// <summary>
         /// The initial rotation angle of the body (at UT 0), in radians.
-        /// A value between 0 and <math>2\pi</math>
+        /// A value between 0 and 2·pi
         /// </summary>
         [KRPCProperty]
         public double InitialRotation {

--- a/service/SpaceCenter/src/Services/Flight.cs
+++ b/service/SpaceCenter/src/Services/Flight.cs
@@ -494,7 +494,7 @@ namespace KRPC.SpaceCenter.Services
         /// <summary>
         /// The dynamic pressure acting on the vessel, in Pascals. This is a measure of the
         /// strength of the aerodynamic forces. It is equal to
-        /// <math>\frac{1}{2} . \mbox{air density} . \mbox{velocity}^2</math>.
+        /// ½ · air density · velocity².
         /// It is commonly denoted <math>Q</math>.
         /// </summary>
         [KRPCProperty]

--- a/tools/TestServer/src/TestService.cs
+++ b/tools/TestServer/src/TestService.cs
@@ -482,5 +482,101 @@ namespace TestServer
                 });
             return evnt.Message;
         }
+
+        /// <summary>
+        /// Deprecated procedure documentation string.
+        /// </summary>
+        [KRPCProcedure]
+        [Obsolete ("Use FloatToString instead.")]
+        public static string DeprecatedProcedure (float value)
+        {
+            return value.ToString (CultureInfo.InvariantCulture);
+        }
+
+        /// <summary>
+        /// Deprecated procedure with no reason documentation string.
+        /// </summary>
+        [KRPCProcedure]
+        [Obsolete]
+        public static string DeprecatedProcedureNoMessage (float value)
+        {
+            return value.ToString (CultureInfo.InvariantCulture);
+        }
+
+        /// <summary>
+        /// Deprecated property documentation string.
+        /// </summary>
+        [KRPCProperty]
+        [Obsolete ("Use StringProperty instead.")]
+        public static string DeprecatedProperty { get; set; }
+
+        /// <summary>
+        /// Deprecated class documentation string.
+        /// </summary>
+        [KRPCClass]
+        [Obsolete ("Use TestClass instead.")]
+        public sealed class DeprecatedClass : Equatable<DeprecatedClass>
+        {
+            public sealed override bool Equals (DeprecatedClass other)
+            {
+                return !ReferenceEquals (other, null);
+            }
+
+            public sealed override int GetHashCode ()
+            {
+                return 0;
+            }
+
+            /// <summary>
+            /// Deprecated method documentation string.
+            /// </summary>
+            [KRPCMethod]
+            [Obsolete ("Use TestClass.GetValue instead.")]
+            public string DeprecatedMethod ()
+            {
+                return "value";
+            }
+        }
+
+        /// <summary>
+        /// Deprecated enum documentation string.
+        /// </summary>
+        [KRPCEnum]
+        [Serializable]
+        [Obsolete ("Use TestEnum instead.")]
+        public enum DeprecatedEnum
+        {
+            /// <summary>
+            /// Deprecated enum ValueA documentation string.
+            /// </summary>
+            ValueA,
+            /// <summary>
+            /// Deprecated enum ValueB documentation string.
+            /// </summary>
+            [Obsolete ("Use ValueA instead.")]
+            ValueB
+        }
+
+        /// <summary>
+        /// Deprecated exception documentation string.
+        /// </summary>
+        [KRPCException]
+        [Obsolete ("Use CustomException instead.")]
+        public sealed class DeprecatedException : System.Exception
+        {
+            public DeprecatedException ()
+            {
+            }
+
+            public DeprecatedException (string message)
+            : base (message)
+            {
+            }
+
+            public DeprecatedException (string message, System.Exception innerException)
+            : base (message, innerException)
+            {
+            }
+        }
     }
 }

--- a/tools/krpctools/CHANGES.txt
+++ b/tools/krpctools/CHANGES.txt
@@ -1,3 +1,6 @@
+v0.6.0
+ * Surface deprecated members in generated documentation and client stubs (#904)
+
 v0.5.4
  * Fix incorrect protobuf DLL (#755)
  * Fix required KSP assemblies not being copied (#755)

--- a/tools/krpctools/krpctools/clientgen/cnano.py
+++ b/tools/krpctools/krpctools/clientgen/cnano.py
@@ -180,6 +180,8 @@ class CnanoGenerator(Generator):
                     "parameters": [],
                     "return_type": return_type(info["type"]),
                     "documentation": info["documentation"],
+                    "deprecated": info["deprecated"],
+                    "deprecated_reason": info["deprecated_reason"],
                 }
             if info["setter"]:
                 properties["set_" + name] = {
@@ -189,6 +191,8 @@ class CnanoGenerator(Generator):
                     ),
                     "return_type": {"ctype": "void", "cvtype": None, "name": None},
                     "documentation": info["documentation"],
+                    "deprecated": info["deprecated"],
+                    "deprecated_reason": info["deprecated_reason"],
                 }
 
         for _, class_info in context["classes"].items():
@@ -200,6 +204,8 @@ class CnanoGenerator(Generator):
                         "parameters": [],
                         "return_type": return_type(info["type"]),
                         "documentation": info["documentation"],
+                        "deprecated": info["deprecated"],
+                        "deprecated_reason": info["deprecated_reason"],
                     }
                 if info["setter"]:
                     class_properties["set_" + name] = {
@@ -212,6 +218,8 @@ class CnanoGenerator(Generator):
                         "return_type": {"ctype": "void", "cvtype": None, "name": None},
                         "return_set_client": False,
                         "documentation": info["documentation"],
+                        "deprecated": info["deprecated"],
+                        "deprecated_reason": info["deprecated_reason"],
                     }
             class_info["properties"] = class_properties
 

--- a/tools/krpctools/krpctools/clientgen/cnano.tmpl
+++ b/tools/krpctools/krpctools/clientgen/cnano.tmpl
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <krpc_cnano/decoder.h>
+#include <krpc_cnano/deprecated.h>
 #include <krpc_cnano/encoder.h>
 #include <krpc_cnano/error.h>
 #include <krpc_cnano/memory.h>
@@ -118,11 +119,15 @@ typedef enum {
 
 {% if procedure.documentation %}{{ procedure.documentation }}
 {% endif %}
+{% if procedure.deprecated %}KRPC_DEPRECATED("{{ procedure.deprecated_reason }}")
+{% endif %}
 krpc_error_t krpc_{{ service_name }}_{{ procedure_name }}({{ procedure_parameters(procedure) }});
 {% endfor %}
 {% for property_name,property in properties.items() %}
 
 {% if property.documentation %}{{ property.documentation }}
+{% endif %}
+{% if property.deprecated %}KRPC_DEPRECATED("{{ property.deprecated_reason }}")
 {% endif %}
 krpc_error_t krpc_{{ service_name }}_{{ property_name }}({{ procedure_parameters(property) }});
 {% endfor %}
@@ -131,17 +136,23 @@ krpc_error_t krpc_{{ service_name }}_{{ property_name }}({{ procedure_parameters
 
 {% if method.documentation %}{{ method.documentation }}
 {% endif %}
+{% if method.deprecated %}KRPC_DEPRECATED("{{ method.deprecated_reason }}")
+{% endif %}
 krpc_error_t krpc_{{ service_name }}_{{ class_name }}_{{ method_name }}({{ method_parameters(service_name, class_name, method) }});
 {% endfor %}
 {% for method_name,method in cls.static_methods.items() %}
 
 {% if method.documentation %}{{ method.documentation }}
 {% endif %}
+{% if method.deprecated %}KRPC_DEPRECATED("{{ method.deprecated_reason }}")
+{% endif %}
 krpc_error_t krpc_{{ service_name }}_{{ class_name }}_{{ method_name }}({{ static_method_parameters(method) }});
 {% endfor %}
 {% for property_name,property in cls.properties.items() %}
 
 {% if property.documentation %}{{ property.documentation }}
+{% endif %}
+{% if property.deprecated %}KRPC_DEPRECATED("{{ property.deprecated_reason }}")
 {% endif %}
 krpc_error_t krpc_{{ service_name }}_{{ class_name }}_{{ property_name }}({{ method_parameters(service_name, class_name, property) }});
 {% endfor %}

--- a/tools/krpctools/krpctools/clientgen/cpp.py
+++ b/tools/krpctools/krpctools/clientgen/cpp.py
@@ -44,6 +44,8 @@ class CppGenerator(Generator):
                         info["getter"]["procedure"]
                     ),
                     "documentation": info["documentation"],
+                    "deprecated": info["deprecated"],
+                    "deprecated_reason": info["deprecated_reason"],
                 }
             if info["setter"]:
                 properties["set_" + name] = {
@@ -54,6 +56,8 @@ class CppGenerator(Generator):
                     "return_type": "void",
                     "return_set_client": False,
                     "documentation": info["documentation"],
+                    "deprecated": info["deprecated"],
+                    "deprecated_reason": info["deprecated_reason"],
                 }
 
         for class_info in context["classes"].values():
@@ -74,6 +78,8 @@ class CppGenerator(Generator):
                             info["getter"]["procedure"]
                         ),
                         "documentation": info["documentation"],
+                        "deprecated": info["deprecated"],
+                        "deprecated_reason": info["deprecated_reason"],
                     }
                 if info["setter"]:
                     class_properties["set_" + name] = {
@@ -86,11 +92,46 @@ class CppGenerator(Generator):
                         "return_type": "void",
                         "return_set_client": False,
                         "documentation": info["documentation"],
+                        "deprecated": info["deprecated"],
+                        "deprecated_reason": info["deprecated_reason"],
                     }
             class_info["properties"] = class_properties
 
         context["properties"] = properties
+
+        # Append a \deprecated doxygen tag for every deprecated member/type
+        deprecatable = (
+            list(context["procedures"].values())
+            + list(context["properties"].values())
+            + list(context["enumerations"].values())
+            + list(context["exceptions"].values())
+            + list(context["classes"].values())
+        )
+        for enm in context["enumerations"].values():
+            deprecatable += list(enm["values"])
+        for class_info in context["classes"].values():
+            deprecatable += (
+                list(class_info["methods"].values())
+                + list(class_info["static_methods"].values())
+                + list(class_info["properties"].values())
+            )
+        for info in deprecatable:
+            self.add_deprecated_doxygen(info)
+
         return context
+
+    @staticmethod
+    def add_deprecated_doxygen(info):
+        if not info.get("deprecated") or not info.get("deprecated_reason"):
+            return
+        tag = " * \\deprecated " + info["deprecated_reason"]
+        documentation = info.get("documentation", "")
+        if documentation:
+            lines = documentation.split("\n")
+            # lines[-1] is the closing ' */'
+            info["documentation"] = "\n".join(lines[:-1] + [" *", tag, " */"])
+        else:
+            info["documentation"] = "\n".join(["/**", tag, " */"])
 
 
 class CppDocParser(DocParser):

--- a/tools/krpctools/krpctools/clientgen/cpp.tmpl
+++ b/tools/krpctools/krpctools/clientgen/cpp.tmpl
@@ -58,6 +58,8 @@ class {{ service_name }} : public Service {
 
 {% if exception.documentation %}{{ exception.documentation | indent(width=2) }}
 {% endif %}
+{% if exception.deprecated %}  [[deprecated{% if exception.deprecated_reason %}("{{ exception.deprecated_reason }}"){% endif %}]]
+{% endif %}
   class {{ exception_name }} : public ::krpc::RPCError {
    public:
     inline explicit {{ exception_name }}(const std::string& msg) : ::krpc::RPCError(msg) {}
@@ -68,9 +70,13 @@ class {{ service_name }} : public Service {
 
 {% if enm.documentation %}{{ enm.documentation | indent(width=2) }}
 {% endif %}
+{% if enm.deprecated %}  [[deprecated{% if enm.deprecated_reason %}("{{ enm.deprecated_reason }}"){% endif %}]]
+{% endif %}
   enum struct {{ enum_name }} {
     {% for value in enm['values'] %}
 {% if value.documentation %}{{ value.documentation | indent(width=4) }}
+{% endif %}
+{% if value.deprecated %}    [[deprecated{% if value.deprecated_reason %}("{{ value.deprecated_reason }}"){% endif %}]]
 {% endif %}
     {{ value.name }} = {{ value.value }}{% if not loop.last %},{% endif %}
 
@@ -81,11 +87,15 @@ class {{ service_name }} : public Service {
 
 {% if procedure.documentation %}{{ procedure.documentation | indent(width=2) }}
 {% endif %}
+{% if procedure.deprecated %}  [[deprecated{% if procedure.deprecated_reason %}("{{ procedure.deprecated_reason }}"){% endif %}]]
+{% endif %}
   {{ procedure.return_type }} {{ procedure_name }}({{ sig_parameters(procedure.parameters) }});
   {% endfor %}
   {% for property_name,property in properties.items() %}
 
 {% if property.documentation %}{{ property.documentation | indent(width=2) }}
+{% endif %}
+{% if property.deprecated %}  [[deprecated{% if property.deprecated_reason %}("{{ property.deprecated_reason }}"){% endif %}]]
 {% endif %}
   {{ property.return_type }} {{ property_name }}({{ sig_parameters(property.parameters) }});
   {% endfor %}
@@ -113,6 +123,8 @@ class {{ service_name }} : public Service {
 
 {% if cls.documentation %}{{ cls.documentation | indent(width=2) }}
 {% endif %}
+{% if cls.deprecated %}  [[deprecated{% if cls.deprecated_reason %}("{{ cls.deprecated_reason }}"){% endif %}]]
+{% endif %}
   class {{ class_name }} : public krpc::Object<{{ class_name }}> {
    public:
     explicit {{ class_name }}(Client* client = nullptr, uint64_t id = 0);
@@ -120,17 +132,23 @@ class {{ service_name }} : public Service {
 
 {% if method.documentation %}{{ method.documentation | indent(width=4) }}
 {% endif %}
+{% if method.deprecated %}    [[deprecated{% if method.deprecated_reason %}("{{ method.deprecated_reason }}"){% endif %}]]
+{% endif %}
     {{ method.return_type }} {{ method_name }}({{ sig_parameters(method.parameters) }});
     {% endfor %}
     {% for method_name,method in cls.static_methods.items() %}
 
 {% if method.documentation %}{{ method.documentation | indent(width=4) }}
 {% endif %}
+{% if method.deprecated %}    [[deprecated{% if method.deprecated_reason %}("{{ method.deprecated_reason }}"){% endif %}]]
+{% endif %}
     static {{ method.return_type }} {{ method_name }}({{ sig_parameters([{'type': 'Client&', 'name': 'client'}] + method.parameters) }});
     {% endfor %}
     {% for property_name,property in cls.properties.items() %}
 
 {% if property.documentation %}{{ property.documentation | indent(width=4) }}
+{% endif %}
+{% if property.deprecated %}    [[deprecated{% if property.deprecated_reason %}("{{ property.deprecated_reason }}"){% endif %}]]
 {% endif %}
     {{ property.return_type }} {{ property_name }}({{ sig_parameters(property.parameters) }});
     {% endfor %}

--- a/tools/krpctools/krpctools/clientgen/cpp.tmpl
+++ b/tools/krpctools/krpctools/clientgen/cpp.tmpl
@@ -58,9 +58,7 @@ class {{ service_name }} : public Service {
 
 {% if exception.documentation %}{{ exception.documentation | indent(width=2) }}
 {% endif %}
-{% if exception.deprecated %}  [[deprecated{% if exception.deprecated_reason %}("{{ exception.deprecated_reason }}"){% endif %}]]
-{% endif %}
-  class {{ exception_name }} : public ::krpc::RPCError {
+  class {% if exception.deprecated %}[[deprecated{% if exception.deprecated_reason %}("{{ exception.deprecated_reason }}"){% endif %}]] {% endif %}{{ exception_name }} : public ::krpc::RPCError {
    public:
     inline explicit {{ exception_name }}(const std::string& msg) : ::krpc::RPCError(msg) {}
   };
@@ -70,15 +68,11 @@ class {{ service_name }} : public Service {
 
 {% if enm.documentation %}{{ enm.documentation | indent(width=2) }}
 {% endif %}
-{% if enm.deprecated %}  [[deprecated{% if enm.deprecated_reason %}("{{ enm.deprecated_reason }}"){% endif %}]]
-{% endif %}
-  enum struct {{ enum_name }} {
+  enum struct {% if enm.deprecated %}[[deprecated{% if enm.deprecated_reason %}("{{ enm.deprecated_reason }}"){% endif %}]] {% endif %}{{ enum_name }} {
     {% for value in enm['values'] %}
 {% if value.documentation %}{{ value.documentation | indent(width=4) }}
 {% endif %}
-{% if value.deprecated %}    [[deprecated{% if value.deprecated_reason %}("{{ value.deprecated_reason }}"){% endif %}]]
-{% endif %}
-    {{ value.name }} = {{ value.value }}{% if not loop.last %},{% endif %}
+    {{ value.name }}{% if value.deprecated %} [[deprecated{% if value.deprecated_reason %}("{{ value.deprecated_reason }}"){% endif %}]]{% endif %} = {{ value.value }}{% if not loop.last %},{% endif %}
 
     {% endfor %}
   };
@@ -123,9 +117,7 @@ class {{ service_name }} : public Service {
 
 {% if cls.documentation %}{{ cls.documentation | indent(width=2) }}
 {% endif %}
-{% if cls.deprecated %}  [[deprecated{% if cls.deprecated_reason %}("{{ cls.deprecated_reason }}"){% endif %}]]
-{% endif %}
-  class {{ class_name }} : public krpc::Object<{{ class_name }}> {
+  class {% if cls.deprecated %}[[deprecated{% if cls.deprecated_reason %}("{{ cls.deprecated_reason }}"){% endif %}]] {% endif %}{{ class_name }} : public krpc::Object<{{ class_name }}> {
    public:
     explicit {{ class_name }}(Client* client = nullptr, uint64_t id = 0);
     {% for method_name,method in cls.methods.items() %}

--- a/tools/krpctools/krpctools/clientgen/csharp.tmpl
+++ b/tools/krpctools/krpctools/clientgen/csharp.tmpl
@@ -28,6 +28,10 @@ using systemAlias = global::System;
 using genericCollectionsAlias = global::System.Collections.Generic;
 #endif
 
+// Generated code references its own deprecated members (e.g. when registering
+// exception types), so suppress the deprecation warnings within this file.
+#pragma warning disable 612, 618
+
 namespace KRPC.Client.Services.{{ service_name }}
 {
     /// <summary>

--- a/tools/krpctools/krpctools/clientgen/csharp.tmpl
+++ b/tools/krpctools/krpctools/clientgen/csharp.tmpl
@@ -80,6 +80,8 @@ namespace KRPC.Client.Services.{{ service_name }}
 
 {% if procedure.documentation %}{{ procedure.documentation | indent(width=8) }}
 {% endif %}
+{% if procedure.deprecated %}        [global::System.Obsolete{% if procedure.deprecated_reason %} ("{{ procedure.deprecated_reason }}"){% endif %}]
+{% endif %}
         [global::KRPC.Client.Attributes.RPCAttribute ("{{ service_name }}", "{{ procedure_name }}")]
         public {{ procedure.return_type }} {{ procedure_name }} ({{ sig_parameters(procedure.parameters) }})
         {
@@ -93,6 +95,8 @@ namespace KRPC.Client.Services.{{ service_name }}
         {% for property_name,property in properties.items() %}
 
 {% if property.documentation %}{{ property.documentation | indent(width=8) }}
+{% endif %}
+{% if property.deprecated %}        [global::System.Obsolete{% if property.deprecated_reason %} ("{{ property.deprecated_reason }}"){% endif %}]
 {% endif %}
         {% if property.getter %}
         [global::KRPC.Client.Attributes.RPCAttribute ("{{ service_name }}", "{{ property.getter.remote_name }}")]
@@ -118,10 +122,14 @@ namespace KRPC.Client.Services.{{ service_name }}
 {% if enm.documentation %}{{ enm.documentation | indent(width=4) }}
 {% endif %}
     [Serializable]
+{% if enm.deprecated %}    [global::System.Obsolete{% if enm.deprecated_reason %} ("{{ enm.deprecated_reason }}"){% endif %}]
+{% endif %}
     public enum {{ enum_name }}
     {
         {% for value in enm['values'] %}
 {% if value.documentation %}{{ value.documentation | indent(width=8) }}
+{% endif %}
+{% if value.deprecated %}        [global::System.Obsolete{% if value.deprecated_reason %} ("{{ value.deprecated_reason }}"){% endif %}]
 {% endif %}
         {{ value.name }} = {{ value.value }}{% if not loop.last %},{% endif %}
 
@@ -133,6 +141,8 @@ namespace KRPC.Client.Services.{{ service_name }}
 {% if exception.documentation %}{{ exception.documentation | indent(width=4) }}
 {% endif %}
     [Serializable]
+{% if exception.deprecated %}    [global::System.Obsolete{% if exception.deprecated_reason %} ("{{ exception.deprecated_reason }}"){% endif %}]
+{% endif %}
     public class {{ exception_name }} : global::KRPC.Client.RPCException
     {
         /// <summary>
@@ -168,6 +178,8 @@ namespace KRPC.Client.Services.{{ service_name }}
 
 {% if cls.documentation %}{{ cls.documentation | indent(width=4) }}
 {% endif %}
+{% if cls.deprecated %}    [global::System.Obsolete{% if cls.deprecated_reason %} ("{{ cls.deprecated_reason }}"){% endif %}]
+{% endif %}
     public class {{ class_name }} : global::KRPC.Client.RemoteObject
     {
         /// <summary>
@@ -179,6 +191,8 @@ namespace KRPC.Client.Services.{{ service_name }}
         {% for method_name,method in cls.methods.items() %}
 
 {% if method.documentation %}{{ method.documentation | indent(width=8) }}
+{% endif %}
+{% if method.deprecated %}        [global::System.Obsolete{% if method.deprecated_reason %} ("{{ method.deprecated_reason }}"){% endif %}]
 {% endif %}
         [global::KRPC.Client.Attributes.RPCAttribute ("{{ service_name }}", "{{ method.remote_name }}")]
         public {{ method.return_type }} {{ method_name }} ({{ sig_parameters(method.parameters) }})
@@ -194,6 +208,8 @@ namespace KRPC.Client.Services.{{ service_name }}
 {% if method.documentation %}{{ method.documentation | indent(width=8) }}
 {% endif %}
         /// <param name="connection">A connection object.</param>
+{% if method.deprecated %}        [global::System.Obsolete{% if method.deprecated_reason %} ("{{ method.deprecated_reason }}"){% endif %}]
+{% endif %}
         [global::KRPC.Client.Attributes.RPCAttribute ("{{ service_name }}", "{{ method.remote_name }}")]
         public static {{ method.return_type }} {{ method_name }} ({{ sig_parameters([{'type': 'IConnection', 'name': 'connection'}] + method.parameters) }})
         {
@@ -209,6 +225,8 @@ namespace KRPC.Client.Services.{{ service_name }}
         {% for property_name,property in cls.properties.items() %}
 
 {% if property.documentation %}{{ property.documentation | indent(width=8) }}
+{% endif %}
+{% if property.deprecated %}        [global::System.Obsolete{% if property.deprecated_reason %} ("{{ property.deprecated_reason }}"){% endif %}]
 {% endif %}
         {% if property.getter %}
         [global::KRPC.Client.Attributes.RPCAttribute ("{{ service_name }}", "{{ property.getter.remote_name }}")]

--- a/tools/krpctools/krpctools/clientgen/generator.py
+++ b/tools/krpctools/krpctools/clientgen/generator.py
@@ -79,6 +79,8 @@ class Generator:
                 "static_methods": {},
                 "properties": {},
                 "documentation": self.parse_documentation(cls["documentation"]),
+                "deprecated": cls.get("deprecated", False),
+                "deprecated_reason": cls.get("deprecated_reason", ""),
             }
 
         for name, enumeration in self._get_defs("enumerations"):
@@ -88,15 +90,21 @@ class Generator:
                         "name": self.parse_name(x["name"]),
                         "value": x["value"],
                         "documentation": self.parse_documentation(x["documentation"]),
+                        "deprecated": x.get("deprecated", False),
+                        "deprecated_reason": x.get("deprecated_reason", ""),
                     }
                     for x in enumeration["values"]
                 ],
                 "documentation": self.parse_documentation(enumeration["documentation"]),
+                "deprecated": enumeration.get("deprecated", False),
+                "deprecated_reason": enumeration.get("deprecated_reason", ""),
             }
 
         for name, exception in self._get_defs("exceptions"):
             context["exceptions"][name] = {
-                "documentation": self.parse_documentation(exception["documentation"])
+                "documentation": self.parse_documentation(exception["documentation"]),
+                "deprecated": exception.get("deprecated", False),
+                "deprecated_reason": exception.get("deprecated_reason", ""),
             }
 
         for name, procedure in self._get_defs("procedures"):
@@ -112,6 +120,8 @@ class Generator:
                     "documentation": self.parse_documentation(
                         procedure["documentation"]
                     ),
+                    "deprecated": procedure.get("deprecated", False),
+                    "deprecated_reason": procedure.get("deprecated_reason", ""),
                 }
 
             elif Attributes.is_a_property_getter(name):
@@ -124,6 +134,8 @@ class Generator:
                         "documentation": self.parse_documentation(
                             procedure["documentation"]
                         ),
+                        "deprecated": procedure.get("deprecated", False),
+                        "deprecated_reason": procedure.get("deprecated_reason", ""),
                     }
                 context["properties"][property_name]["getter"] = {
                     "procedure": procedure,
@@ -142,6 +154,8 @@ class Generator:
                         "documentation": self.parse_documentation(
                             procedure["documentation"]
                         ),
+                        "deprecated": procedure.get("deprecated", False),
+                        "deprecated_reason": procedure.get("deprecated_reason", ""),
                     }
                 context["properties"][property_name]["setter"] = {
                     "procedure": procedure,
@@ -164,6 +178,8 @@ class Generator:
                     "documentation": self.parse_documentation(
                         procedure["documentation"]
                     ),
+                    "deprecated": procedure.get("deprecated", False),
+                    "deprecated_reason": procedure.get("deprecated_reason", ""),
                 }
 
             elif Attributes.is_a_class_static_method(name):
@@ -181,6 +197,8 @@ class Generator:
                     "documentation": self.parse_documentation(
                         procedure["documentation"]
                     ),
+                    "deprecated": procedure.get("deprecated", False),
+                    "deprecated_reason": procedure.get("deprecated_reason", ""),
                 }
 
             elif Attributes.is_a_class_property_getter(name):
@@ -195,6 +213,8 @@ class Generator:
                         "documentation": self.parse_documentation(
                             procedure["documentation"]
                         ),
+                        "deprecated": procedure.get("deprecated", False),
+                        "deprecated_reason": procedure.get("deprecated_reason", ""),
                     }
                 cls["properties"][property_name]["getter"] = {
                     "procedure": procedure,
@@ -215,6 +235,8 @@ class Generator:
                         "documentation": self.parse_documentation(
                             procedure["documentation"]
                         ),
+                        "deprecated": procedure.get("deprecated", False),
+                        "deprecated_reason": procedure.get("deprecated_reason", ""),
                     }
                 cls["properties"][property_name]["setter"] = {
                     "procedure": procedure,

--- a/tools/krpctools/krpctools/clientgen/java.py
+++ b/tools/krpctools/krpctools/clientgen/java.py
@@ -87,6 +87,8 @@ class JavaGenerator(Generator):
                     "parameters": [],
                     "return_type": info["type"],
                     "documentation": info["documentation"],
+                    "deprecated": info["deprecated"],
+                    "deprecated_reason": info["deprecated_reason"],
                 }
             if info["setter"]:
                 properties["set" + upper_camel_case(name)] = {
@@ -97,6 +99,8 @@ class JavaGenerator(Generator):
                     ),
                     "return_type": "void",
                     "documentation": info["documentation"],
+                    "deprecated": info["deprecated"],
+                    "deprecated_reason": info["deprecated_reason"],
                 }
         context["properties"] = properties
 
@@ -111,6 +115,8 @@ class JavaGenerator(Generator):
                         "parameters": [],
                         "return_type": info["type"],
                         "documentation": info["documentation"],
+                        "deprecated": info["deprecated"],
+                        "deprecated_reason": info["deprecated_reason"],
                     }
                 if info["setter"]:
                     class_properties["set" + upper_camel_case(name)] = {
@@ -123,6 +129,8 @@ class JavaGenerator(Generator):
                         ],
                         "return_type": "void",
                         "documentation": info["documentation"],
+                        "deprecated": info["deprecated"],
+                        "deprecated_reason": info["deprecated_reason"],
                     }
             class_info["properties"] = class_properties
 
@@ -191,7 +199,39 @@ class JavaGenerator(Generator):
             hsh = hashlib.sha1(tohash.encode("utf-8")).hexdigest()
             cls["serial_version_uid"] = int(hsh, 16) % (10**18)
 
+        # Append an @deprecated javadoc tag for every deprecated member/type
+        deprecatable = (
+            list(context["procedures"].values())
+            + list(context["properties"].values())
+            + list(context["enumerations"].values())
+            + list(context["exceptions"].values())
+            + list(context["classes"].values())
+        )
+        for enm in context["enumerations"].values():
+            deprecatable += list(enm["values"])
+        for cls in context["classes"].values():
+            deprecatable += (
+                list(cls["methods"].values())
+                + list(cls["static_methods"].values())
+                + list(cls["properties"].values())
+            )
+        for info in deprecatable:
+            self.add_deprecated_javadoc(info)
+
         return context
+
+    @staticmethod
+    def add_deprecated_javadoc(info):
+        if not info.get("deprecated") or not info.get("deprecated_reason"):
+            return
+        tag = " * @deprecated " + info["deprecated_reason"]
+        documentation = info.get("documentation", "")
+        if documentation:
+            lines = documentation.split("\n")
+            # lines[-1] is the closing ' */'
+            info["documentation"] = "\n".join(lines[:-1] + [" *", tag, " */"])
+        else:
+            info["documentation"] = "\n".join(["/**", tag, " */"])
 
 
 class JavaDocParser(DocParser):

--- a/tools/krpctools/krpctools/clientgen/java.tmpl
+++ b/tools/krpctools/krpctools/clientgen/java.tmpl
@@ -45,6 +45,8 @@ public class {{ service_name }} {
 
 {% if exception.documentation %}{{ exception.documentation | indent(width=4) }}
 {% endif %}
+{% if exception.deprecated %}    @Deprecated
+{% endif %}
     public static class {{ exception_name }} extends krpc.client.RPCException {
         private static final long serialVersionUID = {{ exception.serial_version_uid }}L;
 
@@ -67,6 +69,8 @@ public class {{ service_name }} {
 
 {% if procedure.documentation %}{{ procedure.documentation | indent(width=4) }}
 {% endif %}
+{% if procedure.deprecated %}    @Deprecated
+{% endif %}
     @SuppressWarnings({ "unchecked" })
     @RPCInfo(service = "{{ service_name }}", procedure = "{{ procedure.remote_name }}", types = _Types.class)
     public {{ procedure.return_type.name }} {{ procedure_name }}({{ sig_parameters(procedure.parameters) }}) throws RPCException {
@@ -81,9 +85,13 @@ public class {{ service_name }} {
 
 {% if enm.documentation %}{{ enm.documentation | indent(width=4) }}
 {% endif %}
+{% if enm.deprecated %}    @Deprecated
+{% endif %}
     public enum {{ enum_name }} implements RemoteEnum {
         {% for value in enm['values'] %}
 {% if value.documentation %}{{ value.documentation | indent(width=8) }}
+{% endif %}
+{% if value.deprecated %}        @Deprecated
 {% endif %}
         {{ value.name }}({{ value.value }}){% if not loop.last %},{% else %};{% endif %}
 
@@ -115,6 +123,8 @@ public class {{ service_name }} {
 
 {% if cls.documentation %}{{ cls.documentation | indent(width=4) }}
 {% endif %}
+{% if cls.deprecated %}    @Deprecated
+{% endif %}
     public static class {{ class_name }} extends RemoteObject {
 
         private static final long serialVersionUID = {{ cls.serial_version_uid }}L;
@@ -125,6 +135,8 @@ public class {{ service_name }} {
         {% for method_name,method in cls.methods.items()|list + cls.properties.items()|list %}
 
 {% if method.documentation %}{{ method.documentation | indent(width=8) }}
+{% endif %}
+{% if method.deprecated %}        @Deprecated
 {% endif %}
         @SuppressWarnings({ "unchecked" })
         @RPCInfo(service = "{{ service_name }}", procedure = "{{ method.remote_name }}", types = _Types.class)
@@ -139,6 +151,8 @@ public class {{ service_name }} {
         {% for method_name,method in cls.static_methods.items() %}
 
 {% if method.documentation %}{{ method.documentation | indent(width=8) }}
+{% endif %}
+{% if method.deprecated %}        @Deprecated
 {% endif %}
         @SuppressWarnings({ "unchecked" })
         @RPCInfo(service = "{{ service_name }}", procedure = "{{ method.remote_name }}", types = _Types.class)

--- a/tools/krpctools/krpctools/clientgen/java.tmpl
+++ b/tools/krpctools/krpctools/clientgen/java.tmpl
@@ -27,6 +27,9 @@ import krpc.client.RPCInfo;
 import krpc.client.RPCException;
 import krpc.client.Types;
 
+// Generated code references its own deprecated members (e.g. when registering
+// exception types), so suppress the deprecation warnings within this class.
+@SuppressWarnings("deprecation")
 public class {{ service_name }} {
 
     public static {{ service_name }} newInstance(Connection connection) {

--- a/tools/krpctools/krpctools/clientgen/python.py
+++ b/tools/krpctools/krpctools/clientgen/python.py
@@ -116,6 +116,8 @@ class PythonGenerator(Generator):
                     "parameters": [],
                     "return_type": info["type"],
                     "documentation": info["documentation"],
+                    "deprecated": info["deprecated"],
+                    "deprecated_reason": info["deprecated_reason"],
                 }
             if info["setter"]:
                 properties[name]["setter"] = {
@@ -126,6 +128,8 @@ class PythonGenerator(Generator):
                     ),
                     "return_type": "None",
                     "documentation": info["documentation"],
+                    "deprecated": info["deprecated"],
+                    "deprecated_reason": info["deprecated_reason"],
                 }
         context["properties"] = properties
 
@@ -142,6 +146,8 @@ class PythonGenerator(Generator):
                         "parameters": [],
                         "return_type": info["type"],
                         "documentation": info["documentation"],
+                        "deprecated": info["deprecated"],
+                        "deprecated_reason": info["deprecated_reason"],
                     }
                 if info["setter"]:
                     class_properties[name]["setter"] = {
@@ -154,6 +160,8 @@ class PythonGenerator(Generator):
                         ],
                         "return_type": "None",
                         "documentation": info["documentation"],
+                        "deprecated": info["deprecated"],
+                        "deprecated_reason": info["deprecated_reason"],
                     }
             class_info["properties"] = class_properties
 
@@ -279,7 +287,47 @@ class PythonGenerator(Generator):
                     }
                     pos += 1
 
+        self.add_deprecated_docstrings(context)
         return context
+
+    @classmethod
+    def add_deprecated_docstrings(cls, context):
+        # Prepend a "Deprecated:" line to the docstring of every deprecated member/type
+        deprecatable = (
+            list(context["procedures"].values())
+            + [
+                accessor
+                for property in context["properties"].values()
+                for accessor in property.values()
+            ]
+            + list(context["enumerations"].values())
+            + list(context["exceptions"].values())
+            + list(context["classes"].values())
+        )
+        for class_info in context["classes"].values():
+            deprecatable += list(class_info["methods"].values())
+            deprecatable += list(class_info["static_methods"].values())
+            deprecatable += [
+                accessor
+                for property in class_info["properties"].values()
+                for accessor in property.values()
+            ]
+        for info in deprecatable:
+            cls.add_deprecated_docstring(info)
+
+    @staticmethod
+    def add_deprecated_docstring(info):
+        if not info.get("deprecated"):
+            return
+        reason = info.get("deprecated_reason", "")
+        line = "Deprecated. " + reason if reason else "Deprecated."
+        documentation = info.get("documentation", "")
+        if documentation:
+            # documentation is '"""\n<content>\n"""'
+            body = documentation[len('"""\n') : -len('\n"""')]
+            info["documentation"] = '"""\n' + line + "\n\n" + body + '\n"""'
+        else:
+            info["documentation"] = '"""\n' + line + '\n"""'
 
     def parse_default_value(self, value, typ):
         result = super().parse_default_value(value, typ)

--- a/tools/krpctools/krpctools/clientgen/python.tmpl
+++ b/tools/krpctools/krpctools/clientgen/python.tmpl
@@ -1,5 +1,6 @@
 # pylint: disable=line-too-long,invalid-name,redefined-builtin,too-many-lines
 from __future__ import annotations
+import warnings
 from typing import Tuple, Set, Dict, List, Optional, TYPE_CHECKING
 import krpc.schema
 from krpc.schema import KRPC_pb2
@@ -51,6 +52,8 @@ class {{class_name}}(ClassBase):
     def {{prop_name}}(self) -> {{ prop.getter.return_type.spec }}:
 {% if prop.getter.documentation %}{{ prop.getter.documentation | indent(width=8) }}
 {% endif %}
+{% if prop.getter.deprecated %}        warnings.warn("{{ service_name }}.{{ class_name }}.{{ prop_name }} is deprecated{% if prop.getter.deprecated_reason %}: {{ prop.getter.deprecated_reason }}{% endif %}", DeprecationWarning, stacklevel=2)
+{% endif %}
         return self._client._invoke(
             "{{ service_name }}",
             "{{ prop.getter.remote_name }}",
@@ -69,6 +72,8 @@ class {{class_name}}(ClassBase):
     {% if 'setter' in prop %}
     @{{prop_name}}.setter
     def {{prop_name}}({{ arg_list(prop.setter.parameters) }}) -> None:
+{% if prop.setter.deprecated %}        warnings.warn("{{ service_name }}.{{ class_name }}.{{ prop_name }} is deprecated{% if prop.setter.deprecated_reason %}: {{ prop.setter.deprecated_reason }}{% endif %}", DeprecationWarning, stacklevel=2)
+{% endif %}
         return self._client._invoke(
             "{{ service_name }}",
             "{{ prop.setter.remote_name }}",
@@ -99,6 +104,8 @@ class {{class_name}}(ClassBase):
     def {{proc_name}}({{ arg_list(procedure.parameters) }}) -> {{ procedure.return_type.spec }}:
 {% if procedure.documentation %}{{ procedure.documentation | indent(width=8) }}
 {% endif %}
+{% if procedure.deprecated %}        warnings.warn("{{ service_name }}.{{ class_name }}.{{ proc_name }} is deprecated{% if procedure.deprecated_reason %}: {{ procedure.deprecated_reason }}{% endif %}", DeprecationWarning, stacklevel=2)
+{% endif %}
         return self._client._invoke(
             "{{ service_name }}",
             "{{ procedure.remote_name }}",
@@ -126,6 +133,8 @@ class {{class_name}}(ClassBase):
     @StaticMethod
     def {{proc_name}}(cls, {{ static_arg_list(procedure.parameters) }}) -> {{ procedure.return_type.spec }}:
 {% if procedure.documentation %}{{ procedure.documentation | indent(width=8) }}
+{% endif %}
+{% if procedure.deprecated %}        warnings.warn("{{ service_name }}.{{ class_name }}.{{ proc_name }} is deprecated{% if procedure.deprecated_reason %}: {{ procedure.deprecated_reason }}{% endif %}", DeprecationWarning, stacklevel=2)
 {% endif %}
         self = cls
         return cls._client._invoke(
@@ -216,6 +225,8 @@ class {{ service_name }}:
     def {{prop_name}}(self) -> {{ prop.getter.return_type.spec }}:
 {% if prop.getter.documentation %}{{ prop.getter.documentation | indent(width=8) }}
 {% endif %}
+{% if prop.getter.deprecated %}        warnings.warn("{{ service_name }}.{{ prop_name }} is deprecated{% if prop.getter.deprecated_reason %}: {{ prop.getter.deprecated_reason }}{% endif %}", DeprecationWarning, stacklevel=2)
+{% endif %}
         return self._client._invoke(
             "{{ service_name }}",
             "{{ prop.getter.remote_name }}",
@@ -234,6 +245,8 @@ class {{ service_name }}:
     {% if 'setter' in prop %}
     @{{prop_name}}.setter
     def {{prop_name}}({{ arg_list(prop.setter.parameters) }}) -> None:
+{% if prop.setter.deprecated %}        warnings.warn("{{ service_name }}.{{ prop_name }} is deprecated{% if prop.setter.deprecated_reason %}: {{ prop.setter.deprecated_reason }}{% endif %}", DeprecationWarning, stacklevel=2)
+{% endif %}
         return self._client._invoke(
             "{{ service_name }}",
             "{{ prop.setter.remote_name }}",
@@ -263,6 +276,8 @@ class {{ service_name }}:
     {% for proc_name, procedure in procedures.items() %}
     def {{proc_name}}({{ arg_list(procedure.parameters) }}) -> {{ procedure.return_type.spec }}:
 {% if procedure.documentation %}{{ procedure.documentation | indent(width=8) }}
+{% endif %}
+{% if procedure.deprecated %}        warnings.warn("{{ service_name }}.{{ proc_name }} is deprecated{% if procedure.deprecated_reason %}: {{ procedure.deprecated_reason }}{% endif %}", DeprecationWarning, stacklevel=2)
 {% endif %}
         return self._client._invoke(
             "{{ service_name }}",

--- a/tools/krpctools/krpctools/docgen/cnano.tmpl
+++ b/tools/krpctools/krpctools/docgen/cnano.tmpl
@@ -1,6 +1,9 @@
 {% macro service(x) %}{{ mark_documented(x) }}
 Service {{ x.name }}
 
+{% if x.deprecated %}{{ deprecated(x) | indent }}
+
+{% endif %}
 {{ gendoc(x.documentation) | indent }}
 
 {% for member in x.members.values() %}
@@ -16,6 +19,9 @@ Service {{ x.name }}
 {% macro class(x) %}{{ mark_documented(x) }}
 .. type:: krpc_{{ x.service_name }}_{{ x.name }}_t
 
+{% if x.deprecated %}{{ deprecated(x) | indent }}
+
+{% endif %}
 {{ gendoc(x.documentation) | indent }}
 
 {% if hasdoc(x.documentation, './remarks') %}{{ remarks(x.documentation) | indent }}
@@ -36,6 +42,9 @@ Service {{ x.name }}
 {% macro procedure(service_name, x) %}{{ mark_documented(x) }}
 .. function:: krpc_error_t krpc_{{ service_name }}_{{ domain.method_name(x.name) }}({{ parameters(x.return_type, x.parameters) }})
 
+{% if x.deprecated %}{{ deprecated(x) | indent }}
+
+{% endif %}
 {{ gendoc(x.documentation) | indent }}
 
 {{ parameters_description(x.parameters) }}
@@ -58,6 +67,9 @@ Service {{ x.name }}
 .. function:: void krpc_{{ service_name }}_set_{{ x.name }}({{ domain.parameter_type(x.type) }} value)
 {% endif %}
 
+{% if x.deprecated %}{{ deprecated(x) | indent }}
+
+{% endif %}
 {{ gendoc(x.documentation) | indent }}
 
 {% if hasdoc(x.documentation, './returns') %}{{ returns(x.documentation) | indent }}
@@ -74,6 +86,9 @@ Service {{ x.name }}
 {% macro class_method(service_name, class_name, x) %}{{ mark_documented(x) }}
 .. function:: krpc_error_t krpc_{{ service_name }}_{{ class_name }}_{{ domain.method_name(x.name) }}({{ parameters(x.return_type, x.parameters[1:]) }})
 
+{% if x.deprecated %}{{ deprecated(x) | indent }}
+
+{% endif %}
 {{ gendoc(x.documentation) | indent }}
 
 {{ parameters_description(x.parameters[1:]) }}
@@ -91,6 +106,9 @@ Service {{ x.name }}
 {% macro class_static_method(service_name, class_name, x) %}{{ mark_documented(x) }}
 .. function:: krpc_error_t krpc_{{ service_name }}_{{ class_name }}_{{ domain.method_name(x.name) }}({{ parameters(x.return_type, x.parameters) }})
 
+{% if x.deprecated %}{{ deprecated(x) | indent }}
+
+{% endif %}
 {{ gendoc(x.documentation) | indent }}
 
 {{ parameters_description(x.parameters) }}
@@ -112,12 +130,18 @@ Service {{ x.name }}
 {% macro enumeration(x) %}{{ mark_documented(x) }}
 .. type:: krpc_{{ x.service_name }}_{{ x.name }}_t
 
+{% if x.deprecated %}{{ deprecated(x) | indent }}
+
+{% endif %}
 {{ gendoc(x.documentation) | indent }}
 
 {% if hasdoc(x.documentation, './remarks') %}{{ remarks(x.documentation) | indent }}{% endif %}
 {% for value in x.values.values() %}{{ mark_documented(value) }}
    .. macro:: KRPC_{{ x.service_name | upper }}_{{ x.name | upper }}_{{ value.name | upper }}
 
+{% if value.deprecated %}{{ deprecated(value) | indent(width=6) }}
+
+{% endif %}
 {{ gendoc(value.documentation) | indent(width=6) }}
 
 {% if hasdoc(value.documentation, './remarks') %}{{ remarks(value.documentation) | indent(width=6) }}{% endif %}
@@ -127,6 +151,9 @@ Service {{ x.name }}
 {% macro exception(x) %}{{ mark_documented(x) }}
 Exception class {{ x.name }}
 
+{% if x.deprecated %}{{ deprecated(x) | indent }}
+
+{% endif %}
 {{ gendoc(x.documentation) | indent }}
 
 {% if hasdoc(x.documentation, './remarks') %}{{ remarks(x.documentation) | indent }}{% endif %}
@@ -158,6 +185,10 @@ krpc_connection_t connection{% if domain.return_type(return_type) != 'void' %}, 
 .. note::
 
 {{ gendoc(x, './remarks') | indent }}
+{% endmacro %}
+
+{% macro deprecated(x) %}
+.. warning:: Deprecated.{% if x.deprecated_reason != '' %} {{ x.deprecated_reason }}{% endif %}
 {% endmacro %}
 
 {% macro game_scenes(x) %}

--- a/tools/krpctools/krpctools/docgen/cpp.tmpl
+++ b/tools/krpctools/krpctools/docgen/cpp.tmpl
@@ -2,6 +2,9 @@
 .. namespace:: krpc::services
 .. class:: {{ x.name }} : public krpc::Service
 
+{% if x.deprecated %}{{ deprecated(x) | indent }}
+
+{% endif %}
 {{ gendoc(x.documentation) | indent }}
 
    .. function:: {{ x.name }}(krpc::Client* client)
@@ -21,6 +24,9 @@
 {% macro class(x) %}{{ mark_documented(x) }}
 .. class:: {{ x.name }}
 
+{% if x.deprecated %}{{ deprecated(x) | indent }}
+
+{% endif %}
 {{ gendoc(x.documentation) | indent }}
 
 {% if hasdoc(x.documentation, './remarks') %}{{ remarks(x.documentation) | indent }}
@@ -41,6 +47,9 @@
 {% macro procedure(x) %}{{ mark_documented(x) }}
 .. function:: {{ domain.return_type(x.return_type) }} {{ domain.method_name(x.name) | snakecase }}({{ parameters(x.parameters) }})
 
+{% if x.deprecated %}{{ deprecated(x) | indent }}
+
+{% endif %}
 {{ gendoc(x.documentation) | indent }}
 
 {{ parameters_description(x.parameters) }}
@@ -63,6 +72,9 @@
 .. function:: void set_{{ x.name | snakecase }}({{ domain.parameter_type(x.type) }} value)
 {% endif %}
 
+{% if x.deprecated %}{{ deprecated(x) | indent }}
+
+{% endif %}
 {{ gendoc(x.documentation) | indent }}
 
 {% if hasdoc(x.documentation, './returns') %}{{ returns(x.documentation) | indent }}
@@ -79,6 +91,9 @@
 {% macro class_method(x) %}{{ mark_documented(x) }}
 .. function:: {{ domain.return_type(x.return_type) }} {{ domain.method_name(x.name) | snakecase }}({{ parameters(x.parameters[1:]) }})
 
+{% if x.deprecated %}{{ deprecated(x) | indent }}
+
+{% endif %}
 {{ gendoc(x.documentation) | indent }}
 
 {{ parameters_description(x.parameters[1:]) }}
@@ -96,6 +111,9 @@
 {% macro class_static_method(x) %}{{ mark_documented(x) }}
 .. function:: static {{ domain.return_type(x.return_type) }} {{ domain.method_name(x.name) | snakecase }}(Client& connection{% if x.parameters | length > 0 %}, {% endif %}{{ parameters(x.parameters) }})
 
+{% if x.deprecated %}{{ deprecated(x) | indent }}
+
+{% endif %}
 {{ gendoc(x.documentation) | indent }}
 
 {{ parameters_description(x.parameters) }}
@@ -118,12 +136,18 @@
 .. namespace:: krpc::services::{{ x.service_name }}
 .. enum-struct:: {{ x.name }}
 
+{% if x.deprecated %}{{ deprecated(x) | indent }}
+
+{% endif %}
 {{ gendoc(x.documentation) | indent }}
 
 {% if hasdoc(x.documentation, './remarks') %}{{ remarks(x.documentation) | indent }}{% endif %}
 {% for value in x.values.values() %}{{ mark_documented(value) }}
    .. enumerator:: {{ domain.enumeration_name(value.name) | snakecase }}
 
+{% if value.deprecated %}{{ deprecated(value) | indent(width=6) }}
+
+{% endif %}
 {{ gendoc(value.documentation) | indent(width=6) }}
 
 {% if hasdoc(value.documentation, './remarks') %}{{ remarks(value.documentation) | indent(width=6) }}{% endif %}
@@ -134,6 +158,9 @@
 .. namespace:: krpc::services::{{ x.service_name }}
 .. class:: {{ x.name }}
 
+{% if x.deprecated %}{{ deprecated(x) | indent }}
+
+{% endif %}
 {{ gendoc(x.documentation) | indent }}
 
 {% if hasdoc(x.documentation, './remarks') %}{{ remarks(x.documentation) | indent }}{% endif %}
@@ -170,6 +197,10 @@
 .. note::
 
 {{ gendoc(x, './remarks') | indent }}
+{% endmacro %}
+
+{% macro deprecated(x) %}
+.. warning:: Deprecated.{% if x.deprecated_reason != '' %} {{ x.deprecated_reason }}{% endif %}
 {% endmacro %}
 
 {% macro game_scenes(x) %}

--- a/tools/krpctools/krpctools/docgen/csharp.tmpl
+++ b/tools/krpctools/krpctools/docgen/csharp.tmpl
@@ -1,6 +1,9 @@
 {% macro service(x) %}{{ mark_documented(x) }}
 .. class:: {{ x.name }}
 
+{% if x.deprecated %}{{ deprecated(x) | indent }}
+
+{% endif %}
 {{ gendoc(x.documentation) | indent }}
 
 {% for member in x.members.values() %}
@@ -16,6 +19,9 @@
 {% macro class(x) %}{{ mark_documented(x) }}
 .. class:: {{ x.name }}
 
+{% if x.deprecated %}{{ deprecated(x) | indent }}
+
+{% endif %}
 {{ gendoc(x.documentation) | indent }}
 
 {% if hasdoc(x.documentation, './remarks') %}{{ remarks(x.documentation) | indent }}
@@ -36,6 +42,9 @@
 {% macro procedure(x) %}{{ mark_documented(x) }}
 .. method:: {{ domain.return_type(x.return_type) }} {{ x.name }}({{ parameters(x.parameters) }})
 
+{% if x.deprecated %}{{ deprecated(x) | indent }}
+
+{% endif %}
 {{ gendoc(x.documentation) | indent }}
 
 {{ parameters_description(x.parameters) }}
@@ -55,6 +64,9 @@
 {% macro property(x) %}{{ mark_documented(x) }}
 .. property:: {{ domain.return_type(x.type) }} {{ x.name }} {{'{'}}{% if x.getter != None %} get;{% endif %}{% if x.setter != None %} set;{% endif %} {{'}'}}
 
+{% if x.deprecated %}{{ deprecated(x) | indent }}
+
+{% endif %}
 {{ gendoc(x.documentation) | indent }}
 
 {% if hasdoc(x.documentation, './returns') %}{{ returns(x.documentation) | indent }}
@@ -73,6 +85,9 @@
 {% macro class_method(x) %}{{ mark_documented(x) }}
 .. method:: {{ domain.return_type(x.return_type) }} {{ x.name }}({{ parameters(x.parameters[1:]) }})
 
+{% if x.deprecated %}{{ deprecated(x) | indent }}
+
+{% endif %}
 {{ gendoc(x.documentation) | indent }}
 
 {{ parameters_description(x.parameters[1:]) }}
@@ -92,6 +107,9 @@
 {% macro class_static_method(x) %}{{ mark_documented(x) }}
 .. method:: static {{ domain.return_type(x.return_type) }} {{ x.name }}(IConnection connection, {{ parameters(x.parameters) }})
 
+{% if x.deprecated %}{{ deprecated(x) | indent }}
+
+{% endif %}
 {{ gendoc(x.documentation) | indent }}
 
 {{ parameters_description(x.parameters) }}
@@ -115,12 +133,18 @@
 {% macro enumeration(x) %}{{ mark_documented(x) }}
 .. enum:: {{ x.name }}
 
+{% if x.deprecated %}{{ deprecated(x) | indent }}
+
+{% endif %}
 {{ gendoc(x.documentation) | indent }}
 
 {% if hasdoc(x.documentation, './remarks') %}{{ remarks(x.documentation) | indent }}{% endif %}
 {% for value in x.values.values() %}{{ mark_documented(value) }}
    .. value:: {{ value.name }}
 
+{% if value.deprecated %}{{ deprecated(value) | indent(width=6) }}
+
+{% endif %}
 {{ gendoc(value.documentation) | indent(width=6) }}
 
 {% if hasdoc(value.documentation, './remarks') %}{{ remarks(value.documentation) | indent(width=6) }}{% endif %}
@@ -130,6 +154,9 @@
 {% macro exception(x) %}{{ mark_documented(x) }}
 .. class:: {{ x.name }}
 
+{% if x.deprecated %}{{ deprecated(x) | indent }}
+
+{% endif %}
 {{ gendoc(x.documentation) | indent }}
 
 {% if hasdoc(x.documentation, './remarks') %}{{ remarks(x.documentation) | indent }}{% endif %}
@@ -166,6 +193,10 @@
 .. note::
 
 {{ gendoc(x, './remarks') | indent }}
+{% endmacro %}
+
+{% macro deprecated(x) %}
+.. warning:: Deprecated.{% if x.deprecated_reason != '' %} {{ x.deprecated_reason }}{% endif %}
 {% endmacro %}
 
 {% macro game_scenes(x) %}

--- a/tools/krpctools/krpctools/docgen/java.tmpl
+++ b/tools/krpctools/krpctools/docgen/java.tmpl
@@ -1,6 +1,9 @@
 {% macro service(x) %}{{ mark_documented(x) }}
 .. type:: public class {{ x.name }}
 
+{% if x.deprecated %}{{ deprecated(x) | indent }}
+
+{% endif %}
 {{ gendoc(x.documentation) | indent }}
 
 {% for member in x.members.values() %}
@@ -16,6 +19,9 @@
 {% macro class(x) %}{{ mark_documented(x) }}
 .. type:: public class {{ x.name }}
 
+{% if x.deprecated %}{{ deprecated(x) | indent }}
+
+{% endif %}
 {{ gendoc(x.documentation) | indent }}
 
 {% if hasdoc(x.documentation, './remarks') %}{{ remarks(x.documentation) | indent }}
@@ -36,6 +42,9 @@
 {% macro procedure(x) %}{{ mark_documented(x) }}
 .. method:: {{ domain.return_type(x.return_type) }} {{ domain.method_name(x.name) | lower_camelcase  }}({{ parameters(x.parameters) }})
 
+{% if x.deprecated %}{{ deprecated(x) | indent }}
+
+{% endif %}
 {{ gendoc(x.documentation) | indent }}
 
 {% for p in x.parameters %}
@@ -62,6 +71,9 @@
 .. method:: void set{{ domain.method_name(x.name) }}({{ domain.parameter_type(x.type) }} value)
 {% endif %}
 
+{% if x.deprecated %}{{ deprecated(x) | indent }}
+
+{% endif %}
 {{ gendoc(x.documentation) | indent }}
 
 {% if hasdoc(x.documentation, './returns') %}{{ returns(x.documentation) | indent }}
@@ -78,6 +90,9 @@
 {% macro class_method(x) %}{{ mark_documented(x) }}
 .. method:: {{ domain.return_type(x.return_type) }} {{ domain.method_name(x.name) | lower_camelcase }}({{ parameters(x.parameters[1:]) }})
 
+{% if x.deprecated %}{{ deprecated(x) | indent }}
+
+{% endif %}
 {{ gendoc(x.documentation) | indent }}
 
 {% for p in x.parameters[1:] %}
@@ -98,6 +113,9 @@
 {% macro class_static_method(x) %}{{ mark_documented(x) }}
 .. method:: static {{ domain.return_type(x.return_type) }} {{ domain.method_name(x.name) | lower_camelcase }}(Connection connection{% if x.parameters | length > 0 %}, {% endif %}{{ parameters(x.parameters) }})
 
+{% if x.deprecated %}{{ deprecated(x) | indent }}
+
+{% endif %}
 {{ gendoc(x.documentation) | indent }}
 
 {% for p in x.parameters %}
@@ -122,12 +140,18 @@
 {% macro enumeration(x) %}{{ mark_documented(x) }}
 .. type:: public enum {{ x.name }}
 
+{% if x.deprecated %}{{ deprecated(x) | indent }}
+
+{% endif %}
 {{ gendoc(x.documentation) | indent }}
 
 {% if hasdoc(x.documentation, './remarks') %}{{ remarks(x.documentation) | indent }}{% endif %}
 {% for value in x.values.values() %}{{ mark_documented(value) }}
    .. field:: public {{ x.name }} {{ value.name | snakecase | upper }}
 
+{% if value.deprecated %}{{ deprecated(value) | indent(width=6) }}
+
+{% endif %}
 {{ gendoc(value.documentation) | indent(width=6) }}
 
 {% if hasdoc(value.documentation, './remarks') %}{{ remarks(value.documentation) | indent(width=6) }}{% endif %}
@@ -137,6 +161,9 @@
 {% macro exception(x) %}{{ mark_documented(x) }}
 .. type:: public class {{ x.name }}
 
+{% if x.deprecated %}{{ deprecated(x) | indent }}
+
+{% endif %}
 {{ gendoc(x.documentation) | indent }}
 
 {% if hasdoc(x.documentation, './remarks') %}{{ remarks(x.documentation) | indent }}{% endif %}
@@ -156,6 +183,10 @@
 .. note::
 
 {{ gendoc(x, './remarks') | indent }}
+{% endmacro %}
+
+{% macro deprecated(x) %}
+.. warning:: Deprecated.{% if x.deprecated_reason != '' %} {{ x.deprecated_reason }}{% endif %}
 {% endmacro %}
 
 {% macro game_scenes(x) %}

--- a/tools/krpctools/krpctools/docgen/lua.tmpl
+++ b/tools/krpctools/krpctools/docgen/lua.tmpl
@@ -1,6 +1,9 @@
 {% macro service(x) %}{{ mark_documented(x) }}
 .. module:: {{ x.name }}
 
+{% if x.deprecated %}{{ deprecated(x) }}
+
+{% endif %}
 {{ gendoc(x.documentation) }}
 
 {% for member in x.members.values() %}
@@ -16,6 +19,9 @@
 {% macro class(x) %}{{ mark_documented(x) }}
 .. class:: {{ x.name }}
 
+{% if x.deprecated %}{{ deprecated(x) | indent }}
+
+{% endif %}
 {{ gendoc(x.documentation) | indent }}
 
 {% if hasdoc(x.documentation, './remarks') %}{{ remarks(x.documentation) | indent }}
@@ -36,6 +42,9 @@
 {% macro procedure(x) %}{{ mark_documented(x) }}
 .. staticmethod:: {{ x.name | snakecase }}({{ parameters(x.parameters) }})
 
+{% if x.deprecated %}{{ deprecated(x) | indent }}
+
+{% endif %}
 {{ gendoc(x.documentation) | indent }}
 
 {% for p in x.parameters %}
@@ -58,6 +67,9 @@
 {% macro property(x) %}{{ mark_documented(x) }}
 .. attribute:: {{ x.name | snakecase }}: {{ domain.type(x.type) }}
 
+{% if x.deprecated %}{{ deprecated(x) | indent }}
+
+{% endif %}
 {{ gendoc(x.documentation) | indent }}
 
    :Attribute: {% if x.getter != None and x.setter != None %}Can be read or written{% elif x.getter != None %}Read-only, cannot be set{% else %}Write-only, cannot be read{% endif %}
@@ -76,6 +88,9 @@
 {% macro class_method(x) %}{{ mark_documented(x) }}
 .. method:: {{ x.name | snakecase }}({{ parameters(x.parameters[1:]) }})
 
+{% if x.deprecated %}{{ deprecated(x) | indent }}
+
+{% endif %}
 {{ gendoc(x.documentation) | indent }}
 
 {% for p in x.parameters[1:] %}
@@ -98,6 +113,9 @@
 {% macro class_static_method(x) %}{{ mark_documented(x) }}
 .. staticmethod:: {{ x.name | snakecase }}({{ parameters(x.parameters) }})
 
+{% if x.deprecated %}{{ deprecated(x) | indent }}
+
+{% endif %}
 {{ gendoc(x.documentation) | indent }}
 
 {% for p in x.parameters %}
@@ -124,12 +142,18 @@
 {% macro enumeration(x) %}{{ mark_documented(x) }}
 .. class:: {{ x.name }}
 
+{% if x.deprecated %}{{ deprecated(x) | indent }}
+
+{% endif %}
 {{ gendoc(x.documentation) | indent }}
 
 {% if hasdoc(x.documentation, './remarks') %}{{ remarks(x.documentation) | indent }}{% endif %}
 {% for value in x.values.values() %}{{ mark_documented(value) }}
    .. data:: {{ value.name | snakecase }}
 
+{% if value.deprecated %}{{ deprecated(value) | indent(width=6) }}
+
+{% endif %}
 {{ gendoc(value.documentation) | indent(width=6) }}
 
 {% if hasdoc(value.documentation, './remarks') %}{{ remarks(value.documentation) | indent(width=6) }}{% endif %}
@@ -139,6 +163,9 @@
 {% macro exception(x) %}{{ mark_documented(x) }}
 .. class:: {{ x.name }}
 
+{% if x.deprecated %}{{ deprecated(x) | indent }}
+
+{% endif %}
 {{ gendoc(x.documentation) | indent }}
 
 {% if hasdoc(x.documentation, './remarks') %}{{ remarks(x.documentation) | indent }}{% endif %}
@@ -164,4 +191,8 @@
 .. note::
 
 {{ gendoc(x, './remarks') | indent }}
+{% endmacro %}
+
+{% macro deprecated(x) %}
+.. warning:: Deprecated.{% if x.deprecated_reason != '' %} {{ x.deprecated_reason }}{% endif %}
 {% endmacro %}

--- a/tools/krpctools/krpctools/docgen/nodes.py
+++ b/tools/krpctools/krpctools/docgen/nodes.py
@@ -20,12 +20,23 @@ class Appendable:
 
 class Service(Appendable):
     def __init__(
-        self, name, procedures, classes, enumerations, exceptions, documentation, sort
+        self,
+        name,
+        procedures,
+        classes,
+        enumerations,
+        exceptions,
+        documentation,
+        sort,
+        deprecated=False,
+        deprecated_reason="",
     ):
         super().__init__()
         self.name = name
         self.fullname = name
         self.documentation = documentation
+        self.deprecated = deprecated
+        self.deprecated_reason = deprecated_reason
         self.cref = "T:%s" % name
 
         members = []
@@ -87,12 +98,23 @@ class Service(Appendable):
 
 
 class Class(Appendable):
-    def __init__(self, service_name, name, procedures, documentation, sort):
+    def __init__(
+        self,
+        service_name,
+        name,
+        procedures,
+        documentation,
+        sort,
+        deprecated=False,
+        deprecated_reason="",
+    ):
         super().__init__()
         self.service_name = service_name
         self.name = name
         self.fullname = service_name + "." + name
         self.documentation = documentation
+        self.deprecated = deprecated
+        self.deprecated_reason = deprecated_reason
         self.cref = "T:%s.%s" % (service_name, name)
 
         members = []
@@ -150,6 +172,8 @@ class Procedure(Appendable):
         return_type=None,
         return_is_nullable=False,
         game_scenes=None,
+        deprecated=False,
+        deprecated_reason="",
     ):
         super().__init__()
         self.service_name = service_name
@@ -165,6 +189,8 @@ class Procedure(Appendable):
         ]
         self.game_scenes = game_scenes
         self.documentation = documentation
+        self.deprecated = deprecated
+        self.deprecated_reason = deprecated_reason
         self.cref = "M:%s.%s" % (service_name, name)
 
 
@@ -180,10 +206,14 @@ class Property(Appendable):
             self.type = getter.return_type
             self.game_scenes = getter.game_scenes
             self.documentation = getter.documentation
+            self.deprecated = getter.deprecated
+            self.deprecated_reason = getter.deprecated_reason
         else:
             self.type = setter.parameters[0].type
             self.game_scenes = setter.game_scenes
             self.documentation = setter.documentation
+            self.deprecated = setter.deprecated
+            self.deprecated_reason = setter.deprecated_reason
         self.getter = getter
         self.setter = setter
         self.cref = "M:%s.%s" % (service_name, name)
@@ -202,6 +232,8 @@ class ClassMethod(Appendable):
         return_type=None,
         return_is_nullable=False,
         game_scenes=None,
+        deprecated=False,
+        deprecated_reason="",
     ):
         super().__init__()
         name = Attributes.get_class_member_name(name)
@@ -219,6 +251,8 @@ class ClassMethod(Appendable):
         ]
         self.game_scenes = game_scenes
         self.documentation = documentation
+        self.deprecated = deprecated
+        self.deprecated_reason = deprecated_reason
         self.cref = "M:%s.%s.%s" % (service_name, class_name, name)
 
 
@@ -235,6 +269,8 @@ class ClassStaticMethod(Appendable):
         return_type=None,
         return_is_nullable=False,
         game_scenes=None,
+        deprecated=False,
+        deprecated_reason="",
     ):
         super().__init__()
         name = Attributes.get_class_member_name(name)
@@ -252,6 +288,8 @@ class ClassStaticMethod(Appendable):
         ]
         self.game_scenes = game_scenes
         self.documentation = documentation
+        self.deprecated = deprecated
+        self.deprecated_reason = deprecated_reason
         self.cref = "M:%s.%s.%s" % (service_name, class_name, name)
 
 
@@ -266,10 +304,14 @@ class ClassProperty(Appendable):
             self.type = getter.return_type
             self.game_scenes = getter.game_scenes
             self.documentation = getter.documentation
+            self.deprecated = getter.deprecated
+            self.deprecated_reason = getter.deprecated_reason
         else:
             self.type = setter.parameters[1].type
             self.game_scenes = setter.game_scenes
             self.documentation = setter.documentation
+            self.deprecated = setter.deprecated
+            self.deprecated_reason = setter.deprecated_reason
         self.name = name
         self.fullname = service_name + "." + class_name + "." + name
         self.getter = getter
@@ -278,7 +320,16 @@ class ClassProperty(Appendable):
 
 
 class Enumeration(Appendable):
-    def __init__(self, service_name, name, values, documentation, sort):
+    def __init__(
+        self,
+        service_name,
+        name,
+        values,
+        documentation,
+        sort,
+        deprecated=False,
+        deprecated_reason="",
+    ):
         super().__init__()
         self.service_name = service_name
         self.name = name
@@ -286,11 +337,22 @@ class Enumeration(Appendable):
         values = (EnumerationValue(service_name, name, **value) for value in values)
         self.values = OrderedDict((v.name, v) for v in sorted(values, key=sort))
         self.documentation = documentation
+        self.deprecated = deprecated
+        self.deprecated_reason = deprecated_reason
         self.cref = "T:%s.%s" % (service_name, name)
 
 
 class EnumerationValue(Appendable):
-    def __init__(self, service_name, enum_name, name, value, documentation):
+    def __init__(
+        self,
+        service_name,
+        enum_name,
+        name,
+        value,
+        documentation,
+        deprecated=False,
+        deprecated_reason="",
+    ):
         super().__init__()
         self.service_name = service_name
         self.enum_name = enum_name
@@ -298,14 +360,20 @@ class EnumerationValue(Appendable):
         self.fullname = service_name + "." + enum_name + "." + name
         self.value = value
         self.documentation = documentation
+        self.deprecated = deprecated
+        self.deprecated_reason = deprecated_reason
         self.cref = "M:%s.%s.%s" % (service_name, enum_name, name)
 
 
 class ExceptionNode(Appendable):
-    def __init__(self, service_name, name, documentation):
+    def __init__(
+        self, service_name, name, documentation, deprecated=False, deprecated_reason=""
+    ):
         super().__init__()
         self.service_name = service_name
         self.name = name
         self.fullname = service_name + "." + name
         self.documentation = documentation
+        self.deprecated = deprecated
+        self.deprecated_reason = deprecated_reason
         self.cref = "T:%s.%s" % (service_name, name)

--- a/tools/krpctools/krpctools/docgen/python.tmpl
+++ b/tools/krpctools/krpctools/docgen/python.tmpl
@@ -1,6 +1,9 @@
 {% macro service(x) %}{{ mark_documented(x) }}
 .. module:: {{ x.name }}
 
+{% if x.deprecated %}{{ deprecated(x) }}
+
+{% endif %}
 {{ gendoc(x.documentation) }}
 
 {% for member in x.members.values() %}
@@ -16,6 +19,9 @@
 {% macro class(x) %}{{ mark_documented(x) }}
 .. class:: {{ x.name }}
 
+{% if x.deprecated %}{{ deprecated(x) | indent }}
+
+{% endif %}
 {{ gendoc(x.documentation) | indent }}
 
 {% if hasdoc(x.documentation, './remarks') %}{{ remarks(x.documentation) | indent }}
@@ -36,6 +42,9 @@
 {% macro procedure(x) %}{{ mark_documented(x) }}
 .. staticmethod:: {{ domain.method_name(x.name) }}({{ parameters(x.parameters) }})
 
+{% if x.deprecated %}{{ deprecated(x) | indent }}
+
+{% endif %}
 {{ gendoc(x.documentation) | indent }}
 
 {% for p in x.parameters %}
@@ -59,6 +68,9 @@
 {% macro property(x) %}{{ mark_documented(x) }}
 .. attribute:: {{ domain.method_name(x.name) }}
 
+{% if x.deprecated %}{{ deprecated(x) | indent }}
+
+{% endif %}
 {{ gendoc(x.documentation) | indent }}
 
    :Attribute: {% if x.getter != None and x.setter != None %}Can be read or written{% elif x.getter != None %}Read-only, cannot be set{% else %}Write-only, cannot be read{% endif %}
@@ -78,6 +90,9 @@
 {% macro class_method(x) %}{{ mark_documented(x) }}
 .. method:: {{ domain.method_name(x.name) }}({{ parameters(x.parameters[1:]) }})
 
+{% if x.deprecated %}{{ deprecated(x) | indent }}
+
+{% endif %}
 {{ gendoc(x.documentation) | indent }}
 
 {% for p in x.parameters[1:] %}
@@ -101,6 +116,9 @@
 {% macro class_static_method(x) %}{{ mark_documented(x) }}
 .. staticmethod:: {{ domain.method_name(x.name) }}({{ parameters(x.parameters) }})
 
+{% if x.deprecated %}{{ deprecated(x) | indent }}
+
+{% endif %}
 {{ gendoc(x.documentation) | indent }}
 
 {% for p in x.parameters %}
@@ -128,12 +146,18 @@
 {% macro enumeration(x) %}{{ mark_documented(x) }}
 .. class:: {{ x.name }}
 
+{% if x.deprecated %}{{ deprecated(x) | indent }}
+
+{% endif %}
 {{ gendoc(x.documentation) | indent }}
 
 {% if hasdoc(x.documentation, './remarks') %}{{ remarks(x.documentation) | indent }}{% endif %}
 {% for value in x.values.values() %}{{ mark_documented(value) }}
    .. data:: {{ value.name | snakecase }}
 
+{% if value.deprecated %}{{ deprecated(value) | indent(width=6) }}
+
+{% endif %}
 {{ gendoc(value.documentation) | indent(width=6) }}
 
 {% if hasdoc(value.documentation, './remarks') %}{{ remarks(value.documentation) | indent(width=6) }}{% endif %}
@@ -143,6 +167,9 @@
 {% macro exception(x) %}{{ mark_documented(x) }}
 .. class:: {{ x.name }}
 
+{% if x.deprecated %}{{ deprecated(x) | indent }}
+
+{% endif %}
 {{ gendoc(x.documentation) | indent }}
 
 {% if hasdoc(x.documentation, './remarks') %}{{ remarks(x.documentation) | indent }}{% endif %}
@@ -168,6 +195,10 @@
 .. note::
 
 {{ gendoc(x, './remarks') | indent }}
+{% endmacro %}
+
+{% macro deprecated(x) %}
+.. warning:: Deprecated.{% if x.deprecated_reason != '' %} {{ x.deprecated_reason }}{% endif %}
 {% endmacro %}
 
 {% macro game_scenes(x) %}

--- a/tools/krpctools/krpctools/test/clientgen-Empty-cnano.txt
+++ b/tools/krpctools/krpctools/test/clientgen-Empty-cnano.txt
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <krpc_cnano/decoder.h>
+#include <krpc_cnano/deprecated.h>
 #include <krpc_cnano/encoder.h>
 #include <krpc_cnano/error.h>
 #include <krpc_cnano/memory.h>

--- a/tools/krpctools/krpctools/test/clientgen-Empty-csharp.txt
+++ b/tools/krpctools/krpctools/test/clientgen-Empty-csharp.txt
@@ -11,6 +11,10 @@ using systemAlias = global::System;
 using genericCollectionsAlias = global::System.Collections.Generic;
 #endif
 
+// Generated code references its own deprecated members (e.g. when registering
+// exception types), so suppress the deprecation warnings within this file.
+#pragma warning disable 612, 618
+
 namespace KRPC.Client.Services.EmptyService
 {
     /// <summary>

--- a/tools/krpctools/krpctools/test/clientgen-Empty-java.txt
+++ b/tools/krpctools/krpctools/test/clientgen-Empty-java.txt
@@ -10,6 +10,9 @@ import krpc.client.RPCInfo;
 import krpc.client.RPCException;
 import krpc.client.Types;
 
+// Generated code references its own deprecated members (e.g. when registering
+// exception types), so suppress the deprecation warnings within this class.
+@SuppressWarnings("deprecation")
 public class EmptyService {
 
     public static EmptyService newInstance(Connection connection) {

--- a/tools/krpctools/krpctools/test/clientgen-Empty-python.txt
+++ b/tools/krpctools/krpctools/test/clientgen-Empty-python.txt
@@ -1,0 +1,52 @@
+# pylint: disable=line-too-long,invalid-name,redefined-builtin,too-many-lines
+from __future__ import annotations
+import warnings
+from typing import Tuple, Set, Dict, List, Optional, TYPE_CHECKING
+import krpc.schema
+from krpc.schema import KRPC_pb2
+from krpc.types import TypeBase, ClassBase, WrappedClass, DocEnum, StaticMethod
+from krpc.event import Event
+if TYPE_CHECKING:
+    from krpc.services import Client
+
+
+class EmptyService:
+
+    def __init__(self, client: Client) -> None:
+        self._client = client
+
+    def __getattribute__(self, name):
+        # Intercepts calls to obtain classes from the service,
+        # to inject the client instance so that it can be used
+        # for static method calls
+        classes = object.__getattribute__(self, "_classes")
+        if name in classes:
+            client = object.__getattribute__(self, "_client")
+            return WrappedClass(client, classes[name])
+
+        # Intercept calls to obtain enumeration types
+        enumerations = object.__getattribute__(self, "_enumerations")
+        if name in enumerations:
+           return enumerations[name]
+
+        # Intercept calls to obtain exception types
+        exceptions = object.__getattribute__(self, "_exceptions")
+        if name in exceptions:
+           return exceptions[name]
+
+        # Fall back to default behaviour
+        return object.__getattribute__(self, name)
+
+    def __dir__(self):
+        result = object.__dir__(self)
+        result.extend(object.__getattribute__(self, "_classes").keys())
+        result.extend(object.__getattribute__(self, "_enumerations").keys())
+        result.extend(object.__getattribute__(self, "_exceptions").keys())
+        return result
+
+    _classes = {
+    }
+    _enumerations = {
+    }
+    _exceptions = {
+    }

--- a/tools/krpctools/krpctools/test/clientgen-TestService-cnano.txt
+++ b/tools/krpctools/krpctools/test/clientgen-TestService-cnano.txt
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <krpc_cnano/decoder.h>
+#include <krpc_cnano/deprecated.h>
 #include <krpc_cnano/encoder.h>
 #include <krpc_cnano/error.h>
 #include <krpc_cnano/memory.h>
@@ -12,6 +13,10 @@
 extern "C" {
 #endif
 
+/**
+ * Deprecated class documentation string.
+ */
+typedef krpc_object_t krpc_TestService_DeprecatedClass_t;
 /**
  * Class documentation string.
  */
@@ -196,6 +201,20 @@ krpc_error_t krpc_decode_tuple_int32_int64(
 #endif  // KRPC_TYPE_TUPLE_INT32_INT64
 
 /**
+ * Deprecated enum documentation string.
+ */
+typedef enum {
+  /**
+   * Deprecated enum ValueA documentation string.
+   */
+  KRPC_TESTSERVICE_DEPRECATEDENUM_VALUEA = 0,
+  /**
+   * Deprecated enum ValueB documentation string.
+   */
+  KRPC_TESTSERVICE_DEPRECATEDENUM_VALUEB = 1
+} krpc_TestService_DeprecatedEnum_t;
+
+/**
  * Enum documentation string.
  */
 typedef enum {
@@ -226,6 +245,18 @@ krpc_error_t krpc_TestService_BytesToHexString(krpc_connection_t connection, cha
 krpc_error_t krpc_TestService_Counter(krpc_connection_t connection, int32_t * returnValue, const char * id, int32_t divisor);
 
 krpc_error_t krpc_TestService_CreateTestObject(krpc_connection_t connection, krpc_TestService_TestClass_t * returnValue, const char * value);
+
+/**
+ * Deprecated procedure documentation string.
+ */
+KRPC_DEPRECATED("Use FloatToString instead.")
+krpc_error_t krpc_TestService_DeprecatedProcedure(krpc_connection_t connection, char * * returnValue, float value);
+
+/**
+ * Deprecated procedure with no reason documentation string.
+ */
+KRPC_DEPRECATED("")
+krpc_error_t krpc_TestService_DeprecatedProcedureNoMessage(krpc_connection_t connection, char * * returnValue, float value);
 
 krpc_error_t krpc_TestService_DictionaryDefault(krpc_connection_t connection, krpc_dictionary_int32_bool_t * returnValue, const krpc_dictionary_int32_bool_t * x);
 
@@ -292,6 +323,18 @@ krpc_error_t krpc_TestService_ThrowInvalidOperationExceptionLater(krpc_connectio
 
 krpc_error_t krpc_TestService_TupleDefault(krpc_connection_t connection, krpc_tuple_int32_bool_t * returnValue, const krpc_tuple_int32_bool_t * x);
 
+/**
+ * Deprecated property documentation string.
+ */
+KRPC_DEPRECATED("Use StringProperty instead.")
+krpc_error_t krpc_TestService_DeprecatedProperty(krpc_connection_t connection, char * * returnValue);
+
+/**
+ * Deprecated property documentation string.
+ */
+KRPC_DEPRECATED("Use StringProperty instead.")
+krpc_error_t krpc_TestService_set_DeprecatedProperty(krpc_connection_t connection, const char * value);
+
 krpc_error_t krpc_TestService_ObjectProperty(krpc_connection_t connection, krpc_TestService_TestClass_t * returnValue);
 
 krpc_error_t krpc_TestService_set_ObjectProperty(krpc_connection_t connection, krpc_TestService_TestClass_t value);
@@ -309,6 +352,12 @@ krpc_error_t krpc_TestService_set_StringProperty(krpc_connection_t connection, c
 krpc_error_t krpc_TestService_set_StringPropertyPrivateGet(krpc_connection_t connection, const char * value);
 
 krpc_error_t krpc_TestService_StringPropertyPrivateSet(krpc_connection_t connection, char * * returnValue);
+
+/**
+ * Deprecated method documentation string.
+ */
+KRPC_DEPRECATED("Use TestClass.GetValue instead.")
+krpc_error_t krpc_TestService_DeprecatedClass_DeprecatedMethod(krpc_connection_t connection, char * * returnValue, krpc_TestService_DeprecatedClass_t instance);
 
 krpc_error_t krpc_TestService_TestClass_FloatToString(krpc_connection_t connection, char * * returnValue, krpc_TestService_TestClass_t instance, float x);
 
@@ -1284,6 +1333,40 @@ inline krpc_error_t krpc_TestService_CreateTestObject(krpc_connection_t connecti
   return KRPC_OK;
 }
 
+inline krpc_error_t krpc_TestService_DeprecatedProcedure(krpc_connection_t connection, char * * returnValue, float value) {
+  krpc_call_t _call;
+  krpc_argument_t _arguments[1];
+  KRPC_CHECK(krpc_call(&_call, 9999, 39, 1, _arguments));
+  KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_float, &value));
+  krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
+  KRPC_CHECK(krpc_init_result(&_result));
+  KRPC_CHECK(krpc_invoke(connection, &_result.message, &_call.message));
+  if (returnValue) {
+    pb_istream_t _stream;
+    KRPC_CHECK(krpc_get_return_value(&_result, &_stream));
+    KRPC_CHECK(krpc_decode_string(&_stream, returnValue));
+  }
+  KRPC_CHECK(krpc_free_result(&_result));
+  return KRPC_OK;
+}
+
+inline krpc_error_t krpc_TestService_DeprecatedProcedureNoMessage(krpc_connection_t connection, char * * returnValue, float value) {
+  krpc_call_t _call;
+  krpc_argument_t _arguments[1];
+  KRPC_CHECK(krpc_call(&_call, 9999, 40, 1, _arguments));
+  KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_float, &value));
+  krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
+  KRPC_CHECK(krpc_init_result(&_result));
+  KRPC_CHECK(krpc_invoke(connection, &_result.message, &_call.message));
+  if (returnValue) {
+    pb_istream_t _stream;
+    KRPC_CHECK(krpc_get_return_value(&_result, &_stream));
+    KRPC_CHECK(krpc_decode_string(&_stream, returnValue));
+  }
+  KRPC_CHECK(krpc_free_result(&_result));
+  return KRPC_OK;
+}
+
 inline krpc_error_t krpc_TestService_DictionaryDefault(krpc_connection_t connection, krpc_dictionary_int32_bool_t * returnValue, const krpc_dictionary_int32_bool_t * x) {
   krpc_call_t _call;
   krpc_argument_t _arguments[1];
@@ -1787,9 +1870,36 @@ inline krpc_error_t krpc_TestService_TupleDefault(krpc_connection_t connection, 
   return KRPC_OK;
 }
 
+inline krpc_error_t krpc_TestService_DeprecatedProperty(krpc_connection_t connection, char * * returnValue) {
+  krpc_call_t _call;
+  KRPC_CHECK(krpc_call(&_call, 9999, 47, 0, NULL));
+  krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
+  KRPC_CHECK(krpc_init_result(&_result));
+  KRPC_CHECK(krpc_invoke(connection, &_result.message, &_call.message));
+  if (returnValue) {
+    pb_istream_t _stream;
+    KRPC_CHECK(krpc_get_return_value(&_result, &_stream));
+    KRPC_CHECK(krpc_decode_string(&_stream, returnValue));
+  }
+  KRPC_CHECK(krpc_free_result(&_result));
+  return KRPC_OK;
+}
+
+inline krpc_error_t krpc_TestService_set_DeprecatedProperty(krpc_connection_t connection, const char * value) {
+  krpc_call_t _call;
+  krpc_argument_t _arguments[1];
+  KRPC_CHECK(krpc_call(&_call, 9999, 48, 1, _arguments));
+  KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_string, &value));
+  krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
+  KRPC_CHECK(krpc_init_result(&_result));
+  KRPC_CHECK(krpc_invoke(connection, &_result.message, &_call.message));
+  KRPC_CHECK(krpc_free_result(&_result));
+  return KRPC_OK;
+}
+
 inline krpc_error_t krpc_TestService_ObjectProperty(krpc_connection_t connection, krpc_TestService_TestClass_t * returnValue) {
   krpc_call_t _call;
-  KRPC_CHECK(krpc_call(&_call, 9999, 43, 0, NULL));
+  KRPC_CHECK(krpc_call(&_call, 9999, 45, 0, NULL));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
   KRPC_CHECK(krpc_invoke(connection, &_result.message, &_call.message));
@@ -1805,7 +1915,7 @@ inline krpc_error_t krpc_TestService_ObjectProperty(krpc_connection_t connection
 inline krpc_error_t krpc_TestService_set_ObjectProperty(krpc_connection_t connection, krpc_TestService_TestClass_t value) {
   krpc_call_t _call;
   krpc_argument_t _arguments[1];
-  KRPC_CHECK(krpc_call(&_call, 9999, 44, 1, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 46, 1, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_object, &value));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
@@ -1816,7 +1926,7 @@ inline krpc_error_t krpc_TestService_set_ObjectProperty(krpc_connection_t connec
 
 inline krpc_error_t krpc_TestService_StringProperty(krpc_connection_t connection, char * * returnValue) {
   krpc_call_t _call;
-  KRPC_CHECK(krpc_call(&_call, 9999, 39, 0, NULL));
+  KRPC_CHECK(krpc_call(&_call, 9999, 41, 0, NULL));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
   KRPC_CHECK(krpc_invoke(connection, &_result.message, &_call.message));
@@ -1832,7 +1942,7 @@ inline krpc_error_t krpc_TestService_StringProperty(krpc_connection_t connection
 inline krpc_error_t krpc_TestService_set_StringProperty(krpc_connection_t connection, const char * value) {
   krpc_call_t _call;
   krpc_argument_t _arguments[1];
-  KRPC_CHECK(krpc_call(&_call, 9999, 40, 1, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 42, 1, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_string, &value));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
@@ -1844,7 +1954,7 @@ inline krpc_error_t krpc_TestService_set_StringProperty(krpc_connection_t connec
 inline krpc_error_t krpc_TestService_set_StringPropertyPrivateGet(krpc_connection_t connection, const char * value) {
   krpc_call_t _call;
   krpc_argument_t _arguments[1];
-  KRPC_CHECK(krpc_call(&_call, 9999, 41, 1, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 43, 1, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_string, &value));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
@@ -1855,7 +1965,24 @@ inline krpc_error_t krpc_TestService_set_StringPropertyPrivateGet(krpc_connectio
 
 inline krpc_error_t krpc_TestService_StringPropertyPrivateSet(krpc_connection_t connection, char * * returnValue) {
   krpc_call_t _call;
-  KRPC_CHECK(krpc_call(&_call, 9999, 42, 0, NULL));
+  KRPC_CHECK(krpc_call(&_call, 9999, 44, 0, NULL));
+  krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
+  KRPC_CHECK(krpc_init_result(&_result));
+  KRPC_CHECK(krpc_invoke(connection, &_result.message, &_call.message));
+  if (returnValue) {
+    pb_istream_t _stream;
+    KRPC_CHECK(krpc_get_return_value(&_result, &_stream));
+    KRPC_CHECK(krpc_decode_string(&_stream, returnValue));
+  }
+  KRPC_CHECK(krpc_free_result(&_result));
+  return KRPC_OK;
+}
+
+inline krpc_error_t krpc_TestService_DeprecatedClass_DeprecatedMethod(krpc_connection_t connection, char * * returnValue, krpc_TestService_DeprecatedClass_t instance) {
+  krpc_call_t _call;
+  krpc_argument_t _arguments[1];
+  KRPC_CHECK(krpc_call(&_call, 9999, 60, 1, _arguments));
+  KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_uint64, &instance));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
   KRPC_CHECK(krpc_invoke(connection, &_result.message, &_call.message));
@@ -1871,7 +1998,7 @@ inline krpc_error_t krpc_TestService_StringPropertyPrivateSet(krpc_connection_t 
 inline krpc_error_t krpc_TestService_TestClass_FloatToString(krpc_connection_t connection, char * * returnValue, krpc_TestService_TestClass_t instance, float x) {
   krpc_call_t _call;
   krpc_argument_t _arguments[2];
-  KRPC_CHECK(krpc_call(&_call, 9999, 46, 2, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 50, 2, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_uint64, &instance));
   KRPC_CHECK(krpc_add_argument(&_call, 1, &krpc_encode_callback_float, &x));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
@@ -1889,7 +2016,7 @@ inline krpc_error_t krpc_TestService_TestClass_FloatToString(krpc_connection_t c
 inline krpc_error_t krpc_TestService_TestClass_GetValue(krpc_connection_t connection, char * * returnValue, krpc_TestService_TestClass_t instance) {
   krpc_call_t _call;
   krpc_argument_t _arguments[1];
-  KRPC_CHECK(krpc_call(&_call, 9999, 45, 1, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 49, 1, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_uint64, &instance));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
@@ -1906,7 +2033,7 @@ inline krpc_error_t krpc_TestService_TestClass_GetValue(krpc_connection_t connec
 inline krpc_error_t krpc_TestService_TestClass_ObjectToString(krpc_connection_t connection, char * * returnValue, krpc_TestService_TestClass_t instance, krpc_TestService_TestClass_t other) {
   krpc_call_t _call;
   krpc_argument_t _arguments[2];
-  KRPC_CHECK(krpc_call(&_call, 9999, 47, 2, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 51, 2, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_uint64, &instance));
   KRPC_CHECK(krpc_add_argument(&_call, 1, &krpc_encode_callback_object, &other));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
@@ -1924,7 +2051,7 @@ inline krpc_error_t krpc_TestService_TestClass_ObjectToString(krpc_connection_t 
 inline krpc_error_t krpc_TestService_TestClass_OptionalArguments(krpc_connection_t connection, char * * returnValue, krpc_TestService_TestClass_t instance, const char * x, const char * y, const char * z, krpc_TestService_TestClass_t obj) {
   krpc_call_t _call;
   krpc_argument_t _arguments[5];
-  KRPC_CHECK(krpc_call(&_call, 9999, 48, 5, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 52, 5, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_uint64, &instance));
   KRPC_CHECK(krpc_add_argument(&_call, 1, &krpc_encode_callback_string, &x));
   KRPC_CHECK(krpc_add_argument(&_call, 2, &krpc_encode_callback_string, &y));
@@ -1945,7 +2072,7 @@ inline krpc_error_t krpc_TestService_TestClass_OptionalArguments(krpc_connection
 inline krpc_error_t krpc_TestService_TestClass_IntProperty(krpc_connection_t connection, int32_t * returnValue, krpc_TestService_TestClass_t instance) {
   krpc_call_t _call;
   krpc_argument_t _arguments[1];
-  KRPC_CHECK(krpc_call(&_call, 9999, 50, 1, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 54, 1, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_uint64, &instance));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
@@ -1962,7 +2089,7 @@ inline krpc_error_t krpc_TestService_TestClass_IntProperty(krpc_connection_t con
 inline krpc_error_t krpc_TestService_TestClass_set_IntProperty(krpc_connection_t connection, krpc_TestService_TestClass_t instance, int32_t value) {
   krpc_call_t _call;
   krpc_argument_t _arguments[2];
-  KRPC_CHECK(krpc_call(&_call, 9999, 51, 2, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 55, 2, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_uint64, &instance));
   KRPC_CHECK(krpc_add_argument(&_call, 1, &krpc_encode_callback_int32, &value));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
@@ -1975,7 +2102,7 @@ inline krpc_error_t krpc_TestService_TestClass_set_IntProperty(krpc_connection_t
 inline krpc_error_t krpc_TestService_TestClass_ObjectProperty(krpc_connection_t connection, krpc_TestService_TestClass_t * returnValue, krpc_TestService_TestClass_t instance) {
   krpc_call_t _call;
   krpc_argument_t _arguments[1];
-  KRPC_CHECK(krpc_call(&_call, 9999, 52, 1, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 56, 1, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_uint64, &instance));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
@@ -1992,7 +2119,7 @@ inline krpc_error_t krpc_TestService_TestClass_ObjectProperty(krpc_connection_t 
 inline krpc_error_t krpc_TestService_TestClass_set_ObjectProperty(krpc_connection_t connection, krpc_TestService_TestClass_t instance, krpc_TestService_TestClass_t value) {
   krpc_call_t _call;
   krpc_argument_t _arguments[2];
-  KRPC_CHECK(krpc_call(&_call, 9999, 53, 2, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 57, 2, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_uint64, &instance));
   KRPC_CHECK(krpc_add_argument(&_call, 1, &krpc_encode_callback_object, &value));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
@@ -2005,7 +2132,7 @@ inline krpc_error_t krpc_TestService_TestClass_set_ObjectProperty(krpc_connectio
 inline krpc_error_t krpc_TestService_TestClass_set_StringPropertyPrivateGet(krpc_connection_t connection, krpc_TestService_TestClass_t instance, const char * value) {
   krpc_call_t _call;
   krpc_argument_t _arguments[2];
-  KRPC_CHECK(krpc_call(&_call, 9999, 54, 2, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 58, 2, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_uint64, &instance));
   KRPC_CHECK(krpc_add_argument(&_call, 1, &krpc_encode_callback_string, &value));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
@@ -2018,7 +2145,7 @@ inline krpc_error_t krpc_TestService_TestClass_set_StringPropertyPrivateGet(krpc
 inline krpc_error_t krpc_TestService_TestClass_StringPropertyPrivateSet(krpc_connection_t connection, char * * returnValue, krpc_TestService_TestClass_t instance) {
   krpc_call_t _call;
   krpc_argument_t _arguments[1];
-  KRPC_CHECK(krpc_call(&_call, 9999, 55, 1, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 59, 1, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_uint64, &instance));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
@@ -2035,7 +2162,7 @@ inline krpc_error_t krpc_TestService_TestClass_StringPropertyPrivateSet(krpc_con
 inline krpc_error_t krpc_TestService_TestClass_StaticMethod(krpc_connection_t connection, char * * returnValue, const char * a, const char * b) {
   krpc_call_t _call;
   krpc_argument_t _arguments[2];
-  KRPC_CHECK(krpc_call(&_call, 9999, 49, 2, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 53, 2, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_string, &a));
   KRPC_CHECK(krpc_add_argument(&_call, 1, &krpc_encode_callback_string, &b));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;

--- a/tools/krpctools/krpctools/test/clientgen-TestService-cpp.txt
+++ b/tools/krpctools/krpctools/test/clientgen-TestService-cpp.txt
@@ -22,11 +22,43 @@ class TestService : public Service {
   explicit TestService(Client* client);
 
   // Class forward declarations
+  class DeprecatedClass;
   class TestClass;
 
   class CustomException : public ::krpc::RPCError {
    public:
     inline explicit CustomException(const std::string& msg) : ::krpc::RPCError(msg) {}
+  };
+
+  /**
+   * Deprecated exception documentation string.
+   *
+   * \deprecated Use CustomException instead.
+   */
+  [[deprecated("Use CustomException instead.")]]
+  class DeprecatedException : public ::krpc::RPCError {
+   public:
+    inline explicit DeprecatedException(const std::string& msg) : ::krpc::RPCError(msg) {}
+  };
+
+  /**
+   * Deprecated enum documentation string.
+   *
+   * \deprecated Use TestEnum instead.
+   */
+  [[deprecated("Use TestEnum instead.")]]
+  enum struct DeprecatedEnum {
+    /**
+     * Deprecated enum ValueA documentation string.
+     */
+    value_a = 0,
+    /**
+     * Deprecated enum ValueB documentation string.
+     *
+     * \deprecated Use ValueA instead.
+     */
+    [[deprecated("Use ValueA instead.")]]
+    value_b = 1
   };
 
   /**
@@ -60,6 +92,20 @@ class TestService : public Service {
   int32_t counter(std::string id, int32_t divisor);
 
   TestService::TestClass create_test_object(std::string value);
+
+  /**
+   * Deprecated procedure documentation string.
+   *
+   * \deprecated Use FloatToString instead.
+   */
+  [[deprecated("Use FloatToString instead.")]]
+  std::string deprecated_procedure(float value);
+
+  /**
+   * Deprecated procedure with no reason documentation string.
+   */
+  [[deprecated]]
+  std::string deprecated_procedure_no_message(float value);
 
   std::map<int32_t, bool> dictionary_default(std::map<int32_t, bool> x);
 
@@ -126,6 +172,22 @@ class TestService : public Service {
 
   std::tuple<int32_t, bool> tuple_default(std::tuple<int32_t, bool> x);
 
+  /**
+   * Deprecated property documentation string.
+   *
+   * \deprecated Use StringProperty instead.
+   */
+  [[deprecated("Use StringProperty instead.")]]
+  std::string deprecated_property();
+
+  /**
+   * Deprecated property documentation string.
+   *
+   * \deprecated Use StringProperty instead.
+   */
+  [[deprecated("Use StringProperty instead.")]]
+  void set_deprecated_property(std::string value);
+
   TestService::TestClass object_property();
 
   void set_object_property(TestService::TestClass value);
@@ -157,6 +219,10 @@ class TestService : public Service {
   ::krpc::Stream<int32_t> counter_stream(std::string id, int32_t divisor);
 
   ::krpc::Stream<TestService::TestClass> create_test_object_stream(std::string value);
+
+  ::krpc::Stream<std::string> deprecated_procedure_stream(float value);
+
+  ::krpc::Stream<std::string> deprecated_procedure_no_message_stream(float value);
 
   ::krpc::Stream<std::map<int32_t, bool>> dictionary_default_stream(std::map<int32_t, bool> x);
 
@@ -216,6 +282,8 @@ class TestService : public Service {
 
   ::krpc::Stream<std::tuple<int32_t, bool>> tuple_default_stream(std::tuple<int32_t, bool> x);
 
+  ::krpc::Stream<std::string> deprecated_property_stream();
+
   ::krpc::Stream<TestService::TestClass> object_property_stream();
 
   ::krpc::Stream<std::string> string_property_stream();
@@ -235,6 +303,10 @@ class TestService : public Service {
   ::krpc::schema::ProcedureCall counter_call(std::string id, int32_t divisor);
 
   ::krpc::schema::ProcedureCall create_test_object_call(std::string value);
+
+  ::krpc::schema::ProcedureCall deprecated_procedure_call(float value);
+
+  ::krpc::schema::ProcedureCall deprecated_procedure_no_message_call(float value);
 
   ::krpc::schema::ProcedureCall dictionary_default_call(std::map<int32_t, bool> x);
 
@@ -298,6 +370,10 @@ class TestService : public Service {
 
   ::krpc::schema::ProcedureCall tuple_default_call(std::tuple<int32_t, bool> x);
 
+  ::krpc::schema::ProcedureCall deprecated_property_call();
+
+  ::krpc::schema::ProcedureCall set_deprecated_property_call(std::string value);
+
   ::krpc::schema::ProcedureCall object_property_call();
 
   ::krpc::schema::ProcedureCall set_object_property_call(TestService::TestClass value);
@@ -309,6 +385,29 @@ class TestService : public Service {
   ::krpc::schema::ProcedureCall set_string_property_private_get_call(std::string value);
 
   ::krpc::schema::ProcedureCall string_property_private_set_call();
+
+  /**
+   * Deprecated class documentation string.
+   *
+   * \deprecated Use TestClass instead.
+   */
+  [[deprecated("Use TestClass instead.")]]
+  class DeprecatedClass : public krpc::Object<DeprecatedClass> {
+   public:
+    explicit DeprecatedClass(Client* client = nullptr, uint64_t id = 0);
+
+    /**
+     * Deprecated method documentation string.
+     *
+     * \deprecated Use TestClass.GetValue instead.
+     */
+    [[deprecated("Use TestClass.GetValue instead.")]]
+    std::string deprecated_method();
+
+    ::krpc::Stream<std::string> deprecated_method_stream();
+
+    ::krpc::schema::ProcedureCall deprecated_method_call();
+  };
 
   /**
    * Class documentation string.
@@ -392,6 +491,10 @@ class TestService : public Service {
 
 namespace encoder {
 
+  inline std::string encode(const services::TestService::DeprecatedEnum& value) {
+    return krpc::encoder::encode(static_cast<int32_t>(value));
+  }
+
   inline std::string encode(const services::TestService::TestEnum& value) {
     return krpc::encoder::encode(static_cast<int32_t>(value));
   }
@@ -399,6 +502,12 @@ namespace encoder {
 }  // namespace encoder
 
 namespace decoder {
+
+  inline void decode(services::TestService::DeprecatedEnum& value, const std::string& data, Client* client) {
+    int32_t x;
+    decode(x, data, client);
+    value = static_cast<services::TestService::DeprecatedEnum>(x);
+  }
 
   inline void decode(services::TestService::TestEnum& value, const std::string& data, Client* client) {
     int32_t x;
@@ -415,6 +524,9 @@ inline TestService::TestService(Client* client):
   client->add_exception_thrower(
     "TestService", "CustomException",
     [] (const std::string& msg) { throw CustomException(msg); });
+  client->add_exception_thrower(
+    "TestService", "DeprecatedException",
+    [] (const std::string& msg) { throw DeprecatedException(msg); });
 }
 
 inline std::string TestService::add_multiple_values(float x, int32_t y, int64_t z) {
@@ -481,6 +593,24 @@ inline TestService::TestClass TestService::create_test_object(std::string value)
   _args.push_back(encoder::encode(value));
   std::string _data = this->_client->invoke("TestService", "CreateTestObject", _args);
   TestService::TestClass _result;
+  decoder::decode(_result, _data, this->_client);
+  return _result;
+}
+
+inline std::string TestService::deprecated_procedure(float value) {
+  std::vector<std::string> _args;
+  _args.push_back(encoder::encode(value));
+  std::string _data = this->_client->invoke("TestService", "DeprecatedProcedure", _args);
+  std::string _result;
+  decoder::decode(_result, _data, this->_client);
+  return _result;
+}
+
+inline std::string TestService::deprecated_procedure_no_message(float value) {
+  std::vector<std::string> _args;
+  _args.push_back(encoder::encode(value));
+  std::string _data = this->_client->invoke("TestService", "DeprecatedProcedureNoMessage", _args);
+  std::string _result;
   decoder::decode(_result, _data, this->_client);
   return _result;
 }
@@ -744,6 +874,19 @@ inline std::tuple<int32_t, bool> TestService::tuple_default(std::tuple<int32_t, 
   return _result;
 }
 
+inline std::string TestService::deprecated_property() {
+  std::string _data = this->_client->invoke("TestService", "get_DeprecatedProperty");
+  std::string _result;
+  decoder::decode(_result, _data, this->_client);
+  return _result;
+}
+
+inline void TestService::set_deprecated_property(std::string value) {
+  std::vector<std::string> _args;
+  _args.push_back(encoder::encode(value));
+  this->_client->invoke("TestService", "set_DeprecatedProperty", _args);
+}
+
 inline TestService::TestClass TestService::object_property() {
   std::string _data = this->_client->invoke("TestService", "get_ObjectProperty");
   TestService::TestClass _result;
@@ -828,6 +971,18 @@ inline ::krpc::Stream<TestService::TestClass> TestService::create_test_object_st
   std::vector<std::string> _args;
   _args.push_back(encoder::encode(value));
   return ::krpc::Stream<TestService::TestClass>(this->_client, this->_client->build_call("TestService", "CreateTestObject", _args));
+}
+
+inline ::krpc::Stream<std::string> TestService::deprecated_procedure_stream(float value) {
+  std::vector<std::string> _args;
+  _args.push_back(encoder::encode(value));
+  return ::krpc::Stream<std::string>(this->_client, this->_client->build_call("TestService", "DeprecatedProcedure", _args));
+}
+
+inline ::krpc::Stream<std::string> TestService::deprecated_procedure_no_message_stream(float value) {
+  std::vector<std::string> _args;
+  _args.push_back(encoder::encode(value));
+  return ::krpc::Stream<std::string>(this->_client, this->_client->build_call("TestService", "DeprecatedProcedureNoMessage", _args));
 }
 
 inline ::krpc::Stream<std::map<int32_t, bool>> TestService::dictionary_default_stream(std::map<int32_t, bool> x = std::map<int32_t, bool>{{1, false}, {2, true}}) {
@@ -994,6 +1149,10 @@ inline ::krpc::Stream<std::tuple<int32_t, bool>> TestService::tuple_default_stre
   return ::krpc::Stream<std::tuple<int32_t, bool>>(this->_client, this->_client->build_call("TestService", "TupleDefault", _args));
 }
 
+inline ::krpc::Stream<std::string> TestService::deprecated_property_stream() {
+  return ::krpc::Stream<std::string>(this->_client, this->_client->build_call("TestService", "get_DeprecatedProperty"));
+}
+
 inline ::krpc::Stream<TestService::TestClass> TestService::object_property_stream() {
   return ::krpc::Stream<TestService::TestClass>(this->_client, this->_client->build_call("TestService", "get_ObjectProperty"));
 }
@@ -1051,6 +1210,18 @@ inline ::krpc::schema::ProcedureCall TestService::create_test_object_call(std::s
   std::vector<std::string> _args;
   _args.push_back(encoder::encode(value));
   return this->_client->build_call("TestService", "CreateTestObject", _args);
+}
+
+inline ::krpc::schema::ProcedureCall TestService::deprecated_procedure_call(float value) {
+  std::vector<std::string> _args;
+  _args.push_back(encoder::encode(value));
+  return this->_client->build_call("TestService", "DeprecatedProcedure", _args);
+}
+
+inline ::krpc::schema::ProcedureCall TestService::deprecated_procedure_no_message_call(float value) {
+  std::vector<std::string> _args;
+  _args.push_back(encoder::encode(value));
+  return this->_client->build_call("TestService", "DeprecatedProcedureNoMessage", _args);
 }
 
 inline ::krpc::schema::ProcedureCall TestService::dictionary_default_call(std::map<int32_t, bool> x = std::map<int32_t, bool>{{1, false}, {2, true}}) {
@@ -1225,6 +1396,16 @@ inline ::krpc::schema::ProcedureCall TestService::tuple_default_call(std::tuple<
   return this->_client->build_call("TestService", "TupleDefault", _args);
 }
 
+inline ::krpc::schema::ProcedureCall TestService::deprecated_property_call() {
+  return this->_client->build_call("TestService", "get_DeprecatedProperty");
+}
+
+inline ::krpc::schema::ProcedureCall TestService::set_deprecated_property_call(std::string value) {
+  std::vector<std::string> _args;
+  _args.push_back(encoder::encode(value));
+  return this->_client->build_call("TestService", "set_DeprecatedProperty", _args);
+}
+
 inline ::krpc::schema::ProcedureCall TestService::object_property_call() {
   return this->_client->build_call("TestService", "get_ObjectProperty");
 }
@@ -1253,6 +1434,30 @@ inline ::krpc::schema::ProcedureCall TestService::set_string_property_private_ge
 
 inline ::krpc::schema::ProcedureCall TestService::string_property_private_set_call() {
   return this->_client->build_call("TestService", "get_StringPropertyPrivateSet");
+}
+
+inline TestService::DeprecatedClass::DeprecatedClass(Client* client, uint64_t id):
+  Object(client, "TestService::DeprecatedClass", id) {}
+
+inline std::string TestService::DeprecatedClass::deprecated_method() {
+  std::vector<std::string> _args;
+  _args.push_back(encoder::encode(*this));
+  std::string _data = this->_client->invoke("TestService", "DeprecatedClass_DeprecatedMethod", _args);
+  std::string _result;
+  decoder::decode(_result, _data, this->_client);
+  return _result;
+}
+
+inline ::krpc::Stream<std::string> TestService::DeprecatedClass::deprecated_method_stream() {
+  std::vector<std::string> _args;
+  _args.push_back(encoder::encode(*this));
+  return ::krpc::Stream<std::string>(this->_client, this->_client->build_call("TestService", "DeprecatedClass_DeprecatedMethod", _args));
+}
+
+inline ::krpc::schema::ProcedureCall TestService::DeprecatedClass::deprecated_method_call() {
+  std::vector<std::string> _args;
+  _args.push_back(encoder::encode(*this));
+  return this->_client->build_call("TestService", "DeprecatedClass_DeprecatedMethod", _args);
 }
 
 inline TestService::TestClass::TestClass(Client* client, uint64_t id):

--- a/tools/krpctools/krpctools/test/clientgen-TestService-cpp.txt
+++ b/tools/krpctools/krpctools/test/clientgen-TestService-cpp.txt
@@ -35,8 +35,7 @@ class TestService : public Service {
    *
    * \deprecated Use CustomException instead.
    */
-  [[deprecated("Use CustomException instead.")]]
-  class DeprecatedException : public ::krpc::RPCError {
+  class [[deprecated("Use CustomException instead.")]] DeprecatedException : public ::krpc::RPCError {
    public:
     inline explicit DeprecatedException(const std::string& msg) : ::krpc::RPCError(msg) {}
   };
@@ -46,8 +45,7 @@ class TestService : public Service {
    *
    * \deprecated Use TestEnum instead.
    */
-  [[deprecated("Use TestEnum instead.")]]
-  enum struct DeprecatedEnum {
+  enum struct [[deprecated("Use TestEnum instead.")]] DeprecatedEnum {
     /**
      * Deprecated enum ValueA documentation string.
      */
@@ -57,8 +55,7 @@ class TestService : public Service {
      *
      * \deprecated Use ValueA instead.
      */
-    [[deprecated("Use ValueA instead.")]]
-    value_b = 1
+    value_b [[deprecated("Use ValueA instead.")]] = 1
   };
 
   /**
@@ -391,8 +388,7 @@ class TestService : public Service {
    *
    * \deprecated Use TestClass instead.
    */
-  [[deprecated("Use TestClass instead.")]]
-  class DeprecatedClass : public krpc::Object<DeprecatedClass> {
+  class [[deprecated("Use TestClass instead.")]] DeprecatedClass : public krpc::Object<DeprecatedClass> {
    public:
     explicit DeprecatedClass(Client* client = nullptr, uint64_t id = 0);
 

--- a/tools/krpctools/krpctools/test/clientgen-TestService-csharp.txt
+++ b/tools/krpctools/krpctools/test/clientgen-TestService-csharp.txt
@@ -43,6 +43,7 @@ namespace KRPC.Client.Services.TestService
         internal static void AddExceptionTypes (global::KRPC.Client.IConnection serverConnection)
         {
             serverConnection.AddExceptionType ("TestService", "CustomException", typeof (CustomException));
+            serverConnection.AddExceptionType ("TestService", "DeprecatedException", typeof (DeprecatedException));
         }
 
         [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "AddMultipleValues")]
@@ -118,6 +119,34 @@ namespace KRPC.Client.Services.TestService
             };
             ByteString _data = connection.Invoke ("TestService", "CreateTestObject", _args);
             return (global::KRPC.Client.Services.TestService.TestClass)global::KRPC.Client.Encoder.Decode (_data, typeof(global::KRPC.Client.Services.TestService.TestClass), connection);
+        }
+
+        /// <summary>
+        /// Deprecated procedure documentation string.
+        /// </summary>
+        [global::System.Obsolete ("Use FloatToString instead.")]
+        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "DeprecatedProcedure")]
+        public string DeprecatedProcedure (float value)
+        {
+            var _args = new ByteString[] {
+                global::KRPC.Client.Encoder.Encode (value, typeof(float))
+            };
+            ByteString _data = connection.Invoke ("TestService", "DeprecatedProcedure", _args);
+            return (string)global::KRPC.Client.Encoder.Decode (_data, typeof(string), connection);
+        }
+
+        /// <summary>
+        /// Deprecated procedure with no reason documentation string.
+        /// </summary>
+        [global::System.Obsolete]
+        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "DeprecatedProcedureNoMessage")]
+        public string DeprecatedProcedureNoMessage (float value)
+        {
+            var _args = new ByteString[] {
+                global::KRPC.Client.Encoder.Encode (value, typeof(float))
+            };
+            ByteString _data = connection.Invoke ("TestService", "DeprecatedProcedureNoMessage", _args);
+            return (string)global::KRPC.Client.Encoder.Decode (_data, typeof(string), connection);
         }
 
         [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "DictionaryDefault")]
@@ -408,6 +437,24 @@ namespace KRPC.Client.Services.TestService
             return (systemAlias::Tuple<int,bool>)global::KRPC.Client.Encoder.Decode (_data, typeof(systemAlias::Tuple<int,bool>), connection);
         }
 
+        /// <summary>
+        /// Deprecated property documentation string.
+        /// </summary>
+        [global::System.Obsolete ("Use StringProperty instead.")]
+        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "get_DeprecatedProperty")]
+        public string DeprecatedProperty {
+            get {
+                ByteString _data = connection.Invoke ("TestService", "get_DeprecatedProperty");
+                return (string)global::KRPC.Client.Encoder.Decode (_data, typeof(string), connection);
+            }
+            set {
+                var _args = new ByteString[] {
+                    global::KRPC.Client.Encoder.Encode (value, typeof(string))
+                };
+                connection.Invoke ("TestService", "set_DeprecatedProperty", _args);
+            }
+        }
+
         [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "get_ObjectProperty")]
         public global::KRPC.Client.Services.TestService.TestClass ObjectProperty {
             get {
@@ -455,6 +502,24 @@ namespace KRPC.Client.Services.TestService
                 return (string)global::KRPC.Client.Encoder.Decode (_data, typeof(string), connection);
             }
         }
+    }
+
+    /// <summary>
+    /// Deprecated enum documentation string.
+    /// </summary>
+    [Serializable]
+    [global::System.Obsolete ("Use TestEnum instead.")]
+    public enum DeprecatedEnum
+    {
+        /// <summary>
+        /// Deprecated enum ValueA documentation string.
+        /// </summary>
+        ValueA = 0,
+        /// <summary>
+        /// Deprecated enum ValueB documentation string.
+        /// </summary>
+        [global::System.Obsolete ("Use ValueA instead.")]
+        ValueB = 1
     }
 
     /// <summary>
@@ -506,6 +571,70 @@ namespace KRPC.Client.Services.TestService
         /// </summary>
         protected CustomException (SerializationInfo info, StreamingContext context) : base (info, context)
         {
+        }
+    }
+
+    /// <summary>
+    /// Deprecated exception documentation string.
+    /// </summary>
+    [Serializable]
+    [global::System.Obsolete ("Use CustomException instead.")]
+    public class DeprecatedException : global::KRPC.Client.RPCException
+    {
+        /// <summary>
+        /// Construct an DeprecatedException with no message.
+        /// </summary>
+        public DeprecatedException ()
+        {
+        }
+
+        /// <summary>
+        /// Construct an DeprecatedException with the given message.
+        /// </summary>
+        public DeprecatedException (string message) : base (message)
+        {
+        }
+
+        /// <summary>
+        /// Construct an DeprecatedException with the given message and inner exception.
+        /// </summary>
+        public DeprecatedException (string message, Exception inner) : base (message, inner)
+        {
+        }
+
+        /// <summary>
+        /// Construct an DeprecatedException with the given serialization info and streaming context.
+        /// </summary>
+        protected DeprecatedException (SerializationInfo info, StreamingContext context) : base (info, context)
+        {
+        }
+    }
+
+    /// <summary>
+    /// Deprecated class documentation string.
+    /// </summary>
+    [global::System.Obsolete ("Use TestClass instead.")]
+    public class DeprecatedClass : global::KRPC.Client.RemoteObject
+    {
+        /// <summary>
+        /// Construct an instance of this remote object. Should not be called directly. This interface is intended for internal decoding.
+        /// </summary>
+        public DeprecatedClass (global::KRPC.Client.IConnection connection, UInt64 id) : base (connection, id)
+        {
+        }
+
+        /// <summary>
+        /// Deprecated method documentation string.
+        /// </summary>
+        [global::System.Obsolete ("Use TestClass.GetValue instead.")]
+        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "DeprecatedClass_DeprecatedMethod")]
+        public string DeprecatedMethod ()
+        {
+            var _args = new ByteString[] {
+                global::KRPC.Client.Encoder.Encode (this, typeof(TestService.DeprecatedClass))
+            };
+            ByteString _data = connection.Invoke ("TestService", "DeprecatedClass_DeprecatedMethod", _args);
+            return (string)global::KRPC.Client.Encoder.Decode (_data, typeof(string), connection);
         }
     }
 

--- a/tools/krpctools/krpctools/test/clientgen-TestService-csharp.txt
+++ b/tools/krpctools/krpctools/test/clientgen-TestService-csharp.txt
@@ -11,6 +11,10 @@ using systemAlias = global::System;
 using genericCollectionsAlias = global::System.Collections.Generic;
 #endif
 
+// Generated code references its own deprecated members (e.g. when registering
+// exception types), so suppress the deprecation warnings within this file.
+#pragma warning disable 612, 618
+
 namespace KRPC.Client.Services.TestService
 {
     /// <summary>

--- a/tools/krpctools/krpctools/test/clientgen-TestService-java.txt
+++ b/tools/krpctools/krpctools/test/clientgen-TestService-java.txt
@@ -35,8 +35,27 @@ public class TestService {
         }
     }
 
+    /**
+     * Deprecated exception documentation string.
+     *
+     * @deprecated Use CustomException instead.
+     */
+    @Deprecated
+    public static class DeprecatedException extends krpc.client.RPCException {
+        private static final long serialVersionUID = 483570852596919585L;
+
+        public DeprecatedException(String message) {
+            super(message);
+        }
+
+        public DeprecatedException(String message, Exception innerException) {
+            super(message, innerException);
+        }
+    }
+
     private void addExceptionTypes(Connection connection) {
         connection.addExceptionType("TestService", "CustomException", CustomException.class);
+        connection.addExceptionType("TestService", "DeprecatedException", DeprecatedException.class);
     }
 
     @SuppressWarnings({ "unchecked" })
@@ -112,6 +131,36 @@ public class TestService {
         };
         ByteString _data = this.connection.invoke("TestService", "CreateTestObject", _args);
         return (krpc.client.services.TestService.TestClass) Encoder.decode(_data, krpc.client.Types.createClass("TestService", "TestClass"), this.connection);
+    }
+
+    /**
+     * Deprecated procedure documentation string.
+     *
+     * @deprecated Use FloatToString instead.
+     */
+    @Deprecated
+    @SuppressWarnings({ "unchecked" })
+    @RPCInfo(service = "TestService", procedure = "DeprecatedProcedure", types = _Types.class)
+    public String deprecatedProcedure(float value) throws RPCException {
+        ByteString[] _args = new ByteString[] {
+            Encoder.encode(value, krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.FLOAT))
+        };
+        ByteString _data = this.connection.invoke("TestService", "DeprecatedProcedure", _args);
+        return (String) Encoder.decode(_data, krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.STRING), this.connection);
+    }
+
+    /**
+     * Deprecated procedure with no reason documentation string.
+     */
+    @Deprecated
+    @SuppressWarnings({ "unchecked" })
+    @RPCInfo(service = "TestService", procedure = "DeprecatedProcedureNoMessage", types = _Types.class)
+    public String deprecatedProcedureNoMessage(float value) throws RPCException {
+        ByteString[] _args = new ByteString[] {
+            Encoder.encode(value, krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.FLOAT))
+        };
+        ByteString _data = this.connection.invoke("TestService", "DeprecatedProcedureNoMessage", _args);
+        return (String) Encoder.decode(_data, krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.STRING), this.connection);
     }
 
     @SuppressWarnings({ "unchecked" })
@@ -402,6 +451,34 @@ public class TestService {
         return (org.javatuples.Pair<Integer,Boolean>) Encoder.decode(_data, krpc.client.Types.createTuple(krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.SINT32),krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.BOOL)), this.connection);
     }
 
+    /**
+     * Deprecated property documentation string.
+     *
+     * @deprecated Use StringProperty instead.
+     */
+    @Deprecated
+    @SuppressWarnings({ "unchecked" })
+    @RPCInfo(service = "TestService", procedure = "get_DeprecatedProperty", types = _Types.class)
+    public String getDeprecatedProperty() throws RPCException {
+        ByteString _data = this.connection.invoke("TestService", "get_DeprecatedProperty");
+        return (String) Encoder.decode(_data, krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.STRING), this.connection);
+    }
+
+    /**
+     * Deprecated property documentation string.
+     *
+     * @deprecated Use StringProperty instead.
+     */
+    @Deprecated
+    @SuppressWarnings({ "unchecked" })
+    @RPCInfo(service = "TestService", procedure = "set_DeprecatedProperty", types = _Types.class)
+    public void setDeprecatedProperty(String value) throws RPCException {
+        ByteString[] _args = new ByteString[] {
+            Encoder.encode(value, krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.STRING))
+        };
+        this.connection.invoke("TestService", "set_DeprecatedProperty", _args);
+    }
+
     @SuppressWarnings({ "unchecked" })
     @RPCInfo(service = "TestService", procedure = "get_ObjectProperty", types = _Types.class)
     public krpc.client.services.TestService.TestClass getObjectProperty() throws RPCException {
@@ -457,6 +534,48 @@ public class TestService {
     }
 
     /**
+     * Deprecated enum documentation string.
+     *
+     * @deprecated Use TestEnum instead.
+     */
+    @Deprecated
+    public enum DeprecatedEnum implements RemoteEnum {
+        /**
+         * Deprecated enum ValueA documentation string.
+         */
+        VALUE_A(0),
+
+        /**
+         * Deprecated enum ValueB documentation string.
+         *
+         * @deprecated Use ValueA instead.
+         */
+        @Deprecated
+        VALUE_B(1);
+
+        private final int value;
+
+        private DeprecatedEnum (int value) {
+            this.value = value;
+        }
+
+        @Override
+        public int getValue() {
+            return value;
+        }
+
+        public static DeprecatedEnum fromValue(int value) {
+            switch (value) {
+            case 0:
+                 return VALUE_A;
+            case 1:
+                 return VALUE_B;
+            }
+            return null;
+        }
+    }
+
+    /**
      * Enum documentation string.
      */
     public enum TestEnum implements RemoteEnum {
@@ -496,6 +615,38 @@ public class TestService {
                  return VALUE_C;
             }
             return null;
+        }
+    }
+
+    /**
+     * Deprecated class documentation string.
+     *
+     * @deprecated Use TestClass instead.
+     */
+    @Deprecated
+    public static class DeprecatedClass extends RemoteObject {
+
+        private static final long serialVersionUID = 17653684528050254L;
+
+        public DeprecatedClass(Connection connection, long id) {
+            super(connection, id);
+        }
+
+        /**
+         * Deprecated method documentation string.
+         *
+         * @deprecated Use TestClass.GetValue instead.
+         */
+        @Deprecated
+        @SuppressWarnings({ "unchecked" })
+        @RPCInfo(service = "TestService", procedure = "DeprecatedClass_DeprecatedMethod", types = _Types.class)
+        public String deprecatedMethod() throws RPCException
+        {
+            ByteString[] _args = new ByteString[] {
+                Encoder.encode(this, krpc.client.Types.createClass("TestService", "DeprecatedClass"))
+            };
+            ByteString _data = this.connection.invoke("TestService", "DeprecatedClass_DeprecatedMethod", _args);
+            return (String) Encoder.decode(_data, krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.STRING), this.connection);
         }
     }
 
@@ -665,6 +816,10 @@ public class TestService {
                 return krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.SINT32);
             case "CreateTestObject":
                 return krpc.client.Types.createClass("TestService", "TestClass");
+            case "DeprecatedProcedure":
+                return krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.STRING);
+            case "DeprecatedProcedureNoMessage":
+                return krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.STRING);
             case "DictionaryDefault":
                 return krpc.client.Types.createDictionary(krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.SINT32), krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.BOOL));
             case "DoubleToString":
@@ -727,6 +882,10 @@ public class TestService {
                 return krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.SINT32);
             case "TupleDefault":
                 return krpc.client.Types.createTuple(krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.SINT32),krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.BOOL));
+            case "get_DeprecatedProperty":
+                return krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.STRING);
+            case "set_DeprecatedProperty":
+                return null;
             case "get_ObjectProperty":
                 return krpc.client.Types.createClass("TestService", "TestClass");
             case "set_ObjectProperty":
@@ -738,6 +897,8 @@ public class TestService {
             case "set_StringPropertyPrivateGet":
                 return null;
             case "get_StringPropertyPrivateSet":
+                return krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.STRING);
+            case "DeprecatedClass_DeprecatedMethod":
                 return krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.STRING);
             case "TestClass_FloatToString":
                 return krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.STRING);
@@ -799,6 +960,14 @@ public class TestService {
             case "CreateTestObject":
                 return new krpc.schema.KRPC.Type[] {
                     krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.STRING)
+                };
+            case "DeprecatedProcedure":
+                return new krpc.schema.KRPC.Type[] {
+                    krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.FLOAT)
+                };
+            case "DeprecatedProcedureNoMessage":
+                return new krpc.schema.KRPC.Type[] {
+                    krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.FLOAT)
                 };
             case "DictionaryDefault":
                 return new krpc.schema.KRPC.Type[] {
@@ -919,6 +1088,13 @@ public class TestService {
                 return new krpc.schema.KRPC.Type[] {
                     krpc.client.Types.createTuple(krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.SINT32),krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.BOOL))
                 };
+            case "get_DeprecatedProperty":
+                return new krpc.schema.KRPC.Type[] {
+                };
+            case "set_DeprecatedProperty":
+                return new krpc.schema.KRPC.Type[] {
+                    krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.STRING)
+                };
             case "get_ObjectProperty":
                 return new krpc.schema.KRPC.Type[] {
                 };
@@ -939,6 +1115,10 @@ public class TestService {
                 };
             case "get_StringPropertyPrivateSet":
                 return new krpc.schema.KRPC.Type[] {
+                };
+            case "DeprecatedClass_DeprecatedMethod":
+                return new krpc.schema.KRPC.Type[] {
+                    krpc.client.Types.createClass("TestService", "DeprecatedClass")
                 };
             case "TestClass_FloatToString":
                 return new krpc.schema.KRPC.Type[] {

--- a/tools/krpctools/krpctools/test/clientgen-TestService-java.txt
+++ b/tools/krpctools/krpctools/test/clientgen-TestService-java.txt
@@ -10,6 +10,9 @@ import krpc.client.RPCInfo;
 import krpc.client.RPCException;
 import krpc.client.Types;
 
+// Generated code references its own deprecated members (e.g. when registering
+// exception types), so suppress the deprecation warnings within this class.
+@SuppressWarnings("deprecation")
 public class TestService {
 
     public static TestService newInstance(Connection connection) {

--- a/tools/krpctools/krpctools/test/clientgen-TestService-python.txt
+++ b/tools/krpctools/krpctools/test/clientgen-TestService-python.txt
@@ -1,0 +1,1471 @@
+# pylint: disable=line-too-long,invalid-name,redefined-builtin,too-many-lines
+from __future__ import annotations
+import warnings
+from typing import Tuple, Set, Dict, List, Optional, TYPE_CHECKING
+import krpc.schema
+from krpc.schema import KRPC_pb2
+from krpc.types import TypeBase, ClassBase, WrappedClass, DocEnum, StaticMethod
+from krpc.event import Event
+if TYPE_CHECKING:
+    from krpc.services import Client
+
+
+class DeprecatedEnum(DocEnum):
+    """
+    Deprecated. Use TestEnum instead.
+
+    Deprecated enum documentation string.
+    """
+    value_a = 0, """
+Deprecated enum ValueA documentation string.
+"""
+    value_b = 1, """
+Deprecated enum ValueB documentation string.
+"""
+
+
+class TestEnum(DocEnum):
+    """
+    Enum documentation string.
+    """
+    value_a = 0, """
+Enum ValueA documentation string.
+"""
+    value_b = 1, """
+Enum ValueB documentation string.
+"""
+    value_c = 2, """
+Enum ValueC documentation string.
+"""
+
+
+class CustomException(RuntimeError):
+    pass
+
+
+class DeprecatedException(RuntimeError):
+    """
+    Deprecated. Use CustomException instead.
+
+    Deprecated exception documentation string.
+    """
+    pass
+
+
+class DeprecatedClass(ClassBase):
+    """
+    Deprecated. Use TestClass instead.
+
+    Deprecated class documentation string.
+    """
+    def deprecated_method(self) -> str:
+        """
+        Deprecated. Use TestClass.GetValue instead.
+
+        Deprecated method documentation string.
+        """
+        warnings.warn("TestService.DeprecatedClass.deprecated_method is deprecated: Use TestClass.GetValue instead.", DeprecationWarning, stacklevel=2)
+        return self._client._invoke(
+            "TestService",
+            "DeprecatedClass_DeprecatedMethod",
+            [self, ],
+            ["self", ],
+            [self._client._types.class_type("TestService", "DeprecatedClass"), ],
+            self._client._types.string_type
+        )
+
+    def _return_type_deprecated_method(self) -> TypeBase:
+        return self._client._types.string_type
+
+    def _build_call_deprecated_method(self) -> KRPC_pb2.ProcedureCall:
+        return self._client._build_call(
+            "TestService",
+            "DeprecatedClass_DeprecatedMethod",
+            [self, ],
+            ["self", ],
+            [self._client._types.class_type("TestService", "DeprecatedClass"), ],
+            self._client._types.string_type
+        )
+
+
+
+class TestClass(ClassBase):
+    """
+    Class documentation string.
+    """
+    @property
+    def int_property(self) -> int:
+        """
+        Property documentation string.
+        """
+        return self._client._invoke(
+            "TestService",
+            "TestClass_get_IntProperty",
+            [self],
+            ["self"],
+            [self._client._types.class_type("TestService", "TestClass")],
+            self._client._types.sint32_type
+        )
+
+    @int_property.setter
+    def int_property(self, value: int) -> None:
+        return self._client._invoke(
+            "TestService",
+            "TestClass_set_IntProperty",
+            [self, value],
+            ["self", "value"],
+            [self._client._types.class_type("TestService", "TestClass"), self._client._types.sint32_type],
+            None
+        )
+
+    def _return_type_int_property(self) -> TypeBase:
+        return self._client._types.sint32_type
+
+    def _build_call_int_property(self) -> KRPC_pb2.ProcedureCall:
+        return self._client._build_call(
+            "TestService",
+            "TestClass_get_IntProperty",
+            [self],
+            ["self"],
+            [self._client._types.class_type("TestService", "TestClass")],
+            self._client._types.sint32_type
+        )
+
+    @property
+    def object_property(self) -> Optional[TestClass]:
+        return self._client._invoke(
+            "TestService",
+            "TestClass_get_ObjectProperty",
+            [self],
+            ["self"],
+            [self._client._types.class_type("TestService", "TestClass")],
+            self._client._types.class_type("TestService", "TestClass")
+        )
+
+    @object_property.setter
+    def object_property(self, value: TestClass) -> None:
+        return self._client._invoke(
+            "TestService",
+            "TestClass_set_ObjectProperty",
+            [self, value],
+            ["self", "value"],
+            [self._client._types.class_type("TestService", "TestClass"), self._client._types.class_type("TestService", "TestClass")],
+            None
+        )
+
+    def _return_type_object_property(self) -> TypeBase:
+        return self._client._types.class_type("TestService", "TestClass")
+
+    def _build_call_object_property(self) -> KRPC_pb2.ProcedureCall:
+        return self._client._build_call(
+            "TestService",
+            "TestClass_get_ObjectProperty",
+            [self],
+            ["self"],
+            [self._client._types.class_type("TestService", "TestClass")],
+            self._client._types.class_type("TestService", "TestClass")
+        )
+
+    @property
+    def string_property_private_get(self) -> str:
+        raise NotImplementedError
+
+    @string_property_private_get.setter
+    def string_property_private_get(self, value: str) -> None:
+        return self._client._invoke(
+            "TestService",
+            "TestClass_set_StringPropertyPrivateGet",
+            [self, value],
+            ["self", "value"],
+            [self._client._types.class_type("TestService", "TestClass"), self._client._types.string_type],
+            None
+        )
+
+    @property
+    def string_property_private_set(self) -> str:
+        return self._client._invoke(
+            "TestService",
+            "TestClass_get_StringPropertyPrivateSet",
+            [self],
+            ["self"],
+            [self._client._types.class_type("TestService", "TestClass")],
+            self._client._types.string_type
+        )
+
+    def _return_type_string_property_private_set(self) -> TypeBase:
+        return self._client._types.string_type
+
+    def _build_call_string_property_private_set(self) -> KRPC_pb2.ProcedureCall:
+        return self._client._build_call(
+            "TestService",
+            "TestClass_get_StringPropertyPrivateSet",
+            [self],
+            ["self"],
+            [self._client._types.class_type("TestService", "TestClass")],
+            self._client._types.string_type
+        )
+
+    def float_to_string(self, x: float) -> str:
+        return self._client._invoke(
+            "TestService",
+            "TestClass_FloatToString",
+            [self, x],
+            ["self", "x"],
+            [self._client._types.class_type("TestService", "TestClass"), self._client._types.float_type],
+            self._client._types.string_type
+        )
+
+    def _return_type_float_to_string(self) -> TypeBase:
+        return self._client._types.string_type
+
+    def _build_call_float_to_string(self, x: float) -> KRPC_pb2.ProcedureCall:
+        return self._client._build_call(
+            "TestService",
+            "TestClass_FloatToString",
+            [self, x],
+            ["self", "x"],
+            [self._client._types.class_type("TestService", "TestClass"), self._client._types.float_type],
+            self._client._types.string_type
+        )
+
+    def get_value(self) -> str:
+        """
+        Method documentation string.
+        """
+        return self._client._invoke(
+            "TestService",
+            "TestClass_GetValue",
+            [self, ],
+            ["self", ],
+            [self._client._types.class_type("TestService", "TestClass"), ],
+            self._client._types.string_type
+        )
+
+    def _return_type_get_value(self) -> TypeBase:
+        return self._client._types.string_type
+
+    def _build_call_get_value(self) -> KRPC_pb2.ProcedureCall:
+        return self._client._build_call(
+            "TestService",
+            "TestClass_GetValue",
+            [self, ],
+            ["self", ],
+            [self._client._types.class_type("TestService", "TestClass"), ],
+            self._client._types.string_type
+        )
+
+    def object_to_string(self, other: Optional[TestClass]) -> str:
+        return self._client._invoke(
+            "TestService",
+            "TestClass_ObjectToString",
+            [self, other],
+            ["self", "other"],
+            [self._client._types.class_type("TestService", "TestClass"), self._client._types.class_type("TestService", "TestClass")],
+            self._client._types.string_type
+        )
+
+    def _return_type_object_to_string(self) -> TypeBase:
+        return self._client._types.string_type
+
+    def _build_call_object_to_string(self, other: Optional[TestClass]) -> KRPC_pb2.ProcedureCall:
+        return self._client._build_call(
+            "TestService",
+            "TestClass_ObjectToString",
+            [self, other],
+            ["self", "other"],
+            [self._client._types.class_type("TestService", "TestClass"), self._client._types.class_type("TestService", "TestClass")],
+            self._client._types.string_type
+        )
+
+    def optional_arguments(self, x: str, y: str = 'foo', z: str = 'bar', obj: TestClass = None) -> str:
+        return self._client._invoke(
+            "TestService",
+            "TestClass_OptionalArguments",
+            [self, x, y, z, obj],
+            ["self", "x", "y", "z", "obj"],
+            [self._client._types.class_type("TestService", "TestClass"), self._client._types.string_type, self._client._types.string_type, self._client._types.string_type, self._client._types.class_type("TestService", "TestClass")],
+            self._client._types.string_type
+        )
+
+    def _return_type_optional_arguments(self) -> TypeBase:
+        return self._client._types.string_type
+
+    def _build_call_optional_arguments(self, x: str, y: str = 'foo', z: str = 'bar', obj: TestClass = None) -> KRPC_pb2.ProcedureCall:
+        return self._client._build_call(
+            "TestService",
+            "TestClass_OptionalArguments",
+            [self, x, y, z, obj],
+            ["self", "x", "y", "z", "obj"],
+            [self._client._types.class_type("TestService", "TestClass"), self._client._types.string_type, self._client._types.string_type, self._client._types.string_type, self._client._types.class_type("TestService", "TestClass")],
+            self._client._types.string_type
+        )
+
+    @StaticMethod
+    def static_method(cls, a: str = '', b: str = '') -> str:
+        self = cls
+        return cls._client._invoke(
+            "TestService",
+            "TestClass_static_StaticMethod",
+            [a, b],
+            ["a", "b"],
+            [self._client._types.string_type, self._client._types.string_type],
+            self._client._types.string_type
+        )
+
+    @StaticMethod
+    def _return_type_static_method(cls) -> TypeBase:
+        self = cls
+        return self._client._types.string_type
+
+    @StaticMethod
+    def _build_call_static_method(cls, a: str = '', b: str = '') -> KRPC_pb2.ProcedureCall:
+        self = cls
+        return self._client._build_call(
+            "TestService",
+            "TestClass_static_StaticMethod",
+            [a, b],
+            ["a", "b"],
+            [self._client._types.string_type, self._client._types.string_type],
+            self._client._types.string_type
+        )
+
+
+
+class TestService:
+    """
+    Service documentation string.
+    """
+
+    def __init__(self, client: Client) -> None:
+        self._client = client
+
+    def __getattribute__(self, name):
+        # Intercepts calls to obtain classes from the service,
+        # to inject the client instance so that it can be used
+        # for static method calls
+        classes = object.__getattribute__(self, "_classes")
+        if name in classes:
+            client = object.__getattribute__(self, "_client")
+            return WrappedClass(client, classes[name])
+
+        # Intercept calls to obtain enumeration types
+        enumerations = object.__getattribute__(self, "_enumerations")
+        if name in enumerations:
+           return enumerations[name]
+
+        # Intercept calls to obtain exception types
+        exceptions = object.__getattribute__(self, "_exceptions")
+        if name in exceptions:
+           return exceptions[name]
+
+        # Fall back to default behaviour
+        return object.__getattribute__(self, name)
+
+    def __dir__(self):
+        result = object.__dir__(self)
+        result.extend(object.__getattribute__(self, "_classes").keys())
+        result.extend(object.__getattribute__(self, "_enumerations").keys())
+        result.extend(object.__getattribute__(self, "_exceptions").keys())
+        return result
+
+    _classes = {
+        "DeprecatedClass": DeprecatedClass,
+        "TestClass": TestClass,
+    }
+    _enumerations = {
+        "DeprecatedEnum": DeprecatedEnum,
+        "TestEnum": TestEnum,
+    }
+    _exceptions = {
+        "CustomException": CustomException,
+        "DeprecatedException": DeprecatedException,
+    }
+
+    @property
+    def deprecated_property(self) -> str:
+        """
+        Deprecated. Use StringProperty instead.
+
+        Deprecated property documentation string.
+        """
+        warnings.warn("TestService.deprecated_property is deprecated: Use StringProperty instead.", DeprecationWarning, stacklevel=2)
+        return self._client._invoke(
+            "TestService",
+            "get_DeprecatedProperty",
+            [],
+            [],
+            [],
+            self._client._types.string_type
+        )
+
+    @deprecated_property.setter
+    def deprecated_property(self, value: str) -> None:
+        warnings.warn("TestService.deprecated_property is deprecated: Use StringProperty instead.", DeprecationWarning, stacklevel=2)
+        return self._client._invoke(
+            "TestService",
+            "set_DeprecatedProperty",
+            [value],
+            ["value"],
+            [self._client._types.string_type],
+            None
+        )
+
+    def _return_type_deprecated_property(self) -> TypeBase:
+        return self._client._types.string_type
+
+    def _build_call_deprecated_property(self) -> KRPC_pb2.ProcedureCall:
+        return self._client._build_call(
+            "TestService",
+            "get_DeprecatedProperty",
+            [],
+            [],
+            [],
+            self._client._types.string_type
+        )
+
+    @property
+    def object_property(self) -> Optional[TestClass]:
+        return self._client._invoke(
+            "TestService",
+            "get_ObjectProperty",
+            [],
+            [],
+            [],
+            self._client._types.class_type("TestService", "TestClass")
+        )
+
+    @object_property.setter
+    def object_property(self, value: TestClass) -> None:
+        return self._client._invoke(
+            "TestService",
+            "set_ObjectProperty",
+            [value],
+            ["value"],
+            [self._client._types.class_type("TestService", "TestClass")],
+            None
+        )
+
+    def _return_type_object_property(self) -> TypeBase:
+        return self._client._types.class_type("TestService", "TestClass")
+
+    def _build_call_object_property(self) -> KRPC_pb2.ProcedureCall:
+        return self._client._build_call(
+            "TestService",
+            "get_ObjectProperty",
+            [],
+            [],
+            [],
+            self._client._types.class_type("TestService", "TestClass")
+        )
+
+    @property
+    def string_property(self) -> str:
+        """
+        Property documentation string.
+        """
+        return self._client._invoke(
+            "TestService",
+            "get_StringProperty",
+            [],
+            [],
+            [],
+            self._client._types.string_type
+        )
+
+    @string_property.setter
+    def string_property(self, value: str) -> None:
+        return self._client._invoke(
+            "TestService",
+            "set_StringProperty",
+            [value],
+            ["value"],
+            [self._client._types.string_type],
+            None
+        )
+
+    def _return_type_string_property(self) -> TypeBase:
+        return self._client._types.string_type
+
+    def _build_call_string_property(self) -> KRPC_pb2.ProcedureCall:
+        return self._client._build_call(
+            "TestService",
+            "get_StringProperty",
+            [],
+            [],
+            [],
+            self._client._types.string_type
+        )
+
+    @property
+    def string_property_private_get(self) -> str:
+        raise NotImplementedError
+
+    @string_property_private_get.setter
+    def string_property_private_get(self, value: str) -> None:
+        return self._client._invoke(
+            "TestService",
+            "set_StringPropertyPrivateGet",
+            [value],
+            ["value"],
+            [self._client._types.string_type],
+            None
+        )
+
+    @property
+    def string_property_private_set(self) -> str:
+        return self._client._invoke(
+            "TestService",
+            "get_StringPropertyPrivateSet",
+            [],
+            [],
+            [],
+            self._client._types.string_type
+        )
+
+    def _return_type_string_property_private_set(self) -> TypeBase:
+        return self._client._types.string_type
+
+    def _build_call_string_property_private_set(self) -> KRPC_pb2.ProcedureCall:
+        return self._client._build_call(
+            "TestService",
+            "get_StringPropertyPrivateSet",
+            [],
+            [],
+            [],
+            self._client._types.string_type
+        )
+
+    def add_multiple_values(self, x: float, y: int, z: int) -> str:
+        return self._client._invoke(
+            "TestService",
+            "AddMultipleValues",
+            [x, y, z],
+            ["x", "y", "z"],
+            [self._client._types.float_type, self._client._types.sint32_type, self._client._types.sint64_type],
+            self._client._types.string_type
+        )
+
+    def _return_type_add_multiple_values(self) -> TypeBase:
+        return self._client._types.string_type
+
+    def _build_call_add_multiple_values(self, x: float, y: int, z: int) -> KRPC_pb2.ProcedureCall:
+        return self._client._build_call(
+            "TestService",
+            "AddMultipleValues",
+            [x, y, z],
+            ["x", "y", "z"],
+            [self._client._types.float_type, self._client._types.sint32_type, self._client._types.sint64_type],
+            self._client._types.string_type
+        )
+
+    def add_to_object_list(self, l: List[TestClass], value: str) -> List[TestClass]:
+        return self._client._invoke(
+            "TestService",
+            "AddToObjectList",
+            [l, value],
+            ["l", "value"],
+            [self._client._types.list_type(self._client._types.class_type("TestService", "TestClass")), self._client._types.string_type],
+            self._client._types.list_type(self._client._types.class_type("TestService", "TestClass"))
+        )
+
+    def _return_type_add_to_object_list(self) -> TypeBase:
+        return self._client._types.list_type(self._client._types.class_type("TestService", "TestClass"))
+
+    def _build_call_add_to_object_list(self, l: List[TestClass], value: str) -> KRPC_pb2.ProcedureCall:
+        return self._client._build_call(
+            "TestService",
+            "AddToObjectList",
+            [l, value],
+            ["l", "value"],
+            [self._client._types.list_type(self._client._types.class_type("TestService", "TestClass")), self._client._types.string_type],
+            self._client._types.list_type(self._client._types.class_type("TestService", "TestClass"))
+        )
+
+    def blocking_procedure(self, n: int, sum: int = 0) -> int:
+        return self._client._invoke(
+            "TestService",
+            "BlockingProcedure",
+            [n, sum],
+            ["n", "sum"],
+            [self._client._types.sint32_type, self._client._types.sint32_type],
+            self._client._types.sint32_type
+        )
+
+    def _return_type_blocking_procedure(self) -> TypeBase:
+        return self._client._types.sint32_type
+
+    def _build_call_blocking_procedure(self, n: int, sum: int = 0) -> KRPC_pb2.ProcedureCall:
+        return self._client._build_call(
+            "TestService",
+            "BlockingProcedure",
+            [n, sum],
+            ["n", "sum"],
+            [self._client._types.sint32_type, self._client._types.sint32_type],
+            self._client._types.sint32_type
+        )
+
+    def bool_to_string(self, value: bool) -> str:
+        return self._client._invoke(
+            "TestService",
+            "BoolToString",
+            [value],
+            ["value"],
+            [self._client._types.bool_type],
+            self._client._types.string_type
+        )
+
+    def _return_type_bool_to_string(self) -> TypeBase:
+        return self._client._types.string_type
+
+    def _build_call_bool_to_string(self, value: bool) -> KRPC_pb2.ProcedureCall:
+        return self._client._build_call(
+            "TestService",
+            "BoolToString",
+            [value],
+            ["value"],
+            [self._client._types.bool_type],
+            self._client._types.string_type
+        )
+
+    def bytes_to_hex_string(self, value: bytes) -> str:
+        return self._client._invoke(
+            "TestService",
+            "BytesToHexString",
+            [value],
+            ["value"],
+            [self._client._types.bytes_type],
+            self._client._types.string_type
+        )
+
+    def _return_type_bytes_to_hex_string(self) -> TypeBase:
+        return self._client._types.string_type
+
+    def _build_call_bytes_to_hex_string(self, value: bytes) -> KRPC_pb2.ProcedureCall:
+        return self._client._build_call(
+            "TestService",
+            "BytesToHexString",
+            [value],
+            ["value"],
+            [self._client._types.bytes_type],
+            self._client._types.string_type
+        )
+
+    def counter(self, id: str = '', divisor: int = 1) -> int:
+        return self._client._invoke(
+            "TestService",
+            "Counter",
+            [id, divisor],
+            ["id", "divisor"],
+            [self._client._types.string_type, self._client._types.sint32_type],
+            self._client._types.sint32_type
+        )
+
+    def _return_type_counter(self) -> TypeBase:
+        return self._client._types.sint32_type
+
+    def _build_call_counter(self, id: str = '', divisor: int = 1) -> KRPC_pb2.ProcedureCall:
+        return self._client._build_call(
+            "TestService",
+            "Counter",
+            [id, divisor],
+            ["id", "divisor"],
+            [self._client._types.string_type, self._client._types.sint32_type],
+            self._client._types.sint32_type
+        )
+
+    def create_test_object(self, value: str) -> TestClass:
+        return self._client._invoke(
+            "TestService",
+            "CreateTestObject",
+            [value],
+            ["value"],
+            [self._client._types.string_type],
+            self._client._types.class_type("TestService", "TestClass")
+        )
+
+    def _return_type_create_test_object(self) -> TypeBase:
+        return self._client._types.class_type("TestService", "TestClass")
+
+    def _build_call_create_test_object(self, value: str) -> KRPC_pb2.ProcedureCall:
+        return self._client._build_call(
+            "TestService",
+            "CreateTestObject",
+            [value],
+            ["value"],
+            [self._client._types.string_type],
+            self._client._types.class_type("TestService", "TestClass")
+        )
+
+    def deprecated_procedure(self, value: float) -> str:
+        """
+        Deprecated. Use FloatToString instead.
+
+        Deprecated procedure documentation string.
+        """
+        warnings.warn("TestService.deprecated_procedure is deprecated: Use FloatToString instead.", DeprecationWarning, stacklevel=2)
+        return self._client._invoke(
+            "TestService",
+            "DeprecatedProcedure",
+            [value],
+            ["value"],
+            [self._client._types.float_type],
+            self._client._types.string_type
+        )
+
+    def _return_type_deprecated_procedure(self) -> TypeBase:
+        return self._client._types.string_type
+
+    def _build_call_deprecated_procedure(self, value: float) -> KRPC_pb2.ProcedureCall:
+        return self._client._build_call(
+            "TestService",
+            "DeprecatedProcedure",
+            [value],
+            ["value"],
+            [self._client._types.float_type],
+            self._client._types.string_type
+        )
+
+    def deprecated_procedure_no_message(self, value: float) -> str:
+        """
+        Deprecated.
+
+        Deprecated procedure with no reason documentation string.
+        """
+        warnings.warn("TestService.deprecated_procedure_no_message is deprecated", DeprecationWarning, stacklevel=2)
+        return self._client._invoke(
+            "TestService",
+            "DeprecatedProcedureNoMessage",
+            [value],
+            ["value"],
+            [self._client._types.float_type],
+            self._client._types.string_type
+        )
+
+    def _return_type_deprecated_procedure_no_message(self) -> TypeBase:
+        return self._client._types.string_type
+
+    def _build_call_deprecated_procedure_no_message(self, value: float) -> KRPC_pb2.ProcedureCall:
+        return self._client._build_call(
+            "TestService",
+            "DeprecatedProcedureNoMessage",
+            [value],
+            ["value"],
+            [self._client._types.float_type],
+            self._client._types.string_type
+        )
+
+    def dictionary_default(self, x: Dict[int, bool] = {1: False, 2: True}) -> Dict[int, bool]:
+        return self._client._invoke(
+            "TestService",
+            "DictionaryDefault",
+            [x],
+            ["x"],
+            [self._client._types.dictionary_type(self._client._types.sint32_type, self._client._types.bool_type)],
+            self._client._types.dictionary_type(self._client._types.sint32_type, self._client._types.bool_type)
+        )
+
+    def _return_type_dictionary_default(self) -> TypeBase:
+        return self._client._types.dictionary_type(self._client._types.sint32_type, self._client._types.bool_type)
+
+    def _build_call_dictionary_default(self, x: Dict[int, bool] = {1: False, 2: True}) -> KRPC_pb2.ProcedureCall:
+        return self._client._build_call(
+            "TestService",
+            "DictionaryDefault",
+            [x],
+            ["x"],
+            [self._client._types.dictionary_type(self._client._types.sint32_type, self._client._types.bool_type)],
+            self._client._types.dictionary_type(self._client._types.sint32_type, self._client._types.bool_type)
+        )
+
+    def double_to_string(self, value: float) -> str:
+        return self._client._invoke(
+            "TestService",
+            "DoubleToString",
+            [value],
+            ["value"],
+            [self._client._types.double_type],
+            self._client._types.string_type
+        )
+
+    def _return_type_double_to_string(self) -> TypeBase:
+        return self._client._types.string_type
+
+    def _build_call_double_to_string(self, value: float) -> KRPC_pb2.ProcedureCall:
+        return self._client._build_call(
+            "TestService",
+            "DoubleToString",
+            [value],
+            ["value"],
+            [self._client._types.double_type],
+            self._client._types.string_type
+        )
+
+    def echo_test_object(self, value: Optional[TestClass]) -> Optional[TestClass]:
+        return self._client._invoke(
+            "TestService",
+            "EchoTestObject",
+            [value],
+            ["value"],
+            [self._client._types.class_type("TestService", "TestClass")],
+            self._client._types.class_type("TestService", "TestClass")
+        )
+
+    def _return_type_echo_test_object(self) -> TypeBase:
+        return self._client._types.class_type("TestService", "TestClass")
+
+    def _build_call_echo_test_object(self, value: Optional[TestClass]) -> KRPC_pb2.ProcedureCall:
+        return self._client._build_call(
+            "TestService",
+            "EchoTestObject",
+            [value],
+            ["value"],
+            [self._client._types.class_type("TestService", "TestClass")],
+            self._client._types.class_type("TestService", "TestClass")
+        )
+
+    def enum_default_arg(self, x: TestEnum = TestEnum(2)) -> TestEnum:
+        return self._client._invoke(
+            "TestService",
+            "EnumDefaultArg",
+            [x],
+            ["x"],
+            [self._client._types.enumeration_type("TestService", "TestEnum")],
+            self._client._types.enumeration_type("TestService", "TestEnum")
+        )
+
+    def _return_type_enum_default_arg(self) -> TypeBase:
+        return self._client._types.enumeration_type("TestService", "TestEnum")
+
+    def _build_call_enum_default_arg(self, x: TestEnum = TestEnum(2)) -> KRPC_pb2.ProcedureCall:
+        return self._client._build_call(
+            "TestService",
+            "EnumDefaultArg",
+            [x],
+            ["x"],
+            [self._client._types.enumeration_type("TestService", "TestEnum")],
+            self._client._types.enumeration_type("TestService", "TestEnum")
+        )
+
+    def enum_echo(self, x: TestEnum) -> TestEnum:
+        return self._client._invoke(
+            "TestService",
+            "EnumEcho",
+            [x],
+            ["x"],
+            [self._client._types.enumeration_type("TestService", "TestEnum")],
+            self._client._types.enumeration_type("TestService", "TestEnum")
+        )
+
+    def _return_type_enum_echo(self) -> TypeBase:
+        return self._client._types.enumeration_type("TestService", "TestEnum")
+
+    def _build_call_enum_echo(self, x: TestEnum) -> KRPC_pb2.ProcedureCall:
+        return self._client._build_call(
+            "TestService",
+            "EnumEcho",
+            [x],
+            ["x"],
+            [self._client._types.enumeration_type("TestService", "TestEnum")],
+            self._client._types.enumeration_type("TestService", "TestEnum")
+        )
+
+    def enum_return(self) -> TestEnum:
+        return self._client._invoke(
+            "TestService",
+            "EnumReturn",
+            [],
+            [],
+            [],
+            self._client._types.enumeration_type("TestService", "TestEnum")
+        )
+
+    def _return_type_enum_return(self) -> TypeBase:
+        return self._client._types.enumeration_type("TestService", "TestEnum")
+
+    def _build_call_enum_return(self) -> KRPC_pb2.ProcedureCall:
+        return self._client._build_call(
+            "TestService",
+            "EnumReturn",
+            [],
+            [],
+            [],
+            self._client._types.enumeration_type("TestService", "TestEnum")
+        )
+
+    def float_to_string(self, value: float) -> str:
+        """
+        Procedure documentation string.
+        """
+        return self._client._invoke(
+            "TestService",
+            "FloatToString",
+            [value],
+            ["value"],
+            [self._client._types.float_type],
+            self._client._types.string_type
+        )
+
+    def _return_type_float_to_string(self) -> TypeBase:
+        return self._client._types.string_type
+
+    def _build_call_float_to_string(self, value: float) -> KRPC_pb2.ProcedureCall:
+        return self._client._build_call(
+            "TestService",
+            "FloatToString",
+            [value],
+            ["value"],
+            [self._client._types.float_type],
+            self._client._types.string_type
+        )
+
+    def increment_dictionary(self, d: Dict[str, int]) -> Dict[str, int]:
+        return self._client._invoke(
+            "TestService",
+            "IncrementDictionary",
+            [d],
+            ["d"],
+            [self._client._types.dictionary_type(self._client._types.string_type, self._client._types.sint32_type)],
+            self._client._types.dictionary_type(self._client._types.string_type, self._client._types.sint32_type)
+        )
+
+    def _return_type_increment_dictionary(self) -> TypeBase:
+        return self._client._types.dictionary_type(self._client._types.string_type, self._client._types.sint32_type)
+
+    def _build_call_increment_dictionary(self, d: Dict[str, int]) -> KRPC_pb2.ProcedureCall:
+        return self._client._build_call(
+            "TestService",
+            "IncrementDictionary",
+            [d],
+            ["d"],
+            [self._client._types.dictionary_type(self._client._types.string_type, self._client._types.sint32_type)],
+            self._client._types.dictionary_type(self._client._types.string_type, self._client._types.sint32_type)
+        )
+
+    def increment_list(self, l: List[int]) -> List[int]:
+        return self._client._invoke(
+            "TestService",
+            "IncrementList",
+            [l],
+            ["l"],
+            [self._client._types.list_type(self._client._types.sint32_type)],
+            self._client._types.list_type(self._client._types.sint32_type)
+        )
+
+    def _return_type_increment_list(self) -> TypeBase:
+        return self._client._types.list_type(self._client._types.sint32_type)
+
+    def _build_call_increment_list(self, l: List[int]) -> KRPC_pb2.ProcedureCall:
+        return self._client._build_call(
+            "TestService",
+            "IncrementList",
+            [l],
+            ["l"],
+            [self._client._types.list_type(self._client._types.sint32_type)],
+            self._client._types.list_type(self._client._types.sint32_type)
+        )
+
+    def increment_nested_collection(self, d: Dict[str, List[int]]) -> Dict[str, List[int]]:
+        return self._client._invoke(
+            "TestService",
+            "IncrementNestedCollection",
+            [d],
+            ["d"],
+            [self._client._types.dictionary_type(self._client._types.string_type, self._client._types.list_type(self._client._types.sint32_type))],
+            self._client._types.dictionary_type(self._client._types.string_type, self._client._types.list_type(self._client._types.sint32_type))
+        )
+
+    def _return_type_increment_nested_collection(self) -> TypeBase:
+        return self._client._types.dictionary_type(self._client._types.string_type, self._client._types.list_type(self._client._types.sint32_type))
+
+    def _build_call_increment_nested_collection(self, d: Dict[str, List[int]]) -> KRPC_pb2.ProcedureCall:
+        return self._client._build_call(
+            "TestService",
+            "IncrementNestedCollection",
+            [d],
+            ["d"],
+            [self._client._types.dictionary_type(self._client._types.string_type, self._client._types.list_type(self._client._types.sint32_type))],
+            self._client._types.dictionary_type(self._client._types.string_type, self._client._types.list_type(self._client._types.sint32_type))
+        )
+
+    def increment_set(self, h: Set[int]) -> Set[int]:
+        return self._client._invoke(
+            "TestService",
+            "IncrementSet",
+            [h],
+            ["h"],
+            [self._client._types.set_type(self._client._types.sint32_type)],
+            self._client._types.set_type(self._client._types.sint32_type)
+        )
+
+    def _return_type_increment_set(self) -> TypeBase:
+        return self._client._types.set_type(self._client._types.sint32_type)
+
+    def _build_call_increment_set(self, h: Set[int]) -> KRPC_pb2.ProcedureCall:
+        return self._client._build_call(
+            "TestService",
+            "IncrementSet",
+            [h],
+            ["h"],
+            [self._client._types.set_type(self._client._types.sint32_type)],
+            self._client._types.set_type(self._client._types.sint32_type)
+        )
+
+    def increment_tuple(self, t: Tuple[int,int]) -> Tuple[int,int]:
+        return self._client._invoke(
+            "TestService",
+            "IncrementTuple",
+            [t],
+            ["t"],
+            [self._client._types.tuple_type(self._client._types.sint32_type, self._client._types.sint64_type)],
+            self._client._types.tuple_type(self._client._types.sint32_type, self._client._types.sint64_type)
+        )
+
+    def _return_type_increment_tuple(self) -> TypeBase:
+        return self._client._types.tuple_type(self._client._types.sint32_type, self._client._types.sint64_type)
+
+    def _build_call_increment_tuple(self, t: Tuple[int,int]) -> KRPC_pb2.ProcedureCall:
+        return self._client._build_call(
+            "TestService",
+            "IncrementTuple",
+            [t],
+            ["t"],
+            [self._client._types.tuple_type(self._client._types.sint32_type, self._client._types.sint64_type)],
+            self._client._types.tuple_type(self._client._types.sint32_type, self._client._types.sint64_type)
+        )
+
+    def int32_to_string(self, value: int) -> str:
+        return self._client._invoke(
+            "TestService",
+            "Int32ToString",
+            [value],
+            ["value"],
+            [self._client._types.sint32_type],
+            self._client._types.string_type
+        )
+
+    def _return_type_int32_to_string(self) -> TypeBase:
+        return self._client._types.string_type
+
+    def _build_call_int32_to_string(self, value: int) -> KRPC_pb2.ProcedureCall:
+        return self._client._build_call(
+            "TestService",
+            "Int32ToString",
+            [value],
+            ["value"],
+            [self._client._types.sint32_type],
+            self._client._types.string_type
+        )
+
+    def int64_to_string(self, value: int) -> str:
+        return self._client._invoke(
+            "TestService",
+            "Int64ToString",
+            [value],
+            ["value"],
+            [self._client._types.sint64_type],
+            self._client._types.string_type
+        )
+
+    def _return_type_int64_to_string(self) -> TypeBase:
+        return self._client._types.string_type
+
+    def _build_call_int64_to_string(self, value: int) -> KRPC_pb2.ProcedureCall:
+        return self._client._build_call(
+            "TestService",
+            "Int64ToString",
+            [value],
+            ["value"],
+            [self._client._types.sint64_type],
+            self._client._types.string_type
+        )
+
+    def list_default(self, x: List[int] = [1, 2, 3]) -> List[int]:
+        return self._client._invoke(
+            "TestService",
+            "ListDefault",
+            [x],
+            ["x"],
+            [self._client._types.list_type(self._client._types.sint32_type)],
+            self._client._types.list_type(self._client._types.sint32_type)
+        )
+
+    def _return_type_list_default(self) -> TypeBase:
+        return self._client._types.list_type(self._client._types.sint32_type)
+
+    def _build_call_list_default(self, x: List[int] = [1, 2, 3]) -> KRPC_pb2.ProcedureCall:
+        return self._client._build_call(
+            "TestService",
+            "ListDefault",
+            [x],
+            ["x"],
+            [self._client._types.list_type(self._client._types.sint32_type)],
+            self._client._types.list_type(self._client._types.sint32_type)
+        )
+
+    def on_timer(self, milliseconds: int, repeats: int = 1) -> Event:
+        return self._client._invoke(
+            "TestService",
+            "OnTimer",
+            [milliseconds, repeats],
+            ["milliseconds", "repeats"],
+            [self._client._types.uint32_type, self._client._types.uint32_type],
+            self._client._types.event_type
+        )
+
+    def _return_type_on_timer(self) -> TypeBase:
+        return self._client._types.event_type
+
+    def _build_call_on_timer(self, milliseconds: int, repeats: int = 1) -> KRPC_pb2.ProcedureCall:
+        return self._client._build_call(
+            "TestService",
+            "OnTimer",
+            [milliseconds, repeats],
+            ["milliseconds", "repeats"],
+            [self._client._types.uint32_type, self._client._types.uint32_type],
+            self._client._types.event_type
+        )
+
+    def on_timer_using_lambda(self, milliseconds: int) -> Event:
+        return self._client._invoke(
+            "TestService",
+            "OnTimerUsingLambda",
+            [milliseconds],
+            ["milliseconds"],
+            [self._client._types.uint32_type],
+            self._client._types.event_type
+        )
+
+    def _return_type_on_timer_using_lambda(self) -> TypeBase:
+        return self._client._types.event_type
+
+    def _build_call_on_timer_using_lambda(self, milliseconds: int) -> KRPC_pb2.ProcedureCall:
+        return self._client._build_call(
+            "TestService",
+            "OnTimerUsingLambda",
+            [milliseconds],
+            ["milliseconds"],
+            [self._client._types.uint32_type],
+            self._client._types.event_type
+        )
+
+    def optional_arguments(self, x: str, y: str = 'foo', z: str = 'bar', obj: TestClass = None) -> str:
+        return self._client._invoke(
+            "TestService",
+            "OptionalArguments",
+            [x, y, z, obj],
+            ["x", "y", "z", "obj"],
+            [self._client._types.string_type, self._client._types.string_type, self._client._types.string_type, self._client._types.class_type("TestService", "TestClass")],
+            self._client._types.string_type
+        )
+
+    def _return_type_optional_arguments(self) -> TypeBase:
+        return self._client._types.string_type
+
+    def _build_call_optional_arguments(self, x: str, y: str = 'foo', z: str = 'bar', obj: TestClass = None) -> KRPC_pb2.ProcedureCall:
+        return self._client._build_call(
+            "TestService",
+            "OptionalArguments",
+            [x, y, z, obj],
+            ["x", "y", "z", "obj"],
+            [self._client._types.string_type, self._client._types.string_type, self._client._types.string_type, self._client._types.class_type("TestService", "TestClass")],
+            self._client._types.string_type
+        )
+
+    def reset_custom_exception_later(self) -> None:
+        return self._client._invoke(
+            "TestService",
+            "ResetCustomExceptionLater",
+            [],
+            [],
+            [],
+            None
+        )
+
+    def _return_type_reset_custom_exception_later(self) -> TypeBase:
+        return None
+
+    def _build_call_reset_custom_exception_later(self) -> KRPC_pb2.ProcedureCall:
+        return self._client._build_call(
+            "TestService",
+            "ResetCustomExceptionLater",
+            [],
+            [],
+            [],
+            None
+        )
+
+    def reset_invalid_operation_exception_later(self) -> None:
+        return self._client._invoke(
+            "TestService",
+            "ResetInvalidOperationExceptionLater",
+            [],
+            [],
+            [],
+            None
+        )
+
+    def _return_type_reset_invalid_operation_exception_later(self) -> TypeBase:
+        return None
+
+    def _build_call_reset_invalid_operation_exception_later(self) -> KRPC_pb2.ProcedureCall:
+        return self._client._build_call(
+            "TestService",
+            "ResetInvalidOperationExceptionLater",
+            [],
+            [],
+            [],
+            None
+        )
+
+    def return_null_when_not_allowed(self) -> TestClass:
+        return self._client._invoke(
+            "TestService",
+            "ReturnNullWhenNotAllowed",
+            [],
+            [],
+            [],
+            self._client._types.class_type("TestService", "TestClass")
+        )
+
+    def _return_type_return_null_when_not_allowed(self) -> TypeBase:
+        return self._client._types.class_type("TestService", "TestClass")
+
+    def _build_call_return_null_when_not_allowed(self) -> KRPC_pb2.ProcedureCall:
+        return self._client._build_call(
+            "TestService",
+            "ReturnNullWhenNotAllowed",
+            [],
+            [],
+            [],
+            self._client._types.class_type("TestService", "TestClass")
+        )
+
+    def set_default(self, x: Set[int] = {1, 2, 3}) -> Set[int]:
+        return self._client._invoke(
+            "TestService",
+            "SetDefault",
+            [x],
+            ["x"],
+            [self._client._types.set_type(self._client._types.sint32_type)],
+            self._client._types.set_type(self._client._types.sint32_type)
+        )
+
+    def _return_type_set_default(self) -> TypeBase:
+        return self._client._types.set_type(self._client._types.sint32_type)
+
+    def _build_call_set_default(self, x: Set[int] = {1, 2, 3}) -> KRPC_pb2.ProcedureCall:
+        return self._client._build_call(
+            "TestService",
+            "SetDefault",
+            [x],
+            ["x"],
+            [self._client._types.set_type(self._client._types.sint32_type)],
+            self._client._types.set_type(self._client._types.sint32_type)
+        )
+
+    def string_to_int32(self, value: str) -> int:
+        return self._client._invoke(
+            "TestService",
+            "StringToInt32",
+            [value],
+            ["value"],
+            [self._client._types.string_type],
+            self._client._types.sint32_type
+        )
+
+    def _return_type_string_to_int32(self) -> TypeBase:
+        return self._client._types.sint32_type
+
+    def _build_call_string_to_int32(self, value: str) -> KRPC_pb2.ProcedureCall:
+        return self._client._build_call(
+            "TestService",
+            "StringToInt32",
+            [value],
+            ["value"],
+            [self._client._types.string_type],
+            self._client._types.sint32_type
+        )
+
+    def throw_argument_exception(self) -> int:
+        return self._client._invoke(
+            "TestService",
+            "ThrowArgumentException",
+            [],
+            [],
+            [],
+            self._client._types.sint32_type
+        )
+
+    def _return_type_throw_argument_exception(self) -> TypeBase:
+        return self._client._types.sint32_type
+
+    def _build_call_throw_argument_exception(self) -> KRPC_pb2.ProcedureCall:
+        return self._client._build_call(
+            "TestService",
+            "ThrowArgumentException",
+            [],
+            [],
+            [],
+            self._client._types.sint32_type
+        )
+
+    def throw_argument_null_exception(self, foo: str) -> int:
+        return self._client._invoke(
+            "TestService",
+            "ThrowArgumentNullException",
+            [foo],
+            ["foo"],
+            [self._client._types.string_type],
+            self._client._types.sint32_type
+        )
+
+    def _return_type_throw_argument_null_exception(self) -> TypeBase:
+        return self._client._types.sint32_type
+
+    def _build_call_throw_argument_null_exception(self, foo: str) -> KRPC_pb2.ProcedureCall:
+        return self._client._build_call(
+            "TestService",
+            "ThrowArgumentNullException",
+            [foo],
+            ["foo"],
+            [self._client._types.string_type],
+            self._client._types.sint32_type
+        )
+
+    def throw_argument_out_of_range_exception(self, foo: int) -> int:
+        return self._client._invoke(
+            "TestService",
+            "ThrowArgumentOutOfRangeException",
+            [foo],
+            ["foo"],
+            [self._client._types.sint32_type],
+            self._client._types.sint32_type
+        )
+
+    def _return_type_throw_argument_out_of_range_exception(self) -> TypeBase:
+        return self._client._types.sint32_type
+
+    def _build_call_throw_argument_out_of_range_exception(self, foo: int) -> KRPC_pb2.ProcedureCall:
+        return self._client._build_call(
+            "TestService",
+            "ThrowArgumentOutOfRangeException",
+            [foo],
+            ["foo"],
+            [self._client._types.sint32_type],
+            self._client._types.sint32_type
+        )
+
+    def throw_custom_exception(self) -> int:
+        return self._client._invoke(
+            "TestService",
+            "ThrowCustomException",
+            [],
+            [],
+            [],
+            self._client._types.sint32_type
+        )
+
+    def _return_type_throw_custom_exception(self) -> TypeBase:
+        return self._client._types.sint32_type
+
+    def _build_call_throw_custom_exception(self) -> KRPC_pb2.ProcedureCall:
+        return self._client._build_call(
+            "TestService",
+            "ThrowCustomException",
+            [],
+            [],
+            [],
+            self._client._types.sint32_type
+        )
+
+    def throw_custom_exception_later(self) -> int:
+        return self._client._invoke(
+            "TestService",
+            "ThrowCustomExceptionLater",
+            [],
+            [],
+            [],
+            self._client._types.sint32_type
+        )
+
+    def _return_type_throw_custom_exception_later(self) -> TypeBase:
+        return self._client._types.sint32_type
+
+    def _build_call_throw_custom_exception_later(self) -> KRPC_pb2.ProcedureCall:
+        return self._client._build_call(
+            "TestService",
+            "ThrowCustomExceptionLater",
+            [],
+            [],
+            [],
+            self._client._types.sint32_type
+        )
+
+    def throw_invalid_operation_exception(self) -> int:
+        return self._client._invoke(
+            "TestService",
+            "ThrowInvalidOperationException",
+            [],
+            [],
+            [],
+            self._client._types.sint32_type
+        )
+
+    def _return_type_throw_invalid_operation_exception(self) -> TypeBase:
+        return self._client._types.sint32_type
+
+    def _build_call_throw_invalid_operation_exception(self) -> KRPC_pb2.ProcedureCall:
+        return self._client._build_call(
+            "TestService",
+            "ThrowInvalidOperationException",
+            [],
+            [],
+            [],
+            self._client._types.sint32_type
+        )
+
+    def throw_invalid_operation_exception_later(self) -> int:
+        return self._client._invoke(
+            "TestService",
+            "ThrowInvalidOperationExceptionLater",
+            [],
+            [],
+            [],
+            self._client._types.sint32_type
+        )
+
+    def _return_type_throw_invalid_operation_exception_later(self) -> TypeBase:
+        return self._client._types.sint32_type
+
+    def _build_call_throw_invalid_operation_exception_later(self) -> KRPC_pb2.ProcedureCall:
+        return self._client._build_call(
+            "TestService",
+            "ThrowInvalidOperationExceptionLater",
+            [],
+            [],
+            [],
+            self._client._types.sint32_type
+        )
+
+    def tuple_default(self, x: Tuple[int,bool] = (1, False)) -> Tuple[int,bool]:
+        return self._client._invoke(
+            "TestService",
+            "TupleDefault",
+            [x],
+            ["x"],
+            [self._client._types.tuple_type(self._client._types.sint32_type, self._client._types.bool_type)],
+            self._client._types.tuple_type(self._client._types.sint32_type, self._client._types.bool_type)
+        )
+
+    def _return_type_tuple_default(self) -> TypeBase:
+        return self._client._types.tuple_type(self._client._types.sint32_type, self._client._types.bool_type)
+
+    def _build_call_tuple_default(self, x: Tuple[int,bool] = (1, False)) -> KRPC_pb2.ProcedureCall:
+        return self._client._build_call(
+            "TestService",
+            "TupleDefault",
+            [x],
+            ["x"],
+            [self._client._types.tuple_type(self._client._types.sint32_type, self._client._types.bool_type)],
+            self._client._types.tuple_type(self._client._types.sint32_type, self._client._types.bool_type)
+        )

--- a/tools/krpctools/krpctools/test/docgen-TestService-cnano.rst
+++ b/tools/krpctools/krpctools/test/docgen-TestService-cnano.rst
@@ -83,6 +83,39 @@ Service TestService
 
    
 
+   .. function:: krpc_error_t krpc_TestService_DeprecatedProcedure(krpc_connection_t connection, char * * result, float value)
+
+      .. warning:: Deprecated. Use FloatToString instead.
+
+      Deprecated procedure documentation string.
+
+      :Parameters:
+
+
+
+   
+
+   .. function:: krpc_error_t krpc_TestService_DeprecatedProcedureNoMessage(krpc_connection_t connection, char * * result, float value)
+
+      .. warning:: Deprecated.
+
+      Deprecated procedure with no reason documentation string.
+
+      :Parameters:
+
+
+
+   
+
+   .. function:: krpc_error_t krpc_TestService_DeprecatedProperty(krpc_connection_t connection, char * * result)
+   .. function:: void krpc_TestService_set_DeprecatedProperty(const char * value)
+
+      .. warning:: Deprecated. Use StringProperty instead.
+
+      Deprecated property documentation string.
+
+   
+
    .. function:: krpc_error_t krpc_TestService_DictionaryDefault(krpc_connection_t connection, krpc_dictionary_int32_bool_t * result, const krpc_dictionary_int32_bool_t * x)
 
 
@@ -481,6 +514,23 @@ Service TestService
 
 
 
+.. type:: krpc_TestService_DeprecatedClass_t
+
+   .. warning:: Deprecated. Use TestClass instead.
+
+   Deprecated class documentation string.
+
+   .. function:: krpc_error_t krpc_TestService_DeprecatedClass_DeprecatedMethod(krpc_connection_t connection, char * * result)
+
+      .. warning:: Deprecated. Use TestClass.GetValue instead.
+
+      Deprecated method documentation string.
+
+
+   
+
+
+
 .. type:: krpc_TestService_TestEnum_t
 
    Enum documentation string.
@@ -502,4 +552,34 @@ Service TestService
 
 
 
+.. type:: krpc_TestService_DeprecatedEnum_t
+
+   .. warning:: Deprecated. Use TestEnum instead.
+
+   Deprecated enum documentation string.
+
+
+   .. macro:: KRPC_TESTSERVICE_DEPRECATEDENUM_VALUEA
+
+      Deprecated enum ValueA documentation string.
+
+
+   .. macro:: KRPC_TESTSERVICE_DEPRECATEDENUM_VALUEB
+
+      .. warning:: Deprecated. Use ValueA instead.
+
+      Deprecated enum ValueB documentation string.
+
+
+
 Exception class CustomException
+
+
+
+
+
+Exception class DeprecatedException
+
+   .. warning:: Deprecated. Use CustomException instead.
+
+   Deprecated exception documentation string.

--- a/tools/krpctools/krpctools/test/docgen-TestService-cpp.rst
+++ b/tools/krpctools/krpctools/test/docgen-TestService-cpp.rst
@@ -88,6 +88,39 @@
 
    
 
+   .. function:: std::string deprecated_procedure(float value)
+
+      .. warning:: Deprecated. Use FloatToString instead.
+
+      Deprecated procedure documentation string.
+
+      :Parameters:
+
+
+
+   
+
+   .. function:: std::string deprecated_procedure_no_message(float value)
+
+      .. warning:: Deprecated.
+
+      Deprecated procedure with no reason documentation string.
+
+      :Parameters:
+
+
+
+   
+
+   .. function:: std::string deprecated_property()
+   .. function:: void set_deprecated_property(std::string value)
+
+      .. warning:: Deprecated. Use StringProperty instead.
+
+      Deprecated property documentation string.
+
+   
+
    .. function:: std::map<int32_t, bool> dictionary_default(std::map<int32_t, bool> x = std::map<int32_t, bool>({1, false}, {2, true}))
 
 
@@ -486,6 +519,23 @@
 
 
 
+.. class:: DeprecatedClass
+
+   .. warning:: Deprecated. Use TestClass instead.
+
+   Deprecated class documentation string.
+
+   .. function:: std::string deprecated_method()
+
+      .. warning:: Deprecated. Use TestClass.GetValue instead.
+
+      Deprecated method documentation string.
+
+
+   
+
+
+
 .. namespace:: krpc::services::TestService
 .. enum-struct:: TestEnum
 
@@ -509,4 +559,36 @@
 
 
 .. namespace:: krpc::services::TestService
+.. enum-struct:: DeprecatedEnum
+
+   .. warning:: Deprecated. Use TestEnum instead.
+
+   Deprecated enum documentation string.
+
+
+   .. enumerator:: value_a
+
+      Deprecated enum ValueA documentation string.
+
+
+   .. enumerator:: value_b
+
+      .. warning:: Deprecated. Use ValueA instead.
+
+      Deprecated enum ValueB documentation string.
+
+
+
+.. namespace:: krpc::services::TestService
 .. class:: CustomException
+
+
+
+
+
+.. namespace:: krpc::services::TestService
+.. class:: DeprecatedException
+
+   .. warning:: Deprecated. Use CustomException instead.
+
+   Deprecated exception documentation string.

--- a/tools/krpctools/krpctools/test/docgen-TestService-csharp.rst
+++ b/tools/krpctools/krpctools/test/docgen-TestService-csharp.rst
@@ -83,6 +83,38 @@
 
       :Game Scenes: All
 
+   .. method:: string DeprecatedProcedure(float value)
+
+      .. warning:: Deprecated. Use FloatToString instead.
+
+      Deprecated procedure documentation string.
+
+      :parameters:
+
+
+
+      :Game Scenes: All
+
+   .. method:: string DeprecatedProcedureNoMessage(float value)
+
+      .. warning:: Deprecated.
+
+      Deprecated procedure with no reason documentation string.
+
+      :parameters:
+
+
+
+      :Game Scenes: All
+
+   .. property:: string DeprecatedProperty { get; set; }
+
+      .. warning:: Deprecated. Use StringProperty instead.
+
+      Deprecated property documentation string.
+
+      :Game Scenes: All
+
    .. method:: System.Collections.Generic.IDictionary<int,bool> DictionaryDefault(System.Collections.Generic.IDictionary<int,bool> x = { 1: false, 2: true })
 
 
@@ -477,6 +509,23 @@
 
 
 
+.. class:: DeprecatedClass
+
+   .. warning:: Deprecated. Use TestClass instead.
+
+   Deprecated class documentation string.
+
+   .. method:: string DeprecatedMethod()
+
+      .. warning:: Deprecated. Use TestClass.GetValue instead.
+
+      Deprecated method documentation string.
+
+
+      :Game Scenes: All
+
+
+
 .. enum:: TestEnum
 
    Enum documentation string.
@@ -498,4 +547,34 @@
 
 
 
+.. enum:: DeprecatedEnum
+
+   .. warning:: Deprecated. Use TestEnum instead.
+
+   Deprecated enum documentation string.
+
+
+   .. value:: ValueA
+
+      Deprecated enum ValueA documentation string.
+
+
+   .. value:: ValueB
+
+      .. warning:: Deprecated. Use ValueA instead.
+
+      Deprecated enum ValueB documentation string.
+
+
+
 .. class:: CustomException
+
+
+
+
+
+.. class:: DeprecatedException
+
+   .. warning:: Deprecated. Use CustomException instead.
+
+   Deprecated exception documentation string.

--- a/tools/krpctools/krpctools/test/docgen-TestService-java.rst
+++ b/tools/krpctools/krpctools/test/docgen-TestService-java.rst
@@ -62,6 +62,34 @@
       :param String value:
    
 
+   .. method:: String deprecatedProcedure(float value)
+
+      .. warning:: Deprecated. Use FloatToString instead.
+
+      Deprecated procedure documentation string.
+
+      :param float value:
+   
+
+   .. method:: String deprecatedProcedureNoMessage(float value)
+
+      .. warning:: Deprecated.
+
+      Deprecated procedure with no reason documentation string.
+
+      :param float value:
+   
+
+   .. method:: String getDeprecatedProperty()
+
+   .. method:: void setDeprecatedProperty(String value)
+
+      .. warning:: Deprecated. Use StringProperty instead.
+
+      Deprecated property documentation string.
+
+   
+
    .. method:: java.util.Map<Integer,Boolean> dictionaryDefault(java.util.Map<Integer,Boolean> x)
 
 
@@ -378,6 +406,22 @@
 
 
 
+.. type:: public class DeprecatedClass
+
+   .. warning:: Deprecated. Use TestClass instead.
+
+   Deprecated class documentation string.
+
+   .. method:: String deprecatedMethod()
+
+      .. warning:: Deprecated. Use TestClass.GetValue instead.
+
+      Deprecated method documentation string.
+
+   
+
+
+
 .. type:: public enum TestEnum
 
    Enum documentation string.
@@ -399,4 +443,34 @@
 
 
 
+.. type:: public enum DeprecatedEnum
+
+   .. warning:: Deprecated. Use TestEnum instead.
+
+   Deprecated enum documentation string.
+
+
+   .. field:: public DeprecatedEnum VALUE_A
+
+      Deprecated enum ValueA documentation string.
+
+
+   .. field:: public DeprecatedEnum VALUE_B
+
+      .. warning:: Deprecated. Use ValueA instead.
+
+      Deprecated enum ValueB documentation string.
+
+
+
 .. type:: public class CustomException
+
+
+
+
+
+.. type:: public class DeprecatedException
+
+   .. warning:: Deprecated. Use CustomException instead.
+
+   Deprecated exception documentation string.

--- a/tools/krpctools/krpctools/test/docgen-TestService-lua.rst
+++ b/tools/krpctools/krpctools/test/docgen-TestService-lua.rst
@@ -84,6 +84,42 @@ Service documentation string.
 
 
 
+.. staticmethod:: deprecated_procedure(value)
+
+   .. warning:: Deprecated. Use FloatToString instead.
+
+   Deprecated procedure documentation string.
+
+   :param number value:
+   :rtype: string
+
+
+
+
+.. staticmethod:: deprecated_procedure_no_message(value)
+
+   .. warning:: Deprecated.
+
+   Deprecated procedure with no reason documentation string.
+
+   :param number value:
+   :rtype: string
+
+
+
+
+.. attribute:: deprecated_property: string
+
+   .. warning:: Deprecated. Use StringProperty instead.
+
+   Deprecated property documentation string.
+
+   :Attribute: Can be read or written
+   :rtype: string
+
+
+
+
 .. staticmethod:: dictionary_default([x = {1: False, 2: True}])
 
 
@@ -500,6 +536,22 @@ Service documentation string.
 
 
 
+.. class:: DeprecatedClass
+
+   .. warning:: Deprecated. Use TestClass instead.
+
+   Deprecated class documentation string.
+
+   .. method:: deprecated_method()
+
+      .. warning:: Deprecated. Use TestClass.GetValue instead.
+
+      Deprecated method documentation string.
+
+      :rtype: string
+
+
+
 .. class:: TestEnum
 
    Enum documentation string.
@@ -521,4 +573,34 @@ Service documentation string.
 
 
 
+.. class:: DeprecatedEnum
+
+   .. warning:: Deprecated. Use TestEnum instead.
+
+   Deprecated enum documentation string.
+
+
+   .. data:: value_a
+
+      Deprecated enum ValueA documentation string.
+
+
+   .. data:: value_b
+
+      .. warning:: Deprecated. Use ValueA instead.
+
+      Deprecated enum ValueB documentation string.
+
+
+
 .. class:: CustomException
+
+
+
+
+
+.. class:: DeprecatedException
+
+   .. warning:: Deprecated. Use CustomException instead.
+
+   Deprecated exception documentation string.

--- a/tools/krpctools/krpctools/test/docgen-TestService-python.rst
+++ b/tools/krpctools/krpctools/test/docgen-TestService-python.rst
@@ -91,6 +91,45 @@ Service documentation string.
 
 
 
+.. staticmethod:: deprecated_procedure(value)
+
+   .. warning:: Deprecated. Use FloatToString instead.
+
+   Deprecated procedure documentation string.
+
+   :param float value:
+   :rtype: str
+   
+
+
+
+
+.. staticmethod:: deprecated_procedure_no_message(value)
+
+   .. warning:: Deprecated.
+
+   Deprecated procedure with no reason documentation string.
+
+   :param float value:
+   :rtype: str
+   
+
+
+
+
+.. attribute:: deprecated_property
+
+   .. warning:: Deprecated. Use StringProperty instead.
+
+   Deprecated property documentation string.
+
+   :Attribute: Can be read or written
+   :rtype: str
+   
+
+
+
+
 .. staticmethod:: dictionary_default([x = {1: False, 2: True}])
 
 
@@ -551,6 +590,23 @@ Service documentation string.
 
 
 
+.. class:: DeprecatedClass
+
+   .. warning:: Deprecated. Use TestClass instead.
+
+   Deprecated class documentation string.
+
+   .. method:: deprecated_method()
+
+      .. warning:: Deprecated. Use TestClass.GetValue instead.
+
+      Deprecated method documentation string.
+
+      :rtype: str
+   
+
+
+
 .. class:: TestEnum
 
    Enum documentation string.
@@ -572,4 +628,34 @@ Service documentation string.
 
 
 
+.. class:: DeprecatedEnum
+
+   .. warning:: Deprecated. Use TestEnum instead.
+
+   Deprecated enum documentation string.
+
+
+   .. data:: value_a
+
+      Deprecated enum ValueA documentation string.
+
+
+   .. data:: value_b
+
+      .. warning:: Deprecated. Use ValueA instead.
+
+      Deprecated enum ValueB documentation string.
+
+
+
 .. class:: CustomException
+
+
+
+
+
+.. class:: DeprecatedException
+
+   .. warning:: Deprecated. Use CustomException instead.
+
+   Deprecated exception documentation string.

--- a/tools/krpctools/krpctools/test/test_clientgen_python.py
+++ b/tools/krpctools/krpctools/test/test_clientgen_python.py
@@ -1,0 +1,12 @@
+import unittest
+from krpctools.test.clientgentest import ClientGenTestCase
+from krpctools.clientgen.python import PythonGenerator
+
+
+class TestClientGenPython(ClientGenTestCase, unittest.TestCase):
+    language = "python"
+    generator = PythonGenerator
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/krpctools/pylint.rc
+++ b/tools/krpctools/pylint.rc
@@ -5,7 +5,7 @@ variable-rgx=[a-z_][a-z0-9_]{1,30}$
 [DESIGN]
 max-args=10
 max-locals=20
-max-attributes=10
+max-attributes=12
 max-returns=25
 max-branches=25
 


### PR DESCRIPTION
Marking a kRPC member `[Obsolete("reason")]` previously had **no visible effect** — the
scanner ignored it, there was no wire-schema field, and neither generated documentation nor
generated client code carried any deprecation marker, so users only discovered deprecations
from the changelog. This PR threads deprecation through the full pipeline:

**C# attribute → scanner signature → wire schema + JSON → docgen/clientgen → clients**

so a deprecated member now surfaces as a documentation warning, a compiler-level deprecation
marker in every generated client, and a runtime `DeprecationWarning` in the dynamic Python
client.

The feature is **purely informational**: deprecated members remain fully callable. It reads
the standard `System.ObsoleteAttribute` — no new kRPC attribute is introduced.

## Wire compatibility

Additive proto3 change only: new `bool deprecated` / `string deprecated_reason` fields on the
`Service`, `Procedure`, `Class`, `Enumeration`, `EnumerationValue` and `Exception` reflection
messages. Old clients ignore the new fields; old servers never set them. Plain `bool`/`string`
fields work with the Unity-pinned protobuf 3.10.1 and protobuf-lua (no proto3-`optional`
issues).

## What changed

### Wire + server (`protobuf/`, `core/`)
- Added `deprecated` / `deprecated_reason` to the six service-definition messages and
  documented them in the communication-protocol reference.
- New `TypeUtils.GetDeprecated` / `GetPropertyDeprecated` helpers read `[Obsolete]` during
  scanning (properties read from the property, falling back to the accessor).
- Threaded the flag through the signatures, the JSON service definition (`GetObjectData`),
  the internal messages, `KRPC.GetServices`, **and** `MessageExtensions` — both the JSON and
  the protobuf paths, so the dynamic clients that read the `GetServices` response see it.

### Generated docs (`tools/krpctools/.../docgen`)
- Each of the six language domains emits a `.. warning:: Deprecated. <reason>` admonition for
  every deprecated entity.

### Generated clients (`tools/krpctools/.../clientgen`)
Deprecated declarations are now marked natively:

| Client | Marker |
| --- | --- |
| C# | `[global::System.Obsolete("<reason>")]` |
| Java | `@Deprecated` + an `@deprecated <reason>` javadoc tag |
| C++ | `[[deprecated("<reason>")]]` + a `\deprecated` doxygen tag |
| C nano | new `KRPC_DEPRECATED(msg)` attribute macro |
| Python stubs | a `Deprecated.` line prepended to the docstring |

### Dynamic Python client (`client/python`)
- Calling a deprecated procedure, property or class member emits a `DeprecationWarning`.
- The `Deprecated.` notice is prepended to the constructed docstring of every deprecated
  service, procedure, property, class, enumeration, enumeration value and exception.

## Implementation notes
- `TypeUtils.GetDeprecated` guards with `Reflection.HasAttribute` before `GetAttribute`
  (the latter throws when the attribute is absent).
- Generated C#/Java stubs reference their own deprecated members (exception-type
  registration, enum `fromValue`), which trips warnings-as-errors — suppressed file-wide in
  the generated code (`#pragma warning disable 612, 618` for C#, class-level
  `@SuppressWarnings("deprecation")` for Java). C++ `[[deprecated]]` is placed after the
  `class` / `enum struct` keyword and after the enumerator name.

## Tests
- **Core** (`ScannerTest` / `MessageAssert`): deprecated fixtures for every entity kind plus a
  dedicated deprecated service; asserts the flag and reason propagate through `GetServices`.
- **TestServer**: deprecated procedure (with and without a reason), property, class + method,
  enumeration + value, and exception fixtures.
- **krpctools**: regenerated clientgen and docgen golden fixtures.
- **Python client**: `DeprecationWarning` raised on a dynamically-loaded connection; the
  deprecation docstrings are present on the pre-generated stubs.

Fixes #904