### PR TITLE
Fix SAS mode set in same tick as enabling SAS

### DIFF
--- a/service/SpaceCenter/CHANGES.txt
+++ b/service/SpaceCenter/CHANGES.txt
@@ -57,6 +57,7 @@ v0.6.0
  * Fix ResourceHarvester.ExtractionRate returning 0 when part action window is not open (#889)
  * Fix Sensor.Value returning zero when the part action window is not open (#883)
  * Fix Engine.AvailableThrust and MaxThrust for air-breathing engines at supersonic speeds (#924)
+ * Fix Control.SASMode being dropped when set in the same physics tick as enabling SAS (#236)
 
 v0.5.4
  * Fix vessel recovery (#782)

--- a/service/SpaceCenter/src/Services/AutoPilot.cs
+++ b/service/SpaceCenter/src/Services/AutoPilot.cs
@@ -260,12 +260,22 @@ namespace KRPC.SpaceCenter.Services
         /// <remarks>Equivalent to <see cref="Control.SAS"/></remarks>
         [KRPCProperty]
         public bool SAS {
-            get { return InternalVessel.ActionGroups.groups [BaseAction.GetGroupIndex (KSPActionGroup.SAS)]; }
+            get { return GetSAS (InternalVessel); }
             set {
                 if (value && engaged [vesselId] == this)
                     throw new InvalidOperationException("SAS cannot be enabled when the auto-pilot is engaged");
-                InternalVessel.ActionGroups.SetGroup (KSPActionGroup.SAS, value);
+                SetSAS (InternalVessel, value);
             }
+        }
+
+        internal static bool GetSAS (global::Vessel vessel)
+        {
+            return vessel.ActionGroups.groups [BaseAction.GetGroupIndex (KSPActionGroup.SAS)];
+        }
+
+        internal static void SetSAS (global::Vessel vessel, bool value)
+        {
+            vessel.ActionGroups.SetGroup (KSPActionGroup.SAS, value);
         }
 
         /// <summary>
@@ -276,8 +286,34 @@ namespace KRPC.SpaceCenter.Services
         /// <remarks>Equivalent to <see cref="Control.SASMode"/></remarks>
         [KRPCProperty]
         public SASMode SASMode {
-            get { return Control.GetSASMode (InternalVessel); }
-            set { Control.SetSASMode (InternalVessel, value); }
+            get { return GetSASMode (InternalVessel); }
+            set { SetSASMode (InternalVessel, value); }
+        }
+
+        internal static SASMode GetSASMode (global::Vessel vessel)
+        {
+            return vessel.Autopilot.Mode.ToSASMode ();
+        }
+
+        internal static void SetSASMode (global::Vessel vessel, SASMode value)
+        {
+            var autopilot = vessel.Autopilot;
+            var mode = value.FromSASMode ();
+            if (!autopilot.CanSetMode (mode))
+                throw new InvalidOperationException ("Cannot set SAS mode of vessel");
+            // When SAS is enabled and the mode is set in the same physics tick,
+            // VesselAutopilot.Update has not yet enabled the autopilot, so
+            // SetMode would only store the mode. The autopilot then enables with
+            // Enable(StabilityAssist) on the next update, discarding the mode.
+            // Enable atomically with the requested mode to avoid this.
+            if (!autopilot.Enabled && GetSAS (vessel))
+                autopilot.Enable (mode);
+            else
+                autopilot.SetMode (mode);
+            // Update the UI buttons
+            var modeIndex = (int)autopilot.Mode;
+            var modeButtons = UnityEngine.Object.FindObjectOfType<VesselAutopilotUI> ().modeButtons;
+            modeButtons [modeIndex].SetState (true);
         }
 
         /// <summary>

--- a/service/SpaceCenter/src/Services/Control.cs
+++ b/service/SpaceCenter/src/Services/Control.cs
@@ -77,8 +77,8 @@ namespace KRPC.SpaceCenter.Services
         /// <remarks>Equivalent to <see cref="AutoPilot.SAS"/></remarks>
         [KRPCProperty]
         public bool SAS {
-            get { return InternalVessel.ActionGroups.groups [BaseAction.GetGroupIndex (KSPActionGroup.SAS)]; }
-            set { InternalVessel.ActionGroups.SetGroup (KSPActionGroup.SAS, value); }
+            get { return AutoPilot.GetSAS (InternalVessel); }
+            set { AutoPilot.SetSAS (InternalVessel, value); }
         }
 
         /// <summary>
@@ -89,25 +89,8 @@ namespace KRPC.SpaceCenter.Services
         /// <remarks>Equivalent to <see cref="AutoPilot.SASMode"/></remarks>
         [KRPCProperty]
         public SASMode SASMode {
-            get { return GetSASMode (InternalVessel); }
-            set { SetSASMode (InternalVessel, value); }
-        }
-
-        internal static SASMode GetSASMode (global::Vessel vessel)
-        {
-            return vessel.Autopilot.Mode.ToSASMode ();
-        }
-
-        internal static void SetSASMode (global::Vessel vessel, SASMode value)
-        {
-            var mode = value.FromSASMode ();
-            if (!vessel.Autopilot.CanSetMode (mode))
-                throw new InvalidOperationException ("Cannot set SAS mode of vessel");
-            vessel.Autopilot.SetMode (mode);
-            // Update the UI buttons
-            var modeIndex = (int)vessel.Autopilot.Mode;
-            var modeButtons = UnityEngine.Object.FindObjectOfType<VesselAutopilotUI> ().modeButtons;
-            modeButtons [modeIndex].SetState (true);
+            get { return AutoPilot.GetSASMode (InternalVessel); }
+            set { AutoPilot.SetSASMode (InternalVessel, value); }
         }
 
         /// <summary>

--- a/service/SpaceCenter/test/test_control.py
+++ b/service/SpaceCenter/test/test_control.py
@@ -135,44 +135,42 @@ class TestControlMixin:
 
     def test_sas_mode(self):
         sas_mode = self.space_center.SASMode
-        self.control.sas = True
-        self.control.sas_mode = sas_mode.stability_assist
         active = self.vessel == self.space_center.active_vessel
         if active:
             self.vessel.control.add_node(self.space_center.ut + 60, 100, 0, 0)
-        self.assertEqual(self.control.sas_mode, sas_mode.stability_assist)
+        # Enable SAS and set a (non-default) mode with no delay between them,
+        # then wait for the game autopilot to enable: the mode must survive
+        # rather than being reset to StabilityAssist when the autopilot enables
+        # (#236). SAS is switched off first so enabling it below is a real state
+        # change, and the wait is essential - the mode is stored immediately but
+        # was only discarded on the following update when the autopilot enabled.
+        self.control.sas = False
         self.wait()
+        self.control.sas = True
+        self.control.sas_mode = sas_mode.prograde
+        self.wait()
+        self.assertTrue(self.control.sas)
+        self.assertEqual(self.control.sas_mode, sas_mode.prograde)
+        # SAS is now enabled, so further mode changes take effect immediately.
         if active:
             self.control.sas_mode = sas_mode.maneuver
             self.assertEqual(self.control.sas_mode, sas_mode.maneuver)
-            self.wait()
-        self.control.sas_mode = sas_mode.prograde
-        self.assertEqual(self.control.sas_mode, sas_mode.prograde)
-        self.wait()
         self.control.sas_mode = sas_mode.retrograde
         self.assertEqual(self.control.sas_mode, sas_mode.retrograde)
-        self.wait()
         self.control.sas_mode = sas_mode.normal
         self.assertEqual(self.control.sas_mode, sas_mode.normal)
-        self.wait()
         self.control.sas_mode = sas_mode.anti_normal
         self.assertEqual(self.control.sas_mode, sas_mode.anti_normal)
-        self.wait()
         self.control.sas_mode = sas_mode.radial
         self.assertEqual(self.control.sas_mode, sas_mode.radial)
-        self.wait()
         self.control.sas_mode = sas_mode.anti_radial
         self.assertEqual(self.control.sas_mode, sas_mode.anti_radial)
-        self.wait()
-        # No target set, should not change
+        # No target set, so these would be ignored
         # TODO: test with a target set
         # self.control.sas_mode = sas_mode.target
-        # self.assertEqual(self.control.sas_mode, sas_mode.anti_radial)
-        # self.wait()
         # self.control.sas_mode = sas_mode.anti_target
-        # self.assertEqual(self.control.sas_mode, sas_mode.anti_radial)
-        # self.wait()
         self.control.sas_mode = sas_mode.stability_assist
+        self.assertEqual(self.control.sas_mode, sas_mode.stability_assist)
         self.control.sas = False
 
     def test_speed_mode(self):


### PR DESCRIPTION
Setting Control.SASMode immediately after enabling SAS was silently discarded. The game's VesselAutopilot only becomes enabled on its next Update, so at the point SetSASMode ran, VesselAutopilot.SetMode merely stored the mode field. The pending Update then called Enable() with the default StabilityAssist mode, overwriting the requested mode.

Detect this case (SAS action group on but autopilot not yet enabled) and enable atomically with the requested mode via VesselAutopilot.Enable(mode), so the mode survives. The existing test_control.py test_sas_mode is reworked to exercise this with no delay - it enables SAS and sets a non-default mode, then asserts the mode survives the autopilot enabling - and the now-redundant per-mode waits are dropped.

Also minor refactoring: move all SAS logic from Control.cs to Autopilot.cs

Fixes #236 