### PR TITLE
Fix surface frame angular velocity

### DIFF
--- a/service/SpaceCenter/src/Services/ReferenceFrame.cs
+++ b/service/SpaceCenter/src/Services/ReferenceFrame.cs
@@ -668,8 +668,30 @@ namespace KRPC.SpaceCenter.Services
                     var v = InternalVessel.GetOrbit ().GetVel ();
                     return Vector3d.Cross (r, v) / r.sqrMagnitude;
                 }
-                case ReferenceFrameType.VesselSurface:
-                    return InternalVessel.mainBody.angularVelocity;
+                case ReferenceFrameType.VesselSurface: {
+                    // The surface frame's orientation tracks the vessel's inertial
+                    // position (zenith points from the body centre to the vessel) and
+                    // the body's spin axis (north), so its angular velocity is the rate
+                    // at which that basis rotates -- not the body's rotation rate. It is
+                    // the orbital sweep of the zenith axis plus the twist of the north
+                    // direction about the zenith as the vessel's latitude changes.
+                    var vessel = InternalVessel;
+                    var mainBody = vessel.mainBody;
+                    var r = vessel.CoM - mainBody.position;
+                    var v = vessel.GetOrbit ().GetVel ();
+                    var rSqr = r.sqrMagnitude;
+                    var rxv = Vector3d.Cross (r, v);
+                    // Zenith swing (perpendicular to the vertical).
+                    var angularVelocity = rxv / rSqr;
+                    // Twist of the horizon-projected north about the vertical. Vanishes
+                    // on equatorial orbits; singular at the poles (as is the frame).
+                    var spinAxis = (Vector3d)mainBody.transform.up;
+                    var rDotS = Vector3d.Dot (r, spinAxis);
+                    var rPerpSqr = rSqr - rDotS * rDotS;
+                    if (rPerpSqr > rSqr * 1e-6)
+                        angularVelocity += (Vector3d.Dot (spinAxis, rxv) * rDotS / (rPerpSqr * rSqr)) * r;
+                    return angularVelocity;
+                }
                 case ReferenceFrameType.VesselSurfaceVelocity: {
                     var vessel = InternalVessel;
                     var srf_vel = vessel.srf_velocity;

--- a/service/SpaceCenter/test/test_referenceframe.py
+++ b/service/SpaceCenter/test/test_referenceframe.py
@@ -773,6 +773,43 @@ class TestReferenceFrame(krpctest.TestCase):
         orbital_angular_speed = 2 * math.pi / self.vessel.orbit.period
         self.assertAlmostEqual(orbital_angular_speed, norm(ang_vel), delta=5e-4)
 
+    def test_vessel_angular_velocity_surface_frame_low_noise(self):
+        """Regression for #351: a torque-free vessel's angular velocity in the
+        surface reference frame must not be noisier than in the non-rotating frame.
+
+        #351 reported sign-alternating ~0.1 deg/s (~1.7e-3 rad/s) jitter in the
+        surface frame that was absent from the non-rotating frame. Both are derived
+        from the same rigidbody angular velocity and differ only by a rotation and a
+        frame-angular-velocity subtraction, so the surface frame cannot inject
+        frame-specific noise. With the vessel de-spun the per-tick spread is inherent
+        PhysX float noise (~1e-5 rad/s) and is the same in both frames.
+        """
+        self.set_circular_orbit("Kerbin", 100000)
+        self.vessel.control.sas = False
+        self.vessel.control.rcs = False
+        self.set_pitch_heading_roll(0, 90, 0)  # de-spin, level, facing east
+        self.wait(1)
+        surf = self.vessel.surface_reference_frame
+        nonrot = self.kerbin.non_rotating_reference_frame
+        surf_samples = []
+        nonrot_samples = []
+        for _ in range(30):
+            surf_samples.append(self.vessel.angular_velocity(surf))
+            nonrot_samples.append(self.vessel.angular_velocity(nonrot))
+            self.wait(0.05)
+
+        def peak_to_peak(samples):
+            # Largest per-component spread across the samples (rad/s).
+            return max(max(c) - min(c) for c in zip(*samples))
+
+        surf_noise = peak_to_peak(surf_samples)
+        nonrot_noise = peak_to_peak(nonrot_samples)
+        # Comfortably below the ~1.7e-3 rad/s (~0.1 deg/s) reported in #351.
+        self.assertLess(surf_noise, 5e-4)
+        # The surface frame must not be materially noisier than the non-rotating
+        # frame, since both come from the same rigidbody angular velocity.
+        self.assertLess(surf_noise, nonrot_noise + 2e-4)
+
     def test_vessel_angular_velocity_surface_frame_equatorial(self):
         """The surface frame's zenith axis sweeps with the vessel's orbit, so a
         torque-free (inertially-fixed) vessel's angular velocity in that frame equals

--- a/service/SpaceCenter/test/test_referenceframe.py
+++ b/service/SpaceCenter/test/test_referenceframe.py
@@ -746,13 +746,17 @@ class TestReferenceFrame(krpctest.TestCase):
         ang_vel = self.kerbin.angular_velocity(self.kerbin.non_rotating_reference_frame)
         self.assertAlmostEqual(self.kerbin.rotational_speed, norm(ang_vel), delta=1e-5)
 
-    def test_kerbin_angular_velocity_zero_in_vessel_surface_frame(self):
-        """Kerbin co-rotates with the vessel surface frame, so it appears stationary there."""
-        self.assertAlmostEqual(
-            (0, 0, 0),
-            self.kerbin.angular_velocity(self.vessel.surface_reference_frame),
-            delta=1e-4,
-        )
+    def test_kerbin_angular_velocity_in_vessel_surface_frame(self):
+        """The vessel surface frame does NOT co-rotate with Kerbin: its zenith axis
+        sweeps with the vessel's orbit, so its angular velocity is the orbital rate,
+        not the planetary rotation rate. Kerbin (spinning at its rotational speed)
+        therefore appears to rotate at the difference of the two (both along the spin
+        axis for an equatorial orbit).
+        """
+        ang_vel = self.kerbin.angular_velocity(self.vessel.surface_reference_frame)
+        orbital_angular_speed = 2 * math.pi / self.vessel.orbit.period
+        expected = orbital_angular_speed - self.kerbin.rotational_speed
+        self.assertAlmostEqual(expected, norm(ang_vel), delta=1e-4)
 
     def test_kerbin_angular_velocity_in_surface_velocity_frame(self):
         """Kerbin's angular velocity in the surface velocity frame is dominated by the
@@ -768,6 +772,47 @@ class TestReferenceFrame(krpctest.TestCase):
         # Expected magnitude: approximately the orbital angular speed
         orbital_angular_speed = 2 * math.pi / self.vessel.orbit.period
         self.assertAlmostEqual(orbital_angular_speed, norm(ang_vel), delta=5e-4)
+
+    def test_vessel_angular_velocity_surface_frame_equatorial(self):
+        """The surface frame's zenith axis sweeps with the vessel's orbit, so a
+        torque-free (inertially-fixed) vessel's angular velocity in that frame equals
+        the orbital angular speed -- NOT the body's rotation rate, which is ~11x
+        smaller (the frame previously returned body.angularVelocity). On an equatorial
+        orbit there is no twist about the zenith, so the up (x) component is ~zero.
+        """
+        self.set_circular_orbit("Kerbin", 100000)
+        self.vessel.control.sas = False
+        self.vessel.control.rcs = False
+        self.set_pitch_heading_roll(0, 90, 0)  # de-spin (inertially fixed)
+        self.wait(1)
+        ang_vel = self.vessel.angular_velocity(self.vessel.surface_reference_frame)
+        orbital_angular_speed = 2 * math.pi / self.vessel.orbit.period
+        self.assertAlmostEqual(orbital_angular_speed, norm(ang_vel), delta=1e-4)
+        # Locks out the old body.angularVelocity behaviour (~1x rotational speed).
+        self.assertGreater(norm(ang_vel), 5 * self.kerbin.rotational_speed)
+        # No twist about the zenith (x-axis) on an equatorial orbit.
+        self.assertAlmostEqual(0.0, ang_vel[0], delta=5e-5)
+
+    def test_vessel_angular_velocity_surface_frame_inclined_twist(self):
+        """On an inclined orbit at high latitude the surface frame also twists about
+        its zenith axis as the vessel's latitude changes, so an inertially-fixed
+        vessel's angular velocity has a large zenith (x-axis) component. A sweep-only
+        model (Cross(r, v) / r^2) would miss this term and report ~zero there.
+        """
+        # 60 deg inclination, argument of periapsis 90 deg, and epoch = now so the
+        # vessel is teleported to periapsis -- its highest latitude (= inclination),
+        # independent of orbital phase.
+        self.addCleanup(self.set_circular_orbit, "Kerbin", 100000)
+        self.set_orbit("Kerbin", 700000, 0.0, 60.0, 0.0, 90.0, 0.0, self.space_center.ut)
+        self.vessel.control.sas = False
+        self.vessel.control.rcs = False
+        self.set_pitch_heading_roll(0, 90, 0)  # de-spin (inertially fixed)
+        self.wait(1)
+        # The twist term is large only away from the equator; confirm we are there.
+        self.assertGreater(abs(self.vessel.flight().latitude), 30)
+        ang_vel = self.vessel.angular_velocity(self.vessel.surface_reference_frame)
+        # Large twist about the zenith (x-axis); a sweep-only model gives ~zero here.
+        self.assertGreater(abs(ang_vel[0]), 1e-3)
 
     def test_vessel_velocity_zero_in_own_orbital_frame(self):
         """A vessel's velocity in its own orbital reference frame is zero.


### PR DESCRIPTION
Fixes the angular velocity reported for the vessel surface reference frame (`Vessel.SurfaceReferenceFrame`), which was inconsistent with the frame's actual orientation. Spun off from investigating #351.

### The bug

The surface frame's *orientation* tracks the vessel's inertial position: its x-axis (zenith) points from the body centre to the vessel, so as the vessel orbits, the basis sweeps around with the orbit. Its *angular velocity*, however, returned `mainBody.angularVelocity` — the planet's rotation rate — which describes a different frame entirely.

For an inertially-fixed vessel in low Kerbin orbit, `Vessel.AngularVelocity(surface_frame)` should report the rate at which the frame rotates around it: the orbital rate, ~0.18 °/s. Instead it reported the planetary rotation rate, ~0.017 °/s — about 11× too small. The same inconsistency affected velocity transforms into the frame (`VelocityFromWorldSpace` uses the frame's angular velocity for non-origin positions), so velocities of other objects expressed in an orbiting vessel's surface frame were also wrong.

### The fix

Return the actual rotation rate of the basis, which has two parts:

* **Zenith sweep**: `Cross(r, v) / r²` — the rate at which the zenith axis is carried around by the orbit (perpendicular to the vertical).
* **North twist**: `[ŝ·(r×v)] (r·ŝ) / (|r⊥|² r²) · r` — the rate at which the horizon-projected north direction twists about the zenith as the vessel's latitude changes (with `ŝ` the body's spin axis and `|r⊥|² = r² − (r·ŝ)²`).

The twist term vanishes on equatorial orbits, grows large at high latitudes on inclined orbits, and is singular at the poles — as is the frame itself (its projected-north basis vector vanishes there). A guard skips the twist term within ~0.06° of the pole.

Consistency checks:

* For a landed (co-rotating) vessel, `v = ω_body × r` and the formula collapses exactly to `body.angularVelocity` — the old behaviour is preserved in the one regime where it was correct.
* Verified in-game against the frame's numerically-differentiated basis, on both equatorial and inclined orbits.

### Behavioural changes

Note: in release 0.5.4 angular velocity was not implemented and just returned zero, so these changes are just relative to recent changes on main branch.

For vessels in orbit:

* `Vessel.AngularVelocity(surface_frame)` (and any `AngularVelocityFromWorldSpace` through the frame) now reports the true frame rate — dominated by the orbital rate rather than the planetary rotation rate.
* Velocity transforms into/out of the frame at non-origin positions change accordingly; position/velocity derivative consistency now holds.
* The AutoPilot's rate loop uses the frame's angular velocity when the surface frame is its reference frame (the default), so this removes a small steady rate bias (~ω_orbit − ω_body) when holding attitude in orbit.

Landed/co-rotating vessels are unaffected.

### Tests

* `test_kerbin_angular_velocity_in_vessel_surface_frame` — reworked: Kerbin's apparent rotation in the frame is now the difference of the orbital and planetary rates, not zero.
* `test_vessel_angular_velocity_surface_frame_equatorial` — an inertially-fixed vessel's angular velocity in the frame equals the orbital rate, with zero zenith twist; explicitly locks out the old `body.angularVelocity` behaviour.
* `test_vessel_angular_velocity_surface_frame_inclined_twist` — on a 60°-inclined orbit at max latitude, the zenith twist component is large; catches a sweep-only regression.
* `test_vessel_angular_velocity_surface_frame_low_noise` — regression guard for #351: a de-spun vessel's surface-frame angular velocity is no noisier than the non-rotating frame's (the original report does not reproduce on current KSP).
