### PR TITLE
Add Acceleration and AngularAcceleration RPCs

### DIFF
--- a/doc/order.txt
+++ b/doc/order.txt
@@ -188,6 +188,12 @@ SpaceCenter.Vessel.AvailableThrustAt
 SpaceCenter.Vessel.MaxThrust
 SpaceCenter.Vessel.MaxThrustAt
 SpaceCenter.Vessel.MaxVacuumThrust
+SpaceCenter.Vessel.Acceleration
+SpaceCenter.Vessel.AvailableAcceleration
+SpaceCenter.Vessel.AvailableAccelerationAt
+SpaceCenter.Vessel.MaxAcceleration
+SpaceCenter.Vessel.MaxAccelerationAt
+SpaceCenter.Vessel.MaxVacuumAcceleration
 SpaceCenter.Vessel.SpecificImpulse
 SpaceCenter.Vessel.SpecificImpulseAt
 SpaceCenter.Vessel.VacuumSpecificImpulse
@@ -198,9 +204,16 @@ SpaceCenter.Vessel.AvailableTorque
 SpaceCenter.Vessel.AvailableReactionWheelTorque
 SpaceCenter.Vessel.AvailableRCSTorque
 SpaceCenter.Vessel.AvailableRCSForce
+SpaceCenter.Vessel.AvailableRCSAcceleration
 SpaceCenter.Vessel.AvailableEngineTorque
 SpaceCenter.Vessel.AvailableControlSurfaceTorque
 SpaceCenter.Vessel.AvailableOtherTorque
+SpaceCenter.Vessel.AvailableAngularAcceleration
+SpaceCenter.Vessel.AvailableReactionWheelAngularAcceleration
+SpaceCenter.Vessel.AvailableRCSAngularAcceleration
+SpaceCenter.Vessel.AvailableEngineAngularAcceleration
+SpaceCenter.Vessel.AvailableControlSurfaceAngularAcceleration
+SpaceCenter.Vessel.AvailableOtherAngularAcceleration
 SpaceCenter.Vessel.ReferenceFrame
 SpaceCenter.Vessel.OrbitalReferenceFrame
 SpaceCenter.Vessel.SurfaceReferenceFrame
@@ -301,6 +314,7 @@ SpaceCenter.Flight.Velocity
 SpaceCenter.Flight.Speed
 SpaceCenter.Flight.HorizontalSpeed
 SpaceCenter.Flight.VerticalSpeed
+SpaceCenter.Flight.Acceleration
 SpaceCenter.Flight.CenterOfMass
 SpaceCenter.Flight.Rotation
 SpaceCenter.Flight.Direction
@@ -324,6 +338,9 @@ SpaceCenter.Flight.SimulateAerodynamicForceAt
 SpaceCenter.Flight.SimulateAerodynamicTorqueAt
 SpaceCenter.Flight.Lift
 SpaceCenter.Flight.Drag
+SpaceCenter.Flight.AerodynamicAcceleration
+SpaceCenter.Flight.LiftAcceleration
+SpaceCenter.Flight.DragAcceleration
 SpaceCenter.Flight.SpeedOfSound
 SpaceCenter.Flight.Mach
 SpaceCenter.Flight.ReynoldsNumber

--- a/service/SpaceCenter/CHANGES.txt
+++ b/service/SpaceCenter/CHANGES.txt
@@ -58,6 +58,7 @@ v0.6.0
  * Fix Sensor.Value returning zero when the part action window is not open (#883)
  * Fix Engine.AvailableThrust and MaxThrust for air-breathing engines at supersonic speeds (#924)
  * Fix Control.SASMode being dropped when set in the same physics tick as enabling SAS (#236)
+ * Add RPCs for getting acceleration to Flight and Vessel classes (#581)
 
 v0.5.4
  * Fix vessel recovery (#782)

--- a/service/SpaceCenter/src/Services/Flight.cs
+++ b/service/SpaceCenter/src/Services/Flight.cs
@@ -338,6 +338,22 @@ namespace KRPC.SpaceCenter.Services
         }
 
         /// <summary>
+        /// The acceleration of the vessel, in the reference frame <see cref="ReferenceFrame"/>.
+        /// This is the total acceleration, including the acceleration due to gravity, and is the
+        /// time derivative of <see cref="Velocity"/>.
+        /// </summary>
+        /// <returns>The acceleration as a vector. The vector points in the direction of the
+        /// acceleration, and its magnitude is the acceleration of the vessel in <math>m/s^2</math>.</returns>
+        [KRPCProperty]
+        public Tuple3 Acceleration {
+            // Use acceleration_immediate (the raw per-frame change in orbital velocity) rather than
+            // the acceleration field, which KSP boxcar-averages over several frames for the G-force
+            // gauge. The immediate value is the true time derivative of Velocity and responds
+            // without the averaging lag.
+            get { return referenceFrame.DirectionFromWorldSpace (InternalVessel.acceleration_immediate).ToTuple (); }
+        }
+
+        /// <summary>
         /// The position of the center of mass of the vessel,
         /// in the reference frame <see cref="ReferenceFrame"/>
         /// </summary>
@@ -641,6 +657,56 @@ namespace KRPC.SpaceCenter.Services
         [KRPCProperty]
         public Tuple3 Drag {
             get { return (referenceFrame.DirectionFromWorldSpace (WorldDragDirection) * DragMagnitude).ToTuple (); }
+        }
+
+        /// <summary>
+        /// The acceleration of the vessel due to the total aerodynamic forces acting on it
+        /// (<see cref="AerodynamicForce"/> divided by the vessel's mass),
+        /// in reference frame <see cref="ReferenceFrame"/>.
+        /// </summary>
+        /// <returns>A vector pointing in the direction that the vessel is accelerated,
+        /// with its magnitude equal to the acceleration in <math>m/s^2</math>.</returns>
+        [KRPCProperty]
+        public Tuple3 AerodynamicAcceleration {
+            get {
+                var mass = new Vessel (InternalVessel).Mass;
+                Vector3d worldForce;
+                if (FAR.IsAvailable)
+                    worldForce = WorldDragDirection * DragMagnitude + WorldLiftDirection * LiftMagnitude;
+                else
+                    worldForce = WorldAerodynamicForce;
+                return referenceFrame.DirectionFromWorldSpace (worldForce / mass).ToTuple ();
+            }
+        }
+
+        /// <summary>
+        /// The acceleration of the vessel due to <see cref="Lift"/>
+        /// (the aerodynamic lift divided by the vessel's mass),
+        /// in reference frame <see cref="ReferenceFrame"/>.
+        /// </summary>
+        /// <returns>A vector pointing in the direction that the vessel is accelerated,
+        /// with its magnitude equal to the acceleration in <math>m/s^2</math>.</returns>
+        [KRPCProperty]
+        public Tuple3 LiftAcceleration {
+            get {
+                var mass = new Vessel (InternalVessel).Mass;
+                return (referenceFrame.DirectionFromWorldSpace (WorldLiftDirection) * (LiftMagnitude / mass)).ToTuple ();
+            }
+        }
+
+        /// <summary>
+        /// The acceleration of the vessel due to <see cref="Drag"/>
+        /// (the aerodynamic drag divided by the vessel's mass),
+        /// in reference frame <see cref="ReferenceFrame"/>.
+        /// </summary>
+        /// <returns>A vector pointing in the direction that the vessel is accelerated,
+        /// with its magnitude equal to the acceleration in <math>m/s^2</math>.</returns>
+        [KRPCProperty]
+        public Tuple3 DragAcceleration {
+            get {
+                var mass = new Vessel (InternalVessel).Mass;
+                return (referenceFrame.DirectionFromWorldSpace (WorldDragDirection) * (DragMagnitude / mass)).ToTuple ();
+            }
         }
 
         /// <summary>

--- a/service/SpaceCenter/src/Services/Vessel.cs
+++ b/service/SpaceCenter/src/Services/Vessel.cs
@@ -336,6 +336,70 @@ namespace KRPC.SpaceCenter.Services
             get { return ActiveEngines.Sum (e => e.MaxVacuumThrust); }
         }
 
+        /// <summary>
+        /// The acceleration currently produced by the vessel's engines, in
+        /// <math>m/s^2</math>. This is <see cref="Thrust"/> divided by the
+        /// vessel's <see cref="Mass"/>.
+        /// </summary>
+        [KRPCProperty (GameScene = GameScene.Flight)]
+        public float Acceleration {
+            get { return Thrust / Mass; }
+        }
+
+        /// <summary>
+        /// The total available acceleration that can be produced by the vessel's
+        /// active engines, in <math>m/s^2</math>. This is <see cref="AvailableThrust"/>
+        /// divided by the vessel's <see cref="Mass"/>.
+        /// </summary>
+        [KRPCProperty (GameScene = GameScene.Flight)]
+        public float AvailableAcceleration {
+            get { return AvailableThrust / Mass; }
+        }
+
+        /// <summary>
+        /// The total available acceleration that can be produced by the vessel's
+        /// active engines, in <math>m/s^2</math>. This is <see cref="AvailableThrustAt"/>
+        /// divided by the vessel's <see cref="Mass"/>. Takes the given pressure into account.
+        /// </summary>
+        /// <param name="pressure">Atmospheric pressure in atmospheres</param>
+        [KRPCMethod (GameScene = GameScene.Flight)]
+        public float AvailableAccelerationAt (double pressure)
+        {
+            return AvailableThrustAt (pressure) / Mass;
+        }
+
+        /// <summary>
+        /// The total maximum acceleration that can be produced by the vessel's active
+        /// engines, in <math>m/s^2</math>. This is <see cref="MaxThrust"/> divided by
+        /// the vessel's <see cref="Mass"/>.
+        /// </summary>
+        [KRPCProperty (GameScene = GameScene.Flight)]
+        public float MaxAcceleration {
+            get { return MaxThrust / Mass; }
+        }
+
+        /// <summary>
+        /// The total maximum acceleration that can be produced by the vessel's active
+        /// engines, in <math>m/s^2</math>. This is <see cref="MaxThrustAt"/> divided by
+        /// the vessel's <see cref="Mass"/>. Takes the given pressure into account.
+        /// </summary>
+        /// <param name="pressure">Atmospheric pressure in atmospheres</param>
+        [KRPCMethod (GameScene = GameScene.Flight)]
+        public float MaxAccelerationAt (double pressure)
+        {
+            return MaxThrustAt (pressure) / Mass;
+        }
+
+        /// <summary>
+        /// The total maximum acceleration that can be produced by the vessel's active
+        /// engines when the vessel is in a vacuum, in <math>m/s^2</math>. This is
+        /// <see cref="MaxVacuumThrust"/> divided by the vessel's <see cref="Mass"/>.
+        /// </summary>
+        [KRPCProperty (GameScene = GameScene.Flight)]
+        public float MaxVacuumAcceleration {
+            get { return MaxVacuumThrust / Mass; }
+        }
+
         static float SpecificImpulseAtConsumption (IList<Parts.Engine> engines, float fuelConsumption)
         {
             return fuelConsumption > 0f ? engines.Sum (e => e.MaxThrust) / fuelConsumption : 0f;
@@ -507,6 +571,22 @@ namespace KRPC.SpaceCenter.Services
         }
 
         /// <summary>
+        /// The maximum acceleration that the currently active RCS thrusters can generate.
+        /// This is <see cref="AvailableRCSForce"/> divided by the vessel's <see cref="Mass"/>.
+        /// Returns the accelerations in <math>m/s^2</math> along each of the coordinate axes of the
+        /// vessels reference frame (<see cref="ReferenceFrame"/>).
+        /// These axes are equivalent to the right, forward and bottom directions of the vessel.
+        /// </summary>
+        [KRPCProperty (GameScene = GameScene.Flight)]
+        public TupleT3 AvailableRCSAcceleration {
+            get {
+                var mass = Mass;
+                var force = AvailableRCSForceVectors;
+                return new TupleV3 (force.Item1 / mass, force.Item2 / mass).ToTuple ();
+            }
+        }
+
+        /// <summary>
         /// The maximum torque that the currently active and gimballed engines can generate.
         /// Returns the torques in <math>N.m</math> around each of the coordinate axes of the
         /// vessels reference frame (<see cref="ReferenceFrame"/>).
@@ -538,6 +618,104 @@ namespace KRPC.SpaceCenter.Services
         [KRPCProperty (GameScene = GameScene.Flight)]
         public TupleT3 AvailableOtherTorque {
             get { return AvailableOtherTorqueVectors.ToTuple (); }
+        }
+
+        /// <summary>
+        /// The maximum angular acceleration that the vessel can generate. Includes contributions
+        /// from reaction wheels, RCS, gimballed engines and aerodynamic control surfaces.
+        /// This is <see cref="AvailableTorque"/> divided by the vessel's <see cref="MomentOfInertia"/>.
+        /// Returns the angular accelerations in <math>rad/s^2</math> around each of the coordinate
+        /// axes of the vessels reference frame (<see cref="ReferenceFrame"/>).
+        /// These axes are equivalent to the pitch, roll and yaw axes of the vessel.
+        /// </summary>
+        [KRPCProperty (GameScene = GameScene.Flight)]
+        public TupleT3 AvailableAngularAcceleration {
+            get { return DivideByMomentOfInertia (AvailableTorqueVectors).ToTuple (); }
+        }
+
+        /// <summary>
+        /// The maximum angular acceleration that the currently active and powered reaction wheels
+        /// can generate. This is <see cref="AvailableReactionWheelTorque"/> divided by the vessel's
+        /// <see cref="MomentOfInertia"/>.
+        /// Returns the angular accelerations in <math>rad/s^2</math> around each of the coordinate
+        /// axes of the vessels reference frame (<see cref="ReferenceFrame"/>).
+        /// These axes are equivalent to the pitch, roll and yaw axes of the vessel.
+        /// </summary>
+        [KRPCProperty (GameScene = GameScene.Flight)]
+        public TupleT3 AvailableReactionWheelAngularAcceleration {
+            get { return DivideByMomentOfInertia (AvailableReactionWheelTorqueVectors).ToTuple (); }
+        }
+
+        /// <summary>
+        /// The maximum angular acceleration that the currently active RCS thrusters can generate.
+        /// This is <see cref="AvailableRCSTorque"/> divided by the vessel's <see cref="MomentOfInertia"/>.
+        /// Returns the angular accelerations in <math>rad/s^2</math> around each of the coordinate
+        /// axes of the vessels reference frame (<see cref="ReferenceFrame"/>).
+        /// These axes are equivalent to the pitch, roll and yaw axes of the vessel.
+        /// </summary>
+        [KRPCProperty (GameScene = GameScene.Flight)]
+        public TupleT3 AvailableRCSAngularAcceleration {
+            get { return DivideByMomentOfInertia (AvailableRCSTorqueVectors).ToTuple (); }
+        }
+
+        /// <summary>
+        /// The maximum angular acceleration that the currently active and gimballed engines can
+        /// generate. This is <see cref="AvailableEngineTorque"/> divided by the vessel's
+        /// <see cref="MomentOfInertia"/>.
+        /// Returns the angular accelerations in <math>rad/s^2</math> around each of the coordinate
+        /// axes of the vessels reference frame (<see cref="ReferenceFrame"/>).
+        /// These axes are equivalent to the pitch, roll and yaw axes of the vessel.
+        /// </summary>
+        [KRPCProperty (GameScene = GameScene.Flight)]
+        public TupleT3 AvailableEngineAngularAcceleration {
+            get { return DivideByMomentOfInertia (AvailableEngineTorqueVectors).ToTuple (); }
+        }
+
+        /// <summary>
+        /// The maximum angular acceleration that the aerodynamic control surfaces can generate.
+        /// This is <see cref="AvailableControlSurfaceTorque"/> divided by the vessel's
+        /// <see cref="MomentOfInertia"/>.
+        /// Returns the angular accelerations in <math>rad/s^2</math> around each of the coordinate
+        /// axes of the vessels reference frame (<see cref="ReferenceFrame"/>).
+        /// These axes are equivalent to the pitch, roll and yaw axes of the vessel.
+        /// </summary>
+        [KRPCProperty (GameScene = GameScene.Flight)]
+        public TupleT3 AvailableControlSurfaceAngularAcceleration {
+            get { return DivideByMomentOfInertia (AvailableControlSurfaceTorqueVectors).ToTuple (); }
+        }
+
+        /// <summary>
+        /// The maximum angular acceleration that parts (excluding reaction wheels, gimballed engines,
+        /// RCS and control surfaces) can generate. This is <see cref="AvailableOtherTorque"/> divided
+        /// by the vessel's <see cref="MomentOfInertia"/>.
+        /// Returns the angular accelerations in <math>rad/s^2</math> around each of the coordinate
+        /// axes of the vessels reference frame (<see cref="ReferenceFrame"/>).
+        /// These axes are equivalent to the pitch, roll and yaw axes of the vessel.
+        /// </summary>
+        [KRPCProperty (GameScene = GameScene.Flight)]
+        public TupleT3 AvailableOtherAngularAcceleration {
+            get { return DivideByMomentOfInertia (AvailableOtherTorqueVectors).ToTuple (); }
+        }
+
+        /// <summary>
+        /// Divide a (min, max) pair of torque vectors componentwise by the vessel's moment of
+        /// inertia to obtain a (min, max) pair of angular accelerations. Axes with zero moment of
+        /// inertia yield zero to avoid producing NaN/infinity.
+        /// </summary>
+        TupleV3 DivideByMomentOfInertia (TupleV3 torque)
+        {
+            var moi = MomentOfInertiaVector;
+            return new TupleV3 (
+                DivideComponentwise (torque.Item1, moi),
+                DivideComponentwise (torque.Item2, moi));
+        }
+
+        static Vector3d DivideComponentwise (Vector3d numerator, Vector3d denominator)
+        {
+            return new Vector3d (
+                denominator.x != 0 ? numerator.x / denominator.x : 0,
+                denominator.y != 0 ? numerator.y / denominator.y : 0,
+                denominator.z != 0 ? numerator.z / denominator.z : 0);
         }
 
         internal TupleV3 AvailableTorqueVectors {

--- a/service/SpaceCenter/test/test_flight.py
+++ b/service/SpaceCenter/test/test_flight.py
@@ -194,6 +194,43 @@ class TestFlight(krpctest.TestCase):
             longitude = flight.longitude
             self.wait()
 
+    def test_acceleration(self):
+        # On a stable circular orbit the total acceleration (which includes
+        # gravity) is gravitational: directed radially inward with a magnitude
+        # close to the local gravity. KSP's own reported acceleration differs from
+        # mu/r^2 by a few percent on a teleported orbit, so the magnitude is
+        # checked with a loose tolerance; the radially-inward direction is exact.
+        ref = self.vessel.orbit.body.non_rotating_reference_frame
+        flight = self.vessel.flight(ref)
+        g = self.vessel.orbit.body.gravitational_parameter / (
+            self.vessel.orbit.radius**2
+        )
+        acceleration = vector(flight.acceleration)
+        radial_out = normalize(vector(self.vessel.position(ref)))
+        # Directed radially inward (the world-to-frame transform and sign is exact).
+        self.assertAlmostEqual(
+            -norm(acceleration), dot(acceleration, radial_out), delta=0.1
+        )
+        # Gravity-scale magnitude.
+        self.assertAlmostEqual(g, norm(acceleration), delta=1.0)
+
+    def test_aerodynamic_acceleration(self):
+        # aerodynamic_acceleration/lift_acceleration/drag_acceleration should each
+        # equal the corresponding aerodynamic force divided by the vessel's mass.
+        if self.far:
+            self.skipTest("stock aerodynamics only")
+        flight = self.vessel.flight(self.vessel.reference_frame)
+        mass = self.vessel.mass
+        for force_attr, accel_attr in (
+            ("aerodynamic_force", "aerodynamic_acceleration"),
+            ("lift", "lift_acceleration"),
+            ("drag", "drag_acceleration"),
+        ):
+            force = getattr(flight, force_attr)
+            accel = getattr(flight, accel_attr)
+            expected = tuple(f / mass for f in force)
+            self.assertAlmostEqual(expected, accel, delta=1e-3)
+
 
 class TestFlightVerticalSpeed(krpctest.TestCase):
 

--- a/service/SpaceCenter/test/test_vessel.py
+++ b/service/SpaceCenter/test/test_vessel.py
@@ -114,6 +114,44 @@ class TestVessel(krpctest.TestCase):
             ((0, 0, 0), (0, 0, 0)), self.vessel.available_control_surface_torque
         )
 
+    def test_available_angular_acceleration(self):
+        # Each available_*_angular_acceleration should equal the corresponding
+        # available_*_torque divided componentwise by the moment of inertia.
+        self.vessel.control.rcs = True
+        self.wait()
+        moi = self.vessel.moment_of_inertia
+        prefixes = [
+            "available",
+            "available_reaction_wheel",
+            "available_rcs",
+            "available_engine",
+            "available_control_surface",
+            "available_other",
+        ]
+        for prefix in prefixes:
+            accel = getattr(self.vessel, prefix + "_angular_acceleration")
+            torque = getattr(self.vessel, prefix + "_torque")
+            for i in range(2):
+                for j in range(3):
+                    inertia = moi[j]
+                    expected = torque[i][j] / inertia if inertia != 0 else 0
+                    self.assertAlmostEqual(expected, accel[i][j], delta=1e-2)
+        self.vessel.control.rcs = False
+        self.wait()
+
+    def test_available_rcs_acceleration(self):
+        # available_rcs_acceleration should equal available_rcs_force / mass.
+        self.vessel.control.rcs = True
+        self.wait()
+        mass = self.vessel.mass
+        force = self.vessel.available_rcs_force
+        accel = self.vessel.available_rcs_acceleration
+        for i in range(2):
+            for j in range(3):
+                self.assertAlmostEqual(force[i][j] / mass, accel[i][j], delta=1e-2)
+        self.vessel.control.rcs = False
+        self.wait()
+
     def test_bounding_box(self):
         box = self.vessel.bounding_box(self.vessel.reference_frame)
         self.assertAlmostEqual((-1.57, -2.59, -1.57), box[0], places=1)
@@ -351,6 +389,32 @@ class TestVesselEngines(krpctest.TestCase):
         for engine in self.engines:
             engine.active = False
         self.wait(1)
+
+    def test_acceleration(self):
+        # Acceleration members should equal the corresponding thrust divided by
+        # mass. Checked at zero throttle so the mass is stable (no fuel drain).
+        self.control.throttle = 0.0
+        for engine in self.engines:
+            engine.active = True
+        self.wait(0.5)
+        mass = self.vessel.mass
+        self.assertAlmostEqual(0, self.vessel.acceleration, delta=1e-2)
+        self.assertAlmostEqual(
+            self.vessel.available_thrust / mass,
+            self.vessel.available_acceleration,
+            delta=1e-2,
+        )
+        self.assertAlmostEqual(
+            self.vessel.max_thrust / mass, self.vessel.max_acceleration, delta=1e-2
+        )
+        self.assertAlmostEqual(
+            self.vessel.max_vacuum_thrust / mass,
+            self.vessel.max_vacuum_acceleration,
+            delta=1e-2,
+        )
+        for engine in self.engines:
+            engine.active = False
+        self.wait(0.5)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Adds acceleration RPCs wherever a Force/Mass or Torque/MomentOfInertia pair already exists, mirroring the naming and shape of the existing Thrust/Torque members. All new members are pure derived getters — no new game-state reads except KSP's own `Vessel.acceleration_immediate` field for the total-acceleration vector.

## New RPCs

**`Flight`** (all `Tuple3` vectors, m/s², in the flight object's reference frame):
* `Acceleration` — the total acceleration of the vessel, including gravity. Read from KSP's `acceleration_immediate` (the raw per-frame derivative of orbital velocity) rather than `acceleration`, which KSP boxcar-averages over several frames for the G-force gauge.
* `AerodynamicAcceleration`, `LiftAcceleration`, `DragAcceleration` — the corresponding aerodynamic force divided by the vessel's mass. FAR/stock handling mirrors the existing force getters exactly.

**`Vessel`** — thrust-derived scalars (m/s²), one per existing Thrust member:
* `Acceleration`, `AvailableAcceleration`, `MaxAcceleration`, `MaxVacuumAcceleration` (properties)
* `AvailableAccelerationAt(pressure)`, `MaxAccelerationAt(pressure)` (methods)

**`Vessel`** — force/torque-derived min/max pairs:
* `AvailableRCSAcceleration` = `AvailableRCSForce` / mass (m/s²)
* `AvailableAngularAcceleration`, `AvailableReactionWheelAngularAcceleration`, `AvailableRCSAngularAcceleration`, `AvailableEngineAngularAcceleration`, `AvailableControlSurfaceAngularAcceleration`, `AvailableOtherAngularAcceleration` = the corresponding torque divided componentwise by the moment of inertia (rad/s²), with a zero-MoI guard so degenerate axes return 0 rather than NaN/infinity.

## Notes

* `Flight.Acceleration` deliberately exposes the total coordinate acceleration (including gravity) rather than KSP's `perturbation` (non-gravitational/sensed acceleration) — one clear, correctly named quantity instead of two easily confused ones.
* Per-part `Engine` acceleration was considered and rejected: engine thrust ÷ whole-vessel mass is only meaningful at the vessel level.

## Tests

New integration tests use self-consistency assertions (each new member == the force/torque member it derives from ÷ mass/MoI) rather than hardcoded craft numbers:
* `test_flight.py`: `test_acceleration` (radially-inward direction exact, gravity-scale magnitude with loose tolerance — KSP reports a few percent below the analytic μ/r² on a teleported orbit), `test_aerodynamic_acceleration` (skipped under FAR).
* `test_vessel.py`: `test_available_angular_acceleration` (all six variants), `test_available_rcs_acceleration`, and `TestVesselEngines.test_acceleration` for the thrust-derived members.

Fixes #581
