### PR TITLE
Support cross-references in deprecation reasons

### DIFF
--- a/client/python/krpc/service.py
+++ b/client/python/krpc/service.py
@@ -112,8 +112,20 @@ def _construct_func(
     return cast(Callable, fn)  # type: ignore[type-arg]
 
 
+def _parse_deprecation_reason(reason: str) -> str:
+    """Flatten a deprecation reason to plain text. The reason may contain the
+    same see-cref markup as documentation strings; references are converted to
+    Python-cased dotted names."""
+    if "<" not in reason:
+        return reason
+    parser = ElementTree.XMLParser(encoding="UTF-8")
+    node = ElementTree.XML(("<doc>%s</doc>" % reason).encode("UTF-8"), parser=parser)
+    return _parse_documentation_content(node)
+
+
 def _deprecated_doc(doc: str, reason: str) -> str:
     """Prepend a deprecation notice to a constructed docstring"""
+    reason = _parse_deprecation_reason(reason)
     line = "Deprecated. " + reason if reason else "Deprecated."
     return line + "\n\n" + doc if doc else line
 
@@ -126,7 +138,7 @@ def _wrap_deprecated(
     """Wrap an invoker so that calling it emits a DeprecationWarning"""
     message = qualified_name + " is deprecated"
     if reason:
-        message += ": " + reason
+        message += ": " + _parse_deprecation_reason(reason)
 
     def wrapper(*args: object, **kwargs: object) -> object:
         warnings.warn(message, DeprecationWarning, stacklevel=2)

--- a/client/python/krpc/service.py
+++ b/client/python/krpc/service.py
@@ -112,20 +112,29 @@ def _construct_func(
     return cast(Callable, fn)  # type: ignore[type-arg]
 
 
-def _parse_deprecation_reason(reason: str) -> str:
+def _parse_deprecation_reason(reason: str, service_name: str) -> str:
     """Flatten a deprecation reason to plain text. The reason may contain the
     same see-cref markup as documentation strings; references are converted to
-    Python-cased dotted names."""
+    Python-cased dotted names, with the current service's prefix dropped to
+    match the pre-generated stubs."""
     if "<" not in reason:
         return reason
+
+    def parse_cref(ref: str) -> str:
+        name = _parse_cref(ref)
+        prefix = service_name + "."
+        if name.startswith(prefix):
+            name = name[len(prefix) :]
+        return name
+
     parser = ElementTree.XMLParser(encoding="UTF-8")
     node = ElementTree.XML(("<doc>%s</doc>" % reason).encode("UTF-8"), parser=parser)
-    return _parse_documentation_content(node)
+    return _parse_documentation_content(node, parse_cref)
 
 
-def _deprecated_doc(doc: str, reason: str) -> str:
+def _deprecated_doc(doc: str, reason: str, service_name: str) -> str:
     """Prepend a deprecation notice to a constructed docstring"""
-    reason = _parse_deprecation_reason(reason)
+    reason = _parse_deprecation_reason(reason, service_name)
     line = "Deprecated. " + reason if reason else "Deprecated."
     return line + "\n\n" + doc if doc else line
 
@@ -134,11 +143,12 @@ def _wrap_deprecated(
     func: Callable,  # type: ignore[type-arg]
     qualified_name: str,
     reason: str,
+    service_name: str,
 ) -> Callable:  # type: ignore[type-arg]
     """Wrap an invoker so that calling it emits a DeprecationWarning"""
     message = qualified_name + " is deprecated"
     if reason:
-        message += ": " + _parse_deprecation_reason(reason)
+        message += ": " + _parse_deprecation_reason(reason, service_name)
 
     def wrapper(*args: object, **kwargs: object) -> object:
         warnings.warn(message, DeprecationWarning, stacklevel=2)
@@ -157,14 +167,21 @@ def _indent(lines: Iterable[str], level: int) -> List[str]:
     return result
 
 
-def _parse_documentation_node(node: ElementTree.Element) -> str:
+def _parse_cref(ref: str) -> str:
+    """Convert a service-level cref to a Python-cased dotted name"""
+    if ref[0] == "M":
+        refs = ref.split(".")
+        refs[-1] = snake_case(refs[-1])
+        ref = ".".join(refs)
+    return ref[2:]
+
+
+def _parse_documentation_node(
+    node: ElementTree.Element,
+    parse_cref: Callable[[str], str] = _parse_cref,
+) -> str:
     if node.tag == "see":
-        ref = node.attrib["cref"]
-        if ref[0] == "M":
-            refs = ref.split(".")
-            refs[-1] = snake_case(refs[-1])
-            ref = ".".join(refs)
-        return ref[2:]
+        return parse_cref(node.attrib["cref"])
     if node.tag == "paramref":
         return snake_case(node.attrib["name"])
     if node.tag == "c":
@@ -175,7 +192,7 @@ def _parse_documentation_node(node: ElementTree.Element) -> str:
     if node.tag == "list":
         content = "\n"
         for item in node:
-            item_content = _parse_documentation_content(item[0])
+            item_content = _parse_documentation_content(item[0], parse_cref)
             content += (
                 "* %s\n" % "\n".join(_indent(item_content.split("\n"), 2))[2:].rstrip()
             )
@@ -183,10 +200,13 @@ def _parse_documentation_node(node: ElementTree.Element) -> str:
     return node.text or ""
 
 
-def _parse_documentation_content(node: ElementTree.Element) -> str:
+def _parse_documentation_content(
+    node: ElementTree.Element,
+    parse_cref: Callable[[str], str] = _parse_cref,
+) -> str:
     desc = node.text or ""
     for child in node:
-        desc += _parse_documentation_node(child)
+        desc += _parse_documentation_node(child, parse_cref)
         if child.tail:
             desc += child.tail
     return desc.strip()
@@ -224,7 +244,7 @@ def create_service(client: Client, service: KRPC.Service) -> object:
     """Create a new service type"""
     doc = _parse_documentation(service.documentation)
     if service.deprecated:
-        doc = _deprecated_doc(doc, service.deprecated_reason)
+        doc = _deprecated_doc(doc, service.deprecated_reason, service.name)
     cls = cast(
         ServiceBase,
         type(
@@ -317,7 +337,7 @@ class ServiceBase(DynamicType):
         name = remote_cls.name
         doc = _parse_documentation(remote_cls.documentation)
         if remote_cls.deprecated:
-            doc = _deprecated_doc(doc, remote_cls.deprecated_reason)
+            doc = _deprecated_doc(doc, remote_cls.deprecated_reason, cls._name)
         class_type = cls._client._types.class_type(cls._name, name, doc)
         setattr(cls, name, class_type.python_type)
 
@@ -327,13 +347,13 @@ class ServiceBase(DynamicType):
         name = enumeration.name
         doc = _parse_documentation(enumeration.documentation)
         if enumeration.deprecated:
-            doc = _deprecated_doc(doc, enumeration.deprecated_reason)
+            doc = _deprecated_doc(doc, enumeration.deprecated_reason, cls._name)
         enumeration_type = cls._client._types.enumeration_type(cls._name, name, doc)
 
         def value_doc(value: KRPC.EnumerationValue) -> str:
             vdoc = _parse_documentation(value.documentation)
             if value.deprecated:
-                vdoc = _deprecated_doc(vdoc, value.deprecated_reason)
+                vdoc = _deprecated_doc(vdoc, value.deprecated_reason, cls._name)
             return vdoc
 
         enumeration_type.set_values(
@@ -353,7 +373,7 @@ class ServiceBase(DynamicType):
         name = exception.name
         doc = _parse_documentation(exception.documentation)
         if exception.deprecated:
-            doc = _deprecated_doc(doc, exception.deprecated_reason)
+            doc = _deprecated_doc(doc, exception.deprecated_reason, cls._name)
         exception_type = cls._client._types.exception_type(cls._name, name, doc)
         setattr(cls, name, exception_type)
 
@@ -415,9 +435,9 @@ class ServiceBase(DynamicType):
         doc = _parse_documentation(procedure.documentation)
         if procedure.deprecated:
             func = _wrap_deprecated(
-                func, cls._name + "." + name, procedure.deprecated_reason
+                func, cls._name + "." + name, procedure.deprecated_reason, cls._name
             )
-            doc = _deprecated_doc(doc, procedure.deprecated_reason)
+            doc = _deprecated_doc(doc, procedure.deprecated_reason, cls._name)
         cls._add_class_method(name, func, doc=doc)
         cls._add_class_method("_build_call_" + name, build_call)
         cls._add_class_method("_return_type_" + name, lambda cls: return_type)
@@ -438,9 +458,9 @@ class ServiceBase(DynamicType):
         elif setter:
             doc = _parse_documentation(setter.documentation)
         if getter and getter.deprecated:
-            doc = _deprecated_doc(doc or "", getter.deprecated_reason)
+            doc = _deprecated_doc(doc or "", getter.deprecated_reason, cls._name)
         elif setter and setter.deprecated:
-            doc = _deprecated_doc(doc or "", setter.deprecated_reason)
+            doc = _deprecated_doc(doc or "", setter.deprecated_reason, cls._name)
         getter_fn = None
         setter_fn = None
         if getter:
@@ -459,7 +479,7 @@ class ServiceBase(DynamicType):
             )
             if getter.deprecated:
                 getter_fn = _wrap_deprecated(
-                    getter_fn, qualified_name, getter.deprecated_reason
+                    getter_fn, qualified_name, getter.deprecated_reason, cls._name
                 )
             build_call = _construct_func(
                 cls._client._build_call,
@@ -488,7 +508,7 @@ class ServiceBase(DynamicType):
             )
             if setter.deprecated:
                 setter_fn = _wrap_deprecated(
-                    setter_fn, qualified_name, setter.deprecated_reason
+                    setter_fn, qualified_name, setter.deprecated_reason, cls._name
                 )
         name = member_name
         cls._add_property(name, getter_fn, setter_fn, doc=doc)
@@ -540,8 +560,9 @@ class ServiceBase(DynamicType):
                 func,
                 cls._name + "." + class_name + "." + name,
                 procedure.deprecated_reason,
+                cls._name,
             )
-            doc = _deprecated_doc(doc, procedure.deprecated_reason)
+            doc = _deprecated_doc(doc, procedure.deprecated_reason, cls._name)
         class_cls._add_method(name, func, doc=doc)
         class_cls._add_method("_build_call_" + name, build_call)
         class_cls._add_method("_return_type_" + name, lambda self: return_type)
@@ -587,8 +608,9 @@ class ServiceBase(DynamicType):
                 func,
                 cls._name + "." + class_name + "." + name,
                 procedure.deprecated_reason,
+                cls._name,
             )
-            doc = _deprecated_doc(doc, procedure.deprecated_reason)
+            doc = _deprecated_doc(doc, procedure.deprecated_reason, cls._name)
         class_cls._add_class_method(name, func, doc=doc)
         class_cls._add_class_method("_build_call_" + name, build_call)
         class_cls._add_class_method("_return_type_" + name, lambda cls: return_type)
@@ -614,9 +636,9 @@ class ServiceBase(DynamicType):
         elif setter:
             doc = _parse_documentation(setter.documentation)
         if getter and getter.deprecated:
-            doc = _deprecated_doc(doc or "", getter.deprecated_reason)
+            doc = _deprecated_doc(doc or "", getter.deprecated_reason, cls._name)
         elif setter and setter.deprecated:
-            doc = _deprecated_doc(doc or "", setter.deprecated_reason)
+            doc = _deprecated_doc(doc or "", setter.deprecated_reason, cls._name)
         getter_fn: Optional[Callable] = None  # type: ignore[type-arg]
         setter_fn: Optional[Callable] = None  # type: ignore[type-arg]
         if getter:
@@ -638,7 +660,7 @@ class ServiceBase(DynamicType):
             )
             if getter.deprecated:
                 getter_fn = _wrap_deprecated(
-                    getter_fn, qualified_name, getter.deprecated_reason
+                    getter_fn, qualified_name, getter.deprecated_reason, cls._name
                 )
             build_call = _construct_func(
                 cls._client._build_call,
@@ -667,7 +689,7 @@ class ServiceBase(DynamicType):
             )
             if setter.deprecated:
                 setter_fn = _wrap_deprecated(
-                    setter_fn, qualified_name, setter.deprecated_reason
+                    setter_fn, qualified_name, setter.deprecated_reason, cls._name
                 )
         property_name = member_name
         class_cls._add_property(property_name, getter_fn, setter_fn, doc=doc)

--- a/client/python/krpc/test/test_documentation.py
+++ b/client/python/krpc/test/test_documentation.py
@@ -44,7 +44,7 @@ class TestDocumentation(ServerTestCase, unittest.TestCase):
 
     def test_deprecated(self) -> None:
         self.check_doc(
-            "Deprecated. Use FloatToString instead.\n\n"
+            "Deprecated. Use float_to_string instead.\n\n"
             "Deprecated procedure documentation string.",
             self.conn.test_service.deprecated_procedure,
         )
@@ -53,7 +53,7 @@ class TestDocumentation(ServerTestCase, unittest.TestCase):
             self.conn.test_service.deprecated_procedure_no_message,
         )
         self.check_doc(
-            "Deprecated. Use StringProperty instead.\n\n"
+            "Deprecated. Use string_property instead.\n\n"
             "Deprecated property documentation string.",
             type(self.conn.test_service).deprecated_property,
         )

--- a/client/python/krpc/test/test_documentation.py
+++ b/client/python/krpc/test/test_documentation.py
@@ -1,6 +1,7 @@
 import inspect
 import unittest
 from typing import cast
+
 from krpc.test.servertestcase import ServerTestCase
 
 

--- a/core/src/Service/DocumentationUtils.cs
+++ b/core/src/Service/DocumentationUtils.cs
@@ -15,7 +15,34 @@ namespace KRPC.Service
         {
             if (documentation.Length == 0)
                 return string.Empty;
+            return Transform (documentation, ResolveCref);
+        }
 
+        /// <summary>
+        /// Resolve crefs in a deprecation reason (an [Obsolete] attribute message).
+        /// The message is an XML text fragment. Unlike doc comments, the compiler does not
+        /// resolve crefs in attribute strings, so unqualified references are permitted and
+        /// resolved against the declaring type: a member name, a Type.Member pair, or a type
+        /// name (in addition to the fully-qualified compiler form). Messages containing no
+        /// markup are returned unchanged.
+        /// </summary>
+        public static string ResolveDeprecationReason (string reason, Type context)
+        {
+            if (reason.Length == 0 || reason.IndexOf ('<') < 0)
+                return reason;
+            string result;
+            try {
+                result = Transform ("<doc>" + reason + "</doc>", cref => ResolveAuthorCref (cref, context));
+            } catch (XmlException exn) {
+                throw new DocumentationException (
+                    "Failed to parse deprecation reason '" + reason + "' as XML: " + exn.Message);
+            }
+            // Strip the <doc> wrapper element
+            return result.Substring (5, result.Length - 11);
+        }
+
+        static string Transform (string documentation, Func<string, string> resolveCref)
+        {
             var output = new StringBuilder ();
             using (XmlReader reader = XmlReader.Create (new StringReader (documentation))) {
                 var ws = new XmlWriterSettings ();
@@ -32,7 +59,7 @@ namespace KRPC.Service
                                 var name = reader.Name;
                                 var value = reader.Value;
                                 if (name == "cref")
-                                    value = ResolveCref (value);
+                                    value = resolveCref (value);
                                 writer.WriteStartAttribute (name);
                                 writer.WriteValue (value);
                                 writer.WriteEndAttribute ();
@@ -81,9 +108,95 @@ namespace KRPC.Service
             throw new DocumentationException ("Invalid code '" + code + "' in cref '" + cref + "'");
         }
 
+        static string ResolveAuthorCref (string cref, Type context)
+        {
+            // Fully-qualified compiler form, e.g. "M:Full.Name.Of.Type.Member"
+            if (cref.Length > 2 && cref [1] == ':')
+                return ResolveCref (cref);
+            if (cref.Length == 0 || context == null)
+                throw new DocumentationException ("Failed to resolve cref '" + cref + "'");
+            var dot = cref.LastIndexOf ('.');
+            string result = null;
+            if (dot < 0) {
+                // A member of the declaring type, or a type name
+                result = TryResolveMember (context, cref) ?? TryResolveTypeCref (context, cref);
+            } else {
+                // Type.Member, or a (partially) qualified type name
+                var type = FindType (context, cref.Substring (0, dot));
+                if (type != null)
+                    result = TryResolveMember (type, cref.Substring (dot + 1));
+                if (result == null)
+                    result = TryResolveTypeCref (context, cref);
+            }
+            if (result == null)
+                throw new DocumentationException (
+                    "Failed to resolve cref '" + cref + "' in deprecation reason on '" + context.Name + "'");
+            return result;
+        }
+
+        static string TryResolveMember (Type type, string name)
+        {
+            var property = type.GetProperty (name);
+            if (property != null && Reflection.HasAttribute<KRPCPropertyAttribute> (property))
+                return FormatPropertyCref (type, property);
+            MethodInfo method;
+            try {
+                method = type.GetMethod (name);
+            } catch (AmbiguousMatchException) {
+                method = type.GetMethods ().FirstOrDefault (
+                    m => m.Name == name &&
+                    (Reflection.HasAttribute<KRPCProcedureAttribute> (m) ||
+                     Reflection.HasAttribute<KRPCMethodAttribute> (m)));
+            }
+            if (method != null &&
+                (Reflection.HasAttribute<KRPCProcedureAttribute> (method) ||
+                 Reflection.HasAttribute<KRPCMethodAttribute> (method)))
+                return FormatMethodCref (type, method);
+            var field = type.GetField (name);
+            if (field != null && Reflection.HasAttribute<KRPCEnumAttribute> (type))
+                return FormatFieldCref (type, field);
+            return null;
+        }
+
+        static string TryResolveTypeCref (Type context, string name)
+        {
+            var type = FindType (context, name);
+            return type == null ? null : FormatTypeCref (type);
+        }
+
+        /// <summary>
+        /// Find a KRPC-attributed type by (possibly partially qualified) name. Matches the
+        /// context type itself, then types in the context's assembly by simple name, then by
+        /// dotted full-name suffix, then a fully-qualified name in any loaded assembly.
+        /// Throws if the name is ambiguous within the context's assembly.
+        /// </summary>
+        static Type FindType (Type context, string name)
+        {
+            if (context.Name == name)
+                return context;
+            var candidates = context.Assembly.GetTypes ()
+                .Where (t => Reflection.HasAttribute<KRPCServiceAttribute> (t) ||
+                        Reflection.HasAttribute<KRPCClassAttribute> (t) ||
+                        Reflection.HasAttribute<KRPCEnumAttribute> (t))
+                .Where (t => t.Name == name ||
+                        (t.FullName != null && t.FullName.Replace ('+', '.').EndsWith ("." + name, StringComparison.Ordinal)))
+                .ToList ();
+            if (candidates.Count > 1)
+                throw new DocumentationException (
+                    "Ambiguous cref '" + name + "': matches " +
+                    string.Join (", ", candidates.Select (t => t.FullName).ToArray ()));
+            if (candidates.Count == 1)
+                return candidates [0];
+            return Reflection.GetType (name);
+        }
+
         static string ResolveTypeCref (string reference)
         {
-            var type = GetType (reference);
+            return FormatTypeCref (GetType (reference));
+        }
+
+        static string FormatTypeCref (Type type)
+        {
             var name = type.Name;
             if (Reflection.HasAttribute<KRPCServiceAttribute> (type)) {
                 TypeUtils.ValidateKRPCService (type);
@@ -103,6 +216,11 @@ namespace KRPC.Service
             reference = reference.Split (new char[]{'('}) [0];
             var type = GetType (GetTypeName (reference));
             var method = GetMethod (type, GetMemberName (reference));
+            return FormatMethodCref (type, method);
+        }
+
+        static string FormatMethodCref (Type type, MethodInfo method)
+        {
             var name = type.Name + "." + method.Name;
             if (Reflection.HasAttribute<KRPCProcedureAttribute> (method)) {
                 TypeUtils.ValidateKRPCProcedure (method);
@@ -118,6 +236,11 @@ namespace KRPC.Service
         {
             var type = GetType (GetTypeName (reference));
             var property = GetProperty (type, GetMemberName (reference));
+            return FormatPropertyCref (type, property);
+        }
+
+        static string FormatPropertyCref (Type type, PropertyInfo property)
+        {
             var name = type.Name + "." + property.Name;
             if (Reflection.HasAttribute<KRPCServiceAttribute> (type) &&
                 Reflection.HasAttribute<KRPCPropertyAttribute> (property)) {
@@ -135,6 +258,11 @@ namespace KRPC.Service
         {
             var type = GetType (GetTypeName (reference));
             var field = GetField (type, GetMemberName (reference));
+            return FormatFieldCref (type, field);
+        }
+
+        static string FormatFieldCref (Type type, FieldInfo field)
+        {
             var name = type.Name + "." + field.Name;
             if (Reflection.HasAttribute<KRPCEnumAttribute> (type)) {
                 TypeUtils.ValidateKRPCEnum (type);

--- a/core/src/Service/TypeUtils.cs
+++ b/core/src/Service/TypeUtils.cs
@@ -206,16 +206,27 @@ namespace KRPC.Service
         /// <summary>
         /// Get whether the given member is deprecated, i.e. annotated with the standard
         /// [Obsolete] attribute. If it is, <paramref name="reason"/> is set to the
-        /// attribute's message (empty when none was given).
+        /// attribute's message (empty when none was given). The message may contain
+        /// see-cref markup; crefs are resolved relative to the declaring type.
         /// </summary>
         public static bool GetDeprecated (ICustomAttributeProvider member, out string reason)
         {
             if (Reflection.HasAttribute<ObsoleteAttribute> (member)) {
                 reason = Reflection.GetAttribute<ObsoleteAttribute> (member).Message ?? string.Empty;
+                reason = DocumentationUtils.ResolveDeprecationReason (reason, GetDeprecationContext (member));
                 return true;
             }
             reason = string.Empty;
             return false;
+        }
+
+        static Type GetDeprecationContext (ICustomAttributeProvider member)
+        {
+            var type = member as Type;
+            if (type != null)
+                return type;
+            var memberInfo = member as MemberInfo;
+            return memberInfo == null ? null : memberInfo.DeclaringType;
         }
 
         /// <summary>

--- a/core/test/Service/DocumentationUtilsTest.cs
+++ b/core/test/Service/DocumentationUtilsTest.cs
@@ -32,5 +32,56 @@ namespace KRPC.Test.Service
         {
             Assert.Throws<DocumentationException> (() => DocumentationUtils.ResolveCrefs (input));
         }
+
+        [TestCase ("", "")]
+        [TestCase ("Use ProcedureNoArgsNoReturn instead.", "Use ProcedureNoArgsNoReturn instead.")]
+        [TestCase ("Use <see cref='ProcedureNoArgsNoReturn'/> instead.",
+            "Use <see cref=\"M:TestService.ProcedureNoArgsNoReturn\" /> instead.")]
+        [TestCase ("Use <see cref='PropertyWithGetAndSet'/> instead.",
+            "Use <see cref=\"M:TestService.PropertyWithGetAndSet\" /> instead.")]
+        [TestCase ("Use <see cref='TestClass'/> instead.",
+            "Use <see cref=\"T:TestService.TestClass\" /> instead.")]
+        [TestCase ("Use <see cref='TestClass.FloatToString'/> instead.",
+            "Use <see cref=\"M:TestService.TestClass.FloatToString\" /> instead.")]
+        [TestCase ("Use <see cref='TestClass.IntProperty'/> instead.",
+            "Use <see cref=\"M:TestService.TestClass.IntProperty\" /> instead.")]
+        [TestCase ("Use <see cref='TestEnum'/> instead.",
+            "Use <see cref=\"T:TestService.TestEnum\" /> instead.")]
+        [TestCase ("Use <see cref='TestEnum.X'/> instead.",
+            "Use <see cref=\"M:TestService.TestEnum.X\" /> instead.")]
+        [TestCase ("See <see cref='M:KRPC.Test.Service.TestService.ProcedureNoArgsNoReturn'/> and <see cref='TestClass'/>.",
+            "See <see cref=\"M:TestService.ProcedureNoArgsNoReturn\" /> and <see cref=\"T:TestService.TestClass\" />.")]
+        public void ResolveDeprecationReason (string input, string output)
+        {
+            Assert.AreEqual (output, DocumentationUtils.ResolveDeprecationReason (input, typeof (TestService)));
+        }
+
+        [Test]
+        public void ResolveDeprecationReasonInClassContext ()
+        {
+            Assert.AreEqual (
+                "Use <see cref=\"M:TestService.TestClass.FloatToString\" /> instead.",
+                DocumentationUtils.ResolveDeprecationReason (
+                    "Use <see cref='FloatToString'/> instead.", typeof (TestService.TestClass)));
+        }
+
+        [Test]
+        public void ResolveDeprecationReasonInEnumContext ()
+        {
+            Assert.AreEqual (
+                "Use <see cref=\"M:TestService.TestEnum.X\" /> instead.",
+                DocumentationUtils.ResolveDeprecationReason (
+                    "Use <see cref='X'/> instead.", typeof (TestService.TestEnum)));
+        }
+
+        [TestCase ("Use <see cref='NonExistent'/> instead.")]
+        [TestCase ("Use <see cref='NonExistent.Member'/> instead.")]
+        [TestCase ("Use <see cref=''/> instead.")]
+        [TestCase ("Not < valid XML.")]
+        public void ResolveIncorrectDeprecationReason (string input)
+        {
+            Assert.Throws<DocumentationException> (
+                () => DocumentationUtils.ResolveDeprecationReason (input, typeof (TestService)));
+        }
     }
 }

--- a/core/test/Service/ScannerTest.cs
+++ b/core/test/Service/ScannerTest.cs
@@ -64,7 +64,7 @@ namespace KRPC.Test.Service
         {
             var service = services.ServicesList.First (x => x.Name == "TestServiceDeprecated");
             Assert.AreEqual (1, service.Procedures.Count);
-            MessageAssert.IsDeprecated (service, "Use TestService instead.");
+            MessageAssert.IsDeprecated (service, "Use <see cref=\"T:TestService\" /> instead.");
         }
 
         [Test]
@@ -83,7 +83,7 @@ namespace KRPC.Test.Service
                     MessageAssert.HasNoParameters (proc);
                     MessageAssert.HasNoReturnType (proc);
                     MessageAssert.HasGameScene (proc, global::KRPC.Service.GameScene.Flight);
-                    MessageAssert.IsDeprecated (proc, "Use ProcedureNoArgsNoReturn instead.");
+                    MessageAssert.IsDeprecated (proc, "Use <see cref=\"M:TestService.ProcedureNoArgsNoReturn\" /> instead.");
                 } else if (proc.Name == "DeprecatedProcedureNoMessage") {
                     MessageAssert.HasNoParameters (proc);
                     MessageAssert.HasNoReturnType (proc);
@@ -93,12 +93,12 @@ namespace KRPC.Test.Service
                     MessageAssert.HasNoParameters (proc);
                     MessageAssert.HasReturnType (proc, typeof(string));
                     MessageAssert.HasGameScene (proc, global::KRPC.Service.GameScene.Flight);
-                    MessageAssert.IsDeprecated (proc, "Use PropertyWithGet instead.");
+                    MessageAssert.IsDeprecated (proc, "Use <see cref=\"M:TestService.PropertyWithGet\" /> instead.");
                 } else if (proc.Name == "DeprecatedClass_DeprecatedMethod") {
                     MessageAssert.HasParameters (proc, 1);
                     MessageAssert.HasReturnType (proc, typeof(string));
                     MessageAssert.HasGameScene (proc, global::KRPC.Service.GameScene.Flight);
-                    MessageAssert.IsDeprecated (proc, "Use TestClass.FloatToString instead.");
+                    MessageAssert.IsDeprecated (proc, "Use <see cref=\"M:TestService.TestClass.FloatToString\" /> instead.");
                 } else if (proc.Name == "ProcedureSingleArgNoReturn") {
                     MessageAssert.HasParameters (proc, 1);
                     MessageAssert.HasParameter (proc, 0, typeof(string), "x");
@@ -413,7 +413,7 @@ namespace KRPC.Test.Service
                     MessageAssert.HasDocumentation (cls, "<doc>\n<summary>\nA class defined at the top level, but included in a service\n</summary>\n</doc>");
                     MessageAssert.IsNotDeprecated (cls);
                 } else if (cls.Name == "DeprecatedClass") {
-                    MessageAssert.IsDeprecated (cls, "Use TestClass instead.");
+                    MessageAssert.IsDeprecated (cls, "Use <see cref=\"T:TestService.TestClass\" /> instead.");
                 } else {
                     Assert.Fail ();
                 }
@@ -441,9 +441,9 @@ namespace KRPC.Test.Service
                     MessageAssert.HasValues (enumeration, 2);
                     MessageAssert.HasValue (enumeration, 0, "A", 0, "<doc>\n<summary>\nA value that is not deprecated.\n</summary>\n</doc>");
                     MessageAssert.HasValue (enumeration, 1, "B", 1, "<doc>\n<summary>\nA deprecated enumeration value, annotated with a reason.\n</summary>\n</doc>");
-                    MessageAssert.IsDeprecated (enumeration, "Use TestEnum instead.");
+                    MessageAssert.IsDeprecated (enumeration, "Use <see cref=\"T:TestService.TestEnum\" /> instead.");
                     MessageAssert.ValueIsNotDeprecated (enumeration, 0);
-                    MessageAssert.ValueIsDeprecated (enumeration, 1, "Use A instead.");
+                    MessageAssert.ValueIsDeprecated (enumeration, 1, "Use <see cref=\"M:TestService.DeprecatedEnum.A\" /> instead.");
                 } else {
                     Assert.Fail ();
                 }

--- a/core/test/Service/TestService.cs
+++ b/core/test/Service/TestService.cs
@@ -355,7 +355,7 @@ namespace KRPC.Test.Service
         /// A deprecated procedure, annotated with a reason.
         /// </summary>
         [KRPCProcedure]
-        [Obsolete ("Use ProcedureNoArgsNoReturn instead.")]
+        [Obsolete ("Use <see cref='ProcedureNoArgsNoReturn'/> instead.")]
         public static void DeprecatedProcedure ()
         {
         }
@@ -373,7 +373,7 @@ namespace KRPC.Test.Service
         /// A deprecated property, annotated with a reason.
         /// </summary>
         [KRPCProperty]
-        [Obsolete ("Use PropertyWithGet instead.")]
+        [Obsolete ("Use <see cref='PropertyWithGet'/> instead.")]
         public static string DeprecatedProperty {
             get { return string.Empty; }
         }
@@ -382,14 +382,14 @@ namespace KRPC.Test.Service
         /// A deprecated class, annotated with a reason.
         /// </summary>
         [KRPCClass]
-        [Obsolete ("Use TestClass instead.")]
+        [Obsolete ("Use <see cref='TestClass'/> instead.")]
         public class DeprecatedClass
         {
             /// <summary>
             /// A deprecated class method, annotated with a reason.
             /// </summary>
             [KRPCMethod]
-            [Obsolete ("Use TestClass.FloatToString instead.")]
+            [Obsolete ("Use <see cref='TestClass.FloatToString'/> instead.")]
             public string DeprecatedMethod ()
             {
                 return string.Empty;
@@ -401,7 +401,7 @@ namespace KRPC.Test.Service
         /// </summary>
         [KRPCEnum]
         [Serializable]
-        [Obsolete ("Use TestEnum instead.")]
+        [Obsolete ("Use <see cref='TestEnum'/> instead.")]
         public enum DeprecatedEnum
         {
             /// <summary>
@@ -412,7 +412,7 @@ namespace KRPC.Test.Service
             /// <summary>
             /// A deprecated enumeration value, annotated with a reason.
             /// </summary>
-            [Obsolete ("Use A instead.")]
+            [Obsolete ("Use <see cref='A'/> instead.")]
             B
         }
 

--- a/core/test/Service/TestServiceDeprecated.cs
+++ b/core/test/Service/TestServiceDeprecated.cs
@@ -8,7 +8,7 @@ namespace KRPC.Test.Service
     /// A deprecated service, annotated with a reason.
     /// </summary>
     [KRPCService (GameScene = GameScene.Flight)]
-    [Obsolete ("Use TestService instead.")]
+    [Obsolete ("Use <see cref='TestService'/> instead.")]
     public static class TestServiceDeprecated
     {
         [KRPCProcedure]

--- a/tools/TestServer/src/TestService.cs
+++ b/tools/TestServer/src/TestService.cs
@@ -487,7 +487,7 @@ namespace TestServer
         /// Deprecated procedure documentation string.
         /// </summary>
         [KRPCProcedure]
-        [Obsolete ("Use FloatToString instead.")]
+        [Obsolete ("Use <see cref='FloatToString'/> instead.")]
         public static string DeprecatedProcedure (float value)
         {
             return value.ToString (CultureInfo.InvariantCulture);
@@ -507,14 +507,14 @@ namespace TestServer
         /// Deprecated property documentation string.
         /// </summary>
         [KRPCProperty]
-        [Obsolete ("Use StringProperty instead.")]
+        [Obsolete ("Use <see cref='StringProperty'/> instead.")]
         public static string DeprecatedProperty { get; set; }
 
         /// <summary>
         /// Deprecated class documentation string.
         /// </summary>
         [KRPCClass]
-        [Obsolete ("Use TestClass instead.")]
+        [Obsolete ("Use <see cref='TestClass'/> instead.")]
         public sealed class DeprecatedClass : Equatable<DeprecatedClass>
         {
             public sealed override bool Equals (DeprecatedClass other)
@@ -531,7 +531,7 @@ namespace TestServer
             /// Deprecated method documentation string.
             /// </summary>
             [KRPCMethod]
-            [Obsolete ("Use TestClass.GetValue instead.")]
+            [Obsolete ("Use <see cref='TestClass.GetValue'/> instead.")]
             public string DeprecatedMethod ()
             {
                 return "value";
@@ -543,7 +543,7 @@ namespace TestServer
         /// </summary>
         [KRPCEnum]
         [Serializable]
-        [Obsolete ("Use TestEnum instead.")]
+        [Obsolete ("Use <see cref='TestEnum'/> instead.")]
         public enum DeprecatedEnum
         {
             /// <summary>
@@ -553,7 +553,7 @@ namespace TestServer
             /// <summary>
             /// Deprecated enum ValueB documentation string.
             /// </summary>
-            [Obsolete ("Use ValueA instead.")]
+            [Obsolete ("Use <see cref='ValueA'/> instead.")]
             ValueB
         }
 

--- a/tools/krpctools/krpctools/clientgen/cpp.py
+++ b/tools/krpctools/krpctools/clientgen/cpp.py
@@ -15,6 +15,9 @@ class CppGenerator(Generator):
 
     language = CppLanguage()
 
+    plain_cref_separator = "::"
+    parse_plain_cref_member = staticmethod(snake_case)
+
     def parse_set_client(self, procedure):
         return isinstance(self.get_return_type(procedure), ClassType)
 

--- a/tools/krpctools/krpctools/clientgen/docparser.py
+++ b/tools/krpctools/krpctools/clientgen/docparser.py
@@ -1,6 +1,31 @@
 from xml.etree import ElementTree
 
 
+def flatten_deprecation_reason(reason, parse_cref):
+    """Flatten a deprecation reason fragment to plain text, mapping
+    <see cref="..."/> references through parse_cref. Reasons containing
+    no markup are returned unchanged."""
+    if "<" not in reason:
+        return reason
+    parser = ElementTree.XMLParser(encoding="UTF-8")
+    root = ElementTree.XML(("<doc>%s</doc>" % reason).encode("UTF-8"), parser=parser)
+    return _flatten_node(root, parse_cref)
+
+
+def _flatten_node(node, parse_cref):
+    content = node.text or ""
+    for child in node:
+        if child.tag == "see":
+            content += parse_cref(child.attrib["cref"])
+        elif child.tag == "paramref":
+            content += child.attrib["name"]
+        else:
+            content += _flatten_node(child, parse_cref)
+        if child.tail:
+            content += child.tail
+    return content
+
+
 class DocParser:
 
     def parse(self, xml):

--- a/tools/krpctools/krpctools/clientgen/generator.py
+++ b/tools/krpctools/krpctools/clientgen/generator.py
@@ -4,6 +4,7 @@ from krpc.attributes import Attributes
 from krpc.types import Types
 from krpc.utils import snake_case
 from ..utils import lower_camel_case, indent, single_line, as_type, decode_default_value
+from .docparser import flatten_deprecation_reason
 
 
 class Generator:
@@ -40,6 +41,32 @@ class Generator:
         template = env.from_string(self._macro_template)
         content = template.render(context)
         return content.rstrip() + "\n"
+
+    # Separator between name parts when flattening a cref to a plain name
+    plain_cref_separator = "."
+
+    @staticmethod
+    def parse_plain_cref_member(name):
+        return name
+
+    def parse_plain_cref(self, cref):
+        """Convert a service-level cref to a plain language-specific name for
+        embedding in deprecation messages. The current service's prefix is
+        dropped and the member name (the last part of M: crefs) is converted
+        to the language's naming convention."""
+        name = cref[2:]
+        prefix = self._service + "."
+        if name.startswith(prefix):
+            name = name[len(prefix) :]
+        parts = name.split(".")
+        if cref[0] == "M":
+            parts[-1] = self.parse_plain_cref_member(parts[-1])
+        return self.plain_cref_separator.join(parts)
+
+    def parse_deprecation_reason(self, reason):
+        """Flatten a deprecation reason to plain text, mapping cref markup to
+        language-specific names."""
+        return flatten_deprecation_reason(reason, self.parse_plain_cref)
 
     def generate_context_parameters(self, procedure):
         parameters = []
@@ -80,7 +107,9 @@ class Generator:
                 "properties": {},
                 "documentation": self.parse_documentation(cls["documentation"]),
                 "deprecated": cls.get("deprecated", False),
-                "deprecated_reason": cls.get("deprecated_reason", ""),
+                "deprecated_reason": self.parse_deprecation_reason(
+                    cls.get("deprecated_reason", "")
+                ),
             }
 
         for name, enumeration in self._get_defs("enumerations"):
@@ -91,20 +120,26 @@ class Generator:
                         "value": x["value"],
                         "documentation": self.parse_documentation(x["documentation"]),
                         "deprecated": x.get("deprecated", False),
-                        "deprecated_reason": x.get("deprecated_reason", ""),
+                        "deprecated_reason": self.parse_deprecation_reason(
+                            x.get("deprecated_reason", "")
+                        ),
                     }
                     for x in enumeration["values"]
                 ],
                 "documentation": self.parse_documentation(enumeration["documentation"]),
                 "deprecated": enumeration.get("deprecated", False),
-                "deprecated_reason": enumeration.get("deprecated_reason", ""),
+                "deprecated_reason": self.parse_deprecation_reason(
+                    enumeration.get("deprecated_reason", "")
+                ),
             }
 
         for name, exception in self._get_defs("exceptions"):
             context["exceptions"][name] = {
                 "documentation": self.parse_documentation(exception["documentation"]),
                 "deprecated": exception.get("deprecated", False),
-                "deprecated_reason": exception.get("deprecated_reason", ""),
+                "deprecated_reason": self.parse_deprecation_reason(
+                    exception.get("deprecated_reason", "")
+                ),
             }
 
         for name, procedure in self._get_defs("procedures"):
@@ -121,7 +156,9 @@ class Generator:
                         procedure["documentation"]
                     ),
                     "deprecated": procedure.get("deprecated", False),
-                    "deprecated_reason": procedure.get("deprecated_reason", ""),
+                    "deprecated_reason": self.parse_deprecation_reason(
+                        procedure.get("deprecated_reason", "")
+                    ),
                 }
 
             elif Attributes.is_a_property_getter(name):
@@ -135,7 +172,9 @@ class Generator:
                             procedure["documentation"]
                         ),
                         "deprecated": procedure.get("deprecated", False),
-                        "deprecated_reason": procedure.get("deprecated_reason", ""),
+                        "deprecated_reason": self.parse_deprecation_reason(
+                            procedure.get("deprecated_reason", "")
+                        ),
                     }
                 context["properties"][property_name]["getter"] = {
                     "procedure": procedure,
@@ -155,7 +194,9 @@ class Generator:
                             procedure["documentation"]
                         ),
                         "deprecated": procedure.get("deprecated", False),
-                        "deprecated_reason": procedure.get("deprecated_reason", ""),
+                        "deprecated_reason": self.parse_deprecation_reason(
+                            procedure.get("deprecated_reason", "")
+                        ),
                     }
                 context["properties"][property_name]["setter"] = {
                     "procedure": procedure,
@@ -179,7 +220,9 @@ class Generator:
                         procedure["documentation"]
                     ),
                     "deprecated": procedure.get("deprecated", False),
-                    "deprecated_reason": procedure.get("deprecated_reason", ""),
+                    "deprecated_reason": self.parse_deprecation_reason(
+                        procedure.get("deprecated_reason", "")
+                    ),
                 }
 
             elif Attributes.is_a_class_static_method(name):
@@ -198,7 +241,9 @@ class Generator:
                         procedure["documentation"]
                     ),
                     "deprecated": procedure.get("deprecated", False),
-                    "deprecated_reason": procedure.get("deprecated_reason", ""),
+                    "deprecated_reason": self.parse_deprecation_reason(
+                        procedure.get("deprecated_reason", "")
+                    ),
                 }
 
             elif Attributes.is_a_class_property_getter(name):
@@ -214,7 +259,9 @@ class Generator:
                             procedure["documentation"]
                         ),
                         "deprecated": procedure.get("deprecated", False),
-                        "deprecated_reason": procedure.get("deprecated_reason", ""),
+                        "deprecated_reason": self.parse_deprecation_reason(
+                            procedure.get("deprecated_reason", "")
+                        ),
                     }
                 cls["properties"][property_name]["getter"] = {
                     "procedure": procedure,
@@ -236,7 +283,9 @@ class Generator:
                             procedure["documentation"]
                         ),
                         "deprecated": procedure.get("deprecated", False),
-                        "deprecated_reason": procedure.get("deprecated_reason", ""),
+                        "deprecated_reason": self.parse_deprecation_reason(
+                            procedure.get("deprecated_reason", "")
+                        ),
                     }
                 cls["properties"][property_name]["setter"] = {
                     "procedure": procedure,

--- a/tools/krpctools/krpctools/clientgen/java.py
+++ b/tools/krpctools/krpctools/clientgen/java.py
@@ -24,6 +24,8 @@ class JavaGenerator(Generator):
 
     language = JavaLanguage()
 
+    parse_plain_cref_member = staticmethod(lower_camel_case)
+
     def parse_type_specification(self, typ):
         if typ is None:
             return None

--- a/tools/krpctools/krpctools/clientgen/python.py
+++ b/tools/krpctools/krpctools/clientgen/python.py
@@ -22,6 +22,8 @@ class PythonGenerator(Generator):
 
     language = PythonLanguage()
 
+    parse_plain_cref_member = staticmethod(snake_case)
+
     def parse_python_type(self, typ):
         if typ is None:
             return "None"

--- a/tools/krpctools/krpctools/docgen/__init__.py
+++ b/tools/krpctools/krpctools/docgen/__init__.py
@@ -151,6 +151,12 @@ def process_file(domain, services, path):
     def gendoc(xml, selector="./summary"):
         return DocumentationGenerator(domain, services, xml).generate(selector)
 
+    def gendesc(text):
+        # Render a description fragment (e.g. a deprecation reason), which may
+        # contain the same markup as documentation strings
+        xml = "<doc><summary>%s</summary></doc>" % text
+        return DocumentationGenerator(domain, services, xml).generate("./summary")
+
     def see(cref):
         obj = lookup_cref(cref, services)
         return domain.see(obj)
@@ -167,6 +173,7 @@ def process_file(domain, services, path):
         "services": services,
         "hasdoc": hasdoc,
         "gendoc": gendoc,
+        "gendesc": gendesc,
         "see": see,
         "mark_documented": mark_documented,
     }

--- a/tools/krpctools/krpctools/docgen/cnano.tmpl
+++ b/tools/krpctools/krpctools/docgen/cnano.tmpl
@@ -188,7 +188,7 @@ krpc_connection_t connection{% if domain.return_type(return_type) != 'void' %}, 
 {% endmacro %}
 
 {% macro deprecated(x) %}
-.. warning:: Deprecated.{% if x.deprecated_reason != '' %} {{ x.deprecated_reason }}{% endif %}
+.. warning:: Deprecated.{% if x.deprecated_reason != '' %} {{ gendesc(x.deprecated_reason) }}{% endif %}
 {% endmacro %}
 
 {% macro game_scenes(x) %}

--- a/tools/krpctools/krpctools/docgen/cpp.tmpl
+++ b/tools/krpctools/krpctools/docgen/cpp.tmpl
@@ -200,7 +200,7 @@
 {% endmacro %}
 
 {% macro deprecated(x) %}
-.. warning:: Deprecated.{% if x.deprecated_reason != '' %} {{ x.deprecated_reason }}{% endif %}
+.. warning:: Deprecated.{% if x.deprecated_reason != '' %} {{ gendesc(x.deprecated_reason) }}{% endif %}
 {% endmacro %}
 
 {% macro game_scenes(x) %}

--- a/tools/krpctools/krpctools/docgen/csharp.tmpl
+++ b/tools/krpctools/krpctools/docgen/csharp.tmpl
@@ -196,7 +196,7 @@
 {% endmacro %}
 
 {% macro deprecated(x) %}
-.. warning:: Deprecated.{% if x.deprecated_reason != '' %} {{ x.deprecated_reason }}{% endif %}
+.. warning:: Deprecated.{% if x.deprecated_reason != '' %} {{ gendesc(x.deprecated_reason) }}{% endif %}
 {% endmacro %}
 
 {% macro game_scenes(x) %}

--- a/tools/krpctools/krpctools/docgen/java.tmpl
+++ b/tools/krpctools/krpctools/docgen/java.tmpl
@@ -186,7 +186,7 @@
 {% endmacro %}
 
 {% macro deprecated(x) %}
-.. warning:: Deprecated.{% if x.deprecated_reason != '' %} {{ x.deprecated_reason }}{% endif %}
+.. warning:: Deprecated.{% if x.deprecated_reason != '' %} {{ gendesc(x.deprecated_reason) }}{% endif %}
 {% endmacro %}
 
 {% macro game_scenes(x) %}

--- a/tools/krpctools/krpctools/docgen/lua.tmpl
+++ b/tools/krpctools/krpctools/docgen/lua.tmpl
@@ -194,5 +194,5 @@
 {% endmacro %}
 
 {% macro deprecated(x) %}
-.. warning:: Deprecated.{% if x.deprecated_reason != '' %} {{ x.deprecated_reason }}{% endif %}
+.. warning:: Deprecated.{% if x.deprecated_reason != '' %} {{ gendesc(x.deprecated_reason) }}{% endif %}
 {% endmacro %}

--- a/tools/krpctools/krpctools/docgen/python.tmpl
+++ b/tools/krpctools/krpctools/docgen/python.tmpl
@@ -198,7 +198,7 @@
 {% endmacro %}
 
 {% macro deprecated(x) %}
-.. warning:: Deprecated.{% if x.deprecated_reason != '' %} {{ x.deprecated_reason }}{% endif %}
+.. warning:: Deprecated.{% if x.deprecated_reason != '' %} {{ gendesc(x.deprecated_reason) }}{% endif %}
 {% endmacro %}
 
 {% macro game_scenes(x) %}

--- a/tools/krpctools/krpctools/test/clientgen-TestService-cpp.txt
+++ b/tools/krpctools/krpctools/test/clientgen-TestService-cpp.txt
@@ -53,9 +53,9 @@ class TestService : public Service {
     /**
      * Deprecated enum ValueB documentation string.
      *
-     * \deprecated Use ValueA instead.
+     * \deprecated Use DeprecatedEnum::value_a instead.
      */
-    value_b [[deprecated("Use ValueA instead.")]] = 1
+    value_b [[deprecated("Use DeprecatedEnum::value_a instead.")]] = 1
   };
 
   /**
@@ -93,9 +93,9 @@ class TestService : public Service {
   /**
    * Deprecated procedure documentation string.
    *
-   * \deprecated Use FloatToString instead.
+   * \deprecated Use float_to_string instead.
    */
-  [[deprecated("Use FloatToString instead.")]]
+  [[deprecated("Use float_to_string instead.")]]
   std::string deprecated_procedure(float value);
 
   /**
@@ -172,17 +172,17 @@ class TestService : public Service {
   /**
    * Deprecated property documentation string.
    *
-   * \deprecated Use StringProperty instead.
+   * \deprecated Use string_property instead.
    */
-  [[deprecated("Use StringProperty instead.")]]
+  [[deprecated("Use string_property instead.")]]
   std::string deprecated_property();
 
   /**
    * Deprecated property documentation string.
    *
-   * \deprecated Use StringProperty instead.
+   * \deprecated Use string_property instead.
    */
-  [[deprecated("Use StringProperty instead.")]]
+  [[deprecated("Use string_property instead.")]]
   void set_deprecated_property(std::string value);
 
   TestService::TestClass object_property();
@@ -395,9 +395,9 @@ class TestService : public Service {
     /**
      * Deprecated method documentation string.
      *
-     * \deprecated Use TestClass.GetValue instead.
+     * \deprecated Use TestClass::get_value instead.
      */
-    [[deprecated("Use TestClass.GetValue instead.")]]
+    [[deprecated("Use TestClass::get_value instead.")]]
     std::string deprecated_method();
 
     ::krpc::Stream<std::string> deprecated_method_stream();

--- a/tools/krpctools/krpctools/test/clientgen-TestService-csharp.txt
+++ b/tools/krpctools/krpctools/test/clientgen-TestService-csharp.txt
@@ -522,7 +522,7 @@ namespace KRPC.Client.Services.TestService
         /// <summary>
         /// Deprecated enum ValueB documentation string.
         /// </summary>
-        [global::System.Obsolete ("Use ValueA instead.")]
+        [global::System.Obsolete ("Use DeprecatedEnum.ValueA instead.")]
         ValueB = 1
     }
 

--- a/tools/krpctools/krpctools/test/clientgen-TestService-java.txt
+++ b/tools/krpctools/krpctools/test/clientgen-TestService-java.txt
@@ -139,7 +139,7 @@ public class TestService {
     /**
      * Deprecated procedure documentation string.
      *
-     * @deprecated Use FloatToString instead.
+     * @deprecated Use floatToString instead.
      */
     @Deprecated
     @SuppressWarnings({ "unchecked" })
@@ -457,7 +457,7 @@ public class TestService {
     /**
      * Deprecated property documentation string.
      *
-     * @deprecated Use StringProperty instead.
+     * @deprecated Use stringProperty instead.
      */
     @Deprecated
     @SuppressWarnings({ "unchecked" })
@@ -470,7 +470,7 @@ public class TestService {
     /**
      * Deprecated property documentation string.
      *
-     * @deprecated Use StringProperty instead.
+     * @deprecated Use stringProperty instead.
      */
     @Deprecated
     @SuppressWarnings({ "unchecked" })
@@ -551,7 +551,7 @@ public class TestService {
         /**
          * Deprecated enum ValueB documentation string.
          *
-         * @deprecated Use ValueA instead.
+         * @deprecated Use DeprecatedEnum.valueA instead.
          */
         @Deprecated
         VALUE_B(1);
@@ -638,7 +638,7 @@ public class TestService {
         /**
          * Deprecated method documentation string.
          *
-         * @deprecated Use TestClass.GetValue instead.
+         * @deprecated Use TestClass.getValue instead.
          */
         @Deprecated
         @SuppressWarnings({ "unchecked" })

--- a/tools/krpctools/krpctools/test/clientgen-TestService-python.txt
+++ b/tools/krpctools/krpctools/test/clientgen-TestService-python.txt
@@ -60,11 +60,11 @@ class DeprecatedClass(ClassBase):
     """
     def deprecated_method(self) -> str:
         """
-        Deprecated. Use TestClass.GetValue instead.
+        Deprecated. Use TestClass.get_value instead.
 
         Deprecated method documentation string.
         """
-        warnings.warn("TestService.DeprecatedClass.deprecated_method is deprecated: Use TestClass.GetValue instead.", DeprecationWarning, stacklevel=2)
+        warnings.warn("TestService.DeprecatedClass.deprecated_method is deprecated: Use TestClass.get_value instead.", DeprecationWarning, stacklevel=2)
         return self._client._invoke(
             "TestService",
             "DeprecatedClass_DeprecatedMethod",
@@ -384,11 +384,11 @@ class TestService:
     @property
     def deprecated_property(self) -> str:
         """
-        Deprecated. Use StringProperty instead.
+        Deprecated. Use string_property instead.
 
         Deprecated property documentation string.
         """
-        warnings.warn("TestService.deprecated_property is deprecated: Use StringProperty instead.", DeprecationWarning, stacklevel=2)
+        warnings.warn("TestService.deprecated_property is deprecated: Use string_property instead.", DeprecationWarning, stacklevel=2)
         return self._client._invoke(
             "TestService",
             "get_DeprecatedProperty",
@@ -400,7 +400,7 @@ class TestService:
 
     @deprecated_property.setter
     def deprecated_property(self, value: str) -> None:
-        warnings.warn("TestService.deprecated_property is deprecated: Use StringProperty instead.", DeprecationWarning, stacklevel=2)
+        warnings.warn("TestService.deprecated_property is deprecated: Use string_property instead.", DeprecationWarning, stacklevel=2)
         return self._client._invoke(
             "TestService",
             "set_DeprecatedProperty",
@@ -698,11 +698,11 @@ class TestService:
 
     def deprecated_procedure(self, value: float) -> str:
         """
-        Deprecated. Use FloatToString instead.
+        Deprecated. Use float_to_string instead.
 
         Deprecated procedure documentation string.
         """
-        warnings.warn("TestService.deprecated_procedure is deprecated: Use FloatToString instead.", DeprecationWarning, stacklevel=2)
+        warnings.warn("TestService.deprecated_procedure is deprecated: Use float_to_string instead.", DeprecationWarning, stacklevel=2)
         return self._client._invoke(
             "TestService",
             "DeprecatedProcedure",

--- a/tools/krpctools/krpctools/test/docgen-TestService-cnano.rst
+++ b/tools/krpctools/krpctools/test/docgen-TestService-cnano.rst
@@ -85,7 +85,7 @@ Service TestService
 
    .. function:: krpc_error_t krpc_TestService_DeprecatedProcedure(krpc_connection_t connection, char * * result, float value)
 
-      .. warning:: Deprecated. Use FloatToString instead.
+      .. warning:: Deprecated. Use :func:`krpc_TestService_FloatToString` instead.
 
       Deprecated procedure documentation string.
 
@@ -110,7 +110,7 @@ Service TestService
    .. function:: krpc_error_t krpc_TestService_DeprecatedProperty(krpc_connection_t connection, char * * result)
    .. function:: void krpc_TestService_set_DeprecatedProperty(const char * value)
 
-      .. warning:: Deprecated. Use StringProperty instead.
+      .. warning:: Deprecated. Use :func:`krpc_TestService_StringProperty` instead.
 
       Deprecated property documentation string.
 
@@ -516,13 +516,13 @@ Service TestService
 
 .. type:: krpc_TestService_DeprecatedClass_t
 
-   .. warning:: Deprecated. Use TestClass instead.
+   .. warning:: Deprecated. Use :type:`krpc_TestService_TestClass_t` instead.
 
    Deprecated class documentation string.
 
    .. function:: krpc_error_t krpc_TestService_DeprecatedClass_DeprecatedMethod(krpc_connection_t connection, char * * result)
 
-      .. warning:: Deprecated. Use TestClass.GetValue instead.
+      .. warning:: Deprecated. Use :func:`krpc_TestService_TestClass_GetValue` instead.
 
       Deprecated method documentation string.
 
@@ -554,7 +554,7 @@ Service TestService
 
 .. type:: krpc_TestService_DeprecatedEnum_t
 
-   .. warning:: Deprecated. Use TestEnum instead.
+   .. warning:: Deprecated. Use :type:`krpc_TestService_TestEnum_t` instead.
 
    Deprecated enum documentation string.
 
@@ -566,7 +566,7 @@ Service TestService
 
    .. macro:: KRPC_TESTSERVICE_DEPRECATEDENUM_VALUEB
 
-      .. warning:: Deprecated. Use ValueA instead.
+      .. warning:: Deprecated. Use :macro:`KRPC_TESTSERVICE_DEPRECATEDENUM_VALUEA` instead.
 
       Deprecated enum ValueB documentation string.
 

--- a/tools/krpctools/krpctools/test/docgen-TestService-cpp.rst
+++ b/tools/krpctools/krpctools/test/docgen-TestService-cpp.rst
@@ -90,7 +90,7 @@
 
    .. function:: std::string deprecated_procedure(float value)
 
-      .. warning:: Deprecated. Use FloatToString instead.
+      .. warning:: Deprecated. Use :func:`float_to_string` instead.
 
       Deprecated procedure documentation string.
 
@@ -115,7 +115,7 @@
    .. function:: std::string deprecated_property()
    .. function:: void set_deprecated_property(std::string value)
 
-      .. warning:: Deprecated. Use StringProperty instead.
+      .. warning:: Deprecated. Use :func:`string_property` instead.
 
       Deprecated property documentation string.
 
@@ -521,13 +521,13 @@
 
 .. class:: DeprecatedClass
 
-   .. warning:: Deprecated. Use TestClass instead.
+   .. warning:: Deprecated. Use :class:`TestClass` instead.
 
    Deprecated class documentation string.
 
    .. function:: std::string deprecated_method()
 
-      .. warning:: Deprecated. Use TestClass.GetValue instead.
+      .. warning:: Deprecated. Use :func:`TestClass::get_value` instead.
 
       Deprecated method documentation string.
 
@@ -561,7 +561,7 @@
 .. namespace:: krpc::services::TestService
 .. enum-struct:: DeprecatedEnum
 
-   .. warning:: Deprecated. Use TestEnum instead.
+   .. warning:: Deprecated. Use :enum:`TestEnum` instead.
 
    Deprecated enum documentation string.
 
@@ -573,7 +573,7 @@
 
    .. enumerator:: value_b
 
-      .. warning:: Deprecated. Use ValueA instead.
+      .. warning:: Deprecated. Use :enumerator:`DeprecatedEnum::value_a` instead.
 
       Deprecated enum ValueB documentation string.
 

--- a/tools/krpctools/krpctools/test/docgen-TestService-csharp.rst
+++ b/tools/krpctools/krpctools/test/docgen-TestService-csharp.rst
@@ -85,7 +85,7 @@
 
    .. method:: string DeprecatedProcedure(float value)
 
-      .. warning:: Deprecated. Use FloatToString instead.
+      .. warning:: Deprecated. Use :meth:`TestService.FloatToString` instead.
 
       Deprecated procedure documentation string.
 
@@ -109,7 +109,7 @@
 
    .. property:: string DeprecatedProperty { get; set; }
 
-      .. warning:: Deprecated. Use StringProperty instead.
+      .. warning:: Deprecated. Use :prop:`TestService.StringProperty` instead.
 
       Deprecated property documentation string.
 
@@ -511,13 +511,13 @@
 
 .. class:: DeprecatedClass
 
-   .. warning:: Deprecated. Use TestClass instead.
+   .. warning:: Deprecated. Use :type:`TestClass` instead.
 
    Deprecated class documentation string.
 
    .. method:: string DeprecatedMethod()
 
-      .. warning:: Deprecated. Use TestClass.GetValue instead.
+      .. warning:: Deprecated. Use :meth:`TestClass.GetValue` instead.
 
       Deprecated method documentation string.
 
@@ -549,7 +549,7 @@
 
 .. enum:: DeprecatedEnum
 
-   .. warning:: Deprecated. Use TestEnum instead.
+   .. warning:: Deprecated. Use :type:`TestEnum` instead.
 
    Deprecated enum documentation string.
 
@@ -561,7 +561,7 @@
 
    .. value:: ValueB
 
-      .. warning:: Deprecated. Use ValueA instead.
+      .. warning:: Deprecated. Use :enum:`DeprecatedEnum.ValueA` instead.
 
       Deprecated enum ValueB documentation string.
 

--- a/tools/krpctools/krpctools/test/docgen-TestService-java.rst
+++ b/tools/krpctools/krpctools/test/docgen-TestService-java.rst
@@ -64,7 +64,7 @@
 
    .. method:: String deprecatedProcedure(float value)
 
-      .. warning:: Deprecated. Use FloatToString instead.
+      .. warning:: Deprecated. Use :meth:`floatToString(float)` instead.
 
       Deprecated procedure documentation string.
 
@@ -84,7 +84,7 @@
 
    .. method:: void setDeprecatedProperty(String value)
 
-      .. warning:: Deprecated. Use StringProperty instead.
+      .. warning:: Deprecated. Use :meth:`getStringProperty()` instead.
 
       Deprecated property documentation string.
 
@@ -408,13 +408,13 @@
 
 .. type:: public class DeprecatedClass
 
-   .. warning:: Deprecated. Use TestClass instead.
+   .. warning:: Deprecated. Use :type:`TestClass` instead.
 
    Deprecated class documentation string.
 
    .. method:: String deprecatedMethod()
 
-      .. warning:: Deprecated. Use TestClass.GetValue instead.
+      .. warning:: Deprecated. Use :meth:`TestClass.getValue()` instead.
 
       Deprecated method documentation string.
 
@@ -445,7 +445,7 @@
 
 .. type:: public enum DeprecatedEnum
 
-   .. warning:: Deprecated. Use TestEnum instead.
+   .. warning:: Deprecated. Use :type:`TestEnum` instead.
 
    Deprecated enum documentation string.
 
@@ -457,7 +457,7 @@
 
    .. field:: public DeprecatedEnum VALUE_B
 
-      .. warning:: Deprecated. Use ValueA instead.
+      .. warning:: Deprecated. Use :meth:`DeprecatedEnum.VALUE_A` instead.
 
       Deprecated enum ValueB documentation string.
 

--- a/tools/krpctools/krpctools/test/docgen-TestService-lua.rst
+++ b/tools/krpctools/krpctools/test/docgen-TestService-lua.rst
@@ -86,7 +86,7 @@ Service documentation string.
 
 .. staticmethod:: deprecated_procedure(value)
 
-   .. warning:: Deprecated. Use FloatToString instead.
+   .. warning:: Deprecated. Use :meth:`TestService.float_to_string` instead.
 
    Deprecated procedure documentation string.
 
@@ -110,7 +110,7 @@ Service documentation string.
 
 .. attribute:: deprecated_property: string
 
-   .. warning:: Deprecated. Use StringProperty instead.
+   .. warning:: Deprecated. Use :attr:`TestService.string_property` instead.
 
    Deprecated property documentation string.
 
@@ -538,13 +538,13 @@ Service documentation string.
 
 .. class:: DeprecatedClass
 
-   .. warning:: Deprecated. Use TestClass instead.
+   .. warning:: Deprecated. Use :class:`TestService.TestClass` instead.
 
    Deprecated class documentation string.
 
    .. method:: deprecated_method()
 
-      .. warning:: Deprecated. Use TestClass.GetValue instead.
+      .. warning:: Deprecated. Use :meth:`TestService.TestClass.get_value` instead.
 
       Deprecated method documentation string.
 
@@ -575,7 +575,7 @@ Service documentation string.
 
 .. class:: DeprecatedEnum
 
-   .. warning:: Deprecated. Use TestEnum instead.
+   .. warning:: Deprecated. Use :class:`TestService.TestEnum` instead.
 
    Deprecated enum documentation string.
 
@@ -587,7 +587,7 @@ Service documentation string.
 
    .. data:: value_b
 
-      .. warning:: Deprecated. Use ValueA instead.
+      .. warning:: Deprecated. Use :attr:`TestService.DeprecatedEnum.value_a` instead.
 
       Deprecated enum ValueB documentation string.
 

--- a/tools/krpctools/krpctools/test/docgen-TestService-python.rst
+++ b/tools/krpctools/krpctools/test/docgen-TestService-python.rst
@@ -93,7 +93,7 @@ Service documentation string.
 
 .. staticmethod:: deprecated_procedure(value)
 
-   .. warning:: Deprecated. Use FloatToString instead.
+   .. warning:: Deprecated. Use :meth:`float_to_string` instead.
 
    Deprecated procedure documentation string.
 
@@ -119,7 +119,7 @@ Service documentation string.
 
 .. attribute:: deprecated_property
 
-   .. warning:: Deprecated. Use StringProperty instead.
+   .. warning:: Deprecated. Use :attr:`string_property` instead.
 
    Deprecated property documentation string.
 
@@ -592,13 +592,13 @@ Service documentation string.
 
 .. class:: DeprecatedClass
 
-   .. warning:: Deprecated. Use TestClass instead.
+   .. warning:: Deprecated. Use :class:`TestClass` instead.
 
    Deprecated class documentation string.
 
    .. method:: deprecated_method()
 
-      .. warning:: Deprecated. Use TestClass.GetValue instead.
+      .. warning:: Deprecated. Use :meth:`TestClass.get_value` instead.
 
       Deprecated method documentation string.
 
@@ -630,7 +630,7 @@ Service documentation string.
 
 .. class:: DeprecatedEnum
 
-   .. warning:: Deprecated. Use TestEnum instead.
+   .. warning:: Deprecated. Use :class:`TestEnum` instead.
 
    Deprecated enum documentation string.
 
@@ -642,7 +642,7 @@ Service documentation string.
 
    .. data:: value_b
 
-      .. warning:: Deprecated. Use ValueA instead.
+      .. warning:: Deprecated. Use :attr:`DeprecatedEnum.value_a` instead.
 
       Deprecated enum ValueB documentation string.
 


### PR DESCRIPTION
Allow [Obsolete] messages to contain doc-comment-style <see cref='...'/> markup with unqualified references. The compiler does not resolve crefs in attribute strings, so the scanner resolves them against the declaring type and rewrites them to the same service-level crefs used in documentation strings; deprecated_reason then carries the documentation markup dialect on the wire. Plain-text messages pass through unchanged.

docgen renders reasons through each language domain, producing linked Sphinx roles in the deprecation warning admonitions. clientgen flattens them to plain language-cased names (e.g. Module.field_list, fieldList, Module::field_list) in generated attribute strings, javadoc and docstrings, and the dynamic Python client does the same at runtime.