### PR TITLE
Rename job to test-service and run all service tests in it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -370,7 +370,7 @@ jobs:
       - name: test
         run: bazel test //core:test
 
-  test-service-spacecenter:
+  test-service:
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/krpc/buildenv:3.8.0
@@ -384,7 +384,7 @@ jobs:
       - name: setup
         uses: ./.github/actions/build-setup
       - name: test
-        run: bazel test //service/SpaceCenter:test-attitude-error
+        run: bazel test //service/...
 
   test-client-cnano:
     runs-on: ubuntu-latest
@@ -601,7 +601,7 @@ jobs:
       - build-docs-examples
       - test-docs
       - test-core
-      - test-service-spacecenter
+      - test-service
       - test-client-cnano
       - test-client-cpp
       - test-client-csharp

--- a/service/SpaceCenter/test/pylint.rc
+++ b/service/SpaceCenter/test/pylint.rc
@@ -7,6 +7,9 @@ method-rgx=[a-z_][a-z0-9_]{2,60}$
 [DESIGN]
 max-statements=60
 
+[FORMAT]
+max-module-lines=2000
+
 [MESSAGES CONTROL]
 disable=no-member,missing-docstring,similarities,too-few-public-methods,too-many-public-methods,fixme,consider-using-f-string
 

--- a/service/SpaceCenter/test/test_referenceframe.py
+++ b/service/SpaceCenter/test/test_referenceframe.py
@@ -840,7 +840,9 @@ class TestReferenceFrame(krpctest.TestCase):
         # vessel is teleported to periapsis -- its highest latitude (= inclination),
         # independent of orbital phase.
         self.addCleanup(self.set_circular_orbit, "Kerbin", 100000)
-        self.set_orbit("Kerbin", 700000, 0.0, 60.0, 0.0, 90.0, 0.0, self.space_center.ut)
+        self.set_orbit(
+            "Kerbin", 700000, 0.0, 60.0, 0.0, 90.0, 0.0, self.space_center.ut
+        )
         self.vessel.control.sas = False
         self.vessel.control.rcs = False
         self.set_pitch_heading_roll(0, 90, 0)  # de-spin (inertially fixed)


### PR DESCRIPTION
 - Add lint tests that weren't being run in CI to test-service job, along with SpaceCenter unit tests.
 - Fix lint errors