### PR TITLE
Client disconnect cleanup

### DIFF
--- a/server/CHANGES.txt
+++ b/server/CHANGES.txt
@@ -5,6 +5,9 @@ v0.6.0
  * Fix Stream RPCs Executed and Stream RPC Rate always showing 0 in the info window (#879)
  * Improve the server window UI
  * Fix incorrect unit shown for "max. time per update" and "receive timeout" - they are microseconds, not nanoseconds
+ * Add shared component for releasing client-owned in-game state when a client disconnects,
+   used by the services; connectivity checks are cached so all state shares one socket poll
+   per client per frame
 
 v0.5.4
  * Fix memory leaks when switching game scene (#779)

--- a/server/src/KRPC.csproj
+++ b/server/src/KRPC.csproj
@@ -62,7 +62,12 @@
     <Compile Include="UI\Skin.cs" />
     <Compile Include="UI\Window.cs" />
     <Compile Include="Utils\APILoader.cs" />
+    <Compile Include="Utils\ClientCleanupAddon.cs" />
+    <Compile Include="Utils\ClientConnections.cs" />
+    <Compile Include="Utils\ClientOwnedObjects.cs" />
+    <Compile Include="Utils\ClientOwnedOverrides.cs" />
     <Compile Include="Utils\Compatibility.cs" />
+    <Compile Include="Utils\IClientOwnedCollection.cs" />
     <Compile Include="Utils\ConfigurationStorage.cs" />
     <Compile Include="Utils\ConfigurationStorageNode.cs" />
     <Compile Include="Utils\GameScenesExtensions.cs" />

--- a/server/src/Utils/ClientCleanupAddon.cs
+++ b/server/src/Utils/ClientCleanupAddon.cs
@@ -1,0 +1,63 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace KRPC.Utils
+{
+    /// <summary>
+    /// Base class for addons that hold in-game state on behalf of RPC clients. Clears
+    /// all of the addon's client-owned collections when the addon is created and
+    /// destroyed (i.e. on scene changes), and provides Sweep to release state owned by
+    /// disconnected clients, so that a disconnecting client cannot leave the game in a
+    /// stuck state.
+    /// </summary>
+    /// <remarks>
+    /// Subclasses call Sweep from their own Update or FixedUpdate, before acting on
+    /// any client-owned state: addons that affect physics sweep at the top of
+    /// FixedUpdate, so a disconnected client's state is never applied in the physics
+    /// step in which the disconnect is detected; purely visual addons sweep in Update,
+    /// which, unlike FixedUpdate, still runs while the game is paused. Subclasses that
+    /// need their own Awake or OnDestroy must override them and call the base
+    /// implementation (a same-name non-override method would silently shadow it).
+    /// </remarks>
+    public abstract class ClientCleanupAddon : MonoBehaviour
+    {
+        /// <summary>
+        /// The client-owned collections managed by this addon.
+        /// </summary>
+        protected abstract IEnumerable<IClientOwnedCollection> Collections { get; }
+
+        /// <summary>
+        /// Release state owned by disconnected clients.
+        /// </summary>
+        protected void Sweep ()
+        {
+            foreach (var collection in Collections)
+                collection.Sweep ();
+        }
+
+        /// <summary>
+        /// Release all client-owned state.
+        /// </summary>
+        protected void Clear ()
+        {
+            foreach (var collection in Collections)
+                collection.Clear ();
+        }
+
+        /// <summary>
+        /// Wake the addon, releasing any state left over from a previous scene.
+        /// </summary>
+        protected virtual void Awake ()
+        {
+            Clear ();
+        }
+
+        /// <summary>
+        /// Destroy the addon, releasing all client-owned state.
+        /// </summary>
+        protected virtual void OnDestroy ()
+        {
+            Clear ();
+        }
+    }
+}

--- a/server/src/Utils/ClientConnections.cs
+++ b/server/src/Utils/ClientConnections.cs
@@ -1,0 +1,37 @@
+using System.Collections.Generic;
+using KRPC.Server;
+using UnityEngine;
+
+namespace KRPC.Utils
+{
+    /// <summary>
+    /// Connectivity checks for clients, cached per rendered frame so that many
+    /// collections sweeping many entries do not repeatedly poll the same socket.
+    /// </summary>
+    public static class ClientConnections
+    {
+        static readonly IDictionary<IClient, bool> cache = new Dictionary<IClient, bool> ();
+        static int cachedFrame = -1;
+
+        /// <summary>
+        /// Whether the given client has disconnected. A null client (for state set
+        /// from in-game code rather than by an RPC) is never considered disconnected.
+        /// </summary>
+        public static bool Disconnected (IClient client)
+        {
+            if (client == null)
+                return false;
+            var frame = Time.frameCount;
+            if (frame != cachedFrame) {
+                cache.Clear ();
+                cachedFrame = frame;
+            }
+            bool connected;
+            if (!cache.TryGetValue (client, out connected)) {
+                connected = client.Connected;
+                cache [client] = connected;
+            }
+            return !connected;
+        }
+    }
+}

--- a/server/src/Utils/ClientOwnedObjects.cs
+++ b/server/src/Utils/ClientOwnedObjects.cs
@@ -1,0 +1,112 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using KRPC.Server;
+using KRPC.Service;
+
+namespace KRPC.Utils
+{
+    /// <summary>
+    /// A collection of objects, each tagged with the client that added it, so that an
+    /// object can be released when its client disconnects. Objects added outside an
+    /// RPC have a null owner and are only released when the collection is cleared.
+    /// </summary>
+    public sealed class ClientOwnedObjects<T> : IClientOwnedCollection where T : class
+    {
+        sealed class Entry
+        {
+            public T Object;
+            public IClient Owner;
+        }
+
+        readonly List<Entry> entries = new List<Entry> ();
+        readonly Action<T> release;
+
+        /// <summary>
+        /// Create a collection. The release action, if any, is invoked on each object
+        /// released by <see cref="Sweep" /> and <see cref="Clear" /> (but not on
+        /// objects removed with <see cref="Remove" />, whose callers do their own
+        /// teardown).
+        /// </summary>
+        public ClientOwnedObjects (Action<T> release = null)
+        {
+            this.release = release;
+        }
+
+        /// <summary>
+        /// Add an object, owned by the client making the current RPC (or unowned if
+        /// there is no current RPC).
+        /// </summary>
+        public void Add (T obj)
+        {
+            entries.Add (new Entry { Object = obj, Owner = CallContext.Client });
+        }
+
+        /// <summary>
+        /// Whether the collection contains the given object and it is owned by the
+        /// client making the current RPC.
+        /// </summary>
+        public bool OwnedByCaller (T obj)
+        {
+            var entry = entries.Find (x => ReferenceEquals (x.Object, obj));
+            return entry != null && entry.Owner == CallContext.Client;
+        }
+
+        /// <summary>
+        /// Remove an object, regardless of its owner, without invoking the release
+        /// action. Returns false if it was not in the collection.
+        /// </summary>
+        public bool Remove (T obj)
+        {
+            var index = entries.FindIndex (x => ReferenceEquals (x.Object, obj));
+            if (index < 0)
+                return false;
+            entries.RemoveAt (index);
+            return true;
+        }
+
+        /// <summary>
+        /// Remove all objects matching the predicate, without invoking the release
+        /// action.
+        /// </summary>
+        public void RemoveAll (Predicate<T> predicate)
+        {
+            entries.RemoveAll (x => predicate (x.Object));
+        }
+
+        /// <summary>
+        /// A snapshot of the objects in the collection, safe to iterate while the
+        /// collection is modified.
+        /// </summary>
+        public IEnumerable<T> Items {
+            get { return entries.Select (x => x.Object).ToList (); }
+        }
+
+        /// <summary>
+        /// Release the objects whose owning client has disconnected.
+        /// </summary>
+        public void Sweep ()
+        {
+            for (var i = entries.Count - 1; i >= 0; i--) {
+                var entry = entries [i];
+                if (ClientConnections.Disconnected (entry.Owner)) {
+                    entries.RemoveAt (i);
+                    if (release != null)
+                        release (entry.Object);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Release all objects.
+        /// </summary>
+        public void Clear ()
+        {
+            var released = entries.ToList ();
+            entries.Clear ();
+            if (release != null)
+                foreach (var entry in released)
+                    release (entry.Object);
+        }
+    }
+}

--- a/server/src/Utils/ClientOwnedObjects.cs
+++ b/server/src/Utils/ClientOwnedObjects.cs
@@ -24,7 +24,7 @@ namespace KRPC.Utils
 
         /// <summary>
         /// Create a collection. The release action, if any, is invoked on each object
-        /// released by <see cref="Sweep" /> and <see cref="Clear" /> (but not on
+        /// released by <see cref="Sweep" /> and <see cref="Clear()" /> (but not on
         /// objects removed with <see cref="Remove" />, whose callers do their own
         /// teardown).
         /// </summary>
@@ -90,6 +90,21 @@ namespace KRPC.Utils
             for (var i = entries.Count - 1; i >= 0; i--) {
                 var entry = entries [i];
                 if (ClientConnections.Disconnected (entry.Owner)) {
+                    entries.RemoveAt (i);
+                    if (release != null)
+                        release (entry.Object);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Release the objects owned by the given client.
+        /// </summary>
+        public void Clear (IClient owner)
+        {
+            for (var i = entries.Count - 1; i >= 0; i--) {
+                var entry = entries [i];
+                if (entry.Owner == owner) {
                     entries.RemoveAt (i);
                     if (release != null)
                         release (entry.Object);

--- a/server/src/Utils/ClientOwnedOverrides.cs
+++ b/server/src/Utils/ClientOwnedOverrides.cs
@@ -1,0 +1,128 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using KRPC.Server;
+using KRPC.Service;
+
+namespace KRPC.Utils
+{
+    /// <summary>
+    /// An override on a single in-game object, tagged with the client that owns it (so
+    /// it can be released when that client disconnects).
+    /// </summary>
+    public abstract class ClientOwnedEntry
+    {
+        /// <summary>
+        /// The client that owns this entry, or null if it was set outside an RPC.
+        /// </summary>
+        public IClient Owner { get; set; }
+    }
+
+    /// <summary>
+    /// A set of overrides of one kind, keyed by the in-game object being overridden.
+    /// Owns the shared lifecycle: installing an override on enable, releasing it on
+    /// disable, and dropping overrides whose owning client has disconnected or whose
+    /// key object has been destroyed. The per-kind behaviour is supplied as delegates.
+    /// </summary>
+    public sealed class ClientOwnedOverrides<TKey, TEntry> : IClientOwnedCollection
+        where TKey : UnityEngine.Object
+        where TEntry : ClientOwnedEntry
+    {
+        readonly IDictionary<TKey, TEntry> entries = new Dictionary<TKey, TEntry> ();
+        readonly Func<TKey, TEntry> install;
+        readonly Action<TKey, TEntry> release;
+
+        /// <summary>
+        /// Create a set of overrides, installed and released by the given delegates.
+        /// The release delegate should restore any state saved by the install
+        /// delegate, and must handle its key having been destroyed.
+        /// </summary>
+        public ClientOwnedOverrides (Func<TKey, TEntry> install, Action<TKey, TEntry> release)
+        {
+            this.install = install;
+            this.release = release;
+        }
+
+        /// <summary>
+        /// Whether the given object is being overridden.
+        /// </summary>
+        public bool IsSet (TKey key)
+        {
+            return entries.ContainsKey (key);
+        }
+
+        /// <summary>
+        /// The override for the given object, or null if it is not being overridden.
+        /// </summary>
+        public TEntry Get (TKey key)
+        {
+            TEntry entry;
+            return entries.TryGetValue (key, out entry) ? entry : null;
+        }
+
+        /// <summary>
+        /// The override for the given object, re-tagged with the calling client, or
+        /// null if it is not being overridden. Used when changing a live override's
+        /// command.
+        /// </summary>
+        public TEntry Own (TKey key)
+        {
+            var entry = Get (key);
+            if (entry != null)
+                entry.Owner = CallContext.Client;
+            return entry;
+        }
+
+        /// <summary>
+        /// Enable or disable the override on the given object. Enabling installs the
+        /// override (or re-tags an existing one) owned by the calling client;
+        /// disabling releases it.
+        /// </summary>
+        public void Set (TKey key, bool enabled)
+        {
+            var entry = Get (key);
+            if (entry != null) {
+                if (enabled)
+                    entry.Owner = CallContext.Client;
+                else {
+                    release (key, entry);
+                    entries.Remove (key);
+                }
+            } else if (enabled) {
+                entry = install (key);
+                entry.Owner = CallContext.Client;
+                entries [key] = entry;
+            }
+        }
+
+        /// <summary>
+        /// Release the overrides whose key object has been destroyed or whose owning
+        /// client has disconnected.
+        /// </summary>
+        public void Sweep ()
+        {
+            foreach (var key in entries.Keys.ToList ()) {
+                var entry = entries [key];
+                if (Destroyed (key) || ClientConnections.Disconnected (entry.Owner)) {
+                    release (key, entry);
+                    entries.Remove (key);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Release all overrides.
+        /// </summary>
+        public void Clear ()
+        {
+            foreach (var entry in entries)
+                release (entry.Key, entry.Value);
+            entries.Clear ();
+        }
+
+        static bool Destroyed (UnityEngine.Object obj)
+        {
+            return obj == null;
+        }
+    }
+}

--- a/server/src/Utils/IClientOwnedCollection.cs
+++ b/server/src/Utils/IClientOwnedCollection.cs
@@ -1,0 +1,19 @@
+namespace KRPC.Utils
+{
+    /// <summary>
+    /// A collection of in-game state owned by RPC clients, which can release the state
+    /// owned by clients that have disconnected.
+    /// </summary>
+    public interface IClientOwnedCollection
+    {
+        /// <summary>
+        /// Release entries whose owning client has disconnected.
+        /// </summary>
+        void Sweep ();
+
+        /// <summary>
+        /// Release all entries.
+        /// </summary>
+        void Clear ();
+    }
+}

--- a/service/Drawing/src/Addon.cs
+++ b/service/Drawing/src/Addon.cs
@@ -1,9 +1,7 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using KRPC.Server;
 using KRPC.Service;
-using UnityEngine;
+using KRPC.Utils;
 
 namespace KRPC.Drawing
 {
@@ -11,74 +9,50 @@ namespace KRPC.Drawing
     /// Addon for doing the drawing
     /// </summary>
     [KSPAddon (KSPAddon.Startup.Flight, false)]
-    public sealed class Addon : MonoBehaviour
+    public sealed class Addon : ClientCleanupAddon
     {
-        static IDictionary<IClient, IList<IDrawable>> objects = new Dictionary<IClient, IList<IDrawable>> ();
+        static readonly ClientOwnedObjects<IDrawable> objects =
+            new ClientOwnedObjects<IDrawable> (obj => obj.Destroy ());
+
+        static readonly IClientOwnedCollection[] collections = { objects };
+
+        /// <summary>
+        /// The drawing objects.
+        /// </summary>
+        protected override IEnumerable<IClientOwnedCollection> Collections {
+            get { return collections; }
+        }
 
         internal static void AddObject (IDrawable obj)
         {
-            var client = CallContext.Client;
-            if (!objects.ContainsKey (client))
-                objects [client] = new List<IDrawable> ();
-            objects [client].Add (obj);
+            objects.Add (obj);
         }
 
         internal static void RemoveObject (IDrawable obj)
         {
-            var client = CallContext.Client;
-            if (!objects.ContainsKey (client) || !objects [client].Contains (obj))
+            if (!objects.OwnedByCaller (obj))
                 throw new ArgumentException ("Drawing object not found");
             obj.Destroy ();
-            objects [client].Remove (obj);
+            objects.Remove (obj);
         }
 
-        internal static void Clear ()
+        internal static void Clear (bool clientOnly)
         {
-            foreach (var clientObjects in objects.Values)
-                foreach (var obj in clientObjects)
-                    obj.Destroy ();
-            objects.Clear ();
-        }
-
-        internal static void Clear (IClient client)
-        {
-            if (objects.ContainsKey (client)) {
-                foreach (var obj in objects [client])
-                    obj.Destroy ();
-                objects.Remove (client);
-            }
+            if (clientOnly)
+                objects.Clear (CallContext.Client);
+            else
+                objects.Clear ();
         }
 
         /// <summary>
-        /// Wake the addon
-        /// </summary>
-        public void Awake ()
-        {
-        }
-
-        /// <summary>
-        /// Update the addon
+        /// Update the addon: destroy the objects of clients that have disconnected,
+        /// and update the rest.
         /// </summary>
         public void Update ()
         {
-            if (!objects.Any ())
-                return;
-
-            var disconnectedClients = objects.Keys.Where (x => !x.Connected).ToList ();
-            foreach (var client in disconnectedClients)
-                Clear (client);
-
-            foreach (var clientObjects in objects.Values)
-                foreach (var obj in clientObjects)
-                    obj.Update ();
-        }
-
-        /// <summary>
-        /// Destroy the addon
-        /// </summary>
-        public void OnDestroy ()
-        {
-            Clear ();
+            Sweep ();
+            foreach (var obj in objects.Items)
+                obj.Update ();
         }
     }
 }

--- a/service/Drawing/src/Drawing.cs
+++ b/service/Drawing/src/Drawing.cs
@@ -97,10 +97,7 @@ namespace KRPC.Drawing
         [KRPCProcedure]
         public static void Clear (bool clientOnly = false)
         {
-            if (clientOnly)
-                Addon.Clear (CallContext.Client);
-            else
-                Addon.Clear ();
+            Addon.Clear (clientOnly);
         }
     }
 }

--- a/service/Drawing/src/Drawing.cs
+++ b/service/Drawing/src/Drawing.cs
@@ -14,6 +14,7 @@ namespace KRPC.Drawing
     /// </summary>
     /// <remarks>
     /// For drawing and interacting with the user interface, see the UI service.
+    /// Objects drawn by a client are removed when that client disconnects.
     /// </remarks>
     [KRPCService (Id = 3, GameScene = GameScene.Flight)]
     public static class Drawing

--- a/service/SpaceCenter/CHANGES.txt
+++ b/service/SpaceCenter/CHANGES.txt
@@ -64,7 +64,7 @@ v0.6.0
  * Deprecate the string-dictionary Module field, event and action members (#859)
  * Remove forces added by Part.AddForce when the client that added them disconnects
  * Cancel in-progress resource transfers when the client that started them disconnects;
-   a cancelled transfer is marked as complete
+   a canceled transfer is marked as complete
  * Fix part highlighting leaking a client-disconnect event handler each time the flight
    scene is loaded
 

--- a/service/SpaceCenter/CHANGES.txt
+++ b/service/SpaceCenter/CHANGES.txt
@@ -62,6 +62,11 @@ v0.6.0
  * Add RPCs for getting acceleration to Flight and Vessel classes (#581)
  * Add PartField, PartEvent and PartAction API (#859)
  * Deprecate the string-dictionary Module field, event and action members (#859)
+ * Remove forces added by Part.AddForce when the client that added them disconnects
+ * Cancel in-progress resource transfers when the client that started them disconnects;
+   a cancelled transfer is marked as complete
+ * Fix part highlighting leaking a client-disconnect event handler each time the flight
+   scene is loaded
 
 v0.5.4
  * Fix vessel recovery (#782)

--- a/service/SpaceCenter/src/ActuatorControlAddon.cs
+++ b/service/SpaceCenter/src/ActuatorControlAddon.cs
@@ -1,11 +1,8 @@
-using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Reflection;
 using Expansions.Missions.Adjusters;
-using KRPC.Server;
-using KRPC.Service;
 using KRPC.SpaceCenter.ExtensionMethods;
+using KRPC.Utils;
 using UnityEngine;
 
 namespace KRPC.SpaceCenter
@@ -27,7 +24,7 @@ namespace KRPC.SpaceCenter
     /// such gate.
     /// </remarks>
     [KSPAddon (KSPAddon.Startup.Flight, false)]
-    public sealed class ActuatorControlAddon : MonoBehaviour
+    public sealed class ActuatorControlAddon : ClientCleanupAddon
     {
         /// <summary>
         /// Overrides a gimbal's actuation. ModuleGimbal calls this mid-FixedUpdate,
@@ -84,20 +81,11 @@ namespace KRPC.SpaceCenter
         }
 
         /// <summary>
-        /// An override on a single actuator, tagged with the client that owns it (so it
-        /// can be released when that client disconnects).
-        /// </summary>
-        abstract class Entry
-        {
-            public IClient Client;
-        }
-
-        /// <summary>
         /// A gimbal override, installed as an adjuster on the module. The prior active
         /// state is saved and forced on so the module's FixedUpdate (which is skipped
         /// when inactive) runs the adjuster.
         /// </summary>
-        sealed class GimbalEntry : Entry
+        sealed class GimbalEntry : ClientOwnedEntry
         {
             public GimbalAdjuster Adjuster;
             public bool SavedGimbalActive;
@@ -106,7 +94,7 @@ namespace KRPC.SpaceCenter
         /// <summary>
         /// An RCS override, installed as an adjuster on the module.
         /// </summary>
-        sealed class RCSEntry : Entry
+        sealed class RCSEntry : ClientOwnedEntry
         {
             public RCSAdjuster Adjuster;
         }
@@ -118,7 +106,7 @@ namespace KRPC.SpaceCenter
         /// control removed via the <c>ignore*</c> flags. The prior state is saved so it
         /// can be restored on release.
         /// </summary>
-        sealed class ControlSurfaceEntry : Entry
+        sealed class ControlSurfaceEntry : ClientOwnedEntry
         {
             public float Deflection;
             public bool SavedIgnorePitch;
@@ -127,100 +115,22 @@ namespace KRPC.SpaceCenter
             public bool SavedDeploy;
         }
 
-        /// <summary>
-        /// A set of actuator overrides of one kind, keyed by the part module. Owns the
-        /// shared lifecycle: installing an override on enable, releasing it on disable,
-        /// and dropping overrides whose owning client has disconnected or whose module
-        /// has been destroyed. The per-kind behaviour is supplied as delegates.
-        /// </summary>
-        sealed class OverrideRegistry<TModule, TEntry>
-            where TModule : PartModule
-            where TEntry : Entry
-        {
-            readonly IDictionary<TModule, TEntry> entries = new Dictionary<TModule, TEntry> ();
-            readonly Func<TModule, TEntry> install;
-            readonly Action<TModule, TEntry> release;
-
-            public OverrideRegistry (Func<TModule, TEntry> install, Action<TModule, TEntry> release)
-            {
-                this.install = install;
-                this.release = release;
-            }
-
-            public bool IsSet (TModule module)
-            {
-                return entries.ContainsKey (module);
-            }
-
-            /// <summary>
-            /// The override for the given module, or null if it is not being overridden.
-            /// </summary>
-            public TEntry Get (TModule module)
-            {
-                TEntry entry;
-                return entries.TryGetValue (module, out entry) ? entry : null;
-            }
-
-            /// <summary>
-            /// The override for the given module, re-tagged with the calling client, or
-            /// null if it is not being overridden. Used when changing a live override's
-            /// command.
-            /// </summary>
-            public TEntry Own (TModule module)
-            {
-                var entry = Get (module);
-                if (entry != null)
-                    entry.Client = CallContext.Client;
-                return entry;
-            }
-
-            public void Set (TModule module, bool enabled)
-            {
-                var entry = Get (module);
-                if (entry != null) {
-                    if (enabled)
-                        entry.Client = CallContext.Client;
-                    else {
-                        release (module, entry);
-                        entries.Remove (module);
-                    }
-                } else if (enabled) {
-                    entry = install (module);
-                    entry.Client = CallContext.Client;
-                    entries [module] = entry;
-                }
-            }
-
-            /// <summary>
-            /// Drop overrides whose module has been destroyed or whose client has
-            /// disconnected.
-            /// </summary>
-            public void Sweep ()
-            {
-                foreach (var module in entries.Keys.ToList ()) {
-                    var entry = entries [module];
-                    if (Destroyed (module) || Disconnected (entry.Client)) {
-                        release (module, entry);
-                        entries.Remove (module);
-                    }
-                }
-            }
-
-            public void Clear ()
-            {
-                foreach (var entry in entries)
-                    release (entry.Key, entry.Value);
-                entries.Clear ();
-            }
-        }
-
-        static readonly OverrideRegistry<ModuleGimbal, GimbalEntry> gimbals =
-            new OverrideRegistry<ModuleGimbal, GimbalEntry> (InstallGimbal, ReleaseGimbal);
-        static readonly OverrideRegistry<ModuleRCS, RCSEntry> rcs =
-            new OverrideRegistry<ModuleRCS, RCSEntry> (InstallRCS, ReleaseRCS);
-        static readonly OverrideRegistry<ModuleControlSurface, ControlSurfaceEntry> controlSurfaces =
-            new OverrideRegistry<ModuleControlSurface, ControlSurfaceEntry> (
+        static readonly ClientOwnedOverrides<ModuleGimbal, GimbalEntry> gimbals =
+            new ClientOwnedOverrides<ModuleGimbal, GimbalEntry> (InstallGimbal, ReleaseGimbal);
+        static readonly ClientOwnedOverrides<ModuleRCS, RCSEntry> rcs =
+            new ClientOwnedOverrides<ModuleRCS, RCSEntry> (InstallRCS, ReleaseRCS);
+        static readonly ClientOwnedOverrides<ModuleControlSurface, ControlSurfaceEntry> controlSurfaces =
+            new ClientOwnedOverrides<ModuleControlSurface, ControlSurfaceEntry> (
                 InstallControlSurface, RestoreControlSurface);
+
+        static readonly IClientOwnedCollection[] collections = { gimbals, rcs, controlSurfaces };
+
+        /// <summary>
+        /// The actuator override registries.
+        /// </summary>
+        protected override IEnumerable<IClientOwnedCollection> Collections {
+            get { return collections; }
+        }
 
         // The module's adjuster list is private; AddPartModuleAdjuster (which would
         // populate it) is gated behind the Making History expansion, so add/remove
@@ -231,48 +141,18 @@ namespace KRPC.SpaceCenter
             typeof (ModuleRCS).GetField ("adjusterCache", BindingFlags.NonPublic | BindingFlags.Instance);
 
         /// <summary>
-        /// Wake the addon
-        /// </summary>
-        public void Awake ()
-        {
-            Clear ();
-        }
-
-        /// <summary>
-        /// Destroy the addon
-        /// </summary>
-        public void OnDestroy ()
-        {
-            Clear ();
-        }
-
-        static void Clear ()
-        {
-            gimbals.Clear ();
-            rcs.Clear ();
-            controlSurfaces.Clear ();
-        }
-
-        /// <summary>
         /// Drop overrides whose controlling client has disconnected or whose part module has been
         /// destroyed, returning those actuators to normal control. The overrides themselves are
         /// applied by the modules calling into the installed adjusters, so nothing is driven here.
         /// </summary>
         public void FixedUpdate ()
         {
-            gimbals.Sweep ();
-            rcs.Sweep ();
-            controlSurfaces.Sweep ();
+            Sweep ();
         }
 
         static bool Destroyed (UnityEngine.Object module)
         {
             return module == null;
-        }
-
-        static bool Disconnected (IClient client)
-        {
-            return client != null && !client.Connected;
         }
 
         static void CacheAdd (FieldInfo cache, PartModule module, object adjuster)

--- a/service/SpaceCenter/src/PartForcesAddon.cs
+++ b/service/SpaceCenter/src/PartForcesAddon.cs
@@ -1,6 +1,6 @@
 using System.Collections.Generic;
 using KRPC.SpaceCenter.Services.Parts;
-using UnityEngine;
+using KRPC.Utils;
 
 namespace KRPC.SpaceCenter
 {
@@ -8,20 +8,20 @@ namespace KRPC.SpaceCenter
     /// Addon to apply forces to parts.
     /// </summary>
     [KSPAddon (KSPAddon.Startup.Flight, false)]
-    public class PartForcesAddon : MonoBehaviour
+    public sealed class PartForcesAddon : ClientCleanupAddon
     {
-        /// <summary>
-        /// The forces currently begin applied.
-        /// </summary>
-        static readonly IList<Force> forces = new List<Force> ();
-        static readonly IList<Force> instantaneousForces = new List<Force> ();
+        static readonly ClientOwnedObjects<Force> forces =
+            new ClientOwnedObjects<Force> ();
+        static readonly ClientOwnedObjects<Force> instantaneousForces =
+            new ClientOwnedObjects<Force> ();
+
+        static readonly IClientOwnedCollection[] collections = { forces, instantaneousForces };
 
         /// <summary>
-        /// Destroy the addon
+        /// The forces currently being applied.
         /// </summary>
-        public void OnDestroy ()
-        {
-            forces.Clear ();
+        protected override IEnumerable<IClientOwnedCollection> Collections {
+            get { return collections; }
         }
 
         /// <summary>
@@ -41,7 +41,7 @@ namespace KRPC.SpaceCenter
         }
 
         /// <summary>
-        /// Add a force
+        /// Remove a force
         /// </summary>
         static internal void Remove (Force force)
         {
@@ -49,14 +49,16 @@ namespace KRPC.SpaceCenter
         }
 
         /// <summary>
-        /// Apply the forces to the parts
+        /// Apply the forces to the parts, first dropping the forces of any client that
+        /// has disconnected so they are not applied again.
         /// </summary>
         public void FixedUpdate ()
         {
-            foreach (var force in instantaneousForces)
+            Sweep ();
+            foreach (var force in instantaneousForces.Items)
                 force.Update ();
             instantaneousForces.Clear ();
-            foreach (var force in forces)
+            foreach (var force in forces.Items)
                 force.Update ();
         }
     }

--- a/service/SpaceCenter/src/PartHighlightAddon.cs
+++ b/service/SpaceCenter/src/PartHighlightAddon.cs
@@ -1,7 +1,5 @@
 using System.Collections.Generic;
-using KRPC.Server;
-using KRPC.Service;
-using UnityEngine;
+using KRPC.Utils;
 
 namespace KRPC.SpaceCenter
 {
@@ -9,52 +7,49 @@ namespace KRPC.SpaceCenter
     /// Addon to highlight parts.
     /// </summary>
     [KSPAddon (KSPAddon.Startup.Flight, false)]
-    public class PartHighlightAddon : MonoBehaviour
+    public sealed class PartHighlightAddon : ClientCleanupAddon
     {
-        static readonly IDictionary<IClient, IList<Part>> highlight = new Dictionary<IClient, IList<Part>> ();
+        static readonly ClientOwnedObjects<Part> highlighted =
+            new ClientOwnedObjects<Part> (Unhighlight);
+
+        static readonly IClientOwnedCollection[] collections = { highlighted };
 
         /// <summary>
-        /// Set up the addon
+        /// The highlighted parts.
         /// </summary>
-        public void Awake ()
-        {
-            Core.Instance.OnClientDisconnected += (s, e) => Remove (e.Client);
+        protected override IEnumerable<IClientOwnedCollection> Collections {
+            get { return collections; }
         }
 
         /// <summary>
-        /// Destroy the addon
+        /// Remove the highlighting of clients that have disconnected. Runs in Update,
+        /// rather than FixedUpdate, so highlighting is also removed while the game is
+        /// paused.
         /// </summary>
-        public void OnDestroy ()
+        public void Update ()
         {
-            highlight.Clear ();
+            Sweep ();
+        }
+
+        static void Unhighlight (Part part)
+        {
+            if (part == null)
+                return;
+            part.highlightType = Part.HighlightType.OnMouseOver;
+            part.SetHighlight (false, false);
         }
 
         static internal void Add (Part part)
         {
-            if (!highlight.ContainsKey (CallContext.Client))
-                highlight [CallContext.Client] = new List<Part> ();
-            highlight [CallContext.Client].Add (part);
+            highlighted.Add (part);
             part.highlightType = Part.HighlightType.AlwaysOn;
             part.SetHighlight (true, false);
         }
 
         static internal void Remove (Part part)
         {
-            if (highlight.ContainsKey (CallContext.Client))
-                highlight [CallContext.Client].Remove (part);
-            part.highlightType = Part.HighlightType.OnMouseOver;
-            part.SetHighlight (false, false);
-        }
-
-        static internal void Remove (IClient client)
-        {
-            if (!highlight.ContainsKey (client))
-                return;
-            foreach (var part in highlight [client]) {
-                part.highlightType = Part.HighlightType.OnMouseOver;
-                part.SetHighlight (false, false);
-            }
-            highlight.Remove (client);
+            highlighted.Remove (part);
+            Unhighlight (part);
         }
     }
 }

--- a/service/SpaceCenter/src/PilotAddon.cs
+++ b/service/SpaceCenter/src/PilotAddon.cs
@@ -5,6 +5,7 @@ using KRPC.Server;
 using KRPC.Service;
 using KRPC.SpaceCenter.ExtensionMethods;
 using KRPC.SpaceCenter.ExternalAPI;
+using KRPC.Utils;
 using UnityEngine;
 
 namespace KRPC.SpaceCenter
@@ -288,7 +289,7 @@ namespace KRPC.SpaceCenter
         static void CheckClients ()
         {
             foreach (var client in manualInputClients.ToList()) {
-                if (!client.Connected)
+                if (ClientConnections.Disconnected (client))
                     manualInputClients.Remove (client);
             }
             if (manualInputClients.Any ())

--- a/service/SpaceCenter/src/ResourceTransferAddon.cs
+++ b/service/SpaceCenter/src/ResourceTransferAddon.cs
@@ -32,7 +32,7 @@ namespace KRPC.SpaceCenter
         }
 
         /// <summary>
-        /// Update the transfers, first cancelling those whose client has disconnected
+        /// Update the transfers, first canceling those whose client has disconnected
         /// so they move no more resource.
         /// </summary>
         public void FixedUpdate ()

--- a/service/SpaceCenter/src/ResourceTransferAddon.cs
+++ b/service/SpaceCenter/src/ResourceTransferAddon.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using KRPC.SpaceCenter.Services;
+using KRPC.Utils;
 using UnityEngine;
 
 namespace KRPC.SpaceCenter
@@ -8,19 +9,18 @@ namespace KRPC.SpaceCenter
     /// Addon to perform resource transfers between parts.
     /// </summary>
     [KSPAddon (KSPAddon.Startup.Flight, false)]
-    public sealed class ResourceTransferAddon : MonoBehaviour
+    public sealed class ResourceTransferAddon : ClientCleanupAddon
     {
+        static readonly ClientOwnedObjects<ResourceTransfer> transfers =
+            new ClientOwnedObjects<ResourceTransfer> (transfer => transfer.Cancel ());
+
+        static readonly IClientOwnedCollection[] collections = { transfers };
+
         /// <summary>
         /// The transfers currently in progress.
         /// </summary>
-        static readonly List<ResourceTransfer> transfers = new List<ResourceTransfer> ();
-
-        /// <summary>
-        /// Destroy the addon
-        /// </summary>
-        public void OnDestroy ()
-        {
-            transfers.Clear ();
+        protected override IEnumerable<IClientOwnedCollection> Collections {
+            get { return collections; }
         }
 
         /// <summary>
@@ -32,11 +32,13 @@ namespace KRPC.SpaceCenter
         }
 
         /// <summary>
-        /// Update the transfers
+        /// Update the transfers, first cancelling those whose client has disconnected
+        /// so they move no more resource.
         /// </summary>
         public void FixedUpdate ()
         {
-            foreach (var transfer in transfers)
+            Sweep ();
+            foreach (var transfer in transfers.Items)
                 transfer.Update (Time.fixedDeltaTime);
             transfers.RemoveAll (transfer => transfer.Complete);
         }

--- a/service/SpaceCenter/src/Services/AutoPilot.cs
+++ b/service/SpaceCenter/src/Services/AutoPilot.cs
@@ -556,7 +556,7 @@ namespace KRPC.SpaceCenter.Services
             if (autoPilot == null)
                 return false;
             // If the client that engaged the auto-pilot has disconnected, disengage and reset the auto-pilot
-            if (autoPilot.requestingClient != null && !autoPilot.requestingClient.Connected) {
+            if (ClientConnections.Disconnected (autoPilot.requestingClient)) {
                 autoPilot.attitudeController.ReferenceFrame = ReferenceFrame.Surface (vessel);
                 autoPilot.attitudeController.TargetPitch = 0;
                 autoPilot.attitudeController.TargetHeading = 0;

--- a/service/SpaceCenter/src/Services/Control.cs
+++ b/service/SpaceCenter/src/Services/Control.cs
@@ -17,8 +17,10 @@ namespace KRPC.SpaceCenter.Services
     /// Obtained by calling <see cref="Vessel.Control"/>.
     /// </summary>
     /// <remarks>
-    /// Control inputs (such as pitch, yaw and roll) are zeroed when all clients
-    /// that have set one or more of these inputs are no longer connected.
+    /// Control inputs (pitch, yaw, roll, translation, wheel throttle, wheel steering
+    /// and the custom axes) are zeroed when all clients that have set one or more of
+    /// these inputs are no longer connected. The throttle is an exception: it keeps
+    /// its value when clients disconnect.
     /// </remarks>
     [KRPCClass (Service = "SpaceCenter", GameScene = GameScene.Flight)]
     public class Control : Equatable<Control>
@@ -381,6 +383,8 @@ namespace KRPC.SpaceCenter.Services
 
         /// <summary>
         /// The state of the throttle. A value between 0 and 1.
+        /// Unlike the other control inputs, the throttle is not zeroed when the
+        /// clients that set it disconnect.
         /// </summary>
         [KRPCProperty]
         public float Throttle {

--- a/service/SpaceCenter/src/Services/Parts/Part.cs
+++ b/service/SpaceCenter/src/Services/Parts/Part.cs
@@ -124,6 +124,9 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// <summary>
         /// Whether the part is highlighted.
         /// </summary>
+        /// <remarks>
+        /// The highlighting is removed when the client that enabled it disconnects.
+        /// </remarks>
         [KRPCProperty]
         public bool Highlighted {
             get { return InternalPart.HighlightActive; }

--- a/service/SpaceCenter/src/Services/Parts/Part.cs
+++ b/service/SpaceCenter/src/Services/Parts/Part.cs
@@ -928,6 +928,9 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// <param name="position">The position at which the force acts, as a vector.</param>
         /// <param name="referenceFrame">The reference frame that the
         /// force and position are in.</param>
+        /// <remarks>
+        /// The force is removed when the client that added it disconnects.
+        /// </remarks>
         [KRPCMethod]
         public Force AddForce (Tuple3 force, Tuple3 position, ReferenceFrame referenceFrame)
         {

--- a/service/SpaceCenter/src/Services/ResourceTransfer.cs
+++ b/service/SpaceCenter/src/Services/ResourceTransfer.cs
@@ -91,10 +91,20 @@ namespace KRPC.SpaceCenter.Services
         public float TotalAmount { get; private set; }
 
         /// <summary>
-        /// Whether the transfer has completed.
+        /// Whether the transfer has completed. Also becomes true if the transfer is
+        /// cancelled because the client that started it disconnected.
         /// </summary>
         [KRPCProperty]
         public bool Complete { get; private set; }
+
+        /// <summary>
+        /// Cancel the transfer. No more resource is moved and the transfer is marked
+        /// as complete.
+        /// </summary>
+        internal void Cancel ()
+        {
+            Complete = true;
+        }
 
         /// <summary>
         /// The amount of the resource that has been transferred.

--- a/service/SpaceCenter/src/Services/ResourceTransfer.cs
+++ b/service/SpaceCenter/src/Services/ResourceTransfer.cs
@@ -41,6 +41,10 @@ namespace KRPC.SpaceCenter.Services
         /// <param name="toPart">The part to transfer from.</param>
         /// <param name="resource">The name of the resource to transfer.</param>
         /// <param name="maxAmount">The maximum amount of resource to transfer.</param>
+        /// <remarks>
+        /// The transfer is canceled if the client that started it disconnects;
+        /// a canceled transfer is marked as complete.
+        /// </remarks>
         [KRPCMethod]
         public static ResourceTransfer Start (Parts.Part fromPart, Parts.Part toPart, string resource, float maxAmount)
         {
@@ -92,7 +96,7 @@ namespace KRPC.SpaceCenter.Services
 
         /// <summary>
         /// Whether the transfer has completed. Also becomes true if the transfer is
-        /// cancelled because the client that started it disconnected.
+        /// canceled because the client that started it disconnected.
         /// </summary>
         [KRPCProperty]
         public bool Complete { get; private set; }

--- a/service/SpaceCenter/test/test_parts_control_surface.py
+++ b/service/SpaceCenter/test/test_parts_control_surface.py
@@ -127,6 +127,29 @@ class TestPartsControlSurface(krpctest.TestCase):
         self.assertFalse(cs.roll_enabled)
         self.assertFalse(cs.deployed)
 
+    def test_deflection_override_released_on_disconnect(self):
+        cs = self.ctrlsrf
+        self.assertFalse(cs.deflection_override)
+
+        conn = self.connect(use_cached=False)
+        parts = conn.space_center.active_vessel.parts
+        other = parts.with_name("airlinerCtrlSrf")[0].control_surface
+        other.deflection_override = True
+        other.deflection = 1
+        self.wait()
+        self.assertTrue(cs.deflection_override)
+        conn.close()
+
+        # The disconnect restores the prior control-surface state (the axis
+        # baseline and deploy state set up in setUpClass)
+        self.wait()
+        self.assertFalse(cs.deflection_override)
+        self.assertAlmostEqual(0, cs.deflection)
+        self.assertFalse(cs.pitch_enabled)
+        self.assertTrue(cs.yaw_enabled)
+        self.assertFalse(cs.roll_enabled)
+        self.assertFalse(cs.deployed)
+
     def test_surface_area(self):
         self.assertAlmostEqual(1, self.ctrlsrf.surface_area)
         self.assertAlmostEqual(0.2, self.winglet.surface_area)

--- a/service/SpaceCenter/test/test_parts_engine.py
+++ b/service/SpaceCenter/test/test_parts_engine.py
@@ -413,6 +413,22 @@ class TestPartsEngine(krpctest.TestCase, EngineTestBase):
         self.assertRaises(RuntimeError, getattr, engine, "gimbal_actuation")
         self.assertRaises(RuntimeError, setattr, engine, "gimbal_actuation", (0, 0, 0))
 
+    def test_gimbal_override_released_on_disconnect(self):
+        engine = self.get_engine("liquidEngine2")  # LV-T45 "Swivel"
+        self.assertFalse(engine.gimbal_override)
+
+        conn = self.connect(use_cached=False)
+        parts = conn.space_center.active_vessel.parts
+        other = next(iter(parts.with_name("liquidEngine2"))).engine
+        other.gimbal_override = True
+        other.gimbal_actuation = (1, 0, 0)
+        self.wait()
+        self.assertTrue(engine.gimbal_override)
+        conn.close()
+
+        self.wait()
+        self.assertFalse(engine.gimbal_override)
+
     def test_no_thrust_reverser(self):
         engine = self.get_engine("liquidEngine")  # LV-T30 "Reliant"
         self.assertFalse(engine.can_reverse_thrust)

--- a/service/SpaceCenter/test/test_parts_part.py
+++ b/service/SpaceCenter/test/test_parts_part.py
@@ -796,6 +796,40 @@ class TestPartsPart(krpctest.TestCase):
             self.wait(0.5)
         part.highlight_color = init_color
 
+    def test_highlighting_removed_on_disconnect(self):
+        part = self.parts.with_name("Rockomax64.BW")[0]
+        self.assertFalse(part.highlighted)
+
+        conn = self.connect(use_cached=False)
+        other = conn.space_center.active_vessel.parts.with_name("Rockomax64.BW")[0]
+        other.highlighted = True
+        self.wait()
+        self.assertTrue(part.highlighted)
+        conn.close()
+
+        self.wait()
+        self.assertFalse(part.highlighted)
+
+    def test_highlighting_persists_for_connected_client(self):
+        part = self.parts.with_name("Rockomax64.BW")[0]
+        self.assertFalse(part.highlighted)
+        part.highlighted = True
+        self.wait()
+
+        # Another client connecting and disconnecting must not remove the
+        # highlighting owned by this client
+        conn = self.connect(use_cached=False)
+        conn.space_center.active_vessel.parts.root.highlighted = True
+        self.wait()
+        conn.close()
+        self.wait()
+
+        self.assertTrue(part.highlighted)
+        self.assertFalse(self.parts.root.highlighted)
+        part.highlighted = False
+        self.wait()
+        self.assertFalse(part.highlighted)
+
     def test_rotation(self):
         part = self.parts.root
         for target_frame in [

--- a/service/SpaceCenter/test/test_parts_part.py
+++ b/service/SpaceCenter/test/test_parts_part.py
@@ -1,5 +1,6 @@
 import unittest
 import krpctest
+from krpctest.geometry import norm
 
 
 class TestPartsPart(krpctest.TestCase):
@@ -930,6 +931,43 @@ class TestPartsPartForce(krpctest.TestCase):
 
     def test_instantaneous_force(self):
         self.part.instantaneous_force((1, 2, 3), (4, 5, 6), self.part.reference_frame)
+
+
+class TestPartsPartForceDisconnect(krpctest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.new_save()
+        cls.launch_vessel_from_vab("Basic")
+        cls.remove_other_vessels()
+        cls.set_circular_orbit("Kerbin", 100000)
+        cls.vessel = cls.connect().space_center.active_vessel
+
+    def angular_speed(self):
+        ref = self.vessel.orbit.body.non_rotating_reference_frame
+        return norm(self.vessel.angular_velocity(ref))
+
+    def test_force_removed_on_disconnect(self):
+        self.vessel.control.sas = False
+        self.wait()
+
+        # A second client applies a constant torque-producing force; the
+        # vessel spins up while that client is connected
+        conn = self.connect(use_cached=False)
+        part = conn.space_center.active_vessel.parts.root
+        part.add_force((1000, 0, 0), (0, 10, 0), part.reference_frame)
+        before = self.angular_speed()
+        self.wait(1)
+        during = self.angular_speed()
+        self.assertGreater(during - before, 0.05)
+
+        # Disconnecting removes the force and the spin-up stops
+        conn.close()
+        self.wait(1)
+        after1 = self.angular_speed()
+        self.wait(1)
+        after2 = self.angular_speed()
+        self.assertLess(abs(after2 - after1), 0.01)
 
 
 if __name__ == "__main__":

--- a/service/SpaceCenter/test/test_parts_rcs.py
+++ b/service/SpaceCenter/test/test_parts_rcs.py
@@ -213,6 +213,23 @@ class TestPartsRCS(krpctest.TestCase, RCSTestBase):
         self.assertAlmostEqual((0, 0, 0), rcs.rotation_override)
         self.assertAlmostEqual((0, 0, 0), rcs.translation_override)
 
+    def test_input_override_released_on_disconnect(self):
+        rcs = self.get_rcs("RCSBlock.v2")
+        self.assertFalse(rcs.input_override)
+
+        conn = self.connect(use_cached=False)
+        parts = conn.space_center.active_vessel.parts
+        other = parts.with_name("RCSBlock.v2")[0].rcs
+        other.input_override = True
+        other.rotation_override = (1, 0, 0)
+        self.wait()
+        self.assertTrue(rcs.input_override)
+        conn.close()
+
+        self.wait()
+        self.assertFalse(rcs.input_override)
+        self.assertAlmostEqual((0, 0, 0), rcs.rotation_override)
+
     def test_has_fuel(self):
         rcs = self.get_rcs("RCSBlock.v2")
         self.assertTrue(rcs.has_fuel)

--- a/service/SpaceCenter/test/test_resource_transfer.py
+++ b/service/SpaceCenter/test/test_resource_transfer.py
@@ -110,5 +110,50 @@ class TestResourceTransfer(krpctest.TestCase):
         self.assertTrue("Destination part cannot store" in str(cm.exception))
 
 
+class TestResourceTransferDisconnect(krpctest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.new_save()
+        cls.launch_vessel_from_vab("ResourceTransfer")
+        cls.remove_other_vessels()
+        cls.parts = cls.connect().space_center.active_vessel.parts
+
+    def test_transfer_cancelled_on_disconnect(self):
+        from_part = self.parts.with_name("fuelTank")[0]
+        to_part = self.parts.with_name("fuelTankSmallFlat")[0]
+        from_amount = from_part.resources.amount("Oxidizer")
+
+        # A second client starts a transfer that would take several seconds to
+        # complete, then disconnects mid-transfer
+        conn = self.connect(use_cached=False)
+        sc = conn.space_center
+        other_parts = sc.active_vessel.parts
+        sc.ResourceTransfer.start(
+            other_parts.with_name("fuelTank")[0],
+            other_parts.with_name("fuelTankSmallFlat")[0],
+            "Oxidizer",
+            float("inf"),
+        )
+        self.wait(0.5)
+        conn.close()
+        self.wait(0.5)
+
+        # Some, but not all, of the resource was moved before the disconnect
+        # cancelled the transfer (the destination has free space, so the
+        # transfer would still be running had it not been cancelled)...
+        moved = from_amount - from_part.resources.amount("Oxidizer")
+        self.assertGreater(moved, 0.1)
+        self.assertLess(
+            to_part.resources.amount("Oxidizer"), to_part.resources.max("Oxidizer")
+        )
+        # ...and no more is moved afterwards
+        remaining = from_part.resources.amount("Oxidizer")
+        self.wait(1)
+        self.assertAlmostEqual(
+            remaining, from_part.resources.amount("Oxidizer"), places=2
+        )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/service/UI/src/Addon.cs
+++ b/service/UI/src/Addon.cs
@@ -1,8 +1,7 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using KRPC.Server;
 using KRPC.Service;
+using KRPC.Utils;
 using UnityEngine;
 
 namespace KRPC.UI
@@ -11,7 +10,7 @@ namespace KRPC.UI
     /// Addon for managing the UI
     /// </summary>
     [KSPAddon (KSPAddon.Startup.Flight, false)]
-    public sealed class Addon : MonoBehaviour
+    public sealed class Addon : ClientCleanupAddon
     {
         static AssetBundle prefabs;
 
@@ -39,68 +38,45 @@ namespace KRPC.UI
             return obj;
         }
 
-        static IDictionary<IClient, IList<Object>> objects = new Dictionary<IClient, IList<Object>> ();
+        static readonly ClientOwnedObjects<Object> objects =
+            new ClientOwnedObjects<Object> (obj => obj.Destroy ());
+
+        static readonly IClientOwnedCollection[] collections = { objects };
+
+        /// <summary>
+        /// The UI objects.
+        /// </summary>
+        protected override IEnumerable<IClientOwnedCollection> Collections {
+            get { return collections; }
+        }
 
         internal static void Add (Object obj)
         {
-            var client = CallContext.Client;
-            if (!objects.ContainsKey (client))
-                objects [client] = new List<Object> ();
-            objects [client].Add (obj);
+            objects.Add (obj);
         }
 
         internal static void Remove (Object obj)
         {
-            var client = CallContext.Client;
-            if (!objects.ContainsKey (client) || !objects [client].Contains (obj))
+            if (!objects.OwnedByCaller (obj))
                 throw new ArgumentException ("UI object not found");
             obj.Destroy ();
-            objects [client].Remove (obj);
+            objects.Remove (obj);
         }
 
-        internal static void Clear ()
+        internal static void Clear (bool clientOnly)
         {
-            foreach (var clientObjects in objects.Values)
-                foreach (var obj in clientObjects)
-                    obj.Destroy ();
-            objects.Clear ();
-        }
-
-        internal static void Clear (IClient client)
-        {
-            if (objects.ContainsKey (client)) {
-                foreach (var obj in objects [client])
-                    obj.Destroy ();
-                objects.Remove (client);
-            }
+            if (clientOnly)
+                objects.Clear (CallContext.Client);
+            else
+                objects.Clear ();
         }
 
         /// <summary>
-        /// Wake the addon
-        /// </summary>
-        public void Awake ()
-        {
-        }
-
-        /// <summary>
-        /// Update the addon
+        /// Update the addon: destroy the objects of clients that have disconnected.
         /// </summary>
         public void Update ()
         {
-            if (!objects.Any ())
-                return;
-
-            var disconnectedClients = objects.Keys.Where (x => !x.Connected).ToList ();
-            foreach (var client in disconnectedClients)
-                Clear (client);
-        }
-
-        /// <summary>
-        /// Destroy the addon
-        /// </summary>
-        public void OnDestroy ()
-        {
-            Clear ();
+            Sweep ();
         }
     }
 }

--- a/service/UI/src/UI.cs
+++ b/service/UI/src/UI.cs
@@ -91,10 +91,7 @@ namespace KRPC.UI
         [KRPCProcedure]
         public static void Clear (bool clientOnly = false)
         {
-            if (clientOnly)
-                Addon.Clear (CallContext.Client);
-            else
-                Addon.Clear ();
+            Addon.Clear (clientOnly);
         }
     }
 }

--- a/service/UI/src/UI.cs
+++ b/service/UI/src/UI.cs
@@ -36,6 +36,8 @@ namespace KRPC.UI
     /// </summary>
     /// <remarks>
     /// For drawing 3D objects in the flight scene, see the Drawing service.
+    /// User interface elements created by a client are removed when that client
+    /// disconnects.
     /// </remarks>
     [KRPCService (Id = 7, GameScene = GameScene.All)]
     public static class UI

--- a/tools/krpctools/CHANGES.txt
+++ b/tools/krpctools/CHANGES.txt
@@ -1,5 +1,6 @@
 v0.6.0
  * Surface deprecated members in generated documentation and client stubs (#904)
+ * Fix docgen dropping remarks in service-level documentation
 
 v0.5.4
  * Fix incorrect protobuf DLL (#755)

--- a/tools/krpctools/krpctools/docgen/cnano.tmpl
+++ b/tools/krpctools/krpctools/docgen/cnano.tmpl
@@ -6,6 +6,9 @@ Service {{ x.name }}
 {% endif %}
 {{ gendoc(x.documentation) | indent }}
 
+{% if hasdoc(x.documentation, './remarks') %}{{ remarks(x.documentation) | indent }}
+
+{% endif %}
 {% for member in x.members.values() %}
 {% if member.member_type == 'procedure' %}
 {{ procedure(x.name, member) | indent }}

--- a/tools/krpctools/krpctools/docgen/cpp.tmpl
+++ b/tools/krpctools/krpctools/docgen/cpp.tmpl
@@ -7,6 +7,9 @@
 {% endif %}
 {{ gendoc(x.documentation) | indent }}
 
+{% if hasdoc(x.documentation, './remarks') %}{{ remarks(x.documentation) | indent }}
+
+{% endif %}
    .. function:: {{ x.name }}(krpc::Client* client)
 
       Construct an instance of this service.

--- a/tools/krpctools/krpctools/docgen/csharp.tmpl
+++ b/tools/krpctools/krpctools/docgen/csharp.tmpl
@@ -6,6 +6,9 @@
 {% endif %}
 {{ gendoc(x.documentation) | indent }}
 
+{% if hasdoc(x.documentation, './remarks') %}{{ remarks(x.documentation) | indent }}
+
+{% endif %}
 {% for member in x.members.values() %}
 {% if member.member_type == 'procedure' %}
 {{ procedure(member) | indent }}

--- a/tools/krpctools/krpctools/docgen/java.tmpl
+++ b/tools/krpctools/krpctools/docgen/java.tmpl
@@ -6,6 +6,9 @@
 {% endif %}
 {{ gendoc(x.documentation) | indent }}
 
+{% if hasdoc(x.documentation, './remarks') %}{{ remarks(x.documentation) | indent }}
+
+{% endif %}
 {% for member in x.members.values() %}
 {% if member.member_type == 'procedure' %}
 {{ procedure(member) | indent }}

--- a/tools/krpctools/krpctools/docgen/lua.tmpl
+++ b/tools/krpctools/krpctools/docgen/lua.tmpl
@@ -6,6 +6,9 @@
 {% endif %}
 {{ gendoc(x.documentation) }}
 
+{% if hasdoc(x.documentation, './remarks') %}{{ remarks(x.documentation) }}
+
+{% endif %}
 {% for member in x.members.values() %}
 {% if member.member_type == 'procedure' %}
 {{ procedure(member) }}

--- a/tools/krpctools/krpctools/docgen/python.tmpl
+++ b/tools/krpctools/krpctools/docgen/python.tmpl
@@ -6,6 +6,9 @@
 {% endif %}
 {{ gendoc(x.documentation) }}
 
+{% if hasdoc(x.documentation, './remarks') %}{{ remarks(x.documentation) }}
+
+{% endif %}
 {% for member in x.members.values() %}
 {% if member.member_type == 'procedure' %}
 {{ procedure(member) }}


### PR DESCRIPTION
When a client disconnects (script crash, network drop, or exiting without cleanup), any persistent in-game state it set up should be released so the vessel is not left stuck or uncontrollable. The autopilot and actuator control addons already did this; this PR extracts that logic into a reusable component and applies it everywhere it was missing.

## Shared component

New `KRPC.Utils` classes in the server assembly (`server/src/Utils/`), usable by all services:

* **`ClientConnections`** — per-frame cached `IClient.Connected` polling. TCP's `Connected` does real socket I/O per call, so all collections across the mod now share **one socket poll per client per rendered frame**. A null client (state set outside an RPC) is never considered disconnected.
* **`ClientOwnedObjects<T>`** — flat collection of objects tagged with the adding client (`CallContext.Client`), with an optional release callback invoked when entries are swept or cleared, and a per-client `Clear` backing the `Drawing.Clear`/`UI.Clear` `clientOnly` RPCs.
* **`ClientOwnedOverrides<TKey, TEntry>`** — the actuator addon's override registry, generalized: keyed install/release delegates, save/restore of prior state, and release on client disconnect or key-object destruction.
* **`ClientCleanupAddon`** — abstract `MonoBehaviour` base providing `Sweep()`/`Clear()` over the addon's collections and scene-change clearing in `Awake`/`OnDestroy`. Sweep cadence is deliberately per-addon: physics addons sweep at the top of `FixedUpdate` so a disconnected client's state is never applied in the detection tick; visual addons sweep in `Update`, which still runs while the game is paused.

## New behaviour

* **Part forces**: forces added by `Part.AddForce` are removed when the adding client disconnects. Previously they were re-applied every physics tick for the rest of the flight scene. Also fixes `OnDestroy` not clearing instantaneous forces.
* **Resource transfers**: in-progress transfers are canceled when the client that started them disconnects. A canceled transfer is marked as complete, so other clients holding a reference see it stop rather than hang forever.

## Migrations (no behaviour change)

* **ActuatorControlAddon**: its private `Entry`/`OverrideRegistry` machinery replaced by the shared classes (~120 lines removed).
* **PartHighlightAddon**: now swept from `Update` via the shared collection instead of subscribing to `Core.OnClientDisconnected` in `Awake` — the handler was never unsubscribed, leaking one subscription per flight-scene load. Also guards against a highlighted part having been destroyed before its client disconnects.
* **Drawing / UI addons**: their duplicated per-client dictionaries and connectivity polling replaced by the shared collection.
* **AutoPilot / PilotAddon**: disconnect checks routed through the shared cached primitive; the disengage-and-reset and clear-when-all-clients-gone (throttle preserved) semantics are byte-for-byte unchanged.

## Documentation

* The disconnect behaviour is now documented at the public API level for every affected surface: `Control` (inputs zeroed, throttle exception), `Part.Highlighted`, `Part.AddForce`, `ResourceTransfer.Start`/`Complete`, and the Drawing and UI services.
* Fixes docgen dropping `<remarks>` in service-level documentation (every other member type rendered them) — this also restores Drawing's long-lost "see the UI service" cross-reference.

## Testing

New in-game integration tests, following the existing second-connection pattern (`connect(use_cached=False)` → set state → `close()` → assert cleanup from the primary client):

* gimbal / RCS / control-surface override release on disconnect
* part highlighting removed on disconnect + persists for a still-connected client when another client disconnects
* force removed on disconnect (orbital spin-up from a torque-producing force stops)
* resource transfer canceled mid-flow (source amount stops changing, destination not full)
