### PR TITLE
Detect external mods in all game scenes, not just flight

### DIFF
--- a/server/src/KRPC.csproj
+++ b/server/src/KRPC.csproj
@@ -72,6 +72,7 @@
     <Compile Include="Utils\ConfigurationStorageNode.cs" />
     <Compile Include="Utils\GameSceneSwitcher.cs" />
     <Compile Include="Utils\GameScenesExtensions.cs" />
+    <Compile Include="Utils\LoadOnceAddon.cs" />
     <Compile Include="Utils\RectExtensions.cs" />
     <Compile Include="Utils\RectStorage.cs" />
   </ItemGroup>

--- a/server/src/Utils/LoadOnceAddon.cs
+++ b/server/src/Utils/LoadOnceAddon.cs
@@ -1,0 +1,36 @@
+using UnityEngine;
+
+namespace KRPC.Utils
+{
+    /// <summary>
+    /// Base class for addons that load an external API exactly once, in the first
+    /// scene to start.
+    /// </summary>
+    /// <remarks>
+    /// Generic on the derived type so that each addon gets its own <c>loaded</c> flag:
+    /// a static field on a non-generic base would be shared across all subclasses, so
+    /// the first addon to load would suppress every other one. The flag must be static
+    /// (not per-instance) because KSP creates a fresh addon instance in each scene, and
+    /// the API only needs loading once for the lifetime of the game.
+    /// </remarks>
+    public abstract class LoadOnceAddon<T> : MonoBehaviour where T : LoadOnceAddon<T>
+    {
+        static bool loaded;
+
+        /// <summary>
+        /// Load the API, once per game.
+        /// </summary>
+        public void Start ()
+        {
+            if (loaded)
+                return;
+            loaded = true;
+            Load ();
+        }
+
+        /// <summary>
+        /// Load the external API. Called exactly once, in the first scene to start.
+        /// </summary>
+        protected abstract void Load ();
+    }
+}

--- a/service/DockingCamera/src/Addon.cs
+++ b/service/DockingCamera/src/Addon.cs
@@ -1,17 +1,17 @@
-﻿using UnityEngine;
+using KRPC.Utils;
 
 namespace KRPC.DockingCamera
 {
     /// <summary>
     /// kRPC Camera addon.
     /// </summary>
-    [KSPAddon(KSPAddon.Startup.Flight, false)]
-    public sealed class Addon : MonoBehaviour
+    [KSPAddon(KSPAddon.Startup.AllGameScenes, false)]
+    public sealed class Addon : LoadOnceAddon<Addon>
     {
         /// <summary>
         /// Load the Camera API.
         /// </summary>
-        public void Start()
+        protected override void Load()
         {
             API.Load();
         }

--- a/service/LiDAR/src/Addon.cs
+++ b/service/LiDAR/src/Addon.cs
@@ -1,17 +1,17 @@
-﻿using UnityEngine;
+using KRPC.Utils;
 
 namespace KRPC.LiDAR
 {
     /// <summary>
     /// kRPC LiDAR addon.
     /// </summary>
-    [KSPAddon(KSPAddon.Startup.Flight, false)]
-    public sealed class Addon : MonoBehaviour
+    [KSPAddon(KSPAddon.Startup.AllGameScenes, false)]
+    public sealed class Addon : LoadOnceAddon<Addon>
     {
         /// <summary>
         /// Load the LiDAR API.
         /// </summary>
-        public void Start()
+        protected override void Load()
         {
             API.Load();
         }

--- a/service/RemoteTech/src/Addon.cs
+++ b/service/RemoteTech/src/Addon.cs
@@ -1,17 +1,17 @@
-using UnityEngine;
+using KRPC.Utils;
 
 namespace KRPC.RemoteTech
 {
     /// <summary>
     /// kRPC RemoteTech addon.
     /// </summary>
-    [KSPAddon (KSPAddon.Startup.Flight, false)]
-    public sealed class Addon : MonoBehaviour
+    [KSPAddon (KSPAddon.Startup.AllGameScenes, false)]
+    public sealed class Addon : LoadOnceAddon<Addon>
     {
         /// <summary>
         /// Load the RemoteTech API.
         /// </summary>
-        public void Start ()
+        protected override void Load ()
         {
             API.Load ();
         }

--- a/service/SpaceCenter/src/ExternalAPIAddon.cs
+++ b/service/SpaceCenter/src/ExternalAPIAddon.cs
@@ -1,17 +1,18 @@
-using UnityEngine;
+using KRPC.Utils;
 
 namespace KRPC.SpaceCenter
 {
     /// <summary>
     /// Addon to load external APIs.
     /// </summary>
-    [KSPAddon (KSPAddon.Startup.Flight, false)]
-    public sealed class ExternalAPIAddon : MonoBehaviour
+    [KSPAddon (KSPAddon.Startup.AllGameScenes, false)]
+    public sealed class ExternalAPIAddon : LoadOnceAddon<ExternalAPIAddon>
     {
         /// <summary>
-        /// Load external APIs.
+        /// Load external APIs. The APIs are resolved purely from the loaded
+        /// assemblies, so they do not depend on the flight runtime being active.
         /// </summary>
-        public void Start ()
+        protected override void Load ()
         {
             ExternalAPI.AGX.Load ();
             ExternalAPI.FAR.Load ();


### PR DESCRIPTION
The addons that probe for external mods only ran on flight-scene entry, so RemoteTech.IsAvailable (used by the throttle gate) and the RemoteTech, docking camera and LiDAR service "available" checks reported false in the main menu, space center and editor. Load them once in the first scene instead, via AllGameScenes with a guard, so mod presence is reported correctly in every scene. These are pure assembly/version checks (AGX, FAR, RemoteTech, DockingCamKURS, LiDAR) and don't need the flight runtime.

InfernalRobotics and KerbalAlarmClock are deliberately left flight-scoped: their wrappers grab the mod's running controller instance, which only exists in flight.