### PR TITLE
Many Small Fixes

### DIFF
--- a/doc/order.txt
+++ b/doc/order.txt
@@ -774,7 +774,7 @@ SpaceCenter.PartAction
 SpaceCenter.PartAction.Module
 SpaceCenter.PartAction.Name
 SpaceCenter.PartAction.GuiName
-SpaceCenter.PartAction.Set
+SpaceCenter.PartAction.Activated
 SpaceCenter.ConfigNode
 SpaceCenter.ConfigNode.Name
 SpaceCenter.ConfigNode.Values

--- a/doc/src/tutorials/reference-frames.rst
+++ b/doc/src/tutorials/reference-frames.rst
@@ -544,6 +544,10 @@ velocity relative to the surface:
       .. literalinclude:: /scripts/tutorials/reference-frames/SurfacePrograde.py
          :language: python
 
+.. note:: :attr:`Vessel.surface_velocity_reference_frame` is singular when the
+   vessel's surface speed is zero (hovering, landed). Calling this when the
+   vessel is stationary will raise an error.
+
 This code uses the :attr:`Vessel.surface_velocity_reference_frame`, pictured
 below:
 

--- a/service/SpaceCenter/CHANGES.txt
+++ b/service/SpaceCenter/CHANGES.txt
@@ -4,6 +4,7 @@ v0.6.0
  * Canonicalize AutoPilot attitude-error vectors for equivalent quaternions at exactly 180° (#571)
  * Fix Maneuver and ManeuverOrbital reference frame velocity (previously returned zero; now returns the orbital velocity at the node UT)
  * Fix angular velocity for VesselSurface, VesselSurfaceVelocity, CelestialBodyOrbital, Maneuver, ManeuverOrbital, Part, PartCenterOfMass, DockingPort and Thrust reference frames (previously returned zero)
+ * Fix ControlSurface.AvailableTorque returning inconsistent signs (ModuleControlSurface negates the roll axis); now normalised to positive/negative torque like other parts
  * Fix LookRotation2 producing NaN for rotations near 180° by using Shepperd's method
  * Fix VesselSurfaceVelocity reference frame producing NaN when surface velocity is near zero; now throws InvalidOperationException
  * Fix ReferenceFrame.CreateHybrid using velocity frame's angular velocity instead of the angularVelocity frame

--- a/service/SpaceCenter/CHANGES.txt
+++ b/service/SpaceCenter/CHANGES.txt
@@ -3,7 +3,7 @@ v0.6.0
    aerodynamic control surfaces, including deployed airbrakes (#622)
  * Canonicalize AutoPilot attitude-error vectors for equivalent quaternions at exactly 180° (#571)
  * Fix Maneuver and ManeuverOrbital reference frame velocity (previously returned zero; now returns the orbital velocity at the node UT)
- * Fix angular velocity for VesselSurface, VesselSurfaceVelocity, CelestialBodyOrbital, ManeuverOrbital, Part, PartCenterOfMass, DockingPort and Thrust reference frames (previously returned zero)
+ * Fix angular velocity for VesselSurface, VesselSurfaceVelocity, CelestialBodyOrbital, Maneuver, ManeuverOrbital, Part, PartCenterOfMass, DockingPort and Thrust reference frames (previously returned zero)
  * Fix LookRotation2 producing NaN for rotations near 180° by using Shepperd's method
  * Fix VesselSurfaceVelocity reference frame producing NaN when surface velocity is near zero; now throws InvalidOperationException
  * Fix ReferenceFrame.CreateHybrid using velocity frame's angular velocity instead of the angularVelocity frame

--- a/service/SpaceCenter/src/Services/Parts/ControlSurface.cs
+++ b/service/SpaceCenter/src/Services/Parts/ControlSurface.cs
@@ -157,7 +157,14 @@ namespace KRPC.SpaceCenter.Services.Parts
                 // GetPotentialTorque already applies the authority limiter (via
                 // ModuleControlSurface.GetPotentialLift, which scales the deflection by
                 // authorityLimiter * 0.01), so no further scaling is needed here.
-                return controlSurface.GetPotentialTorque ();
+                var torque = controlSurface.GetPotentialTorque ();
+                // ModuleControlSurface.GetPotentialTorque negates the roll (y) axis of both the
+                // positive and negative torque vectors, unlike other ITorqueProvider
+                // implementations. Normalise to the kRPC convention (positive torque >= 0,
+                // negative torque <= 0) with Math.Abs, matching ITorqueProviderExtensions.Sum.
+                return new TupleV3 (
+                    new Vector3d (Math.Abs (torque.Item1.x), Math.Abs (torque.Item1.y), Math.Abs (torque.Item1.z)),
+                    new Vector3d (-Math.Abs (torque.Item2.x), -Math.Abs (torque.Item2.y), -Math.Abs (torque.Item2.z)));
             }
         }
     }

--- a/service/SpaceCenter/src/Services/Parts/Module.cs
+++ b/service/SpaceCenter/src/Services/Parts/Module.cs
@@ -553,7 +553,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         /// <param name="name"></param>
         /// <param name="value"></param>
-        [Obsolete("Filter <see cref='ActionList'/> by <see cref='PartAction.GuiName'/> and call <see cref='PartAction.Set'/> instead.")]
+        [Obsolete("Filter <see cref='ActionList'/> by <see cref='PartAction.GuiName'/> and set <see cref='PartAction.Activated'/> instead.")]
         [KRPCMethod]
         public void SetAction (string name, bool value = true)
         {
@@ -565,7 +565,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         /// <param name="id"></param>
         /// <param name="value"></param>
-        [Obsolete("Filter <see cref='ActionList'/> by <see cref='PartAction.Name'/> and call <see cref='PartAction.Set'/> instead.")]
+        [Obsolete("Filter <see cref='ActionList'/> by <see cref='PartAction.Name'/> and set <see cref='PartAction.Activated'/> instead.")]
         [KRPCMethod]
         public void SetActionById (string id, bool value = true)
         {

--- a/service/SpaceCenter/src/Services/Parts/PartAction.cs
+++ b/service/SpaceCenter/src/Services/Parts/PartAction.cs
@@ -60,16 +60,16 @@ namespace KRPC.SpaceCenter.Services.Parts
 
         /// <summary>
         /// Activate or deactivate the action. Equivalent to triggering the action from an action
-        /// group.
+        /// group. Set to <c>true</c> to activate the action, or <c>false</c> to deactivate it.
         /// </summary>
-        /// <param name="value"><c>true</c> to activate the action, <c>false</c> to deactivate it.</param>
-        [KRPCMethod]
-        public void Set (bool value = true)
-        {
-            action.Invoke (new KSPActionParam (
-                action.actionGroup,
-                value ? KSPActionType.Activate : KSPActionType.Deactivate
-            ));
+        [KRPCProperty]
+        public bool Activated {
+            set {
+                action.Invoke (new KSPActionParam (
+                    action.actionGroup,
+                    value ? KSPActionType.Activate : KSPActionType.Deactivate
+                ));
+            }
         }
     }
 }

--- a/service/SpaceCenter/src/Services/Parts/Propellant.cs
+++ b/service/SpaceCenter/src/Services/Parts/Propellant.cs
@@ -66,9 +66,8 @@ namespace KRPC.SpaceCenter.Services.Parts
         }
 
         /// <summary>
-        /// The current amount of propellant.
+        /// The current amount of propellant consumed in the current physics update.
         /// </summary>
-        // TODO: units?
         [KRPCProperty]
         public double CurrentAmount {
             get
@@ -76,9 +75,8 @@ namespace KRPC.SpaceCenter.Services.Parts
         }
 
         /// <summary>
-        /// The required amount of propellant.
+        /// The required amount of propellant for the current physics update.
         /// </summary>
-        // TODO: units?
         [KRPCProperty]
         public double CurrentRequirement {
             get
@@ -89,7 +87,6 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// The total amount of the underlying resource currently reachable given
         /// resource flow rules.
         /// </summary>
-        // TODO: units?
         [KRPCProperty]
         public double TotalResourceAvailable {
             get
@@ -100,7 +97,6 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// The total vehicle capacity for the underlying propellant resource,
         /// restricted by resource flow rules.
         /// </summary>
-        // TODO: units?
         [KRPCProperty]
         public double TotalResourceCapacity {
             get
@@ -111,7 +107,6 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// If this propellant should be ignored when calculating required mass flow
         /// given specific impulse.
         /// </summary>
-        // TODO: units?
         [KRPCProperty]
         public bool IgnoreForIsp {
             get

--- a/service/SpaceCenter/src/Services/Parts/RCS.cs
+++ b/service/SpaceCenter/src/Services/Parts/RCS.cs
@@ -242,11 +242,11 @@ namespace KRPC.SpaceCenter.Services.Parts
                 torque = rcs.enablePitch ? posY * forceZ - posZ * forceY : 0d;
                 if (torque > 0) torqueX += torque;
                 else torqueXn += -torque;
-                // Torque around Y axis (yaw)
+                // Torque around Y axis (roll)
                 torque = rcs.enableRoll ? posZ * forceX - posX * forceZ : 0d;
                 if (torque > 0) torqueY += torque;
                 else torqueYn += -torque;
-                // Torque around Z axis (roll)
+                // Torque around Z axis (yaw)
                 torque = rcs.enableYaw ? posX * forceY - posY * forceX : 0d;
                 if (torque > 0) torqueZ += torque;
                 else torqueZn += -torque;

--- a/service/SpaceCenter/src/Services/ReferenceFrame.cs
+++ b/service/SpaceCenter/src/Services/ReferenceFrame.cs
@@ -703,8 +703,14 @@ namespace KRPC.SpaceCenter.Services
                     var a_srf = grav - Vector3d.Cross (vessel.mainBody.angularVelocity, v_orb);
                     return vessel.mainBody.angularVelocity + Vector3d.Cross (srf_vel, a_srf) / srf_vel.sqrMagnitude;
                 }
-                case ReferenceFrameType.Maneuver:
-                    return Vector3d.zero;
+                case ReferenceFrameType.Maneuver: {
+                    // The burn vector is stored in prograde/normal/radial components, so it rotates
+                    // with the orbital frame. The z-axis (arbitrary inertial projection) introduces
+                    // a small spin correction about ŷ that is neglected here.
+                    var r = node.patch.getRelativePositionAtUT (node.UT).SwapYZ ();
+                    var v = node.patch.getOrbitalVelocityAtUT (node.UT).SwapYZ ();
+                    return Vector3d.Cross (r, v) / r.sqrMagnitude;
+                }
                 case ReferenceFrameType.ManeuverOrbital: {
                     var r = node.patch.getRelativePositionAtUT (node.UT).SwapYZ ();
                     var v = node.patch.getOrbitalVelocityAtUT (node.UT).SwapYZ ();

--- a/service/SpaceCenter/test/test_parts_module.py
+++ b/service/SpaceCenter/test/test_parts_module.py
@@ -62,8 +62,8 @@ class TestPartsModule(krpctest.TestCase):
         for candidate in module.action_list:
             if candidate.name == "MakeReferenceToggle":
                 action = candidate
-        action.set(True)
-        action.set(False)
+        action.enabled = True
+        action.enabled = False
 
     def test_solar_panel(self):
         part = self.parts.with_name("solarPanels2")[0]
@@ -200,10 +200,10 @@ class TestPartsModule(krpctest.TestCase):
 
         toggle = next(a for a in action_list if a.gui_name == "Toggle Light")
         self.assertIsNotNone(self._visible_event(module, "Lights On"))
-        toggle.set(True)
+        toggle.activated = True
         self.wait()
         self.assertIsNotNone(self._visible_event(module, "Lights Off"))
-        toggle.set(False)
+        toggle.activated = False
         self.wait()
         self.assertIsNotNone(self._visible_event(module, "Lights On"))
 

--- a/tools/krpctools/krpctools/docgen/cpp.py
+++ b/tools/krpctools/krpctools/docgen/cpp.py
@@ -85,6 +85,8 @@ class CppDomain(Domain):
             )
         ):
             name[-1] = snake_case(name[-1])
+        if isinstance(obj, (Property, ClassProperty)) and obj.getter is None:
+            name[-1] = "set_" + name[-1]
         return self.shorten_ref(".".join(name)).replace(".", "::")
 
     def see(self, obj):

--- a/tools/krpctools/krpctools/docgen/java.py
+++ b/tools/krpctools/krpctools/docgen/java.py
@@ -111,7 +111,10 @@ class JavaDomain(Domain):
             name = ".".join(name)
         elif isinstance(obj, (Property, ClassProperty)):
             name = name.split(".")
-            name[-1] = "get" + name[-1] + "()"
+            if obj.getter is not None:
+                name[-1] = "get" + name[-1] + "()"
+            else:
+                name[-1] = "set" + name[-1] + "(" + self.type(obj.type) + ")"
             name = ".".join(name)
         elif isinstance(obj, EnumerationValue):
             name = name.split(".")


### PR DESCRIPTION
A collection of small, independent fixes and cleanups to the SpaceCenter service, docgen, and docs.

## Behaviour fixes

- **Normalize `ControlSurface.AvailableTorque` sign.** `ModuleControlSurface.GetPotentialTorque` negates the roll (y) component of both the positive and negative torque vectors, unlike other `ITorqueProvider` implementations, so the per-part RPC reported inconsistent signs. Normalised with `Math.Abs` to the kRPC convention (positive torque ≥ 0, negative torque ≤ 0), matching `ITorqueProviderExtensions.Sum` and the ReactionWheel/Engine paths.
- **Add angular velocity to the `Maneuver` reference frame.** Previously returned zero; now computed as `Cross(r, v) / r²` at the node UT, matching the adjacent `ManeuverOrbital` case.

## API consistency

- **`PartAction.Set(bool)` → `PartAction.Activated` set-only property.** Brings the API in line with kRPC conventions. Obsolete-message crefs in `Module.SetAction`/`SetActionById` and the integration test are updated accordingly.
- **Fix docgen cross-references to set-only properties.** The C++ and Java docgen resolved a property cref to its getter symbol, but a set-only property (like the new `PartAction.Activated`) has no getter, so the reference target didn't exist and the Sphinx build failed. The reference now points at the setter symbol when there is no getter.

## Documentation & comment cleanups

- **Fix roll/yaw axis comment labels in the RCS torque calculation** (comments only — the code was already correct).
- **Clarify `Propellant` property docstrings** (`CurrentAmount`, `CurrentRequirement`) and drop stale `// TODO: units?` comments.
- **Document the surface-velocity reference frame singularity** in the reference-frames tutorial.
