### PR TITLE
Documentation website fixes

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -42,21 +42,23 @@ jobs:
       - name: setup
         uses: ./.github/actions/build-setup
         with:
-          long-version: "false"
+          # A tag build is a release: keep the plain version so it publishes
+          # under /<version>/. A main build is a dev build: take the suffixed
+          # version (set-version.py) so it publishes under /dev/.
+          long-version: ${{ startsWith(github.ref, 'refs/tags/') && 'false' || 'true' }}
       - name: determine target
         id: target
+        # The buildenv container has no bash, so this runs under POSIX sh. The
+        # subpath follows the version stamped in config.bzl: a suffixed (dev)
+        # version publishes under /dev/, a plain release version under /x.y.z/.
         run: |
-          if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
-            # Frozen per-release build, published under its version number.
-            echo "subpath=${GITHUB_REF#refs/tags/v}" >> "$GITHUB_OUTPUT"
-            echo "define=" >> "$GITHUB_OUTPUT"
-          else
-            # Rolling build of main, published under /dev/.
-            echo "subpath=dev" >> "$GITHUB_OUTPUT"
-            echo "define=--define docs_channel=dev" >> "$GITHUB_OUTPUT"
-          fi
+          version=$(sed -n 's/^version = "\(.*\)"$/\1/p' config.bzl)
+          case "$version" in
+            *-*) echo "subpath=dev" >> "$GITHUB_OUTPUT" ;;
+            *) echo "subpath=$version" >> "$GITHUB_OUTPUT" ;;
+          esac
       - name: build
-        run: bazel build //doc:html ${{ steps.target.outputs.define }}
+        run: bazel build //doc:html
       - name: publish
         env:
           SUBPATH: ${{ steps.target.outputs.subpath }}

--- a/doc/BUILD.bazel
+++ b/doc/BUILD.bazel
@@ -35,6 +35,7 @@ stage_files(
     ]) + [
         "src/_static/custom.css",
         "src/_static/external-links.js",
+        "src/_templates/build-info.html",
         "src/dictionary.txt",
         ":changelog",
         ":cnano-api",
@@ -130,7 +131,10 @@ genrule(
     name = "conf",
     srcs = ["conf.py.tmpl"],
     outs = ["src/conf.py"],
-    cmd = "sed -e 's/%VERSION%/" + docs_version + "/g' -e 's/%SUBPATH%/" + docs_version + "/g' \"$<\" > \"$@\"",
+    # %VERSION%/%SUBPATH% get the channel ('dev' or the release number);
+    # %BUILDVERSION% keeps the full version, including a dev build's commit-sha
+    # suffix, which conf.py turns into the footer commit link.
+    cmd = "sed -e 's/%VERSION%/" + docs_version + "/g' -e 's/%SUBPATH%/" + docs_version + "/g' -e 's/%BUILDVERSION%/" + version + "/g' \"$<\" > \"$@\"",
 )
 
 sphinx_build(

--- a/doc/BUILD.bazel
+++ b/doc/BUILD.bazel
@@ -118,22 +118,19 @@ py_binary(
     ],
 )
 
-# The subpath a docs build is published under. Defaults to the release version
-# (a frozen /<version>/ build); CI selects 'dev' for main-branch builds with
-# `--define docs_channel=dev`.
-config_setting(
-    name = "docs_dev",
-    values = {"define": "docs_channel=dev"},
-)
+# Release builds carry a plain "x.y.z" version; CI stamps dev builds with a
+# "-<build>-<sha>" suffix (tools/github-actions/set-version.py). A dev build is
+# published under /dev/ and stamped "dev" so the theme's version switcher and
+# old-version warning banner flag it as unreleased; a release publishes under
+# /<version>/ stamped with its number. Deriving the channel from the version
+# string keeps the docs in step with the version everything else builds with.
+docs_version = "dev" if "-" in version else version
 
 genrule(
     name = "conf",
     srcs = ["conf.py.tmpl"],
     outs = ["src/conf.py"],
-    cmd = select({
-        ":docs_dev": "sed -e 's/%VERSION%/" + version + "/g' -e 's/%SUBPATH%/dev/g' \"$<\" > \"$@\"",
-        "//conditions:default": "sed -e 's/%VERSION%/" + version + "/g' -e 's/%SUBPATH%/" + version + "/g' \"$<\" > \"$@\"",
-    }),
+    cmd = "sed -e 's/%VERSION%/" + docs_version + "/g' -e 's/%SUBPATH%/" + docs_version + "/g' \"$<\" > \"$@\"",
 )
 
 sphinx_build(
@@ -141,7 +138,9 @@ sphinx_build(
     srcs = [":srcs"],
     out = "html.zip",
     builder = "html",
-    opts = {"version": version},
+    # Stamp -Dversion to match conf.py's version, so DOCUMENTATION_OPTIONS.VERSION
+    # is "dev" for a dev build and the release number otherwise.
+    opts = {"version": docs_version},
     sphinx_build = ":sphinx-build",
 )
 

--- a/doc/conf.py.tmpl
+++ b/doc/conf.py.tmpl
@@ -28,8 +28,18 @@ graphviz_output_format = 'svg'
 html_theme = 'pydata_sphinx_theme'
 htmlhelp_basename = 'krpc-doc'
 html_static_path = ['crafts', 'scripts', '_static']
+templates_path = ['_templates']
 html_css_files = ['custom.css']
 html_js_files = ['external-links.js']
+
+# A dev build's version carries a "-<build>-<sha>" suffix (set-version.py); a
+# release version does not. Surface that commit sha as a footer link so a dev
+# page shows which commit it was built from. %BUILDVERSION% is the full
+# config.bzl version, substituted by the :conf genrule.
+build_version = '%BUILDVERSION%'
+html_context = {}
+if '-' in build_version:
+    html_context['build_commit'] = build_version.rsplit('-', 1)[-1]
 
 # Per-version publishing. %SUBPATH% is
 # the path this build is published under: a release version (e.g. '0.5.4') or
@@ -56,6 +66,8 @@ html_theme_options = {
     # Show all six client languages in the header (getting-started, tutorials
     # and the languages); the remaining sections collapse into "More".
     'header_links_before_dropdown': 8,
+    # Footer commit link, rendered by _templates/build-info.html for dev builds.
+    'footer_center': ['build-info'],
     'navbar_end': ['version-switcher', 'theme-switcher', 'navbar-icon-links'],
     'icon_links': [
         {

--- a/doc/conf.py.tmpl
+++ b/doc/conf.py.tmpl
@@ -31,9 +31,9 @@ html_js_files = ['external-links.js']
 
 # Per-version publishing. %SUBPATH% is
 # the path this build is published under: a release version (e.g. '0.5.4') or
-# 'dev'. It is substituted by the :conf genrule and defaults to the release
-# version; CI overrides it to 'dev' for main-branch builds. html_baseurl gives
-# correct canonical links per subpath.
+# 'dev'. The :conf genrule substitutes it with 'dev' when config.bzl's version
+# carries a dev suffix and with the release number otherwise. html_baseurl
+# gives correct canonical links per subpath.
 html_baseurl = 'https://krpc.github.io/krpc/%SUBPATH%/'
 
 html_theme_options = {

--- a/doc/conf.py.tmpl
+++ b/doc/conf.py.tmpl
@@ -1,9 +1,11 @@
+import datetime
 import os
 
 project = 'kRPC'
 version = '%VERSION%'
 release = version
-copyright = '2015-2023, kRPC Org'
+# End year is the build year, so the footer stays current without edits.
+copyright = '2015-%d, kRPC Org' % datetime.date.today().year
 author = ''
 
 master_doc = 'index'

--- a/doc/src/_templates/build-info.html
+++ b/doc/src/_templates/build-info.html
@@ -1,0 +1,6 @@
+{%- if build_commit %}
+<p class="build-info">
+  Built from commit
+  <a href="https://github.com/krpc/krpc/commit/{{ build_commit }}">{{ build_commit }}</a>
+</p>
+{%- endif %}


### PR DESCRIPTION
Follow-ups to the versioned documentation website (#951) after its first deploy to `gh-pages`.

**Derive the docs release/dev channel from the version string.** The docs build previously distinguished a release from a dev build with a `--define docs_channel=dev` flag set only on main-branch runs, while the `build-setup` step forced the plain version with `long-version: false` — a holdover that made the rolling main-branch docs masquerade as a clean release. Now the dev build takes the suffixed version every other CI job already uses (`set-version.py`, e.g. `0.5.4-46215-3ddb487`) and the channel is derived from it: a plain `x.y.z` is a release, a suffixed `x.y.z-<build>-<sha>` is a dev build.

This fixes two bugs from the first deploy:
- **The docs workflow failed** at the `determine target` step with `sh: [[: not found` — the buildenv container has no bash, so the step ran under POSIX `sh` and the bash-only `[[` test broke. It now uses a `case` statement.
- **The dev site's version banner was suppressed.** `config.bzl`'s version tracks the last release, so the dev build was stamped `0.5.4` — identical to the switcher's preferred version — and the theme presented the rolling dev docs as the stable release.

**Auto-fill the docs copyright end year at build time.** The footer read `2015-2023`; the end year is now computed from the build date in `conf.py`, so it stays current without a yearly edit.

**Show the source commit in the dev docs footer.** A dev build's version already carries the commit sha as a suffix; it's now surfaced as a footer link to the GitHub commit.