### PR TITLE
Add Engine.Flameout

### DIFF
--- a/doc/order.txt
+++ b/doc/order.txt
@@ -879,6 +879,7 @@ SpaceCenter.Engine.PropellantNames
 SpaceCenter.Engine.PropellantRatios
 SpaceCenter.Engine.Propellants
 SpaceCenter.Engine.HasFuel
+SpaceCenter.Engine.Flameout
 SpaceCenter.Engine.Throttle
 SpaceCenter.Engine.ThrottleLocked
 SpaceCenter.Engine.IndependentThrottle

--- a/service/SpaceCenter/CHANGES.txt
+++ b/service/SpaceCenter/CHANGES.txt
@@ -18,6 +18,7 @@ v0.6.0
  * Add Flight.SurfacePrograde and Flight.SurfaceRetrograde direction vectors (surface-relative velocity direction, matching navball surface mode) (#582)
  * Add Flight.SimulateAerodynamicTorqueAt (#825)
  * Add Control.AeroSurfaces to enable/disable pitch, yaw and roll on all control surfaces (#827)
+ * Add Engine.Flameout (#311)
  * Add Control.EngineGimbals to enable/disable gimbal on all gimballed engines (#827)
  * Add Module.AllFieldsById to expose all part module field values, including those not
    visible in the UI (#858)

--- a/service/SpaceCenter/src/Services/Parts/Engine.cs
+++ b/service/SpaceCenter/src/Services/Parts/Engine.cs
@@ -375,6 +375,18 @@ namespace KRPC.SpaceCenter.Services.Parts
         }
 
         /// <summary>
+        /// Whether the engine has flamed out - it is active but has run out of
+        /// propellant, so it is producing no thrust. This is the signal a client
+        /// can use to decide when to activate the next stage. Note that on a
+        /// vessel with drop tanks or asparagus staging some engines can flame out
+        /// while others keep burning.
+        /// </summary>
+        [KRPCProperty]
+        public bool Flameout {
+            get { return CurrentEngine.flameout; }
+        }
+
+        /// <summary>
         /// The current throttle setting for the engine. A value between 0 and 1.
         /// This is not necessarily the same as the vessel's main throttle
         /// setting, as some engines take time to adjust their throttle

--- a/service/SpaceCenter/test/test_parts_engine.py
+++ b/service/SpaceCenter/test/test_parts_engine.py
@@ -268,6 +268,22 @@ class TestPartsEngine(krpctest.TestCase, EngineTestBase):
         self.assertFalse(engine.has_fuel)
         engine.active = False
 
+    def test_flameout(self):
+        engine = self.get_engine("liquidEngine")  # LV-T30 "Reliant"
+        self.assertFalse(engine.flameout)
+
+    def test_flameout_no_fuel(self):
+        engine = self.get_engine("liquidEngine3.v2")  # LV-909 "Terrier"
+        self.assertFalse(engine.flameout)
+        # Flameout is only flagged once an ignited engine is commanded to
+        # produce thrust and finds no propellant, so open the throttle.
+        engine.active = True
+        self.vessel.control.throttle = 1
+        self.wait(0.5)
+        self.assertTrue(engine.flameout)
+        self.vessel.control.throttle = 0
+        engine.active = False
+
     def test_thrust_limit(self):
         engine = self.get_engine("liquidEngine")  # LV-T30 "Reliant"
         thrust = 205600


### PR DESCRIPTION
Exposes KSP's `ModuleEngines.flameout` as a new `Engine.Flameout` property: `true` when an engine is active but has run out of propellant, so it is producing no thrust.

This is the client-side primitive requested in #311 for detecting when to stage.

Fixes #311 