### PR TITLE
Fix the auto-pilot breaking after revert to launch

### DIFF
--- a/service/SpaceCenter/CHANGES.txt
+++ b/service/SpaceCenter/CHANGES.txt
@@ -42,6 +42,9 @@ v0.6.0
  * Fix VesselOrbital reference frame angular velocity (missing Coriolis correction) (#823)
  * Fix Vessel.AvailableTorque due to sign inconsistency in KSP's ITorqueProvider implementations (#525)
  * Fix AutoPilot.Error to return the absolute value of the normalized angle (#893)
+ * Fix the auto-pilot no longer controlling the vessel after a Revert to Launch when a
+   client keeps its auto-pilot object across the reload (it appeared engaged but stopped
+   driving the vessel until the game was restarted)
  * Fix CelestialBody.Rotation returning incorrect values before a flight scene loads (#890)
  * Fix ResourceConverter.State and ResourceHarvester.ThermalEfficiency misreading the KSP status string (#892)
  * Fix Waypoint.MeanAltitude, SurfaceAltitude, BedrockAltitude (#891)

--- a/service/SpaceCenter/src/PilotAddon.cs
+++ b/service/SpaceCenter/src/PilotAddon.cs
@@ -286,6 +286,7 @@ namespace KRPC.SpaceCenter
         public void Awake ()
         {
             Clear ();
+            GameEvents.onVesselDestroy.Add (OnVesselDestroy);
         }
 
         /// <summary>
@@ -293,6 +294,7 @@ namespace KRPC.SpaceCenter
         /// </summary>
         public void OnDestroy ()
         {
+            GameEvents.onVesselDestroy.Remove (OnVesselDestroy);
             Clear ();
         }
 
@@ -305,6 +307,32 @@ namespace KRPC.SpaceCenter
             controlDelegates.Clear ();
             remoteTechSanctionedDelegates.Clear ();
             attitudeControllers.Clear ();
+        }
+
+        /// <summary>
+        /// Tear down all control state for a vessel as soon as it is destroyed rather than only
+        /// at scene teardown via <see cref="Clear"/>.
+        /// </summary>
+        void OnVesselDestroy (Vessel vessel)
+        {
+            Remove (vessel);
+        }
+
+        static void Remove (Vessel vessel)
+        {
+            Action<FlightCtrlState> action;
+            if (controlDelegates.TryGetValue (vessel, out action)) {
+                vessel.OnFlyByWire -= new FlightInputCallback (action);
+                if (RemoteTech.IsAvailable && remoteTechSanctionedDelegates.Contains (vessel) &&
+                    RemoteTech.RemoveSanctionedPilot != null)
+                    RemoteTech.RemoveSanctionedPilot (vessel.id, action);
+                controlDelegates.Remove (vessel);
+            }
+            remoteTechSanctionedDelegates.Remove (vessel);
+            currentInputs.Remove (vessel);
+            manualInputs.Remove (vessel);
+            autoPilotInputs.Remove (vessel);
+            attitudeControllers.Remove (vessel.id);
         }
 
         /// <summary>

--- a/service/SpaceCenter/src/Services/AutoPilot.cs
+++ b/service/SpaceCenter/src/Services/AutoPilot.cs
@@ -24,12 +24,17 @@ namespace KRPC.SpaceCenter.Services
     {
         static readonly HashSet<Guid> showInfoUI = new HashSet<Guid> ();
         readonly Guid vesselId;
-        readonly AttitudeController attitudeController;
 
         internal AutoPilot (global::Vessel vessel)
         {
             vesselId = vessel.id;
-            attitudeController = PilotAddon.GetAttitudeController (vessel);
+        }
+
+        /// <summary>
+        /// The vessel's attitude controller.
+        /// </summary>
+        AttitudeController Controller {
+            get { return PilotAddon.GetAttitudeController (InternalVessel); }
         }
 
         /// <summary>
@@ -123,12 +128,12 @@ namespace KRPC.SpaceCenter.Services
         /// </summary>
         [KRPCProperty]
         public bool Engaged {
-            get { return attitudeController.Engaged; }
+            get { return Controller.Engaged; }
             set {
                 if (value)
-                    attitudeController.Engage (CallContext.Client);
+                    Controller.Engage (CallContext.Client);
                 else
-                    attitudeController.Disengage ();
+                    Controller.Disengage ();
             }
         }
 
@@ -193,7 +198,7 @@ namespace KRPC.SpaceCenter.Services
         [KRPCMethod]
         public void Reset ()
         {
-            attitudeController.Reset ();
+            Controller.Reset ();
         }
 
         /// <summary>
@@ -206,7 +211,7 @@ namespace KRPC.SpaceCenter.Services
         /// </remarks>
         [KRPCProperty]
         public ReferenceFrame ReferenceFrame {
-            get { return attitudeController.ReferenceFrame; }
+            get { return Controller.ReferenceFrame; }
             set {
                 if (ReferenceEquals (value, null))
                     throw new ArgumentNullException ("ReferenceFrame");
@@ -227,7 +232,7 @@ namespace KRPC.SpaceCenter.Services
                 if (rotatesWithVessel) {
                     throw new ArgumentException ("Invalid reference frame; must not rotate with the vessel");
                 }
-                attitudeController.ReferenceFrame = value;
+                Controller.ReferenceFrame = value;
             }
         }
 
@@ -242,8 +247,8 @@ namespace KRPC.SpaceCenter.Services
         /// </remarks>
         [KRPCProperty]
         public float TargetPitch {
-            get { return (float)attitudeController.TargetPitch; }
-            set { attitudeController.TargetPitch = value; }
+            get { return (float)Controller.TargetPitch; }
+            set { Controller.TargetPitch = value; }
         }
 
         /// <summary>
@@ -256,8 +261,8 @@ namespace KRPC.SpaceCenter.Services
         /// </remarks>
         [KRPCProperty]
         public float TargetHeading {
-            get { return (float)attitudeController.TargetHeading; }
-            set { attitudeController.TargetHeading = value; }
+            get { return (float)Controller.TargetHeading; }
+            set { Controller.TargetHeading = value; }
         }
 
         /// <summary>
@@ -277,8 +282,8 @@ namespace KRPC.SpaceCenter.Services
         /// </remarks>
         [KRPCProperty]
         public float TargetRoll {
-            get { return (float)attitudeController.TargetRoll; }
-            set { attitudeController.TargetRoll = value; }
+            get { return (float)Controller.TargetRoll; }
+            set { Controller.TargetRoll = value; }
         }
 
         /// <summary>
@@ -297,8 +302,8 @@ namespace KRPC.SpaceCenter.Services
         /// </remarks>
         [KRPCProperty]
         public Tuple3 UpReference {
-            get { return attitudeController.UpReference.ToTuple (); }
-            set { attitudeController.UpReference = value.ToVector (); }
+            get { return Controller.UpReference.ToTuple (); }
+            set { Controller.UpReference = value.ToVector (); }
         }
 
         /// <summary>
@@ -315,8 +320,8 @@ namespace KRPC.SpaceCenter.Services
         [KRPCMethod]
         public void TargetPitchAndHeading (float pitch, float heading)
         {
-            attitudeController.TargetPitch = pitch;
-            attitudeController.TargetHeading = heading;
+            Controller.TargetPitch = pitch;
+            Controller.TargetHeading = heading;
         }
 
         /// <summary>
@@ -345,7 +350,7 @@ namespace KRPC.SpaceCenter.Services
         [KRPCMethod]
         public void SetDirectionAndUp (Tuple3 direction, Tuple3 up, float roll = 0)
         {
-            attitudeController.SetTargetDirectionAndUp (direction.ToVector (), up.ToVector (), roll);
+            Controller.SetTargetDirectionAndUp (direction.ToVector (), up.ToVector (), roll);
         }
 
         /// <summary>
@@ -354,8 +359,8 @@ namespace KRPC.SpaceCenter.Services
         /// </summary>
         [KRPCProperty]
         public Tuple3 TargetDirection {
-            get { return attitudeController.TargetDirection.ToTuple (); }
-            set { attitudeController.SetTargetDirection (value.ToVector ()); }
+            get { return Controller.TargetDirection.ToTuple (); }
+            set { Controller.SetTargetDirection (value.ToVector ()); }
         }
 
         /// <summary>
@@ -364,8 +369,8 @@ namespace KRPC.SpaceCenter.Services
         /// </summary>
         [KRPCProperty]
         public Tuple4 TargetRotation {
-            get { return attitudeController.TargetRotation.ToTuple (); }
-            set { attitudeController.SetTargetRotation (value.ToQuaternion ()); }
+            get { return Controller.TargetRotation.ToTuple (); }
+            set { Controller.SetTargetRotation (value.ToQuaternion ()); }
         }
 
         /// <summary>
@@ -376,7 +381,7 @@ namespace KRPC.SpaceCenter.Services
         /// </summary>
         [KRPCProperty]
         public float CurrentTargetPitch {
-            get { return (float)attitudeController.EffectiveTargetPitch; }
+            get { return (float)Controller.EffectiveTargetPitch; }
         }
 
         /// <summary>
@@ -387,7 +392,7 @@ namespace KRPC.SpaceCenter.Services
         /// </summary>
         [KRPCProperty]
         public float CurrentTargetHeading {
-            get { return (float)attitudeController.EffectiveTargetHeading; }
+            get { return (float)Controller.EffectiveTargetHeading; }
         }
 
         /// <summary>
@@ -398,7 +403,7 @@ namespace KRPC.SpaceCenter.Services
         /// </summary>
         [KRPCProperty]
         public float CurrentTargetRoll {
-            get { return (float)attitudeController.EffectiveTargetRoll; }
+            get { return (float)Controller.EffectiveTargetRoll; }
         }
 
         /// <summary>
@@ -409,7 +414,7 @@ namespace KRPC.SpaceCenter.Services
         /// </summary>
         [KRPCProperty]
         public Tuple3 CurrentTargetDirection {
-            get { return attitudeController.EffectiveTargetDirection.ToTuple (); }
+            get { return Controller.EffectiveTargetDirection.ToTuple (); }
         }
 
         /// <summary>
@@ -419,7 +424,7 @@ namespace KRPC.SpaceCenter.Services
         /// </summary>
         [KRPCProperty]
         public Tuple4 CurrentTargetRotation {
-            get { return attitudeController.EffectiveTargetRotation.ToTuple (); }
+            get { return Controller.EffectiveTargetRotation.ToTuple (); }
         }
 
         /// <summary>
@@ -436,8 +441,8 @@ namespace KRPC.SpaceCenter.Services
 
         void WaitWithDeadline (DateTime deadline)
         {
-            if (Error > attitudeController.StoppingAngleThreshold ||
-                InternalVessel.GetComponent<Rigidbody> ().angularVelocity.magnitude > attitudeController.StoppingVelocityThreshold) {
+            if (Error > Controller.StoppingAngleThreshold ||
+                InternalVessel.GetComponent<Rigidbody> ().angularVelocity.magnitude > Controller.StoppingVelocityThreshold) {
                 if (DateTime.UtcNow > deadline)
                     throw new TimeoutException ("AutoPilot timed out waiting to reach target direction");
                 throw new YieldException<Action> (() => WaitWithDeadline (deadline));
@@ -450,8 +455,8 @@ namespace KRPC.SpaceCenter.Services
         /// </summary>
         [KRPCProperty]
         public float StoppingAngleThreshold {
-            get { return attitudeController.StoppingAngleThreshold; }
-            set { attitudeController.StoppingAngleThreshold = value; }
+            get { return Controller.StoppingAngleThreshold; }
+            set { Controller.StoppingAngleThreshold = value; }
         }
 
         /// <summary>
@@ -461,8 +466,8 @@ namespace KRPC.SpaceCenter.Services
         /// </summary>
         [KRPCProperty]
         public float StoppingVelocityThreshold {
-            get { return attitudeController.StoppingVelocityThreshold; }
-            set { attitudeController.StoppingVelocityThreshold = value; }
+            get { return Controller.StoppingVelocityThreshold; }
+            set { Controller.StoppingVelocityThreshold = value; }
         }
 
         // The vessel's current attitude, decomposed into pitch/heading/roll in the AP reference frame.
@@ -506,7 +511,7 @@ namespace KRPC.SpaceCenter.Services
         public float Error {
             get {
                 if (Engaged)
-                    return TotalError (attitudeController.TargetRotation, attitudeController.TargetDirection, !double.IsNaN (attitudeController.TargetRoll));
+                    return TotalError (Controller.TargetRotation, Controller.TargetDirection, !double.IsNaN (Controller.TargetRoll));
                 if (SAS && SASMode != SASMode.StabilityAssist)
                     return Math.Abs (GeometryExtensions.NormAngle (Vector3.Angle (InternalVessel.ReferenceTransform.up, SASTargetDirection ())));
                 throw new InvalidOperationException ("The auto-pilot is not engaged");
@@ -527,8 +532,8 @@ namespace KRPC.SpaceCenter.Services
             get {
                 if (!Engaged)
                     throw new InvalidOperationException ("The auto-pilot is not engaged");
-                return attitudeController.AttitudeErrorTo (
-                    attitudeController.TargetRotation, attitudeController.TargetDirection).ToTuple ();
+                return Controller.AttitudeErrorTo (
+                    Controller.TargetRotation, Controller.TargetDirection).ToTuple ();
             }
         }
 
@@ -573,10 +578,10 @@ namespace KRPC.SpaceCenter.Services
             get {
                 if (!Engaged)
                     throw new InvalidOperationException ("The auto-pilot is not engaged");
-                if (double.IsNaN (attitudeController.TargetRoll))
+                if (double.IsNaN (Controller.TargetRoll))
                     throw new InvalidOperationException ("No target roll has been set");
-                return (float)attitudeController.RollErrorTo (
-                    attitudeController.TargetRotation, attitudeController.TargetDirection);
+                return (float)Controller.RollErrorTo (
+                    Controller.TargetRotation, Controller.TargetDirection);
             }
         }
 
@@ -593,7 +598,7 @@ namespace KRPC.SpaceCenter.Services
             get {
                 if (!Engaged)
                     throw new InvalidOperationException ("The auto-pilot is not engaged");
-                return TotalError (attitudeController.EffectiveTargetRotation, attitudeController.EffectiveTargetDirection, !double.IsNaN (attitudeController.EffectiveTargetRoll));
+                return TotalError (Controller.EffectiveTargetRotation, Controller.EffectiveTargetDirection, !double.IsNaN (Controller.EffectiveTargetRoll));
             }
         }
 
@@ -610,9 +615,9 @@ namespace KRPC.SpaceCenter.Services
             get {
                 if (!Engaged)
                     throw new InvalidOperationException ("The auto-pilot is not engaged");
-                return attitudeController.AttitudeErrorTo (
-                    attitudeController.EffectiveTargetRotation,
-                    attitudeController.EffectiveTargetDirection).ToTuple ();
+                return Controller.AttitudeErrorTo (
+                    Controller.EffectiveTargetRotation,
+                    Controller.EffectiveTargetDirection).ToTuple ();
             }
         }
 
@@ -656,10 +661,10 @@ namespace KRPC.SpaceCenter.Services
             get {
                 if (!Engaged)
                     throw new InvalidOperationException ("The auto-pilot is not engaged");
-                if (double.IsNaN (attitudeController.EffectiveTargetRoll))
+                if (double.IsNaN (Controller.EffectiveTargetRoll))
                     throw new InvalidOperationException ("No target roll has been set");
-                return (float)attitudeController.RollErrorTo (
-                    attitudeController.EffectiveTargetRotation, attitudeController.EffectiveTargetDirection);
+                return (float)Controller.RollErrorTo (
+                    Controller.EffectiveTargetRotation, Controller.EffectiveTargetDirection);
             }
         }
 
@@ -669,8 +674,8 @@ namespace KRPC.SpaceCenter.Services
         /// </summary>
         [KRPCProperty]
         public double RollStartAngle {
-            get { return attitudeController.RollStartAngle; }
-            set { attitudeController.RollStartAngle = value; }
+            get { return Controller.RollStartAngle; }
+            set { Controller.RollStartAngle = value; }
         }
 
         /// <summary>
@@ -680,8 +685,8 @@ namespace KRPC.SpaceCenter.Services
         /// </summary>
         [KRPCProperty]
         public double RollEngageAngle {
-            get { return attitudeController.RollEngageAngle; }
-            set { attitudeController.RollEngageAngle = value; }
+            get { return Controller.RollEngageAngle; }
+            set { Controller.RollEngageAngle = value; }
         }
 
         /// <summary>
@@ -692,8 +697,8 @@ namespace KRPC.SpaceCenter.Services
         /// </summary>
         [KRPCProperty]
         public Tuple3 MaxAngularVelocity {
-            get { return attitudeController.MaxAngularVelocity.ToTuple (); }
-            set { attitudeController.MaxAngularVelocity = value.ToVector (); }
+            get { return Controller.MaxAngularVelocity.ToTuple (); }
+            set { Controller.MaxAngularVelocity = value.ToVector (); }
         }
 
         /// <summary>
@@ -705,8 +710,8 @@ namespace KRPC.SpaceCenter.Services
         /// </summary>
         [KRPCProperty]
         public double PitchYawAttenuationAngle {
-            get { return attitudeController.PitchYawAttenuationAngle; }
-            set { attitudeController.PitchYawAttenuationAngle = value; }
+            get { return Controller.PitchYawAttenuationAngle; }
+            set { Controller.PitchYawAttenuationAngle = value; }
         }
 
         /// <summary>
@@ -717,8 +722,8 @@ namespace KRPC.SpaceCenter.Services
         /// </summary>
         [KRPCProperty]
         public double RollAttenuationAngle {
-            get { return attitudeController.RollAttenuationAngle; }
-            set { attitudeController.RollAttenuationAngle = value; }
+            get { return Controller.RollAttenuationAngle; }
+            set { Controller.RollAttenuationAngle = value; }
         }
 
         /// <summary>
@@ -728,8 +733,8 @@ namespace KRPC.SpaceCenter.Services
         /// </summary>
         [KRPCProperty]
         public bool AutoTune {
-            get { return attitudeController.AutoTune; }
-            set { attitudeController.AutoTune = value; }
+            get { return Controller.AutoTune; }
+            set { Controller.AutoTune = value; }
         }
 
         /// <summary>
@@ -739,8 +744,8 @@ namespace KRPC.SpaceCenter.Services
         /// </summary>
         [KRPCProperty]
         public Tuple3 TimeToPeak {
-            get { return attitudeController.TimeToPeak.ToTuple (); }
-            set { attitudeController.TimeToPeak = value.ToVector (); }
+            get { return Controller.TimeToPeak.ToTuple (); }
+            set { Controller.TimeToPeak = value.ToVector (); }
         }
 
         /// <summary>
@@ -752,8 +757,8 @@ namespace KRPC.SpaceCenter.Services
         /// </summary>
         [KRPCProperty]
         public double SoftStartTime {
-            get { return attitudeController.SoftStartTime; }
-            set { attitudeController.SoftStartTime = value; }
+            get { return Controller.SoftStartTime; }
+            set { Controller.SoftStartTime = value; }
         }
 
         /// <summary>
@@ -767,8 +772,8 @@ namespace KRPC.SpaceCenter.Services
         /// </summary>
         [KRPCProperty]
         public double TargetSmoothingTime {
-            get { return attitudeController.TargetSmoothingTime; }
-            set { attitudeController.TargetSmoothingTime = value; }
+            get { return Controller.TargetSmoothingTime; }
+            set { Controller.TargetSmoothingTime = value; }
         }
 
         /// <summary>
@@ -778,8 +783,8 @@ namespace KRPC.SpaceCenter.Services
         /// </summary>
         [KRPCProperty]
         public Tuple3 Overshoot {
-            get { return attitudeController.Overshoot.ToTuple (); }
-            set { attitudeController.Overshoot = value.ToVector (); }
+            get { return Controller.Overshoot.ToTuple (); }
+            set { Controller.Overshoot = value.ToVector (); }
         }
 
         /// <summary>
@@ -792,13 +797,13 @@ namespace KRPC.SpaceCenter.Services
         [KRPCProperty]
         public Tuple3 PitchPIDGains {
             get {
-                var pid = attitudeController.PitchPID;
+                var pid = Controller.PitchPID;
                 return new Tuple3 (pid.Kp, pid.Ki, pid.Kd);
             }
             set {
                 if (value == null)
                     throw new ArgumentNullException (nameof (PitchPIDGains));
-                attitudeController.PitchPID.SetParameters (value.Item1, value.Item2, value.Item3);
+                Controller.PitchPID.SetParameters (value.Item1, value.Item2, value.Item3);
             }
         }
 
@@ -812,13 +817,13 @@ namespace KRPC.SpaceCenter.Services
         [KRPCProperty]
         public Tuple3 RollPIDGains {
             get {
-                var pid = attitudeController.RollPID;
+                var pid = Controller.RollPID;
                 return new Tuple3 (pid.Kp, pid.Ki, pid.Kd);
             }
             set {
                 if (value == null)
                     throw new ArgumentNullException (nameof (RollPIDGains));
-                attitudeController.RollPID.SetParameters (value.Item1, value.Item2, value.Item3);
+                Controller.RollPID.SetParameters (value.Item1, value.Item2, value.Item3);
             }
         }
 
@@ -832,13 +837,13 @@ namespace KRPC.SpaceCenter.Services
         [KRPCProperty]
         public Tuple3 YawPIDGains {
             get {
-                var pid = attitudeController.YawPID;
+                var pid = Controller.YawPID;
                 return new Tuple3 (pid.Kp, pid.Ki, pid.Kd);
             }
             set {
                 if (value == null)
                     throw new ArgumentNullException (nameof (YawPIDGains));
-                attitudeController.YawPID.SetParameters (value.Item1, value.Item2, value.Item3);
+                Controller.YawPID.SetParameters (value.Item1, value.Item2, value.Item3);
             }
         }
 
@@ -856,8 +861,8 @@ namespace KRPC.SpaceCenter.Services
         /// </summary>
         [KRPCProperty]
         public RateFilterMode PitchYawRateFilterMode {
-            get { return attitudeController.PitchYawRateFilterMode; }
-            set { attitudeController.PitchYawRateFilterMode = value; }
+            get { return Controller.PitchYawRateFilterMode; }
+            set { Controller.PitchYawRateFilterMode = value; }
         }
 
         /// <summary>
@@ -868,8 +873,8 @@ namespace KRPC.SpaceCenter.Services
         /// </summary>
         [KRPCProperty]
         public RateFilterMode RollRateFilterMode {
-            get { return attitudeController.RollRateFilterMode; }
-            set { attitudeController.RollRateFilterMode = value; }
+            get { return Controller.RollRateFilterMode; }
+            set { Controller.RollRateFilterMode = value; }
         }
 
         /// <summary>
@@ -880,8 +885,8 @@ namespace KRPC.SpaceCenter.Services
         /// </summary>
         [KRPCProperty]
         public double PitchYawOscillationFrequency {
-            get { return attitudeController.PitchYawOscillationFrequency; }
-            set { attitudeController.PitchYawOscillationFrequency = value; }
+            get { return Controller.PitchYawOscillationFrequency; }
+            set { Controller.PitchYawOscillationFrequency = value; }
         }
 
         /// <summary>
@@ -890,8 +895,8 @@ namespace KRPC.SpaceCenter.Services
         /// </summary>
         [KRPCProperty]
         public double RollOscillationFrequency {
-            get { return attitudeController.RollOscillationFrequency; }
-            set { attitudeController.RollOscillationFrequency = value; }
+            get { return Controller.RollOscillationFrequency; }
+            set { Controller.RollOscillationFrequency = value; }
         }
 
         /// <summary>
@@ -902,8 +907,8 @@ namespace KRPC.SpaceCenter.Services
         /// </summary>
         [KRPCProperty]
         public double OscillationNotchQ {
-            get { return attitudeController.OscillationNotchQ; }
-            set { attitudeController.OscillationNotchQ = value; }
+            get { return Controller.OscillationNotchQ; }
+            set { Controller.OscillationNotchQ = value; }
         }
 
         /// <summary>
@@ -916,8 +921,8 @@ namespace KRPC.SpaceCenter.Services
         /// </summary>
         [KRPCProperty]
         public MitigationMode OscillationBandwidthFloorMode {
-            get { return attitudeController.BandwidthFloorMode; }
-            set { attitudeController.BandwidthFloorMode = value; }
+            get { return Controller.BandwidthFloorMode; }
+            set { Controller.BandwidthFloorMode = value; }
         }
 
         /// <summary>
@@ -928,8 +933,8 @@ namespace KRPC.SpaceCenter.Services
         /// </summary>
         [KRPCProperty]
         public double OscillationBandwidthFloor {
-            get { return attitudeController.OscillationBandwidthFloor; }
-            set { attitudeController.OscillationBandwidthFloor = value; }
+            get { return Controller.OscillationBandwidthFloor; }
+            set { Controller.OscillationBandwidthFloor = value; }
         }
 
         /// <summary>
@@ -941,8 +946,8 @@ namespace KRPC.SpaceCenter.Services
         /// </summary>
         [KRPCProperty]
         public MitigationMode OscillationFeedforwardMode {
-            get { return attitudeController.FeedforwardMode; }
-            set { attitudeController.FeedforwardMode = value; }
+            get { return Controller.FeedforwardMode; }
+            set { Controller.FeedforwardMode = value; }
         }
 
         /// <summary>
@@ -955,8 +960,8 @@ namespace KRPC.SpaceCenter.Services
         /// </summary>
         [KRPCProperty]
         public MitigationMode OscillationOutputFilterMode {
-            get { return attitudeController.OutputFilterMode; }
-            set { attitudeController.OutputFilterMode = value; }
+            get { return Controller.OutputFilterMode; }
+            set { Controller.OutputFilterMode = value; }
         }
 
         /// <summary>
@@ -966,7 +971,7 @@ namespace KRPC.SpaceCenter.Services
         /// </summary>
         [KRPCProperty]
         public double PitchYawControlOscillation {
-            get { return attitudeController.PitchYawControlOscillation; }
+            get { return Controller.PitchYawControlOscillation; }
         }
 
         /// <summary>
@@ -976,7 +981,7 @@ namespace KRPC.SpaceCenter.Services
         /// </summary>
         [KRPCProperty]
         public double RollControlOscillation {
-            get { return attitudeController.RollControlOscillation; }
+            get { return Controller.RollControlOscillation; }
         }
 
         /// <summary>
@@ -986,7 +991,7 @@ namespace KRPC.SpaceCenter.Services
         /// </summary>
         [KRPCProperty]
         public Tuple3 OscillationLevel {
-            get { return attitudeController.OscillationLevel.ToTuple (); }
+            get { return Controller.OscillationLevel.ToTuple (); }
         }
 
         /// <summary>
@@ -996,7 +1001,7 @@ namespace KRPC.SpaceCenter.Services
         /// </summary>
         [KRPCProperty]
         public bool PitchYawOscillationLatched {
-            get { return attitudeController.PitchYawOscillationLatched; }
+            get { return Controller.PitchYawOscillationLatched; }
         }
 
         /// <summary>
@@ -1005,7 +1010,7 @@ namespace KRPC.SpaceCenter.Services
         /// </summary>
         [KRPCProperty]
         public bool RollOscillationLatched {
-            get { return attitudeController.RollOscillationLatched; }
+            get { return Controller.RollOscillationLatched; }
         }
 
         /// <summary>
@@ -1015,7 +1020,7 @@ namespace KRPC.SpaceCenter.Services
         /// </summary>
         [KRPCProperty]
         public double PitchYawOscillationDetectedFrequency {
-            get { return attitudeController.PitchYawOscillationDetectedFrequency; }
+            get { return Controller.PitchYawOscillationDetectedFrequency; }
         }
 
         /// <summary>
@@ -1025,7 +1030,7 @@ namespace KRPC.SpaceCenter.Services
         /// </summary>
         [KRPCProperty]
         public double RollOscillationDetectedFrequency {
-            get { return attitudeController.RollOscillationDetectedFrequency; }
+            get { return Controller.RollOscillationDetectedFrequency; }
         }
 
         /// <summary>
@@ -1042,8 +1047,8 @@ namespace KRPC.SpaceCenter.Services
         /// </summary>
         [KRPCProperty]
         public bool DiagnosticLogging {
-            get { return attitudeController.DiagnosticLogging; }
-            set { attitudeController.DiagnosticLogging = value; }
+            get { return Controller.DiagnosticLogging; }
+            set { Controller.DiagnosticLogging = value; }
         }
 
         /// <summary>
@@ -1056,14 +1061,14 @@ namespace KRPC.SpaceCenter.Services
         /// </summary>
         [KRPCProperty]
         public string DiagnosticLog {
-            get { return attitudeController.GetDiagnosticLog (); }
+            get { return Controller.GetDiagnosticLog (); }
         }
 
         /// <summary>
         /// Measured angular velocity (raw, roll-invariant frame, rad/s) for the in-game info window.
         /// </summary>
         internal Tuple3 MeasuredAngularVelocity {
-            get { return attitudeController.MeasuredAngularVelocity.ToTuple (); }
+            get { return Controller.MeasuredAngularVelocity.ToTuple (); }
         }
 
         /// <summary>
@@ -1071,14 +1076,14 @@ namespace KRPC.SpaceCenter.Services
         /// in-game info window.
         /// </summary>
         internal Tuple3 TargetAngularVelocity {
-            get { return attitudeController.TargetAngularVelocity.ToTuple (); }
+            get { return Controller.TargetAngularVelocity.ToTuple (); }
         }
 
         /// <summary>
         /// Per-axis hold-gated mitigation weight in [0,1] for the in-game info window.
         /// </summary>
         internal Tuple3 MitigationLevel {
-            get { return attitudeController.MitigationLevel.ToTuple (); }
+            get { return Controller.MitigationLevel.ToTuple (); }
         }
 
         /// <summary>
@@ -1086,7 +1091,7 @@ namespace KRPC.SpaceCenter.Services
         /// automatically, for the in-game info window's envelope-readout colouring.
         /// </summary>
         internal double OscillationControlThreshold {
-            get { return attitudeController.OscillationControlThreshold; }
+            get { return Controller.OscillationControlThreshold; }
         }
 
         /// <summary>
@@ -1102,7 +1107,7 @@ namespace KRPC.SpaceCenter.Services
         /// info window (1 = holding, 0 = slewing).
         /// </summary>
         internal double PitchYawHoldFactor {
-            get { return attitudeController.PitchYawHoldFactor; }
+            get { return Controller.PitchYawHoldFactor; }
         }
 
         /// <summary>
@@ -1110,35 +1115,35 @@ namespace KRPC.SpaceCenter.Services
         /// for the in-game info window.
         /// </summary>
         internal double RollHoldFactor {
-            get { return attitudeController.RollHoldFactor; }
+            get { return Controller.RollHoldFactor; }
         }
 
         /// <summary>
         /// Per-axis latch (suppression) ramp in [0,1] for the in-game info window.
         /// </summary>
         internal Tuple3 SuppressionRamp {
-            get { return attitudeController.SuppressionRamp.ToTuple (); }
+            get { return Controller.SuppressionRamp.ToTuple (); }
         }
 
         /// <summary>
         /// Per-axis oscillation-control back-off in [0,1] for the in-game info window.
         /// </summary>
         internal Tuple3 OscillationBackoff {
-            get { return attitudeController.OscillationBackoff.ToTuple (); }
+            get { return Controller.OscillationBackoff.ToTuple (); }
         }
 
         /// <summary>
         /// Per-axis applied feedforward-cut fraction in [0,1] for the in-game info window.
         /// </summary>
         internal Tuple3 FeedforwardCut {
-            get { return attitudeController.FeedforwardCut.ToTuple (); }
+            get { return Controller.FeedforwardCut.ToTuple (); }
         }
 
         /// <summary>
         /// Per-axis output-filter blend weight in [0,1] for the in-game info window.
         /// </summary>
         internal Tuple3 OutputFilterWeight {
-            get { return attitudeController.OutputFilterWeight.ToTuple (); }
+            get { return Controller.OutputFilterWeight.ToTuple (); }
         }
 
         /// <summary>
@@ -1147,14 +1152,14 @@ namespace KRPC.SpaceCenter.Services
         /// </summary>
         internal int ActiveSuppressionTool (int axis)
         {
-            return attitudeController.ActiveSuppressionTool (axis);
+            return Controller.ActiveSuppressionTool (axis);
         }
 
         /// <summary>
         /// The oscillation level at which an axis latches as flexible, for the in-game info window.
         /// </summary>
         internal double OscillationLatchThreshold {
-            get { return attitudeController.OscillationLatchThreshold; }
+            get { return Controller.OscillationLatchThreshold; }
         }
 
         /// <summary>

--- a/service/SpaceCenter/test/test_autopilot.py
+++ b/service/SpaceCenter/test/test_autopilot.py
@@ -2202,5 +2202,74 @@ class TestAutoPilotOtherVessel(krpctest.TestCase):
         ap.engaged = False
 
 
+class TestAutoPilotRevertToLaunch(krpctest.TestCase):
+    # Regression for the auto-pilot no longer engaging after a Revert to Launch. A client
+    # that keeps its auto-pilot handle across the revert (a persistent connection, or a
+    # script re-run without reconnecting) must be able to re-engage and actually control
+    # the vessel — previously the handle pointed at an orphaned controller that the
+    # per-tick pilot loop never drove, so the vessel was left uncontrolled until a game
+    # restart.
+
+    @classmethod
+    def setUpClass(cls):
+        cls.new_save()
+        cls.remove_other_vessels()
+        cls.launch_vessel_from_vab("AutoPilot")
+
+    def wait_for_flight(self):
+        conn = self.connect()
+
+        def in_flight():
+            try:
+                return (
+                    conn.krpc.game_scene == conn.krpc.GameScene.flight
+                    and conn.space_center.active_vessel is not None
+                    and conn.space_center.active_vessel.parts.root is not None
+                )
+            except RuntimeError:
+                return False
+
+        self.wait_until(in_flight, timeout=60, message="flight scene after revert")
+
+    def assert_pilot_loop_drives(self, auto_pilot, vessel):
+        # An engaged auto-pilot that the per-tick pilot loop is actually driving forces the
+        # stock SAS action group off every physics tick. Enabling SAS and watching it clear
+        # is a ground-independent signal that the engaged handle is wired to the vessel's
+        # live controller — a revert leaves the craft on the launch pad, where it cannot be
+        # slewed to a target, so this checks the drive path rather than actual rotation.
+        auto_pilot.reference_frame = vessel.surface_reference_frame
+        auto_pilot.target_pitch_and_heading(0, 90)
+        vessel.control.sas = True
+        auto_pilot.engaged = True
+        self.assertTrue(auto_pilot.engaged)
+        self.wait_until(
+            lambda: not vessel.control.sas,
+            timeout=5,
+            message="the auto-pilot to hold SAS off",
+        )
+
+    def test_reengage_after_revert_to_launch(self):
+        space_center = self.connect().space_center
+        vessel = space_center.active_vessel
+        auto_pilot = vessel.auto_pilot
+
+        # The pilot loop drives the vessel before the revert.
+        self.assert_pilot_loop_drives(auto_pilot, vessel)
+
+        # Revert to launch with the auto-pilot still engaged, as the bug report describes.
+        self.assertTrue(space_center.can_revert_to_launch)
+        space_center.revert_to_launch()
+        self.wait_for_flight()
+
+        # Reuse the same auto-pilot handle after the scene reload. Pre-fix the handle
+        # pointed at a controller orphaned from the live per-vessel registry, so it
+        # reported engaged but the pilot loop never drove the recreated vessel (SAS was
+        # never forced off) until the game was restarted.
+        space_center = self.connect().space_center
+        vessel = space_center.active_vessel
+        self.assert_pilot_loop_drives(auto_pilot, vessel)
+        auto_pilot.engaged = False
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
The auto-pilot stopped working after a "Revert to Launch": with it engaged, reverting left it unable to drive the vessel, and it would not re-engage (shown greyed out) when the script was re-run, until the game was restarted.

**Root cause.** `AutoPilot` cached its `AttitudeController` at construction — the only piece of its state not resolved live by vessel id (everything else goes through `InternalVessel`). The controllers live in a static per-vessel registry that is recreated when the flight scene reloads. A client that keeps its auto-pilot object across the revert — the usual pattern, set once at the top of a script — keeps reusing the same server-side object, now pointing at a controller orphaned from the recreated registry: `Engaged` is set on the orphan, but the per-tick pilot loop consults the live registry and never drives the vessel. Only restarting the game, which drops the connection and its cached objects, recovered it.

**Fix.** Resolve the controller live from the registry on each access, like `InternalVessel`, so an auto-pilot object re-binds to the current controller after a reload. Also tear down per-vessel pilot state on `onVesselDestroy` — detach the fly-by-wire callback, revoke any RemoteTech sanctioned pilot, and drop the vessel's registry entries — instead of relying only on the wholesale clear at scene teardown, which left delegates bound to dead vessels.

**Testing.** Adds `TestAutoPilotRevertToLaunch`: it engages the auto-pilot, reverts to launch, and reuses the same auto-pilot object to confirm the pilot loop drives the recreated vessel. A reverted craft sits on the launch pad and cannot be slewed to a target, so the test relies on a driven auto-pilot forcing the SAS action group off every tick. Verified failing before the fix and passing after, with the existing auto-pilot tests still passing.
