### PR TITLE
Bazel run test targets

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -196,6 +196,20 @@ test_suite(
     ],
 )
 
+# The tests that need the game, which //:test does not cover:
+# `bazel run //:test-ingame -- [pytest args]` runs them, launching the game as needed, and
+# `bazel run //:run-ksp` starts the game on its own, to run tests against without
+# restarting it each time.
+alias(
+    name = "test-ingame",
+    actual = "//tools/krpctest:test-ingame",
+)
+
+alias(
+    name = "run-ksp",
+    actual = "//tools/krpctest:run-ksp",
+)
+
 test_suite(
     name = "lint",
     tests = [

--- a/Development-Guide.md
+++ b/Development-Guide.md
@@ -97,8 +97,8 @@ automatically.
 
 To run the **integration tests** (see "Running the Tests" below) you do need a real copy of the
 game, since those launch KSP. Point the test tooling at it by setting the `KSP_DIR` environment
-variable to the KSP install directory — the `krpc-install`, `krpc-run-ksp` and `pytest` commands all
-pick it up (and also accept an equivalent `--ksp-dir` option). For example:
+variable to the KSP install directory — every command below picks it up (and they also accept an
+equivalent `--ksp-dir` option). For example:
 ```
 export KSP_DIR="$HOME/.local/share/Steam/steamapps/common/Kerbal Space Program"
 ```
@@ -202,26 +202,42 @@ Note: these tests do not require the game to be running. They test the various c
 using the game. For communication tests, a tool called "TestServer" is used. This runs a version of
 the server plugin without needing to launch the game.
 
-kRPC also includes a suite of tests that test interaction with the KSP. This requires the game to be
-running. To run these tests:
- * First install the python client package and the `krpctest` package. This can be done using:
-   ```
-   bazel build //client/python //tools/krpctest
-   pip install --upgrade bazel-bin/client/python/krpc-<version>.tar.gz
-   pip install --upgrade bazel-bin/tools/krpctest/krpctest-<version>.tar.gz
-   ```
-   These python packages are also available from the GitHub releases page. Installing `krpctest`
-   provides the `krpc-install` and `krpc-run-ksp` console scripts, and registers a pytest
-   plugin so the tests run with `pytest`.
- * Then run the tests using `pytest`. With no arguments it runs every
-   `service/*/test` directory. Pass test directories or files, or `-k`, to run a subset. The KSP
-   install is taken from the `KSP_DIR` environment variable (or the `--ksp-dir` option); one of them
-   must be set. KSP is automatically launched (if its not already running) and the required mods are
-   managed automatically.
+kRPC also includes a suite of tests that test interaction with KSP. These need the game, so they
+are not part of `//:test`. Run them with:
+```
+bazel run //:test-ingame
+```
+With no arguments this runs every `service/*/test` directory. Anything after `--` is passed
+through to pytest, so pass test directories or files, or `-k`, to run a subset:
+```
+bazel run //:test-ingame -- service/SpaceCenter/test/test_camera.py -v
+bazel run //:test-ingame -- -k test_camera_mode
+```
+The KSP install is taken from the `KSP_DIR` environment variable (or the `--ksp-dir` option); one
+of them must be set. The mod is built and installed, KSP is launched (if it is not already
+running) and the required mods are managed, all automatically. The test framework and the python
+client are built from the repository too, so your changes to either are picked up by the next run
+with nothing to reinstall.
 
-If the game is already running (via `krpc-run-ksp` - see below) then running `pytest` does not launch
-the game, it just makes use of the existing running game. If the game is not in the expected state (e.g.
-the wrong mods are installed) then the tests will fail.
+To keep the game up across an extended run of test iterations, start it separately in another
+terminal and leave it running:
+```
+bazel run //:run-ksp -- --load-game=krpctest
+```
+Then run the tests against it, telling them not to launch a game of their own:
+```
+bazel run //:test-ingame -- --no-launch service/SpaceCenter/test/test_camera.py -v
+```
+The tests reuse the running game rather than restarting it, and leave it running afterwards. Two
+things to know: a game the tests did not start is never modified, so it must already have the mods
+the tests ask for (which is why the whole suite cannot run this way — it needs a relaunch per mod
+set, and `--no-launch` will fail instead); and if a test run is killed rather than interrupted it
+cannot stop a game it did start, so clean up with `pkill -f KSP.x86_64`.
+
+The `krpctest` and python client packages are also on the GitHub releases page, for testing
+against KSP from outside a checkout of this repository. Installing them with `pip` provides the
+`krpc-install` and `krpc-run-ksp` console scripts, and registers a pytest plugin so the tests run
+with `pytest` directly — the equivalents of the two Bazel targets above.
 
 ## Tools
 
@@ -231,14 +247,20 @@ Included in the project are various tools to aid development.
    - Builds the documentation website and starts a local webserver, rebuilding automatically as you
    edit the sources. A web browser is opened at `http://localhost:8080` once the site is ready; pass
    `-- --no-browser` to skip that, or `-- --port <PORT>` to serve on a different port.
- * `krpc-install`
-   - Console script from the `krpctest` package. It builds the `//:krpc` release archive and the
-   `TestingTools` DLL, and installs them into the GameData directory of the KSP install given by
-   `KSP_DIR` (or `--ksp-dir`). Run it from the repository root.
- * `krpc-run-ksp`
-   - Console script from the `krpctest` package. It uses `krpc-install` to install the mod (as
-   above) and then launches the game. It also pipes the game's log output to the terminal for ease
-   of debugging.
+ * `bazel run //:test-ingame`
+   - Runs the tests that need the game, as described under "Running the Tests" above. Arguments
+   after `--` are passed to pytest.
+ * `bazel run //:run-ksp`
+   - Installs the mod and launches the game, piping its log output to the terminal for ease of
+   debugging. `--mods` chooses which third-party mods to install, and the `--load-*` options
+   auto-load a save, switch vessel or launch a craft on startup; pass `-- --help` for the full
+   list.
+ * `krpc-install` and `krpc-run-ksp`
+   - Console scripts from the `krpctest` package, for use outside a checkout of this repository.
+   `krpc-install` builds the `//:krpc` release archive and the `TestingTools` DLL and installs
+   them into the GameData directory of the KSP install given by `KSP_DIR` (or `--ksp-dir`).
+   `krpc-run-ksp` installs the mod that way and then launches the game, and is what
+   `bazel run //:run-ksp` runs.
 
 ## Bazel cheat sheet
 

--- a/tools/krpctest/BUILD.bazel
+++ b/tools/krpctest/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_python//python:defs.bzl", "py_library")
+load("@rules_python//python:defs.bzl", "py_binary", "py_library")
 load("//:config.bzl", "python_version", "version")
 load("//tools/build:python.bzl", "py_lint_test", "py_sdist", "py_test")
 
@@ -21,6 +21,31 @@ genrule(
     srcs = ["//:python_version"],
     outs = ["krpctest/version.py"],
     cmd = 'cp "$<" "$@"',
+)
+
+# Run the integration tests that need the game: `bazel run //:test-ingame -- [pytest args]`.
+# The tests themselves are read from the repository (the runner works there rather than in
+# the runfiles tree), so adding or editing one needs no change here.
+py_binary(
+    name = "test-ingame",
+    srcs = ["run_tests.py"],
+    main = "run_tests.py",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":krpctest_lib",
+        "@pypi//pytest",
+    ],
+)
+
+# Install the mod and run the game: `bazel run //:run-ksp -- [--mods=... --load-*=...]`.
+# This is the module behind the krpc-run-ksp console script, run directly: it takes the
+# repository from BUILD_WORKSPACE_DIRECTORY and runs KSP in KSP_DIR, so it needs no wrapper.
+py_binary(
+    name = "run-ksp",
+    srcs = ["krpctest/run_ksp.py"],
+    main = "krpctest/run_ksp.py",
+    visibility = ["//visibility:public"],
+    deps = [":krpctest_lib"],
 )
 
 py_sdist(

--- a/tools/krpctest/README.md
+++ b/tools/krpctest/README.md
@@ -12,8 +12,10 @@ Installing the package provides:
 - a pytest plugin — so `pytest` discovers and runs the `krpctest.TestCase` tests natively,
   launching and managing KSP automatically.
 
-See the [Development Guide](../../Development-Guide.md) for how to install these packages and run
-the test suite.
+From a checkout of the kRPC repository there is no need to install the package: `bazel run
+//:test-ingame` runs the tests and `bazel run //:run-ksp` runs the game, taking this package and
+the client from the build. See the [Development Guide](../../Development-Guide.md) for both ways
+of running the test suite.
 
 ## TestingTools
 

--- a/tools/krpctest/krpctest/env.py
+++ b/tools/krpctest/krpctest/env.py
@@ -25,9 +25,19 @@ def get_ksp_dir(ksp_dir=None):
 
 
 def get_repo_root():
-    """The repository root, found by walking up from the working directory looking for
-    MODULE.bazel. Tests run from a service's test directory, which is inside the repo,
-    even though KSP_DIR points at a separate KSP install."""
+    """The repository root.
+
+    Under `bazel run`, bazel names the root in BUILD_WORKSPACE_DIRECTORY. Take it from there
+    rather than searching: the process starts in the runfiles tree, which sits under bazel's
+    execroot, and the execroot has a MODULE.bazel of its own that the search below would
+    find first.
+
+    Otherwise, walk up from the working directory looking for MODULE.bazel. Tests run from a
+    service's test directory, which is inside the repo, even though KSP_DIR points at a
+    separate KSP install."""
+    workspace = os.environ.get("BUILD_WORKSPACE_DIRECTORY")
+    if workspace:
+        return workspace
     path = os.getcwd()
     while True:
         if os.path.exists(os.path.join(path, "MODULE.bazel")):

--- a/tools/krpctest/krpctest/game.py
+++ b/tools/krpctest/krpctest/game.py
@@ -198,6 +198,23 @@ def _unsatisfiable_message(required, installed=None):
     )
 
 
+def _run_ksp_command(mods_arg):
+    """The command that starts a game to test against, written the way the reader runs it:
+    the bazel target from a checkout, the console script from an installed package."""
+    if os.environ.get("BUILD_WORKSPACE_DIRECTORY"):
+        prefix = "bazel run //:run-ksp -- "
+    else:
+        prefix = "krpc-run-ksp "
+    return (prefix + "--load-game=krpctest " + mods_arg).strip()
+
+
+def _run_tests_command():
+    """The command that runs the suite, written the way the reader runs it."""
+    if os.environ.get("BUILD_WORKSPACE_DIRECTORY"):
+        return "bazel run //:test-ingame"
+    return "pytest"
+
+
 def _mismatch_message(required, installed):
     parts = []
     missing = sorted(required - installed)
@@ -209,9 +226,9 @@ def _mismatch_message(required, installed):
     suffix = ("--mods=" + ",".join(sorted(required))) if required else "--mods="
     return (
         "The running KSP has the wrong mods (%s). It was not started by the tests, so it "
-        "will not be modified. Restart it with the correct mods, e.g. "
-        "`krpc-run-ksp --load-game=krpctest %s`, or run the suite with "
-        "`pytest`." % ("; ".join(parts), suffix)
+        "will not be modified. Restart it with the correct mods, e.g. `%s`, or run the "
+        "suite with `%s` and let it manage the game."
+        % ("; ".join(parts), _run_ksp_command(suffix), _run_tests_command())
     )
 
 
@@ -245,11 +262,11 @@ def ensure_game(mods=None):
         _stop_ksp()
     elif not _auto_launch_enabled():
         raise RuntimeError(
-            "No kRPC server is reachable and auto-launch is disabled "
-            "(KRPC_AUTO_LAUNCH=0). Start KSP first, e.g. "
-            "`krpc-run-ksp --load-game=krpctest"
-            + ((" --mods=" + ",".join(sorted(required))) if required else "")
-            + "`."
+            "No kRPC server is reachable and auto-launch is disabled (--no-launch or "
+            "KRPC_AUTO_LAUNCH=0). Start KSP first, e.g. `%s`, and wait for it to load."
+            % _run_ksp_command(
+                ("--mods=" + ",".join(sorted(required))) if required else ""
+            )
         )
     # Launch (from cold, or after stopping a wrong-state game we own) and confirm the
     # required mods actually became available before running any tests against it.

--- a/tools/krpctest/krpctest/game.py
+++ b/tools/krpctest/krpctest/game.py
@@ -67,10 +67,10 @@ def _auto_launch_enabled():
     return os.environ.get("KRPC_AUTO_LAUNCH", "1") != "0"
 
 
-def copy_blank_save(name):
+def copy_blank_save(name, ksp_dir=None):
     """Copy the bundled blank save into the KSP install's saves/<name>/persistent.sfs."""
     blank_save = str(files("krpctest").joinpath(name + ".sfs"))
-    save_path = os.path.join(get_ksp_dir(), "saves", name)
+    save_path = os.path.join(get_ksp_dir(ksp_dir), "saves", name)
     if not os.path.exists(save_path):
         os.makedirs(save_path)
     shutil.copy(blank_save, os.path.join(save_path, "persistent.sfs"))

--- a/tools/krpctest/krpctest/pytest_plugin.py
+++ b/tools/krpctest/krpctest/pytest_plugin.py
@@ -1,9 +1,10 @@
 """pytest plugin for the kRPC integration tests.
 
 Registered via the ``pytest11`` entry point (see pyproject.toml), so it loads automatically
-whenever pytest runs with krpctest installed. It adds two small pieces of behaviour:
+whenever pytest runs with krpctest installed. It adds a few small pieces of behaviour:
 
- * a ``--ksp-dir`` option that points the framework at a KSP install, and
+ * a ``--ksp-dir`` option that points the framework at a KSP install,
+ * a ``--no-launch`` option for running against a game started separately, and
  * ordering the collected tests by their required mods so KSP is restarted at most once per
    distinct mod set (stock tests first).
 
@@ -23,6 +24,12 @@ def pytest_addoption(parser):
         metavar="DIR",
         help="path to the KSP install (defaults to $KSP_DIR)",
     )
+    parser.addoption(
+        "--no-launch",
+        action="store_true",
+        default=False,
+        help="require an already-running game rather than launching one",
+    )
 
 
 def pytest_configure(config):
@@ -30,6 +37,12 @@ def pytest_configure(config):
     ksp_dir = config.getoption("--ksp-dir")
     if ksp_dir is not None:
         os.environ["KSP_DIR"] = ksp_dir
+    # Likewise, auto-launch is off when KRPC_AUTO_LAUNCH is 0. Use this when running against
+    # a game started separately: a game that is still loading has no server to connect to
+    # yet, and without it the framework would launch a second game and reinstall the mod
+    # underneath the first.
+    if config.getoption("--no-launch"):
+        os.environ["KRPC_AUTO_LAUNCH"] = "0"
 
 
 def _mods_key(item):

--- a/tools/krpctest/krpctest/run_ksp.py
+++ b/tools/krpctest/krpctest/run_ksp.py
@@ -13,8 +13,10 @@ import os
 import subprocess
 import sys
 import time
+from importlib.resources import files
 
 from krpctest.env import get_ksp_dir
+from krpctest.game import copy_blank_save
 from krpctest.install import MODS, install
 from krpctest.version import __version__
 
@@ -23,6 +25,19 @@ from krpctest.version import __version__
 # cross-platform (Windows/macOS) support.
 _KSP_BINARY = "KSP.x86_64"
 _KSP_LOG = "KSP.log"
+
+
+def _stage_blank_save(name, ksp_dir):
+    """Create the save --load-game asked for, when it is one of the saves bundled with the
+    package (krpctest, krpctest_career) and the KSP install does not have it yet. The test
+    framework stages these when it launches the game itself, so without this a manual run
+    against an install that has never run the tests reaches the main menu with nothing to
+    load. An existing save is left alone: it is the state being iterated on."""
+    if not files("krpctest").joinpath(name + ".sfs").is_file():
+        return
+    if os.path.exists(os.path.join(ksp_dir, "saves", name)):
+        return
+    copy_blank_save(name, ksp_dir)
 
 
 def _terminate(proc):
@@ -170,6 +185,8 @@ def main():
 
     ksp_dir = get_ksp_dir(args.ksp_dir)
     install(mods=mods, ksp_dir=ksp_dir)
+    if args.load_game is not None:
+        _stage_blank_save(args.load_game, ksp_dir)
 
     proc = subprocess.Popen(  # pylint: disable=consider-using-with
         [os.path.join(ksp_dir, _KSP_BINARY), *ksp_args], cwd=ksp_dir

--- a/tools/krpctest/run_tests.py
+++ b/tools/krpctest/run_tests.py
@@ -1,0 +1,41 @@
+"""Run the kRPC integration tests that need the game: `bazel run //:test-ingame`.
+
+Arguments are passed straight through to pytest, so
+
+    bazel run //:test-ingame -- service/SpaceCenter/test/test_camera.py -v
+
+behaves like that pytest invocation. With no arguments the whole suite runs, as pytest.ini
+points pytest at every service's test directory.
+
+The mod, the test framework and the generated client stubs are all dependencies of this
+binary, so each run tests the current sources with nothing to install first. KSP itself is
+installed into KSP_DIR, launched and stopped by the framework (see krpctest.game).
+"""
+
+import os
+import sys
+
+import pytest
+
+
+def main():
+    """Run pytest against the tests in the repository."""
+    # Under `bazel run` the process starts in the runfiles tree. Work in the directory bazel
+    # was invoked from instead, so that test paths given on the command line mean what they
+    # would for a bare pytest, and so that the framework's nested bazel calls and the tests'
+    # craft fixtures resolve against the repository rather than a tree of symlinks. pytest
+    # finds pytest.ini by searching upwards, so its settings apply from any subdirectory.
+    workspace = os.environ.get("BUILD_WORKSPACE_DIRECTORY")
+    if not workspace:
+        sys.exit("This tool must be run via `bazel run //:test-ingame`.")
+    os.chdir(os.environ.get("BUILD_WORKING_DIRECTORY", workspace))
+
+    # krpctest is a library here rather than an installed distribution, so it has no
+    # pytest11 entry point for pytest to discover the plugin through; name it explicitly.
+    # This belongs here and not in pytest.ini, which is also read when krpctest is
+    # installed -- pytest would then register the plugin twice and fail.
+    return pytest.main(["-p", "krpctest.pytest_plugin", *sys.argv[1:]])
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Running the in-game integration tests previously meant building the `krpctest` and python client sdists, `pip install`ing them, and then invoking `pytest` / `krpc-run-ksp`. That is a manual step that has to be repeated whenever either package changes. This adds Bazel run targets so the tests and the game can be driven straight from a checkout, with the mod, the test framework and the generated client stubs all built from the current sources on each run and nothing to reinstall.

**New targets.**

 * `bazel run //:test-ingame -- [pytest args]` runs the tests that need the game (the ones `//:test` does not cover). Arguments after `--` pass through to pytest, so a directory, file, or `-k` selects a subset; with none, the whole suite runs.
 * `bazel run //:run-ksp -- [--mods=... --load-*=...]` installs the mod and launches the game, for iterating against a game left running across many test runs.

**Repository root under `bazel run`.** Both entry points now take the repository from `BUILD_WORKSPACE_DIRECTORY` rather than searching upwards for `MODULE.bazel` — under `bazel run` the process starts in the runfiles tree beneath the execroot, which has a `MODULE.bazel` of its own that the search would find first. `run_tests.py` also `chdir`s to `BUILD_WORKING_DIRECTORY` so command-line test paths and craft fixtures resolve against the repository, and registers the pytest plugin explicitly (the in-tree library has no `pytest11` entry point to discover it through).

**`--no-launch`.** A new pytest option (setting `KRPC_AUTO_LAUNCH=0`) makes a run reuse a game started separately with `//:run-ksp` instead of launching one of its own, so the game stays up across repeated iterations. `krpc-run-ksp` now also stages the bundled blank save when `--load-game` names one the install does not have yet, matching what the framework does when it launches the game itself.

**Docs.** The Development Guide, the `krpctest` README and the tools list now present the Bazel targets as the primary way to run the tests, with the `pip`-installed `krpc-install` / `krpc-run-ksp` console scripts documented as the equivalent for use outside a checkout.
