### PR TITLE
Add per-part aerodynamic drag and lift

### DIFF
--- a/doc/order.txt
+++ b/doc/order.txt
@@ -684,6 +684,8 @@ SpaceCenter.Part.BoundingBox
 SpaceCenter.Part.Direction
 SpaceCenter.Part.Velocity
 SpaceCenter.Part.Rotation
+SpaceCenter.Part.Lift
+SpaceCenter.Part.Drag
 SpaceCenter.Part.MomentOfInertia
 SpaceCenter.Part.InertiaTensor
 SpaceCenter.Part.ReferenceFrame

--- a/service/SpaceCenter/CHANGES.txt
+++ b/service/SpaceCenter/CHANGES.txt
@@ -18,6 +18,8 @@ v0.6.0
  * Fix waypoint mean altitude not including bedrock height (#801)
  * Add Flight.SurfacePrograde and Flight.SurfaceRetrograde direction vectors (surface-relative velocity direction, matching navball surface mode) (#582)
  * Add Flight.SimulateAerodynamicTorqueAt (#825)
+ * Add Part.Drag and Part.Lift returning the aerodynamic drag and lift forces acting on an
+   individual part (#459)
  * Add Control.AeroSurfaces to enable/disable pitch, yaw and roll on all control surfaces (#827)
  * Add Engine.Flameout (#311)
  * Add Control.EngineGimbals to enable/disable gimbal on all gimballed engines (#827)

--- a/service/SpaceCenter/src/Services/Parts/Part.cs
+++ b/service/SpaceCenter/src/Services/Parts/Part.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using CompoundParts;
 using KRPC.Service.Attributes;
 using KRPC.SpaceCenter.ExtensionMethods;
+using KRPC.SpaceCenter.ExternalAPI;
 using KRPC.Utils;
 using UnityEngine;
 using Tuple3 = System.Tuple<double, double, double>;
@@ -837,6 +838,93 @@ namespace KRPC.SpaceCenter.Services.Parts
             if (ReferenceEquals (referenceFrame, null))
                 throw new ArgumentNullException (nameof (referenceFrame));
             return referenceFrame.RotationFromWorldSpace (InternalPart.transform.rotation).ToTuple ();
+        }
+
+        /// <summary>
+        /// The aerodynamic <a href="https://en.wikipedia.org/wiki/Aerodynamic_force">lift</a>
+        /// currently acting on the part.
+        /// </summary>
+        /// <returns>A vector pointing in the direction that the force acts,
+        /// with its magnitude equal to the strength of the force in Newtons.</returns>
+        /// <param name="referenceFrame">The reference frame that the returned
+        /// vector is in.</param>
+        /// <remarks>
+        /// Not available when the Ferram Aerospace Research mod is installed.
+        /// </remarks>
+        [KRPCMethod]
+        public Tuple3 Lift (ReferenceFrame referenceFrame)
+        {
+            if (ReferenceEquals (referenceFrame, null))
+                throw new ArgumentNullException (nameof (referenceFrame));
+            CheckNoFAR ();
+            return referenceFrame.DirectionFromWorldSpace (WorldLift).ToTuple ();
+        }
+
+        /// <summary>
+        /// The aerodynamic <a href="https://en.wikipedia.org/wiki/Aerodynamic_force">drag</a>
+        /// currently acting on the part.
+        /// </summary>
+        /// <returns>A vector pointing in the direction that the force acts,
+        /// with its magnitude equal to the strength of the force in Newtons.</returns>
+        /// <param name="referenceFrame">The reference frame that the returned
+        /// vector is in.</param>
+        /// <remarks>
+        /// Not available when the Ferram Aerospace Research mod is installed.
+        /// </remarks>
+        [KRPCMethod]
+        public Tuple3 Drag (ReferenceFrame referenceFrame)
+        {
+            if (ReferenceEquals (referenceFrame, null))
+                throw new ArgumentNullException (nameof (referenceFrame));
+            CheckNoFAR ();
+            return referenceFrame.DirectionFromWorldSpace (WorldDrag).ToTuple ();
+        }
+
+        /// <summary>
+        /// The lift force acting on the part, in world space, in Newtons.
+        /// </summary>
+        Vector3d WorldLift {
+            get {
+                var part = InternalPart;
+                Vector3d lift = Vector3d.zero;
+                if (!part.hasLiftModule) {
+                    Vector3 bodyLift = part.transform.rotation * (part.bodyLiftScalar * part.DragCubes.LiftForce);
+                    bodyLift = Vector3.ProjectOnPlane (bodyLift, -part.dragVectorDir);
+                    lift += bodyLift;
+                }
+                foreach (var module in part.Modules) {
+                    var wing = module as ModuleLiftingSurface;
+                    if (wing != null)
+                        lift += wing.liftForce;
+                }
+                return lift * 1000f;
+            }
+        }
+
+        /// <summary>
+        /// The drag force acting on the part, in world space, in Newtons.
+        /// </summary>
+        Vector3d WorldDrag {
+            get {
+                var part = InternalPart;
+                Vector3d drag = -(Vector3d)part.dragVectorDir * part.dragScalar;
+                foreach (var module in part.Modules) {
+                    var wing = module as ModuleLiftingSurface;
+                    if (wing != null)
+                        drag += wing.dragForce;
+                }
+                return drag * 1000f;
+            }
+        }
+
+        /// <summary>
+        /// Throws if the Ferram Aerospace Research mod is installed, as it replaces
+        /// the stock aerodynamic model these forces are read from.
+        /// </summary>
+        static void CheckNoFAR ()
+        {
+            if (FAR.IsAvailable)
+                throw new InvalidOperationException ("Not available; FAR is installed");
         }
 
         /// <summary>

--- a/service/SpaceCenter/test/test_parts_part.py
+++ b/service/SpaceCenter/test/test_parts_part.py
@@ -46,6 +46,10 @@ class TestPartsPart(krpctest.TestCase):
         self.assertAlmostEqual(2610, part.dry_mass, places=2)
         self.assertFalse(part.shielded)
         self.assertAlmostEqual(0, part.dynamic_pressure, places=3)
+        if not self.far_available:
+            # Stationary on the pad, so no aerodynamic forces act on the part.
+            self.assertAlmostEqual(0, norm(part.drag(part.reference_frame)), places=3)
+            self.assertAlmostEqual(0, norm(part.lift(part.reference_frame)), places=3)
         self.assertEqual(20, part.impact_tolerance)
         self.assertTrue(part.crossfeed)
         self.assertFalse(part.is_fuel_line)


### PR DESCRIPTION
Adds `Part.Drag` and `Part.Lift` to the SpaceCenter service, returning the aerodynamic drag and lift forces acting on an individual part as vectors in a given reference frame, with magnitudes in Newtons.

The forces are read from the stock aerodynamic model the same way `Flight` sums them across the whole vessel: drag from the part's `dragScalar`/`dragVectorDir` plus each `ModuleLiftingSurface`'s drag, and lift from the part's body lift (projected off the drag direction) plus each lifting surface's lift. Because they depend on the stock model, both throw when Ferram Aerospace Research is installed, mirroring how FAR replaces the vessel-level aerodynamic reporting.

**Testing.** Extended `test_parts_part.py` to assert both forces are zero for a part sitting stationary on the pad (skipped when FAR is present).

Fixes #459
