### PR TITLE
Defer camera property writes across a mode switch

### DIFF
--- a/service/SpaceCenter/CHANGES.txt
+++ b/service/SpaceCenter/CHANGES.txt
@@ -2,6 +2,7 @@ v0.6.0
  * Fix Flight.SimulateAerodynamicForceAt ignoring the current deflection of
    aerodynamic control surfaces, including deployed airbrakes (#622)
  * Fix Parachute.Deploy being a silent no-op for RealChute parachutes (#382)
+ * Fix Camera Distance, Pitch, Heading and FoV setters being lost when set during a camera mode switch (#318)
  * Fix Maneuver and ManeuverOrbital reference frame velocity (previously returned zero; now returns the orbital velocity at the node UT)
  * Fix angular velocity for VesselSurface, VesselSurfaceVelocity, CelestialBodyOrbital, Maneuver, ManeuverOrbital, Part, PartCenterOfMass, DockingPort and Thrust reference frames (previously returned zero)
  * Fix ControlSurface.AvailableTorque returning inconsistent signs (ModuleControlSurface negates the roll axis); now normalised to positive/negative torque like other parts

--- a/service/SpaceCenter/src/CameraAddon.cs
+++ b/service/SpaceCenter/src/CameraAddon.cs
@@ -1,0 +1,141 @@
+using System.Collections.Generic;
+using System.Linq;
+using KRPC.SpaceCenter.Services;
+
+namespace KRPC.SpaceCenter
+{
+    /// <summary>
+    /// The camera properties whose writes are deferred across a mode switch.
+    /// </summary>
+    enum CameraProperty
+    {
+        Distance,
+        Pitch,
+        Heading,
+        FoV
+    }
+
+    /// <summary>
+    /// Addon that re-applies camera property writes (distance, pitch, heading, field of
+    /// view) that were issued while the camera was switching mode.
+    /// </summary>
+    /// <remarks>
+    /// A camera mode switch (Flight/IVA/Map) plays a fade that takes a second or two
+    /// before the destination camera is live and settled. A write issued in that window
+    /// is lost: while the destination camera settles it drives its own distance/pitch/
+    /// heading each frame, snapping back to a default and overwriting anything written
+    /// earlier. KSP exposes no "transition in progress" flag - the manager's mode is set
+    /// synchronously, ahead of the visible fade - so rather than detect the transition,
+    /// each pending write is re-applied whenever the live value has drifted away from it,
+    /// and is only cleared once the value has held on its own (without needing to be
+    /// re-applied) for a short settle window. Re-applying keeps the value pinned through
+    /// the transition; the settle check tells when the camera has stopped fighting it.
+    /// This is mode-agnostic and does not depend on the per-transition fade mechanics.
+    /// There is a single global camera in KSP, so the pending writes are held in a static
+    /// table (last writer wins) rather than per client.
+    /// </remarks>
+    [KSPAddon (KSPAddon.Startup.Flight, false)]
+    public sealed class CameraAddon : UnityEngine.MonoBehaviour
+    {
+        sealed class PendingWrite
+        {
+            public CameraMode TargetMode;
+            public float Value;
+            public int FramesLeft;
+            public int SettledFrames;
+        }
+
+        // Consecutive frames the live value must hold on its own (no re-apply needed)
+        // before the write is considered settled and cleared. Long enough to outlast the
+        // brief snap-backs during a transition, short enough to release promptly once the
+        // camera settles. Update runs on the render tick, so this is rendered frames.
+        const int SettleFrames = 30;
+
+        // Overall budget to keep re-applying a write before giving up, comfortably longer
+        // than the longest mode-switch settle. Guards a value the camera never accepts
+        // (e.g. requested out of range) or a target mode that never arrives because the
+        // script switched again, so neither can pin a write forever.
+        const int RetryFrames = 1200;
+
+        static readonly Dictionary<CameraProperty, PendingWrite> pending =
+            new Dictionary<CameraProperty, PendingWrite> ();
+
+        /// <summary>
+        /// Record a camera property write to be re-applied until it takes. A superseding
+        /// write to the same property overwrites the entry, so rapid re-requests cannot
+        /// accumulate.
+        /// </summary>
+        internal static void Request (CameraProperty property, CameraMode mode, float value)
+        {
+            pending [property] = new PendingWrite {
+                TargetMode = mode,
+                Value = value,
+                FramesLeft = RetryFrames,
+                SettledFrames = 0
+            };
+        }
+
+        /// <summary>
+        /// Wake the addon.
+        /// </summary>
+        public void Awake ()
+        {
+            pending.Clear ();
+        }
+
+        /// <summary>
+        /// Destroy the addon.
+        /// </summary>
+        public void OnDestroy ()
+        {
+            pending.Clear ();
+        }
+
+        /// <summary>
+        /// Re-apply pending camera writes. Runs on the render tick, where the flight
+        /// camera updates, rather than in FixedUpdate.
+        /// </summary>
+        public void Update ()
+        {
+            if (pending.Count == 0)
+                return;
+            CameraMode mode;
+            try {
+                mode = Camera.CurrentMode;
+            } catch {
+                // The camera is momentarily in an unknown state; try again next frame.
+                return;
+            }
+            foreach (var property in pending.Keys.ToList ()) {
+                var entry = pending [property];
+                if (mode != entry.TargetMode) {
+                    // Still transitioning, or the script switched to a different mode.
+                    // Keep waiting, but count down so a mode that never arrives cannot
+                    // pin the write forever.
+                    if (--entry.FramesLeft <= 0)
+                        pending.Remove (property);
+                    continue;
+                }
+                try {
+                    // The live value is read before re-applying, so it reflects whether
+                    // the previous frame's write survived the camera's own updates. Once
+                    // it has held on its own for the settle window the camera has stopped
+                    // overwriting it and the write is done; until then, re-apply it.
+                    if (Camera.Converged (property, entry.Value)) {
+                        if (++entry.SettledFrames >= SettleFrames)
+                            pending.Remove (property);
+                    } else {
+                        entry.SettledFrames = 0;
+                        Camera.ApplyRaw (property, entry.Value);
+                    }
+                    if (--entry.FramesLeft <= 0)
+                        pending.Remove (property);
+                } catch {
+                    // The property is not supported in this mode (e.g. distance in IVA);
+                    // stop retrying.
+                    pending.Remove (property);
+                }
+            }
+        }
+    }
+}

--- a/service/SpaceCenter/src/KRPC.SpaceCenter.csproj
+++ b/service/SpaceCenter/src/KRPC.SpaceCenter.csproj
@@ -75,6 +75,7 @@
     <Compile Include="ExtensionMethods\VesselSituationExtensions.cs" />
     <Compile Include="ExtensionMethods\VesselTypeExtensions.cs" />
     <Compile Include="ActuatorControlAddon.cs" />
+    <Compile Include="CameraAddon.cs" />
     <Compile Include="ExternalAPIAddon.cs" />
     <Compile Include="ExternalAPI\AGX.cs" />
     <Compile Include="ExternalAPI\FAR.cs" />

--- a/service/SpaceCenter/src/Services/Camera.cs
+++ b/service/SpaceCenter/src/Services/Camera.cs
@@ -44,14 +44,7 @@ namespace KRPC.SpaceCenter.Services
         [KRPCProperty]
         public CameraMode Mode {
             get {
-                if (MapView.MapIsEnabled)
-                    return CameraMode.Map;
-                var mode = CameraManager.Instance.currentCameraMode;
-                if (mode == CameraManager.CameraMode.Flight)
-                    return FlightCamera.fetch.mode.ToCameraMode ();
-                if (mode == CameraManager.CameraMode.IVA)
-                    return CameraMode.IVA;
-                throw new InvalidOperationException ("Unknown camera mode " + CameraManager.Instance.currentCameraMode);
+                return CurrentMode;
             }
             set {
                 if (value == CameraMode.Map && !MapView.MapIsEnabled)
@@ -85,6 +78,24 @@ namespace KRPC.SpaceCenter.Services
                         break;
                     }
                 }
+            }
+        }
+
+        /// <summary>
+        /// The current mode of the camera, as reported by the game's camera manager.
+        /// Shared with <see cref="CameraAddon"/>, which uses it to tell when a mode
+        /// switch has completed before re-applying a deferred property write.
+        /// </summary>
+        internal static CameraMode CurrentMode {
+            get {
+                if (MapView.MapIsEnabled)
+                    return CameraMode.Map;
+                var mode = CameraManager.Instance.currentCameraMode;
+                if (mode == CameraManager.CameraMode.Flight)
+                    return FlightCamera.fetch.mode.ToCameraMode ();
+                if (mode == CameraManager.CameraMode.IVA)
+                    return CameraMode.IVA;
+                throw new InvalidOperationException ("Unknown camera mode " + CameraManager.Instance.currentCameraMode);
             }
         }
 
@@ -143,36 +154,47 @@ namespace KRPC.SpaceCenter.Services
         [KRPCProperty]
         public float Pitch {
             get {
-                switch (Mode) {
-                case CameraMode.Map:
-                    return PlanetariumCamera.fetch.getPitch ();
-                case CameraMode.IVA:
-                    var camera = InternalCamera.Instance;
-                    return (float) InternalCameraExtensions.GetPitch(camera);
-                default:
-                    return FlightCamera.fetch.getPitch ();
-                }
+                return ReadPitch ();
             }
             set {
-                switch (Mode) {
-                case CameraMode.Map:
-                    {
-                        var camera = PlanetariumCamera.fetch;
-                        camera.camPitch = GeometryExtensions.ToRadians (value).Clamp (camera.minPitch, camera.maxPitch);
-                        break;
-                    }
-                case CameraMode.IVA:
-                    {
-                        var camera = InternalCamera.Instance;
-                        InternalCameraExtensions.SetPitch(camera, value.Clamp(camera.minPitch, camera.maxPitch));
-                        break;
-                    }
-                default:
-                    {
-                        var camera = FlightCamera.fetch;
-                        camera.camPitch = GeometryExtensions.ToRadians (value).Clamp (camera.minPitch, camera.maxPitch);
-                        break;
-                    }
+                CameraAddon.Request (CameraProperty.Pitch, CurrentMode, value);
+                ApplyPitch (value);
+            }
+        }
+
+        static float ReadPitch ()
+        {
+            switch (CurrentMode) {
+            case CameraMode.Map:
+                return PlanetariumCamera.fetch.getPitch ();
+            case CameraMode.IVA:
+                var camera = InternalCamera.Instance;
+                return (float) InternalCameraExtensions.GetPitch(camera);
+            default:
+                return FlightCamera.fetch.getPitch ();
+            }
+        }
+
+        static void ApplyPitch (float value)
+        {
+            switch (CurrentMode) {
+            case CameraMode.Map:
+                {
+                    var camera = PlanetariumCamera.fetch;
+                    camera.camPitch = GeometryExtensions.ToRadians (value).Clamp (camera.minPitch, camera.maxPitch);
+                    break;
+                }
+            case CameraMode.IVA:
+                {
+                    var camera = InternalCamera.Instance;
+                    InternalCameraExtensions.SetPitch(camera, value.Clamp(camera.minPitch, camera.maxPitch));
+                    break;
+                }
+            default:
+                {
+                    var camera = FlightCamera.fetch;
+                    camera.camPitch = GeometryExtensions.ToRadians (value).Clamp (camera.minPitch, camera.maxPitch);
+                    break;
                 }
             }
         }
@@ -183,29 +205,40 @@ namespace KRPC.SpaceCenter.Services
         [KRPCProperty]
         public float Heading {
             get {
-                switch (Mode) {
-                case CameraMode.Map:
-                    return PlanetariumCamera.fetch.getYaw ();
-                case CameraMode.IVA:
-                    var camera = InternalCamera.Instance;
-                    return (float) InternalCameraExtensions.GetRot(camera);
-                default:
-                    return FlightCamera.fetch.getYaw ();
-                }
+                return ReadHeading ();
             }
             set {
-                switch (Mode) {
-                case CameraMode.Map:
-                    PlanetariumCamera.fetch.camHdg = GeometryExtensions.ToRadians (value);
-                    break;
-                case CameraMode.IVA:
-                    var camera = InternalCamera.Instance;
-                    InternalCameraExtensions.SetRot(camera, value.Clamp(-camera.maxRot, camera.maxRot));
-                    break;
-                default:
-                    FlightCamera.fetch.camHdg = GeometryExtensions.ToRadians (value);
-                    break;
-                }
+                CameraAddon.Request (CameraProperty.Heading, CurrentMode, value);
+                ApplyHeading (value);
+            }
+        }
+
+        static float ReadHeading ()
+        {
+            switch (CurrentMode) {
+            case CameraMode.Map:
+                return PlanetariumCamera.fetch.getYaw ();
+            case CameraMode.IVA:
+                var camera = InternalCamera.Instance;
+                return (float) InternalCameraExtensions.GetRot(camera);
+            default:
+                return FlightCamera.fetch.getYaw ();
+            }
+        }
+
+        static void ApplyHeading (float value)
+        {
+            switch (CurrentMode) {
+            case CameraMode.Map:
+                PlanetariumCamera.fetch.camHdg = GeometryExtensions.ToRadians (value);
+                break;
+            case CameraMode.IVA:
+                var camera = InternalCamera.Instance;
+                InternalCameraExtensions.SetRot(camera, value.Clamp(-camera.maxRot, camera.maxRot));
+                break;
+            default:
+                FlightCamera.fetch.camHdg = GeometryExtensions.ToRadians (value);
+                break;
             }
         }
 
@@ -216,31 +249,42 @@ namespace KRPC.SpaceCenter.Services
         [KRPCProperty]
         public float Distance {
             get {
-                switch (Mode) {
-                case CameraMode.Map:
-                    return PlanetariumCamera.fetch.Distance * ScaledSpace.ScaleFactor;
-                case CameraMode.IVA:
-                    throw new NotImplementedException ();
-                default:
-                    return FlightCamera.fetch.Distance;
-                }
+                return ReadDistance ();
             }
             set {
-                switch (Mode) {
-                case CameraMode.Map:
-                    {
-                        var camera = PlanetariumCamera.fetch;
-                        camera.SetDistance ((value / ScaledSpace.ScaleFactor).Clamp (camera.minDistance, camera.maxDistance));
-                        break;
-                    }
-                case CameraMode.IVA:
-                    throw new NotImplementedException ();
-                default:
-                    {
-                        var camera = FlightCamera.fetch;
-                        camera.SetDistance (value.Clamp (camera.minDistance, camera.maxDistance));
-                        break;
-                    }
+                CameraAddon.Request (CameraProperty.Distance, CurrentMode, value);
+                ApplyDistance (value);
+            }
+        }
+
+        static float ReadDistance ()
+        {
+            switch (CurrentMode) {
+            case CameraMode.Map:
+                return PlanetariumCamera.fetch.Distance * ScaledSpace.ScaleFactor;
+            case CameraMode.IVA:
+                throw new NotImplementedException ();
+            default:
+                return FlightCamera.fetch.Distance;
+            }
+        }
+
+        static void ApplyDistance (float value)
+        {
+            switch (CurrentMode) {
+            case CameraMode.Map:
+                {
+                    var camera = PlanetariumCamera.fetch;
+                    camera.SetDistance ((value / ScaledSpace.ScaleFactor).Clamp (camera.minDistance, camera.maxDistance));
+                    break;
+                }
+            case CameraMode.IVA:
+                throw new NotImplementedException ();
+            default:
+                {
+                    var camera = FlightCamera.fetch;
+                    camera.SetDistance (value.Clamp (camera.minDistance, camera.maxDistance));
+                    break;
                 }
             }
         }
@@ -252,34 +296,96 @@ namespace KRPC.SpaceCenter.Services
         [KRPCProperty]
         public float FoV {
             get {
-                switch (Mode) {
-                case CameraMode.Map:
-                    throw new NotImplementedException ();
-                case CameraMode.IVA:
-                    var camera = InternalCamera.Instance;
-                    return (float) InternalCameraExtensions.GetFoV(camera);
-                default:
-                    return FlightCamera.fetch.FieldOfView;
-                }
+                return ReadFoV ();
             }
             set {
-                switch (Mode) {
-                case CameraMode.Map:
-                    throw new NotImplementedException ();
-                case CameraMode.IVA:
-                    {
-                        var camera = InternalCamera.Instance;
-                        InternalCameraExtensions.SetZoom(camera, (value / (float) InternalCameraExtensions.GetDefaultFoV(camera)).Clamp(camera.maxZoom, camera.minZoom));
-                        break;
-                    }
-                default:
-                    {
-                        var camera = FlightCamera.fetch;
-                        camera.SetFoV(value.Clamp (camera.fovMin, camera.fovMax));
-                        break;
-                    }
+                CameraAddon.Request (CameraProperty.FoV, CurrentMode, value);
+                ApplyFoV (value);
+            }
+        }
+
+        static float ReadFoV ()
+        {
+            switch (CurrentMode) {
+            case CameraMode.Map:
+                throw new NotImplementedException ();
+            case CameraMode.IVA:
+                var camera = InternalCamera.Instance;
+                return (float) InternalCameraExtensions.GetFoV(camera);
+            default:
+                return FlightCamera.fetch.FieldOfView;
+            }
+        }
+
+        static void ApplyFoV (float value)
+        {
+            switch (CurrentMode) {
+            case CameraMode.Map:
+                throw new NotImplementedException ();
+            case CameraMode.IVA:
+                {
+                    var camera = InternalCamera.Instance;
+                    InternalCameraExtensions.SetZoom(camera, (value / (float) InternalCameraExtensions.GetDefaultFoV(camera)).Clamp(camera.maxZoom, camera.minZoom));
+                    break;
+                }
+            default:
+                {
+                    var camera = FlightCamera.fetch;
+                    camera.SetFoV(value.Clamp (camera.fovMin, camera.fovMax));
+                    break;
                 }
             }
+        }
+
+        /// <summary>
+        /// Re-apply a deferred property write. Called by <see cref="CameraAddon"/> once
+        /// the camera has reached the mode the write was requested for. Mirrors the
+        /// concrete write each setter performs.
+        /// </summary>
+        internal static void ApplyRaw (CameraProperty property, float value)
+        {
+            switch (property) {
+            case CameraProperty.Distance:
+                ApplyDistance (value);
+                break;
+            case CameraProperty.Pitch:
+                ApplyPitch (value);
+                break;
+            case CameraProperty.Heading:
+                ApplyHeading (value);
+                break;
+            case CameraProperty.FoV:
+                ApplyFoV (value);
+                break;
+            }
+        }
+
+        /// <summary>
+        /// Whether the live camera has reached a requested property value, within a
+        /// per-property tolerance. Distance is compared relatively because the flight
+        /// camera lerps toward its target over several frames; pitch, heading and field
+        /// of view are compared as angles in degrees. Heading wraps at 360 degrees.
+        /// </summary>
+        internal static bool Converged (CameraProperty property, float value)
+        {
+            switch (property) {
+            case CameraProperty.Distance:
+                return Math.Abs (ReadDistance () - value) <= Math.Max (0.1f, 0.01f * Math.Abs (value));
+            case CameraProperty.Pitch:
+                return Math.Abs (ReadPitch () - value) <= 0.1f;
+            case CameraProperty.Heading:
+                return AngleDifference (ReadHeading (), value) <= 0.1f;
+            case CameraProperty.FoV:
+                return Math.Abs (ReadFoV () - value) <= 0.1f;
+            default:
+                return true;
+            }
+        }
+
+        static float AngleDifference (float a, float b)
+        {
+            var difference = Math.Abs (a - b) % 360f;
+            return difference > 180f ? 360f - difference : difference;
         }
 
         /// <summary>

--- a/service/SpaceCenter/test/test_camera.py
+++ b/service/SpaceCenter/test/test_camera.py
@@ -129,5 +129,30 @@ class TestCameraMap(krpctest.TestCase, CameraTestBase):
         cls.wait(1)
 
 
+class TestCameraDistanceDuringSwitch(krpctest.TestCase):
+    # Runs last so its deliberately unsettled camera state does not leak into the
+    # other camera test classes (new_save does not reload when already in flight).
+    @classmethod
+    def setUpClass(cls):
+        cls.new_save()
+        cls.set_circular_orbit("Kerbin", 1000000)
+        space_center = cls.connect().space_center
+        cls.camera = space_center.camera
+        cls.mode = space_center.CameraMode
+
+    def test_distance_survives_camera_settle(self):
+        # Regression for #318: while the camera is still settling (as it is just
+        # after the vessel is placed / the scene loads), switch mode and set the
+        # distance with no wait. During the settle the camera drives its distance
+        # back to the default, so without deferral the write is lost; it must be
+        # re-applied and hold once the camera settles.
+        self.set_circular_orbit("Kerbin", 1000000)
+        self.camera.mode = self.mode.chase
+        self.camera.distance = 15
+        self.wait(3)
+        self.assertEqual(self.mode.chase, self.camera.mode)
+        self.assertAlmostEqual(15, self.camera.distance, places=0)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Camera Distance/Pitch/Heading/FoV setters applied once immediately, so a write issued during a camera mode switch (Flight/IVA/Map) was lost: while the destination camera settles it drives its distance/pitch/heading from its own transform each frame, snapping back to a default and overwriting anything written earlier.

Add a CameraAddon that records each write and, while the camera is in the requested mode, re-applies it whenever the live value has drifted away, clearing it once it holds on its own for a short settle window (with a frame-budget backstop). The setters keep an immediate fast path, so the settled, non-switching case is unchanged.

Fixes #318.