### PR TITLE
Add Vessel.Loaded and Vessel.Packed

### DIFF
--- a/doc/order.txt
+++ b/doc/order.txt
@@ -170,6 +170,8 @@ SpaceCenter.Vessel
 SpaceCenter.Vessel.Name
 SpaceCenter.Vessel.Type
 SpaceCenter.Vessel.Situation
+SpaceCenter.Vessel.Loaded
+SpaceCenter.Vessel.Packed
 SpaceCenter.Vessel.Recoverable
 SpaceCenter.Vessel.Recover
 SpaceCenter.Vessel.MET

--- a/service/SpaceCenter/CHANGES.txt
+++ b/service/SpaceCenter/CHANGES.txt
@@ -24,6 +24,7 @@ v0.6.0
  * Add Part.Drag and Part.Lift returning the aerodynamic drag and lift forces acting on an
    individual part (#459)
  * Add Control.AeroSurfaces to enable/disable pitch, yaw and roll on all control surfaces (#827)
+ * Add Vessel.Loaded and Vessel.Packed to report a vessel's loading and on-rails state
  * Add Engine.Flameout (#311)
  * Add Control.EngineGimbals to enable/disable gimbal on all gimballed engines (#827)
  * Add Module.AllFieldsById to expose all part module field values, including those not

--- a/service/SpaceCenter/src/Services/Vessel.cs
+++ b/service/SpaceCenter/src/Services/Vessel.cs
@@ -95,6 +95,26 @@ namespace KRPC.SpaceCenter.Services
         }
 
         /// <summary>
+        /// Whether the vessel is loaded, i.e. its parts are instantiated in the scene
+        /// because it is within loading range of the active vessel. A vessel that is not
+        /// loaded exists only as orbital data and is always on-rails (see <see cref="Packed" />).
+        /// </summary>
+        [KRPCProperty]
+        public bool Loaded {
+            get { return InternalVessel.loaded; }
+        }
+
+        /// <summary>
+        /// Whether the vessel is packed (on-rails). A packed vessel has its physics
+        /// simulation suspended and follows its orbit analytically. A vessel that is not
+        /// loaded (see <see cref="Loaded" />) is always packed.
+        /// </summary>
+        [KRPCProperty]
+        public bool Packed {
+            get { return InternalVessel.packed; }
+        }
+
+        /// <summary>
         /// Whether the vessel is recoverable.
         /// </summary>
         [KRPCProperty]

--- a/service/SpaceCenter/test/test_vessel.py
+++ b/service/SpaceCenter/test/test_vessel.py
@@ -31,6 +31,12 @@ class TestVessel(krpctest.TestCase):
     def test_situation(self):
         self.assertEqual(self.Situation.orbiting, self.vessel.situation)
 
+    def test_loaded(self):
+        self.assertTrue(self.vessel.loaded)
+
+    def test_packed(self):
+        self.assertFalse(self.vessel.packed)
+
     def test_recoverable(self):
         self.assertFalse(self.vessel.recoverable)
         self.assertRaises(RuntimeError, self.vessel.recover)


### PR DESCRIPTION
Expose whether a vessel's parts are instantiated in the scene (loaded) and whether its physics simulation is suspended, i.e. it is on-rails (packed). Both are direct reads of the corresponding KSP vessel fields.

An unloaded vessel is always packed, since KSP will not take a vessel off-rails until it has been loaded; the documentation notes this dependency.