### PR TITLE
Validate GameData against a known-valid set before launching KSP from tests

### DIFF
--- a/tools/krpctest/krpctest/game.py
+++ b/tools/krpctest/krpctest/game.py
@@ -86,6 +86,10 @@ def _auto_launch_enabled():
     return os.environ.get("KRPC_AUTO_LAUNCH", "1") != "0"
 
 
+def _gamedata_check_enabled():
+    return os.environ.get("KRPC_SKIP_GAMEDATA_CHECK", "0") != "1"
+
+
 def copy_blank_save(name, ksp_dir=None):
     """Copy the bundled blank save into the KSP install's saves/<name>/persistent.sfs."""
     blank_save = str(files("krpctest").joinpath(name + ".sfs"))
@@ -149,7 +153,7 @@ def _install_mods(required):
         "building and installing kRPC (mods: %s)",
         ", ".join(sorted(required)) or "none",
     )
-    install(mods=sorted(required))
+    install(mods=sorted(required), validate_gamedata=_gamedata_check_enabled())
 
 
 def _launch_ksp(required):

--- a/tools/krpctest/krpctest/install.py
+++ b/tools/krpctest/krpctest/install.py
@@ -5,7 +5,10 @@ into the KSP install (from ``KSP_DIR`` or ``--ksp-dir``) - exactly as a user
 installs a release - then adds the test-only bits the public release omits (the
 ``TestingTools`` add-on and the test ``settings.cfg``). The optional set of managed
 third-party mods (RemoteTech, InfernalRobotics, KerbalAlarmClock) used by some service
-tests is reconciled so GameData contains exactly the requested set.
+tests is reconciled so GameData contains exactly the requested set. Finally GameData is
+validated against the known-valid set, so an unexpected mod left over from an earlier
+session is reported up front instead of silently stopping the server from starting; a dev
+deliberately running an unmanaged mod can opt out with ``--skip-gamedata-check``.
 
 Run it from the repository root, either as the ``krpc-install`` console script or with
 ``python -m krpctest.install``. It is also called directly by the test framework (see
@@ -49,6 +52,33 @@ MODS = {
 
 # All managed GameData subdirs, every one a candidate for removal during reconcile.
 _ALL_MOD_SUBDIRS = [subdir for comps in MODS.values() for _, subdir in comps]
+
+# GameData entries a valid test install always permits, on top of the managed-mod subdirs
+# and whatever mods a test requests. Stock KSP ships Squad and SquadExpansion; install()
+# lays down kRPC and the ModuleManager assembly; ModuleManager writes these cache files
+# into GameData at runtime. The versioned ModuleManager.<ver>.dll is matched separately
+# (see _is_module_manager_dll).
+_BASELINE_GAMEDATA = frozenset(
+    {
+        "Squad",
+        "SquadExpansion",
+        "kRPC",
+        "ModuleManager.ConfigCache",
+        "ModuleManager.ConfigSHA",
+        "ModuleManager.Physics",
+        "ModuleManager.TechTree",
+    }
+)
+
+
+def _is_module_manager_dll(entry):
+    """Whether entry is the ModuleManager assembly, whose filename embeds its version."""
+    return entry.startswith("ModuleManager") and entry.endswith(".dll")
+
+
+def _requested_mod_subdirs(mods):
+    """GameData subdir names the given managed mods install (including dependencies)."""
+    return {subdir for mod in mods for _, subdir in MODS[mod]}
 
 
 def _mod_archive_src(target, subdir):
@@ -104,10 +134,12 @@ def _normalize_permissions(path):
             os.chmod(os.path.join(root, name), 0o644)
 
 
-def install(mods=(), ksp_dir=None):
+def install(mods=(), ksp_dir=None, validate_gamedata=True):
     """Build the mod and install it (plus exactly the requested managed mods) into the KSP
     GameData directory. mods is an iterable of names from MODS; ksp_dir defaults to the
-    KSP install given by KSP_DIR."""
+    KSP install given by KSP_DIR. Set validate_gamedata=False to skip the check that
+    GameData holds only the known-valid set, for a dev deliberately running an unmanaged
+    mod alongside the tests."""
     mods = list(mods)
     unknown = [m for m in mods if m not in MODS]
     if unknown:
@@ -152,12 +184,38 @@ def install(mods=(), ksp_dir=None):
         os.chmod(module_manager, 0o644)
 
     _reconcile_mods(mods, root, gamedata_root)
+    if validate_gamedata:
+        _validate_gamedata(gamedata_root, _requested_mod_subdirs(mods))
+
+
+def _validate_gamedata(gamedata_root, requested_subdirs):
+    """Fail if GameData contains anything outside the known-valid test install.
+
+    A valid install is the stock game plus kRPC, ModuleManager, and exactly the managed
+    mods a test requested. Anything else — a mod left behind by an earlier session, a stray
+    manual install — is reported rather than ignored: an unexpected assembly that fails to
+    load (for example one that needs a Harmony build which is not installed) stops the kRPC
+    server from starting, and KSP then sits at the space center while the test waits forever
+    for a server that never comes up, with nothing pointing at the cause."""
+    allowed = _BASELINE_GAMEDATA | set(requested_subdirs)
+    unexpected = [
+        entry
+        for entry in sorted(os.listdir(gamedata_root))
+        if entry not in allowed and not _is_module_manager_dll(entry)
+    ]
+    if unexpected:
+        raise RuntimeError(
+            "Unexpected entries in %s: %s. The integration tests require a known-clean "
+            "GameData: the stock game plus kRPC, ModuleManager and only the mods a test "
+            "requests. Remove the listed entries and re-run."
+            % (gamedata_root, ", ".join(unexpected))
+        )
 
 
 def _reconcile_mods(mods, root, gamedata_root):
     """Make the managed mods in gamedata_root exactly the requested set."""
     requested = [comp for mod in mods for comp in MODS[mod]]
-    requested_subdirs = {subdir for _, subdir in requested}
+    requested_subdirs = _requested_mod_subdirs(mods)
 
     # Remove any managed mod that is not requested.
     for subdir in _ALL_MOD_SUBDIRS:
@@ -205,10 +263,21 @@ def main():
         metavar="DIR",
         help="path to the KSP install (defaults to $KSP_DIR)",
     )
+    parser.add_argument(
+        "--skip-gamedata-check",
+        action="store_true",
+        default=False,
+        help="skip the check that GameData holds only the known-valid set, to allow "
+        "an unmanaged mod to remain installed",
+    )
     args = parser.parse_args()
     mods = [m for m in args.mods.split(",") if m]
     try:
-        install(mods=mods, ksp_dir=args.ksp_dir)
+        install(
+            mods=mods,
+            ksp_dir=args.ksp_dir,
+            validate_gamedata=not args.skip_gamedata_check,
+        )
     except (ValueError, RuntimeError) as ex:
         sys.stderr.write("Error: %s\n" % ex)
         return 1

--- a/tools/krpctest/krpctest/pytest_plugin.py
+++ b/tools/krpctest/krpctest/pytest_plugin.py
@@ -4,7 +4,8 @@ Registered via the ``pytest11`` entry point (see pyproject.toml), so it loads au
 whenever pytest runs with krpctest installed. It adds a few small pieces of behaviour:
 
  * a ``--ksp-dir`` option that points the framework at a KSP install,
- * a ``--no-launch`` option for running against a game started separately, and
+ * a ``--no-launch`` option for running against a game started separately,
+ * a ``--skip-gamedata-check`` option for launching with an unmanaged mod installed, and
  * ordering the collected tests by their required mods so KSP is restarted at most once per
    distinct mod set (stock tests first).
 
@@ -30,6 +31,13 @@ def pytest_addoption(parser):
         default=False,
         help="require an already-running game rather than launching one",
     )
+    parser.addoption(
+        "--skip-gamedata-check",
+        action="store_true",
+        default=False,
+        help="skip the check that GameData holds only the known-valid set, to launch "
+        "with an unmanaged mod installed",
+    )
 
 
 def pytest_configure(config):
@@ -43,6 +51,10 @@ def pytest_configure(config):
     # underneath the first.
     if config.getoption("--no-launch"):
         os.environ["KRPC_AUTO_LAUNCH"] = "0"
+    # Likewise, the GameData validity check is skipped when KRPC_SKIP_GAMEDATA_CHECK is 1.
+    # Use this to auto-launch with an unmanaged mod deliberately installed alongside kRPC.
+    if config.getoption("--skip-gamedata-check"):
+        os.environ["KRPC_SKIP_GAMEDATA_CHECK"] = "1"
 
 
 def _mods_key(item):

--- a/tools/krpctest/krpctest/run_ksp.py
+++ b/tools/krpctest/krpctest/run_ksp.py
@@ -126,6 +126,13 @@ def main():
         metavar="DIR",
         help="path to the KSP install (defaults to $KSP_DIR)",
     )
+    parser.add_argument(
+        "--skip-gamedata-check",
+        action="store_true",
+        default=False,
+        help="skip the check that GameData holds only the known-valid set, to launch "
+        "with an unmanaged mod installed",
+    )
 
     autoload = parser.add_argument_group(
         "auto-load options",
@@ -184,7 +191,7 @@ def main():
             ksp_args.append("%s=%s" % (flag, value))
 
     ksp_dir = get_ksp_dir(args.ksp_dir)
-    install(mods=mods, ksp_dir=ksp_dir)
+    install(mods=mods, ksp_dir=ksp_dir, validate_gamedata=not args.skip_gamedata_check)
     if args.load_game is not None:
         _stage_blank_save(args.load_game, ksp_dir)
 

--- a/tools/krpctest/krpctest/test/test_install.py
+++ b/tools/krpctest/krpctest/test/test_install.py
@@ -1,0 +1,65 @@
+import os
+import shutil
+import tempfile
+import krpctest
+from krpctest.install import _validate_gamedata
+
+# A clean no-mod GameData: the stock game, kRPC, the ModuleManager assembly and its
+# runtime-generated cache files.
+_CLEAN = [
+    "Squad",
+    "SquadExpansion",
+    "kRPC",
+    "ModuleManager.4.2.3.dll",
+    "ModuleManager.ConfigCache",
+    "ModuleManager.ConfigSHA",
+    "ModuleManager.Physics",
+    "ModuleManager.TechTree",
+]
+
+
+class TestValidateGamedata(krpctest.TestCase):
+    game_required = False
+
+    def setUp(self):
+        self.gamedata = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.gamedata, ignore_errors=True)
+
+    def _populate(self, entries):
+        for entry in entries:
+            with open(os.path.join(self.gamedata, entry), "w", encoding="utf-8"):
+                pass
+
+    def test_clean_baseline_passes(self):
+        self._populate(_CLEAN)
+        _validate_gamedata(self.gamedata, set())
+
+    def test_partial_baseline_passes(self):
+        # The ModuleManager cache files do not exist until the first KSP launch, so a
+        # fresh install must still validate without them.
+        self._populate(["Squad", "SquadExpansion", "kRPC", "ModuleManager.4.2.3.dll"])
+        _validate_gamedata(self.gamedata, set())
+
+    def test_any_module_manager_version_passes(self):
+        self._populate(["Squad", "SquadExpansion", "kRPC", "ModuleManager.9.9.9.dll"])
+        _validate_gamedata(self.gamedata, set())
+
+    def test_unexpected_mod_raises(self):
+        self._populate(_CLEAN + ["KSPCommunityPartModules"])
+        with self.assertRaises(RuntimeError) as cm:
+            _validate_gamedata(self.gamedata, set())
+        self.assertIn("KSPCommunityPartModules", str(cm.exception))
+
+    def test_requested_mod_allowed(self):
+        self._populate(_CLEAN + ["RealChute", "000_Harmony"])
+        _validate_gamedata(self.gamedata, {"RealChute", "000_Harmony"})
+
+    def test_requested_mod_missing_from_set_raises(self):
+        # A managed mod present in GameData but not among the requested subdirs is still
+        # unexpected — reconcile should have removed it.
+        self._populate(_CLEAN + ["RealChute"])
+        with self.assertRaises(RuntimeError) as cm:
+            _validate_gamedata(self.gamedata, set())
+        self.assertIn("RealChute", str(cm.exception))


### PR DESCRIPTION
The test harness only reconciles the managed mods it knows about, so a mod left in GameData by an earlier session was left in place. Its assembly then fails to load, the kRPC server never starts, and the run hangs at "waiting for kRPC server" with nothing pointing at the cause.

`install()` now checks GameData after reconciling and raises listing any entry outside the known-valid set: the stock game, kRPC, ModuleManager, and the mods the test requested. Unexpected entries are reported for the user to remove rather than deleted automatically.

A `--skip-gamedata-check` flag (on `krpc-install`, `krpc-run-ksp` and the `pytest` runner) opts out, for a dev deliberately running an unmanaged mod alongside the tests.