### PR TITLE
Factor the decouple/undock settle wait into a shared helper

### DIFF
--- a/service/SpaceCenter/src/KRPC.SpaceCenter.csproj
+++ b/service/SpaceCenter/src/KRPC.SpaceCenter.csproj
@@ -155,6 +155,7 @@
     <Compile Include="Services\Parts\PartEvent.cs" />
     <Compile Include="Services\Parts\PartField.cs" />
     <Compile Include="Services\Parts\Parts.cs" />
+    <Compile Include="Services\Parts\PartSeparation.cs" />
     <Compile Include="Services\Parts\Propellant.cs" />
     <Compile Include="Services\Parts\RCS.cs" />
     <Compile Include="Services\Parts\Radiator.cs" />

--- a/service/SpaceCenter/src/Services/Parts/Decoupler.cs
+++ b/service/SpaceCenter/src/Services/Parts/Decoupler.cs
@@ -1,7 +1,5 @@
 using System;
-using System.Collections.Generic;
 using System.Linq;
-using KRPC.Service;
 using KRPC.Service.Attributes;
 using KRPC.SpaceCenter.ExtensionMethods;
 using KRPC.Utils;
@@ -77,17 +75,7 @@ namespace KRPC.SpaceCenter.Services.Parts
             // Fire the decoupler
             decoupler.Decouple();
 
-            return PostDecouple (preVesselIds);
-        }
-
-        Vessel PostDecouple (IList<Guid> preVesselIds, int wait = 0)
-        {
-            // FIXME: sometimes after decoupling, KSP changes it's mind as to what the active vessel is, so we wait for 10 frames before getting the active vessel
-            // Wait while the decoupler hasn't fired
-            if (wait < 10 || !Decoupled)
-                throw new YieldException<Func<Vessel>> (() => PostDecouple(preVesselIds, wait + 1));
-            // Return the newly created vessel
-            return new Vessel (FlightGlobals.Vessels.Select (v => v.id).Except (preVesselIds).First ());
+            return PartSeparation.NewVessel (preVesselIds, () => Decoupled);
         }
 
         /// <summary>

--- a/service/SpaceCenter/src/Services/Parts/DockingPort.cs
+++ b/service/SpaceCenter/src/Services/Parts/DockingPort.cs
@@ -1,7 +1,5 @@
 using System;
-using System.Collections.Generic;
 using System.Linq;
-using KRPC.Service;
 using KRPC.Service.Attributes;
 using KRPC.SpaceCenter.ExtensionMethods;
 using KRPC.Utils;
@@ -135,21 +133,11 @@ namespace KRPC.SpaceCenter.Services.Parts
             // Try calling "Decouple Node" or "Undock" on this part and on the port we are docked to, if any
             if (InvokeEvent (port, "Decouple Node") || InvokeEvent (port, "Undock") ||
                 (dockedPort != null && (InvokeEvent (dockedPort, "Decouple Node") || InvokeEvent (dockedPort, "Undock")))) {
-                return PostUndock (preVesselIds);
+                return PartSeparation.NewVessel (preVesselIds, () => State != DockingPortState.Docked);
             }
 
             // Failed to undock
             throw new InvalidOperationException ("Failed to undock, a suitable event to trigger was not found");
-        }
-
-        Vessel PostUndock (IList<Guid> preVesselIds, int wait = 0)
-        {
-            // FIXME: sometimes after undocking, KSP changes it's mind as to what the active vessel is, so we wait for 10 frames before getting the active vessel
-            // Wait while the port is docked
-            if (wait < 10 || State == DockingPortState.Docked)
-                throw new YieldException<Func<Vessel>> (() => PostUndock(preVesselIds, wait + 1));
-            // Return the newly created vessel
-            return new Vessel (FlightGlobals.Vessels.Select (v => v.id).Except (preVesselIds).Single ());
         }
 
         /// <summary>

--- a/service/SpaceCenter/src/Services/Parts/PartSeparation.cs
+++ b/service/SpaceCenter/src/Services/Parts/PartSeparation.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using KRPC.Service;
+
+namespace KRPC.SpaceCenter.Services.Parts
+{
+    /// <summary>
+    /// Shared logic for the RPCs that split a vessel in two — decoupling and undocking — each of
+    /// which returns the newly created vessel.
+    /// </summary>
+    static class PartSeparation
+    {
+        /// <summary>
+        /// Number of frames to wait after triggering a separation before reading the resulting
+        /// vessel. KSP does not finalise the split on the frame the event fires: for a few frames
+        /// afterwards the new vessel may not yet be present in <c>FlightGlobals.Vessels</c>, and KSP
+        /// can briefly change which vessel it treats as active. Ten frames is a conservative margin
+        /// for that to settle.
+        /// </summary>
+        const int SettleFrames = 10;
+
+        /// <summary>
+        /// Yields until the separation has completed (<paramref name="separated"/> returns true) and
+        /// the settle margin has elapsed, then returns the vessel that <c>FlightGlobals.Vessels</c>
+        /// gained relative to <paramref name="preVesselIds"/> — the snapshot of vessel ids taken
+        /// before the separation was triggered. A single separation produces exactly one new vessel.
+        /// </summary>
+        internal static Vessel NewVessel (IList<Guid> preVesselIds, Func<bool> separated, int wait = 0)
+        {
+            if (wait < SettleFrames || !separated ())
+                throw new YieldException<Func<Vessel>> (
+                    () => NewVessel (preVesselIds, separated, wait + 1));
+            return new Vessel (
+                FlightGlobals.Vessels.Select (v => v.id).Except (preVesselIds).Single ());
+        }
+    }
+}


### PR DESCRIPTION
`Decoupler.Decouple` and `DockingPort.Undock` each duplicated the same logic: after triggering the split, wait ten frames and until the parts have actually separated, then return the vessel that `FlightGlobals` gained. Both carried the same FIXME about the magic ten-frame wait.

Move it to `PartSeparation.NewVessel`, which documents why the wait exists (KSP does not finalise the split on the frame the event fires; the new vessel and the active-vessel assignment take a few frames to settle) and why ten frames. Each caller now supplies only its own "separated" predicate. The decoupler path also switches from `First` to `Single` to match the undock path, asserting the invariant that a single separation yields exactly one new vessel.