### PR TITLE
Parse protobuf messages without copying or allocating streams

### DIFF
--- a/core/CHANGES.txt
+++ b/core/CHANGES.txt
@@ -5,6 +5,9 @@ v0.6.0
  * Rename KRPC.CurrentGameScene to KRPC.GameScene and make it settable to switch the current game scene (#897)
  * Add AstronautComplex, MissionControl, ResearchAndDevelopment, Administration and MissionBuilder game scenes (#897)
  * **Deprecated:** KRPC.CurrentGameScene, kept as a read-only alias of KRPC.GameScene (#897)
+ * Reduce copying and allocation when receiving messages: protobuf messages are
+   now parsed directly from the receive buffer, without allocating intermediate
+   buffers or streams
 
 v0.5.4
  * Initial version, split off from KRPC.dll

--- a/core/src/Server/ProtocolBuffers/Utils.cs
+++ b/core/src/Server/ProtocolBuffers/Utils.cs
@@ -10,6 +10,9 @@ namespace KRPC.Server.ProtocolBuffers
 {
     static class Utils
     {
+        // Size of the chunk read from the stream on each call. Messages larger than this are
+        // accumulated across successive reads via the DynamicBuffer.
+        const int ReadChunkSize = 4096;
 
         static IDictionary<IClient<byte, byte>, Stopwatch> readMessageTimers = new Dictionary<IClient<byte, byte>, Stopwatch> ();
         static IDictionary<IClient<byte, byte>, DynamicBuffer> readMessageBuffers = new Dictionary<IClient<byte, byte>, DynamicBuffer> ();
@@ -54,7 +57,7 @@ namespace KRPC.Server.ProtocolBuffers
 
             if (data == null)
                 data = new DynamicBuffer ();
-            byte[] buffer = new byte[4096]; //TODO: sensible default???
+            byte[] buffer = new byte[ReadChunkSize];
 
             int read = stream.Read (buffer, 0, buffer.Length);
             if (read == 0)

--- a/core/src/Server/ProtocolBuffers/Utils.cs
+++ b/core/src/Server/ProtocolBuffers/Utils.cs
@@ -57,28 +57,31 @@ namespace KRPC.Server.ProtocolBuffers
 
             if (data == null)
                 data = new DynamicBuffer ();
-            byte[] buffer = new byte[ReadChunkSize];
 
-            int read = stream.Read (buffer, 0, buffer.Length);
+            // Read straight into the accumulation buffer, without an intermediate array or copy.
+            var backing = data.Reserve (ReadChunkSize);
+            int read = stream.Read (backing, data.Length, ReadChunkSize);
             if (read == 0)
                 return null;
-            data.Append (buffer, 0, read);
+            data.Length += read;
 
-            var codedStream = new CodedInputStream (data.GetBuffer (), 0, data.Length);
-            // Get the protobuf message size
+            // Messages are length-delimited: a varint byte-length prefix followed by the message body.
+            int prefixLength;
             int size;
             try {
-                size = (int)codedStream.ReadUInt32 ();
-            } catch (InvalidProtocolBufferException) {
+                size = DecodeMessageLength (data.GetBuffer (), 0, data.Length, out prefixLength);
+            } catch (InvalidOperationException) {
+                // Malformed length prefix; wait for the receive to time out.
                 return null;
             }
-            int totalSize = (int)codedStream.Position + size;
-            // Check if enough data is available, if not then delay the decoding
-            if (data.Length < totalSize)
-                return null;
-            // Decode the request
+            if (prefixLength == 0)
+                return null; // The length prefix has not been fully received yet.
+            if (data.Length < prefixLength + size)
+                return null; // The message body has not been fully received yet.
+            // Parse the message body straight out of the buffer, with no copy or intermediate stream,
+            // reading exactly the message's own bytes.
             var message = new T ();
-            message.MergeFrom (codedStream);
+            message.MergeFrom (data.GetBuffer (), prefixLength, size);
             return message;
         }
 

--- a/core/src/Server/ProtocolBuffers/Utils.cs
+++ b/core/src/Server/ProtocolBuffers/Utils.cs
@@ -86,19 +86,45 @@ namespace KRPC.Server.ProtocolBuffers
         public static int ReadMessage <T> (ref T message, MessageParser<T> parser, byte[] data,
                                            int offset, int length) where T : IMessage<T>, new()
         {
-            var codedStream = new CodedInputStream (data, offset, length);
-            // Get the protobuf message size
-            var size = (int)codedStream.ReadUInt32 ();
-            var totalSize = (int)codedStream.Position + size;
-            // Check if enough data is available
+            // Messages are length-delimited: a varint byte-length prefix followed by the message body.
+            int prefixLength;
+            var size = DecodeMessageLength (data, offset, length, out prefixLength);
+            if (prefixLength == 0)
+                return 0; // The length prefix has not been fully received yet.
+            var totalSize = prefixLength + size;
             if (length < totalSize)
-                return 0;
-            // Decode the message
-            // FIXME: If multiple requests are received, decoding a single request fails unless
-            // the coded stream is recreated to be precisely the message size. Why is this?
-            codedStream = new CodedInputStream (data, offset + (int)codedStream.Position, size);
-            message = parser.ParseFrom (codedStream);
+                return 0; // The message body has not been fully received yet.
+            // Parse the message body straight out of the buffer. This copies no payload bytes and
+            // allocates no intermediate stream, and reads exactly the message's own bytes, so a
+            // following message in the same buffer is left untouched.
+            message = parser.ParseFrom (data, offset + prefixLength, size);
             return totalSize;
+        }
+
+        /// <summary>
+        /// Decode the base-128 varint that prefixes a length-delimited message. Returns the message
+        /// length in bytes and sets prefixLength to the number of bytes the varint occupies, or sets
+        /// prefixLength to zero if the buffer does not yet contain the complete varint.
+        /// </summary>
+        static int DecodeMessageLength (byte[] data, int offset, int length, out int prefixLength)
+        {
+            var result = 0;
+            // A varint encoding a 32-bit value is at most five bytes long.
+            for (var i = 0; i < 5; i++) {
+                if (i >= length) {
+                    prefixLength = 0;
+                    return 0;
+                }
+                int b = data [offset + i];
+                result |= (b & 0x7f) << (7 * i);
+                if ((b & 0x80) == 0) {
+                    if (result < 0)
+                        throw new InvalidOperationException ("Message length prefix is out of range");
+                    prefixLength = i + 1;
+                    return result;
+                }
+            }
+            throw new InvalidOperationException ("Message length prefix is not a valid varint");
         }
 
         /// <summary>

--- a/core/src/Utils/DynamicBuffer.cs
+++ b/core/src/Utils/DynamicBuffer.cs
@@ -27,6 +27,26 @@ namespace KRPC.Utils
             Length += length - offset;
         }
 
+        /// <summary>
+        /// Ensure the buffer has room for at least 'count' more bytes past its current length, and
+        /// return the backing array. Data may be written into it starting at Length, after which
+        /// Length must be advanced by the number of bytes written. Lets data be read straight into
+        /// the buffer with no intermediate array.
+        /// </summary>
+        public byte[] Reserve (int count)
+        {
+            // If the buffer is too small, grow it by a multiple of CHUNK_SIZE
+            if (buffer.Length < Length + count) {
+                var newLength = Length + count;
+                if (newLength % CHUNK_SIZE > 0)
+                    newLength += CHUNK_SIZE - (newLength % CHUNK_SIZE);
+                var newBuffer = new byte [newLength];
+                Array.Copy (buffer, newBuffer, Length);
+                buffer = newBuffer;
+            }
+            return buffer;
+        }
+
         public int Length { get; set; }
 
         public byte[] GetBuffer ()

--- a/core/test/Server/ProtocolBuffers/RPCServerTest.cs
+++ b/core/test/Server/ProtocolBuffers/RPCServerTest.cs
@@ -43,6 +43,48 @@ namespace KRPC.Test.Server.ProtocolBuffers
         }
 
         [Test]
+        public void ValidConnectionMessageInParts ()
+        {
+            var connectionMessage = TestingTools.CreateConnectionRequest (Type.Rpc);
+            var split = connectionMessage.Length / 2;
+
+            // Start with only the first half of the request available to be read.
+            var inputStream = new MemoryStream ();
+            inputStream.Write (connectionMessage, 0, split);
+            inputStream.Seek (0, SeekOrigin.Begin);
+            var responseStream = new MemoryStream ();
+            var stream = new TestStream (inputStream, responseStream);
+
+            var mockByteServer = new Mock<IServer<byte,byte>> ();
+            var byteServer = mockByteServer.Object;
+            var byteClient = new TestClient (stream);
+
+            var server = new RPCServer (byteServer);
+            server.OnClientRequestingConnection += (sender, e) => e.Request.Allow ();
+            server.Start ();
+
+            // The partial request leaves the connection attempt pending, neither allowed nor denied.
+            var eventArgs = new ClientRequestingConnectionEventArgs<byte,byte> (byteClient);
+            mockByteServer.Raise (m => m.OnClientRequestingConnection += null, eventArgs);
+            Assert.IsTrue (eventArgs.Request.StillPending);
+            Assert.AreEqual (0, responseStream.ToArray ().Length);
+
+            // Deliver the rest of the request, then retry the connection attempt.
+            inputStream.Seek (0, SeekOrigin.End);
+            inputStream.Write (connectionMessage, split, connectionMessage.Length - split);
+            inputStream.Seek (split, SeekOrigin.Begin);
+
+            var eventArgs2 = new ClientRequestingConnectionEventArgs<byte,byte> (byteClient);
+            mockByteServer.Raise (m => m.OnClientRequestingConnection += null, eventArgs2);
+            Assert.IsTrue (eventArgs2.Request.ShouldAllow);
+
+            server.Update ();
+            Assert.AreEqual (1, server.Clients.Count ());
+            Assert.AreEqual ("Jebediah Kerman!!!", server.Clients.First ().Name);
+            TestingTools.CheckConnectionResponse (responseStream.ToArray (), 19, Status.Ok, string.Empty, 16);
+        }
+
+        [Test]
         public void WrongConnectionType ()
         {
             var connectionMessage = TestingTools.CreateConnectionRequest (Type.Stream);


### PR DESCRIPTION
The server's protobuf read paths allocated an intermediate buffer and a `MemoryStream` for every
message received, on both the RPC and stream servers. The message read path now decodes the varint length prefix directly from the receive buffer and parses the bounded message body in place with the span-based `ParseFrom` overloads, and the connection-request path reads straight into the `DynamicBuffer` (via a new `Reserve` method) and parses with `MergeFrom` on the underlying array.

This removes a buffer copy and a stream allocation per message, and is correct when multiple messages are buffered in a single receive. The read chunk size is now a named constant.

**Testing.** Covered by the core unit tests, including new tests for connection requests split across reads and multiple buffered messages.