### PR TITLE
Make websocket connection request handling robust

### DIFF
--- a/core/CHANGES.txt
+++ b/core/CHANGES.txt
@@ -8,6 +8,10 @@ v0.6.0
  * Reduce copying and allocation when receiving messages: protobuf messages are
    now parsed directly from the receive buffer, without allocating intermediate
    buffers or streams
+ * Fix the websocket servers rejecting connection requests that arrive split
+   across multiple reads; requests are now buffered until complete
+ * Fix websocket connection URL query parameter parsing: parameters are now
+   found in any position and are percent-decoded
 
 v0.5.4
  * Initial version, split off from KRPC.dll

--- a/core/src/Server/HTTP/Request.cs
+++ b/core/src/Server/HTTP/Request.cs
@@ -26,6 +26,26 @@ namespace KRPC.Server.HTTP
             return FromString (Encoding.ASCII.GetString (data, index, count));
         }
 
+        /// <summary>
+        /// Get the value of a query string parameter, or null if it is not present. Handles the
+        /// parameter appearing in any position, and percent-decodes the value.
+        /// </summary>
+        public string QueryParameter (string key)
+        {
+            var query = URI.Query;
+            if (query.StartsWith ("?", StringComparison.Ordinal))
+                query = query.Substring (1);
+            foreach (var pair in query.Split ('&')) {
+                if (pair.Length == 0)
+                    continue;
+                var i = pair.IndexOf ('=');
+                var name = i == -1 ? pair : pair.Substring (0, i);
+                if (Uri.UnescapeDataString (name) == key)
+                    return i == -1 ? string.Empty : Uri.UnescapeDataString (pair.Substring (i + 1));
+            }
+            return null;
+        }
+
         public static Request FromString (string content)
         {
             var request = new Request ();

--- a/core/src/Server/WebSockets/ConnectionRequest.cs
+++ b/core/src/Server/WebSockets/ConnectionRequest.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Security.Cryptography;
 using System.Text;
@@ -11,19 +13,62 @@ namespace KRPC.Server.WebSockets
     {
         const string WEB_SOCKETS_KEY = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
         const int BUFFER_SIZE = 4096;
+        // Seconds to wait for the rest of a request that arrived split across reads before rejecting it.
+        const double TIMEOUT = 3;
         static readonly SHA1 sha1 = SHA1.Create ();
 
+        static readonly IDictionary<IClient<byte,byte>, DynamicBuffer> readBuffers =
+            new Dictionary<IClient<byte,byte>, DynamicBuffer> ();
+        static readonly IDictionary<IClient<byte,byte>, Stopwatch> readTimers =
+            new Dictionary<IClient<byte,byte>, Stopwatch> ();
+
         /// <summary>
-        /// Read a websockets connection request. If the request is invalid,
-        /// writes the approprate HTTP response and denies the connection attempt.
+        /// Read a websockets connection request. If the request is invalid, writes the appropriate
+        /// HTTP response and denies the connection attempt. Returns null without denying the request
+        /// if it has not been fully received yet, in which case the connection attempt should be
+        /// retried later.
         /// </summary>
         public static Request ReadRequest (ClientRequestingConnectionEventArgs<byte,byte> args)
         {
-            var stream = args.Client.Stream;
+            var client = args.Client;
+            var stream = client.Stream;
+
+            // The request may arrive split across several reads. Accumulate it until the blank line
+            // terminating the HTTP headers has been received.
+            DynamicBuffer buffer;
+            if (!readBuffers.TryGetValue (client, out buffer)) {
+                buffer = new DynamicBuffer ();
+                readBuffers [client] = buffer;
+            }
+            if (stream.DataAvailable) {
+                var chunk = new byte [BUFFER_SIZE];
+                var count = stream.Read (chunk, 0);
+                buffer.Append (chunk, 0, count);
+            }
+
+            if (!EndOfHeaders (buffer)) {
+                // Not all of the request has arrived. Wait for more data, up to the timeout.
+                Stopwatch timer;
+                if (!readTimers.TryGetValue (client, out timer)) {
+                    timer = Stopwatch.StartNew ();
+                    readTimers [client] = timer;
+                }
+                if (timer.ElapsedSeconds () > TIMEOUT) {
+                    Reset (client);
+                    Logger.WriteLine (
+                        "WebSockets connection request not received after waiting " + TIMEOUT + " seconds",
+                        Logger.Severity.Error);
+                    args.Request.Deny ();
+                    stream.Write (Response.CreateBadRequest ().ToBytes ());
+                    return null;
+                }
+                // Leave the connection attempt pending; it will be retried.
+                return null;
+            }
+
+            Reset (client);
             try {
-                var buffer = new byte [BUFFER_SIZE];
-                var count = stream.Read (buffer, 0);
-                var request = Request.FromBytes (buffer, 0, count);
+                var request = Request.FromBytes (buffer.GetBuffer (), 0, buffer.Length);
                 CheckValid (request);
                 Logger.WriteLine ("WebSockets: received valid connection request", Logger.Severity.Debug);
                 return request;
@@ -33,12 +78,33 @@ namespace KRPC.Server.WebSockets
                 stream.Write (e.Response.ToBytes ());
                 return null;
             } catch (MalformedRequestException e) {
-                // TODO: wait for timeout seconds to see if the request was truncated
                 Logger.WriteLine ("Malformed WebSockets connection request: " + e.Message, Logger.Severity.Error);
                 args.Request.Deny ();
                 stream.Write (Response.CreateBadRequest ().ToBytes ());
                 return null;
             }
+        }
+
+        static void Reset (IClient<byte,byte> client)
+        {
+            readBuffers.Remove (client);
+            readTimers.Remove (client);
+        }
+
+        /// <summary>
+        /// Returns true once the buffer contains the blank line (\r\n\r\n) that terminates the
+        /// HTTP request headers.
+        /// </summary>
+        static bool EndOfHeaders (DynamicBuffer buffer)
+        {
+            var data = buffer.GetBuffer ();
+            var length = buffer.Length;
+            for (var i = 0; i + 3 < length; i++) {
+                if (data [i] == (byte)'\r' && data [i + 1] == (byte)'\n' &&
+                    data [i + 2] == (byte)'\r' && data [i + 3] == (byte)'\n')
+                    return true;
+            }
+            return false;
         }
 
         public static byte[] WriteResponse (string key)

--- a/core/src/Server/WebSockets/RPCServer.cs
+++ b/core/src/Server/WebSockets/RPCServer.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using KRPC.Service.Messages;
@@ -72,14 +71,10 @@ namespace KRPC.Server.WebSockets
         /// </summary>
         public static string GetClientName (HTTP.Request request)
         {
-            string name = string.Empty;
-            var query = request.URI.Query;
-            // TODO: make this name extraction more robust
-            if (query.StartsWith ("?name=", StringComparison.CurrentCulture))
-                name = query.Substring ("?name=".Length);
-            else if (request.Headers.ContainsKey ("origin"))
+            var name = request.QueryParameter ("name");
+            if (name == null && request.Headers.ContainsKey ("origin"))
                 name = request.Headers ["origin"].First ();
-            return Uri.UnescapeDataString (name);
+            return name ?? string.Empty;
         }
     }
 }

--- a/core/src/Server/WebSockets/RPCServer.cs
+++ b/core/src/Server/WebSockets/RPCServer.cs
@@ -45,6 +45,9 @@ namespace KRPC.Server.WebSockets
                 Logger.WriteLine ("WebSockets: client connection denied (" + address + ")", Logger.Severity.Error);
                 return null;
             }
+            if (request == null)
+                // The request has not been fully received yet; retry on a later update.
+                return null;
             var clientName = GetClientName (request);
             clientKeys [args.Client] = request.Headers ["sec-websocket-key"].Single ();
             return new RPCClient (clientName, args.Client, shouldEcho);

--- a/core/src/Server/WebSockets/StreamServer.cs
+++ b/core/src/Server/WebSockets/StreamServer.cs
@@ -66,13 +66,11 @@ namespace KRPC.Server.WebSockets
         /// </summary>
         public static Guid GetGuid (HTTP.Request request)
         {
-            // TODO: make this id extraction more robust
-            var query = request.URI.Query;
-            if (!query.StartsWith ("?id=", StringComparison.CurrentCulture)) {
+            var id = request.QueryParameter ("id");
+            if (id == null) {
                 Logger.WriteLine ("Invalid WebSockets URI: id is not set in query string", Logger.Severity.Error);
                 return Guid.Empty;
             }
-            var id = query.Substring ("?id=".Length);
             try {
                 var bytes = Convert.FromBase64String (id);
                 var length = bytes.Length;

--- a/core/src/Server/WebSockets/StreamServer.cs
+++ b/core/src/Server/WebSockets/StreamServer.cs
@@ -35,6 +35,9 @@ namespace KRPC.Server.WebSockets
             var request = ConnectionRequest.ReadRequest (args);
             if (args.Request.ShouldDeny)
                 return null;
+            if (request == null)
+                // The request has not been fully received yet; retry on a later update.
+                return null;
             var guid = GetGuid (request);
             if (guid == Guid.Empty) {
                 args.Client.Stream.Write (HTTP.Response.CreateBadRequest ().ToBytes ());

--- a/core/test/Server/WebSockets/RPCServerTest.cs
+++ b/core/test/Server/WebSockets/RPCServerTest.cs
@@ -139,8 +139,63 @@ namespace KRPC.Test.Server.WebSockets
         [Test]
         public void InvalidConnectionRequestGarbage ()
         {
-            var response = CheckInvalidConnectionRequest ("deadbeef".ToBytes ());
+            var response = CheckInvalidConnectionRequest ("deadbeef\r\n\r\n");
             Assert.AreEqual ("HTTP/1.1 400 Bad Request\r\n\r\n", response);
+        }
+
+        [Test]
+        public void ValidConnectionRequestSplitAcrossReads ()
+        {
+            var ascii = Encoding.ASCII;
+            var requestBytes = ascii.GetBytes (
+                "GET / HTTP/1.1\r\n" +
+                "Host: localhost\r\n" +
+                "Upgrade: websocket\r\n" +
+                "Connection: Upgrade\r\n" +
+                "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n" +
+                "Sec-WebSocket-Version: 13\r\n\r\n");
+            var split = requestBytes.Length / 2;
+
+            // Start with only the first half of the request available to be read.
+            var inputStream = new MemoryStream ();
+            inputStream.Write (requestBytes, 0, split);
+            inputStream.Seek (0, SeekOrigin.Begin);
+            var responseStream = new MemoryStream ();
+            var stream = new TestStream (inputStream, responseStream);
+
+            var mockByteServer = new Mock<IServer<byte, byte>> ();
+            var byteServer = mockByteServer.Object;
+            var byteClient = new TestClient (stream);
+
+            var server = new KRPC.Server.WebSockets.RPCServer (byteServer);
+            server.OnClientRequestingConnection += (sender, e) => e.Request.Allow ();
+            server.Start ();
+
+            // The partial request leaves the connection attempt pending, neither allowed nor denied.
+            var eventArgs = new ClientRequestingConnectionEventArgs<byte, byte> (byteClient);
+            mockByteServer.Raise (m => m.OnClientRequestingConnection += null, eventArgs);
+            Assert.IsTrue (eventArgs.Request.StillPending);
+
+            // Deliver the rest of the request, then retry the connection attempt.
+            inputStream.Seek (0, SeekOrigin.End);
+            inputStream.Write (requestBytes, split, requestBytes.Length - split);
+            inputStream.Seek (split, SeekOrigin.Begin);
+
+            var eventArgs2 = new ClientRequestingConnectionEventArgs<byte, byte> (byteClient);
+            mockByteServer.Raise (m => m.OnClientRequestingConnection += null, eventArgs2);
+            Assert.IsTrue (eventArgs2.Request.ShouldAllow);
+
+            server.Update ();
+            Assert.AreEqual (1, server.Clients.Count ());
+
+            var response = ascii.GetString (responseStream.ToArray ());
+            Assert.AreEqual (
+                "HTTP/1.1 101 Switching Protocols\r\n" +
+                "Upgrade: websocket\r\n" +
+                "Connection: Upgrade\r\n" +
+                "Sec-WebSocket-Accept: s3pPLMBiTxaQ9kYGzzhZRbK+xOo=\r\n\r\n",
+                response
+            );
         }
 
         [Test]

--- a/core/test/Server/WebSockets/RPCServerTest.cs
+++ b/core/test/Server/WebSockets/RPCServerTest.cs
@@ -137,6 +137,15 @@ namespace KRPC.Test.Server.WebSockets
         }
 
         [Test]
+        public void GetClientNameFromReorderedQuery ()
+        {
+            var request = KRPC.Server.HTTP.Request.FromString (
+                "GET /?foo=bar&name=Jeb%20Kerman HTTP/1.1\r\nHost: localhost\r\n\r\n");
+            Assert.AreEqual (
+                "Jeb Kerman", KRPC.Server.WebSockets.RPCServer.GetClientName (request));
+        }
+
+        [Test]
         public void InvalidConnectionRequestGarbage ()
         {
             var response = CheckInvalidConnectionRequest ("deadbeef\r\n\r\n");

--- a/core/test/Server/WebSockets/StreamServerTest.cs
+++ b/core/test/Server/WebSockets/StreamServerTest.cs
@@ -60,6 +60,16 @@ namespace KRPC.Test.Server.WebSockets
         }
 
         [Test]
+        public void GetGuidFromReorderedQuery ()
+        {
+            var guid = new Guid ("1234567890abcdef1234567890abcdef".ToBytes ());
+            var base64 = Convert.ToBase64String (guid.ToByteArray ());
+            var request = KRPC.Server.HTTP.Request.FromString (
+                "GET /?foo=bar&id=" + base64 + " HTTP/1.1\r\nHost: localhost\r\n\r\n");
+            Assert.AreEqual (guid, StreamServer.GetGuid (request));
+        }
+
+        [Test]
         public void InvalidConnectionRequestNoGuid ()
         {
             var ascii = Encoding.ASCII;


### PR DESCRIPTION
**Problem.** The websocket servers parsed a connection request from a single read: a handshake that arrived split across multiple reads was rejected outright, and the connection URL query parser only found the client-id parameter in a fixed position and did not percent-decode it.

**Fix.** Connection requests are now accumulated across reads until the header terminator arrives, leaving the connection attempt pending in the meantime with a timeout, mirroring the protobuf server's partial-request handling. Query parsing moves to a shared `Request.QueryParameter` helper that finds a parameter in any position and percent-decodes it, used by both the RPC and stream servers.

**Testing.** New unit tests cover split handshakes and query parameter positions on both servers.
