### PR TITLE
Fix lost stream-update notifications and blocked freezes in the C++ client

### DIFF
--- a/client/cpp/CHANGES.txt
+++ b/client/cpp/CHANGES.txt
@@ -9,6 +9,9 @@ v0.6.0
    (default) the system install is required; when ON FetchContent is used.
  * Add KRPC_FETCH_DEPS option to enable FetchContent for all dependencies at once
  * Mark deprecated members with the [[deprecated]] attribute (#904)
+ * Fix stream update notifications being lost, which could leave
+   Client::wait_for_stream_update sleeping through the update it was waiting for
+ * Fix Client::freeze_streams blocking forever when no stream is producing updates
 
 v0.5.2
  * Use protobuf-lite

--- a/client/cpp/include/krpc/object.hpp
+++ b/client/cpp/include/krpc/object.hpp
@@ -18,9 +18,8 @@ class Object {
   friend bool operator==(const Object<U>&, const Object<U>&);
   template <typename U>
   friend bool operator<(const Object<U>&, const Object<U>&);
-  // TODO: Ideally the following fields should be private, but they are needed by the
-  // encoder and decoder. They can't be a 'friend' due to the circular dependency
-  // that would introduce.
+  // Public because the encoder and decoder need them; they cannot be granted access with 'friend'
+  // without introducing a circular dependency between this header and theirs.
   Client* _client;
   uint64_t _id;
 

--- a/client/cpp/src/client.cpp
+++ b/client/cpp/src/client.cpp
@@ -68,16 +68,10 @@ std::string Client::invoke(const schema::Request& request) {
 }
 
 std::string Client::invoke(const schema::ProcedureCall& call) {
-  // TODO: is there a way to avoid copying the ProcedureCall in order to create a Request?
   schema::Request request;
-  schema::ProcedureCall* call2 = request.add_calls();
-  call2->set_service(call.service());
-  call2->set_procedure(call.procedure());
-  for (const auto& arg : call.arguments()) {
-    schema::Argument* arg2 = call2->add_arguments();
-    arg2->set_position(arg.position());
-    arg2->set_value(arg.value());
-  }
+  // Copied because the call is received by const reference and a Request owns its calls, so it
+  // cannot be moved in. CopyFrom also stays correct if ProcedureCall gains fields.
+  request.add_calls()->CopyFrom(call);
   return this->invoke(request);
 }
 

--- a/client/cpp/src/stream_manager.cpp
+++ b/client/cpp/src/stream_manager.cpp
@@ -145,11 +145,16 @@ void StreamManager::update_thread_main(StreamManager* stream_manager,
         break;
       } catch (EncodingError&) {  // NOLINT(bugprone-empty-catch): need more bytes
       }
+      // Handle a freeze request even when no update message is arriving, so that
+      // freezing does not block until the next message when no stream is producing
+      // updates. Only applies between messages: partial data means a message is
+      // mid-transfer, and it is read to completion first.
+      if (data.empty() && should_freeze->load()) break;
     }
     if (stop->load()) break;
 
     // Decode and apply the update
-    apply_update(connection->receive(size));
+    if (size > 0) apply_update(connection->receive(size));
 
     // Check if updates should freeze
     if (should_freeze->load()) {

--- a/client/cpp/src/stream_manager.cpp
+++ b/client/cpp/src/stream_manager.cpp
@@ -124,7 +124,13 @@ void StreamManager::update_thread_main(StreamManager* stream_manager,
     decoder::decode(update, data, client);
     for (const auto& result : update.results())
       stream_manager->update(result.id(), result.result());
-    stream_manager->condition.notify_all();
+    {
+      // Notify while holding the condition mutex, so that a notification cannot
+      // fire between a waiter checking the stream value and entering its wait --
+      // it would be lost and the waiter would sleep through the update.
+      std::lock_guard<std::mutex> guard(stream_manager->condition_mutex);
+      stream_manager->condition.notify_all();
+    }
     for (const auto& callback : stream_manager->callbacks) callback.second();
   };
 

--- a/client/cpp/test/test_stream.cpp
+++ b/client/cpp/test/test_stream.cpp
@@ -478,11 +478,12 @@ TEST_F(test_stream, test_stream_freeze_many) {
   for (size_t i = 0; i < streams.size(); i++) ASSERT_NE(values[i], streams[i]());
 }
 
-// FIXME: reenable test
-// TEST_F(test_stream, test_stream_stop_while_frozen) {
-//   auto s = test_service.counter_stream("test_stream.test_stream_stop_while_frozen");
-//   conn.freeze_streams();
-// }
+// Freezes with a stream that is not producing updates (it is never started), then
+// tears the connection down while still frozen.
+TEST_F(test_stream, test_stream_stop_while_frozen) {
+  auto s = test_service.counter_stream("test_stream.test_stream_stop_while_frozen");
+  conn.freeze_streams();
+}
 
 TEST_F(test_stream, test_default_constructable) {
   krpc::Stream<int> s;

--- a/client/cpp/test/test_stream.cpp
+++ b/client/cpp/test/test_stream.cpp
@@ -272,41 +272,52 @@ TEST_F(test_stream, test_wait_timeout_long) {
   x.release();
 }
 
-// TODO: fix these tests on Travis CI and re-enable
-// TEST_F(test_stream, test_wait_update) {
-//   auto x = test_service.counter_stream("test_stream.test_wait_update", 10);
-//   conn.acquire_stream_update();
-//   auto count = x();
-//   ASSERT_LT(count, 10);
-//   while (count < 10) {
-//     conn.wait_for_stream_update();
-//     count += 1;
-//     ASSERT_EQ(count, x());
-//   }
-//   conn.release_stream_update();
-// }
-//
-// TEST_F(test_stream, test_wait_update_timeout_short) {
-//   auto x = test_service.counter_stream("test_stream.test_wait_update_timeout_short", 10);
-//   conn.acquire_stream_update();
-//   auto count = x();
-//   conn.wait_for_stream_update(0);
-//   ASSERT_EQ(count, x());
-//   conn.release_stream_update();
-// }
-//
-// TEST_F(test_stream, test_wait_update_timeout_long) {
-//   auto x = test_service.counter_stream("test_stream.test_wait_update_timeout_long", 10);
-//   conn.acquire_stream_update();
-//   auto count = x();
-//   ASSERT_LT(count, 10);
-//   while (count < 10) {
-//     conn.wait_for_stream_update(10);
-//     count += 1;
-//     ASSERT_EQ(count, x());
-//   }
-//   conn.release_stream_update();
-// }
+// These tests wait for an update first, to synchronize on an update message
+// boundary before reading their baseline count; each subsequent wait then
+// corresponds to exactly one update message, which advances the counter value
+// by exactly one (the counter's divisor slows value changes to one per ten
+// server ticks, so each change is sent in its own update message).
+
+TEST_F(test_stream, test_wait_update) {
+  auto x = test_service.counter_stream("test_stream.test_wait_update", 10);
+  conn.acquire_stream_update();
+  x.start(false);
+  conn.wait_for_stream_update();
+  auto count = x();
+  ASSERT_LT(count, 10);
+  while (count < 10) {
+    conn.wait_for_stream_update();
+    count += 1;
+    ASSERT_EQ(count, x());
+  }
+  conn.release_stream_update();
+}
+
+TEST_F(test_stream, test_wait_update_timeout_short) {
+  auto x = test_service.counter_stream("test_stream.test_wait_update_timeout_short", 10);
+  conn.acquire_stream_update();
+  x.start(false);
+  conn.wait_for_stream_update();
+  auto count = x();
+  conn.wait_for_stream_update(0);
+  ASSERT_EQ(count, x());
+  conn.release_stream_update();
+}
+
+TEST_F(test_stream, test_wait_update_timeout_long) {
+  auto x = test_service.counter_stream("test_stream.test_wait_update_timeout_long", 10);
+  conn.acquire_stream_update();
+  x.start(false);
+  conn.wait_for_stream_update();
+  auto count = x();
+  ASSERT_LT(count, 10);
+  while (count < 10) {
+    conn.wait_for_stream_update(10);
+    count += 1;
+    ASSERT_EQ(count, x());
+  }
+  conn.release_stream_update();
+}
 
 TEST_F(test_stream, test_callback) {
   std::atomic<int> test_callback_value(-1);


### PR DESCRIPTION
Two long-standing bugs in the C++ client's stream machinery, found by re-enabling tests disabled as flaky in 2018.

**Lost notifications.** The stream update thread called `notify_all` on the update condition without holding its mutex, so a notification could fire between a waiter checking the stream value and entering its wait, and be lost — leaving `wait_for_stream_update` sleeping through the update it was waiting for. This is why the three `wait_for_stream_update` tests could never be stabilised. The update thread now notifies while holding the condition mutex, matching the Python client, and the tests are re-enabled in the shape of the Python client's equivalents (the stream is started while the condition is held, and the first wait synchronises on an update-message boundary before the baseline count is read).

**Blocked freezes.** `freeze_streams` was only acknowledged by the update thread after applying an update message, so with no started stream — or no stream whose value is changing — it blocked forever. The disabled `test_stream_stop_while_frozen` predates deferred stream start; when streams stopped auto-starting on creation, its stream stopped producing updates and the freeze hung, matching the date it was disabled. The update thread now also acknowledges a freeze from the receive loop's timeout path, between messages, so freezing is bounded by the receive poll interval. The test is re-enabled verbatim.

Also copies the call into stream requests with `CopyFrom` rather than field-by-field, so future fields are not dropped, and documents why the `Object` fields are public.