### PR TITLE
SpaceCenter correctness and performance fixes

### DIFF
--- a/doc/order.txt
+++ b/doc/order.txt
@@ -1192,6 +1192,7 @@ SpaceCenter.Wheel.DriveLimiter
 SpaceCenter.Wheel.Steerable
 SpaceCenter.Wheel.SteeringEnabled
 SpaceCenter.Wheel.SteeringInverted
+SpaceCenter.Wheel.SteeringAngleAuto
 SpaceCenter.Wheel.SteeringAngleLimit
 SpaceCenter.Wheel.SteeringResponseTime
 SpaceCenter.Wheel.HasSuspension

--- a/service/SpaceCenter/CHANGES.txt
+++ b/service/SpaceCenter/CHANGES.txt
@@ -146,6 +146,16 @@ v0.6.0
    Orbit.ClosestApproaches (#334)
  * Fix Part.Lift, Flight.Lift and Flight.AerodynamicForce including stale body lift for
    parts whose body lift the game suppresses . e.g. a pod with a heatshield attached (#971)
+ * Fix RCS.Active reporting a shielded thruster as inactive when it is able to
+   thrust while shielded
+ * Add Wheel.SteeringAngleAuto to get/set automatic speed-based steering angle limiting
+ * Fix maneuver node reference frame positions being computed relative to the
+   active vessel, giving wrong positions for maneuver nodes on other vessels
+ * Fix Node objects whose maneuver node was removed by Control.RemoveNodes,
+   another Node object or the in-game UI: all members now raise an error,
+   instead of silently reading and writing the detached node
+ * Improve performance of CommNode.IsVessel, CommNode.Vessel,
+   Vessel.AngularVelocity and reference frame angular velocities
 
 v0.5.4
  * Fix vessel recovery (#782)

--- a/service/SpaceCenter/src/AutoPilot/AttitudeController.cs
+++ b/service/SpaceCenter/src/AutoPilot/AttitudeController.cs
@@ -1402,7 +1402,7 @@ namespace KRPC.SpaceCenter.AutoPilot
         /// </summary>
         Vector3 ComputeCurrentAngularVelocity ()
         {
-            var worldAngularVelocity = vessel.InternalVessel.GetComponent<Rigidbody> ().angularVelocity;
+            var worldAngularVelocity = vessel.InternalVessel.WorldAngularVelocity ();
             var localAngularVelocity = ReferenceFrame.AngularVelocityFromWorldSpace (worldAngularVelocity);
             // Express the measured angular velocity in the controller's sign convention.
             //
@@ -1529,7 +1529,7 @@ namespace KRPC.SpaceCenter.AutoPilot
             // from-rest flip has no committed plane, so latch the arbitrary-but-consistent geodesic
             // axis instead — either way the flip then rides a fixed plane, not the precessing live axis.
             if (!antipodeLatched) {
-                var worldOmega = vessel.InternalVessel.GetComponent<Rigidbody> ().angularVelocity;
+                var worldOmega = vessel.InternalVessel.WorldAngularVelocity ();
                 Vector3d omegaAp = ReferenceFrame.AngularVelocityFromWorldSpace (worldOmega);
                 var omegaPerp = omegaAp - Vector3d.Dot (omegaAp, currentDirection) * currentDirection;
                 antipodeLatchedNormal = omegaPerp.magnitude >= AntipodeLeadRate

--- a/service/SpaceCenter/src/ExtensionMethods/GeometryExtensions.cs
+++ b/service/SpaceCenter/src/ExtensionMethods/GeometryExtensions.cs
@@ -242,7 +242,9 @@ namespace KRPC.SpaceCenter.ExtensionMethods
             switch (order) {
             case AxisOrder.YZX:
                 {
-                    // FIXME: use double precision arithmetic
+                    // The double-precision QuaternionD.eulerAngles cannot be used: its native
+                    // Internal_ToEulerRad binding is stripped from KSP's runtime and throws a
+                    // missing-method error. Round-trip through the single-precision Quaternion.
                     var angles = new Quaternion ((float)q.z, (float)q.x, (float)q.y, (float)q.w).eulerAngles;
                     result = new Vector3d (angles.z, angles.x, angles.y);
                     break;
@@ -278,7 +280,9 @@ namespace KRPC.SpaceCenter.ExtensionMethods
             QuaternionD result;
             switch (order) {
             case AxisOrder.YZX:
-                // FIXME: use double precision arithmetic
+                // The double-precision QuaternionD.Euler cannot be used: its native
+                // Internal_FromEulerRad binding is stripped from KSP's runtime and throws a
+                // missing-method error. Round-trip through the single-precision Quaternion.
                 var angles = new Vector3 ((float)eulerAngles.y, (float)eulerAngles.z, (float)eulerAngles.x);
                 var tmp = Quaternion.Euler (angles);
                 result = new QuaternionD (tmp.y, tmp.z, tmp.x, tmp.w);

--- a/service/SpaceCenter/src/ExtensionMethods/VesselExtensions.cs
+++ b/service/SpaceCenter/src/ExtensionMethods/VesselExtensions.cs
@@ -18,6 +18,14 @@ namespace KRPC.SpaceCenter.ExtensionMethods
         }
 
         /// <summary>
+        /// The total mass of the vessel's parts, including resources, in kg.
+        /// </summary>
+        internal static float WetMass (this global::Vessel vessel)
+        {
+            return vessel.parts.Sum (part => part.WetMass ());
+        }
+
+        /// <summary>
         /// Activation stage numbers for the vessel, preferring stock
         /// delta-v data and falling back to staging icons when unavailable.
         /// </summary>

--- a/service/SpaceCenter/src/ExtensionMethods/VesselExtensions.cs
+++ b/service/SpaceCenter/src/ExtensionMethods/VesselExtensions.cs
@@ -1,10 +1,22 @@
 using System.Collections.Generic;
 using System.Linq;
+using UnityEngine;
 
 namespace KRPC.SpaceCenter.ExtensionMethods
 {
     static class VesselExtensions
     {
+        /// <summary>
+        /// The angular velocity of the vessel in world space, in radians per second.
+        /// The vessel behaviour is attached to the root part's game object, so the
+        /// vessel's rigidbody is the root part's, available from its cached rb field
+        /// without a GetComponent lookup.
+        /// </summary>
+        internal static Vector3 WorldAngularVelocity (this global::Vessel vessel)
+        {
+            return vessel.rootPart.rb.angularVelocity;
+        }
+
         /// <summary>
         /// Activation stage numbers for the vessel, preferring stock
         /// delta-v data and falling back to staging icons when unavailable.

--- a/service/SpaceCenter/src/Services/AutoPilot.cs
+++ b/service/SpaceCenter/src/Services/AutoPilot.cs
@@ -442,7 +442,7 @@ namespace KRPC.SpaceCenter.Services
         void WaitWithDeadline (DateTime deadline)
         {
             if (Error > Controller.StoppingAngleThreshold ||
-                InternalVessel.GetComponent<Rigidbody> ().angularVelocity.magnitude > Controller.StoppingVelocityThreshold) {
+                InternalVessel.WorldAngularVelocity ().magnitude > Controller.StoppingVelocityThreshold) {
                 if (DateTime.UtcNow > deadline)
                     throw new TimeoutException ("AutoPilot timed out waiting to reach target direction");
                 throw new YieldException<Action> (() => WaitWithDeadline (deadline));

--- a/service/SpaceCenter/src/Services/CommNode.cs
+++ b/service/SpaceCenter/src/Services/CommNode.cs
@@ -66,20 +66,31 @@ namespace KRPC.SpaceCenter.Services
         }
 
         /// <summary>
+        /// The KSP vessel this node belongs to, or null if it is not a vessel's node.
+        /// A vessel's node is constructed with the vessel's transform, so the vessel
+        /// component can be read straight off it without scanning every vessel in the
+        /// game. The vessel's connection is checked to confirm the node is its current
+        /// one, so a stale node from a rebuilt network is not treated as the vessel's.
+        /// </summary>
+        global::Vessel InternalVessel {
+            get {
+                var transform = InternalNode.transform;
+                if (transform == null)
+                    return null;
+                var vessel = transform.GetComponent<global::Vessel> ();
+                if (vessel == null)
+                    return null;
+                var connection = vessel.Connection;
+                return connection != null && connection.Comm == InternalNode ? vessel : null;
+            }
+        }
+
+        /// <summary>
         /// Whether the communication node is a vessel.
         /// </summary>
         [KRPCProperty]
         public bool IsVessel {
-            get {
-                // FIXME: this is inefficient
-                var node = InternalNode;
-                foreach (var x in FlightGlobals.Vessels) {
-                    var connection = x.Connection;
-                    if (connection != null && connection.Comm == InternalNode)
-                        return true;
-                }
-                return false;
-            }
+            get { return InternalVessel != null; }
         }
 
         /// <summary>
@@ -88,14 +99,10 @@ namespace KRPC.SpaceCenter.Services
         [KRPCProperty]
         public Vessel Vessel {
             get {
-                // FIXME: this is inefficient
-                var node = InternalNode;
-                foreach (var x in FlightGlobals.Vessels) {
-                    var connection = x.Connection;
-                    if (connection != null && connection.Comm == InternalNode)
-                        return new Vessel (x);
-                }
-                throw new InvalidOperationException ("Communication node is not part of a vessel");
+                var vessel = InternalVessel;
+                if (vessel == null)
+                    throw new InvalidOperationException ("Communication node is not part of a vessel");
+                return new Vessel (vessel);
             }
         }
     }

--- a/service/SpaceCenter/src/Services/Flight.cs
+++ b/service/SpaceCenter/src/Services/Flight.cs
@@ -222,8 +222,7 @@ namespace KRPC.SpaceCenter.Services
         /// Reference area used for lift and drag calculations
         /// </summary>
         double ReferenceArea {
-            // TODO: avoid creating vessel object
-            get { return new Vessel (InternalVessel).Mass / (BallisticCoefficient * DragCoefficient); }
+            get { return InternalVessel.WetMass () / (BallisticCoefficient * DragCoefficient); }
         }
 
         /// <summary>

--- a/service/SpaceCenter/src/Services/Node.cs
+++ b/service/SpaceCenter/src/Services/Node.cs
@@ -78,10 +78,28 @@ namespace KRPC.SpaceCenter.Services
         /// </summary>
         public ManeuverNode InternalNode { get; private set; }
 
+        /// <summary>
+        /// The KSP maneuver node, checked to still be part of the vessel's flight plan.
+        /// A node can be removed through this object, through another object wrapping
+        /// the same node (including Control.RemoveNodes), or manually in the in-game
+        /// UI; in all cases accessing it through this object is an error.
+        /// </summary>
+        ManeuverNode SafeNode {
+            get {
+                var node = InternalNode;
+                if (node != null) {
+                    var solver = InternalVessel.patchedConicSolver;
+                    if (solver != null && solver.maneuverNodes.Contains (node))
+                        return node;
+                }
+                throw new InvalidOperationException ("Maneuver node has been removed");
+            }
+        }
+
         internal Vector3d WorldBurnVector {
             get {
-                var prograde = InternalNode.patch.getOrbitalVelocityAtUT (InternalNode.UT).SwapYZ ().normalized;
-                var normal = InternalNode.patch.GetOrbitNormal ().SwapYZ ().normalized;
+                var prograde = SafeNode.patch.getOrbitalVelocityAtUT (SafeNode.UT).SwapYZ ().normalized;
+                var normal = SafeNode.patch.GetOrbitNormal ().SwapYZ ().normalized;
                 var radial = Vector3d.Cross (normal, prograde);
                 return Prograde * prograde + Normal * normal + Radial * radial;
             }
@@ -93,9 +111,9 @@ namespace KRPC.SpaceCenter.Services
         /// </summary>
         [KRPCProperty]
         public double Prograde {
-            get { return InternalNode.DeltaV.z; }
+            get { return SafeNode.DeltaV.z; }
             set {
-                InternalNode.DeltaV.z = value;
+                SafeNode.DeltaV.z = value;
                 Update ();
             }
         }
@@ -106,9 +124,9 @@ namespace KRPC.SpaceCenter.Services
         /// </summary>
         [KRPCProperty]
         public double Normal {
-            get { return InternalNode.DeltaV.y; }
+            get { return SafeNode.DeltaV.y; }
             set {
-                InternalNode.DeltaV.y = value;
+                SafeNode.DeltaV.y = value;
                 Update ();
             }
         }
@@ -119,9 +137,9 @@ namespace KRPC.SpaceCenter.Services
         /// </summary>
         [KRPCProperty]
         public double Radial {
-            get { return InternalNode.DeltaV.x; }
+            get { return SafeNode.DeltaV.x; }
             set {
-                InternalNode.DeltaV.x = value;
+                SafeNode.DeltaV.x = value;
                 Update ();
             }
         }
@@ -134,10 +152,10 @@ namespace KRPC.SpaceCenter.Services
         /// </remarks>
         [KRPCProperty]
         public double DeltaV {
-            get { return InternalNode.DeltaV.magnitude; }
+            get { return SafeNode.DeltaV.magnitude; }
             set {
-                var direction = InternalNode.DeltaV.normalized;
-                InternalNode.DeltaV = new Vector3d (direction.x * value, direction.y * value, direction.z * value);
+                var direction = SafeNode.DeltaV.normalized;
+                SafeNode.DeltaV = new Vector3d (direction.x * value, direction.y * value, direction.z * value);
                 Update ();
             }
         }
@@ -148,7 +166,7 @@ namespace KRPC.SpaceCenter.Services
         /// </summary>
         [KRPCProperty]
         public double RemainingDeltaV {
-            get { return InternalNode.GetBurnVector (InternalNode.patch).magnitude; }
+            get { return SafeNode.GetBurnVector (SafeNode.patch).magnitude; }
         }
 
         /// <summary>
@@ -186,7 +204,7 @@ namespace KRPC.SpaceCenter.Services
         {
             if (ReferenceEquals (referenceFrame, null))
                 referenceFrame = ReferenceFrame.Orbital (InternalVessel);
-            return referenceFrame.DirectionFromWorldSpace (InternalNode.GetBurnVector (InternalNode.patch)).ToTuple ();
+            return referenceFrame.DirectionFromWorldSpace (SafeNode.GetBurnVector (SafeNode.patch)).ToTuple ();
         }
 
         /// <summary>
@@ -194,9 +212,9 @@ namespace KRPC.SpaceCenter.Services
         /// </summary>
         [KRPCProperty]
         public double UT {
-            get { return InternalNode.UT; }
+            get { return SafeNode.UT; }
             set {
-                InternalNode.UT = value;
+                SafeNode.UT = value;
                 Update ();
             }
         }
@@ -230,13 +248,10 @@ namespace KRPC.SpaceCenter.Services
         [KRPCMethod]
         public void Remove ()
         {
-            if (InternalNode == null)
-                throw new InvalidOperationException ("Node does not exist");
-            if (InternalVessel.patchedConicSolver == null)
-                throw new InvalidOperationException ("Cannot remove maneuver node");
-            InternalNode.RemoveSelf ();
+            // Note: the Node object itself is not removed from the object store; that
+            // is the object-lifetime gap tracked by issue #771
+            SafeNode.RemoveSelf ();
             InternalNode = null;
-            // TODO: delete this Node object
         }
 
         /// <summary>
@@ -249,7 +264,7 @@ namespace KRPC.SpaceCenter.Services
         /// </summary>
         [KRPCProperty]
         public ReferenceFrame ReferenceFrame {
-            get { return ReferenceFrame.Object (InternalVessel, InternalNode); }
+            get { return ReferenceFrame.Object (InternalVessel, SafeNode); }
         }
 
         /// <summary>
@@ -268,7 +283,7 @@ namespace KRPC.SpaceCenter.Services
         /// </summary>
         [KRPCProperty]
         public ReferenceFrame OrbitalReferenceFrame {
-            get { return ReferenceFrame.Orbital (InternalVessel, InternalNode); }
+            get { return ReferenceFrame.Orbital (InternalVessel, SafeNode); }
         }
 
         /// <summary>
@@ -282,7 +297,7 @@ namespace KRPC.SpaceCenter.Services
         {
             if (ReferenceEquals (referenceFrame, null))
                 throw new ArgumentNullException (nameof (referenceFrame));
-            return referenceFrame.PositionFromWorldSpace (InternalNode.patch.getPositionAtUT (InternalNode.UT)).ToTuple ();
+            return referenceFrame.PositionFromWorldSpace (SafeNode.patch.getPositionAtUT (SafeNode.UT)).ToTuple ();
         }
 
         /// <summary>

--- a/service/SpaceCenter/src/Services/Parts/Experiment.cs
+++ b/service/SpaceCenter/src/Services/Parts/Experiment.cs
@@ -82,8 +82,11 @@ namespace KRPC.SpaceCenter.Services.Parts
                 throw new InvalidOperationException ("Experiment already contains data");
             if (Inoperable)
                 throw new InvalidOperationException ("Experiment is inoperable");
-            // Stock experiments
-            // FIXME: Don't use private API!!!
+            // Stock experiments. KSP has no public method that runs an experiment without
+            // also showing the results dialog: DeployExperiment, DeployAction and
+            // DeployExperimentExternal all start gatherData(showDialog: true), and the only
+            // dialog-free caller, OnActive, is gated on staging configuration. So invoke the
+            // private gatherData coroutine directly, mirroring KSP's own staging path.
             var gatherData = experiment.GetType ().GetMethod ("gatherData", BindingFlags.NonPublic | BindingFlags.Instance);
             if (gatherData != null)
             {

--- a/service/SpaceCenter/src/Services/Parts/RCS.cs
+++ b/service/SpaceCenter/src/Services/Parts/RCS.cs
@@ -62,16 +62,16 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// Whether the RCS thrusters are active.
         /// An RCS thruster is inactive if the RCS action group is disabled
         /// (<see cref="Control.RCS"/>), the RCS thruster itself is not enabled
-        /// (<see cref="Enabled"/>) or it is covered by a fairing (<see cref="Part.Shielded"/>).
+        /// (<see cref="Enabled"/>), or it is covered by a fairing
+        /// (<see cref="Part.Shielded"/>) and cannot thrust while shielded.
         /// </summary>
         [KRPCProperty]
         public bool Active {
             get {
-                // TODO: what about rcs.shieldedCanThrust?
                 var p = Part.InternalPart;
                 return
                 p.vessel.ActionGroups.groups [BaseAction.GetGroupIndex (KSPActionGroup.RCS)] &&
-                !p.ShieldedFromAirstream &&
+                (!p.ShieldedFromAirstream || rcs.shieldedCanThrust) &&
                 rcs.rcsEnabled &&
                 rcs.isEnabled &&
                 !rcs.isJustForShow;

--- a/service/SpaceCenter/src/Services/Parts/Wheel.cs
+++ b/service/SpaceCenter/src/Services/Parts/Wheel.cs
@@ -352,25 +352,22 @@ namespace KRPC.SpaceCenter.Services.Parts
             }
         }
 
-        // FIXME: isn't working
-        // /// <summary>
-        // /// Whether the wheel steering is limited in relationship to speed.
-        // /// </summary>
-        // [KRPCProperty]
-        // public bool SteeringAngleAuto
-        // {
-        //     get
-        //     {
-        //         CheckSteering();
-        //         return steering.autoSteeringAdjust;
-        //     }
-        //     set
-        //     {
-        //         CheckSteering();
-        //         steering.autoSteeringAdjust = value;
-        //         steering.steer
-        //     }
-        // }
+        /// <summary>
+        /// Whether the steering angle is automatically limited based on the vessel's speed,
+        /// reducing the maximum angle as the vessel moves faster. See also
+        /// <see cref="SteeringAngleLimit" />.
+        /// </summary>
+        [KRPCProperty]
+        public bool SteeringAngleAuto {
+            get {
+                CheckSteering();
+                return steering.autoSteeringAdjust;
+            }
+            set {
+                CheckSteering();
+                steering.autoSteeringAdjust = value;
+            }
+        }
 
         /// <summary>
         /// The steering angle limit.

--- a/service/SpaceCenter/src/Services/ReferenceFrame.cs
+++ b/service/SpaceCenter/src/Services/ReferenceFrame.cs
@@ -407,11 +407,12 @@ namespace KRPC.SpaceCenter.Services
                 case ReferenceFrameType.Maneuver:
                 case ReferenceFrameType.ManeuverOrbital:
                     {
-                        // TODO: is there a better way to do this?
-                        // node.patch.getPositionAtUT (node.UT) appears to return a position vector
-                        // in a different space to vessel.GetWorldPos3D()
-                        var vesselPos = FlightGlobals.ActiveVessel.CoM;
-                        var vesselOrbitPos = FlightGlobals.ActiveVessel.orbit.getPositionAtUT (Planetarium.GetUniversalTime ());
+                        // Orbit positions don't exactly coincide with transform world
+                        // positions, so the node's orbit position is corrected by the
+                        // offset between the two spaces, measured on the node's vessel
+                        // whose position is known in both.
+                        var vesselPos = InternalVessel.CoM;
+                        var vesselOrbitPos = InternalVessel.orbit.getPositionAtUT (Planetarium.GetUniversalTime ());
                         var nodeOrbitPos = node.patch.getPositionAtUT (node.UT);
                         return vesselPos - vesselOrbitPos + nodeOrbitPos;
                     }

--- a/service/SpaceCenter/src/Services/ReferenceFrame.cs
+++ b/service/SpaceCenter/src/Services/ReferenceFrame.cs
@@ -662,7 +662,7 @@ namespace KRPC.SpaceCenter.Services
                     return Vector3d.Cross (r, v) / r.sqrMagnitude;
                 }
                 case ReferenceFrameType.Vessel:
-                    return InternalVessel.GetComponent<Rigidbody> ().angularVelocity;
+                    return InternalVessel.WorldAngularVelocity ();
                 case ReferenceFrameType.VesselOrbital: {
                     var r = InternalVessel.CoM - InternalVessel.mainBody.position;
                     var v = InternalVessel.GetOrbit ().GetVel ();
@@ -718,11 +718,11 @@ namespace KRPC.SpaceCenter.Services
                 }
                 case ReferenceFrameType.Part:
                 case ReferenceFrameType.PartCenterOfMass:
-                    return InternalPart.vessel.GetComponent<Rigidbody> ().angularVelocity;
+                    return InternalPart.vessel.WorldAngularVelocity ();
                 case ReferenceFrameType.DockingPort:
-                    return dockingPort.vessel.GetComponent<Rigidbody> ().angularVelocity;
+                    return dockingPort.vessel.WorldAngularVelocity ();
                 case ReferenceFrameType.Thrust:
-                    return InternalPart.vessel.GetComponent<Rigidbody> ().angularVelocity;
+                    return InternalPart.vessel.WorldAngularVelocity ();
                 case ReferenceFrameType.Relative:
                     return parent.AngularVelocityToWorldSpace (relativeAngularVelocity);
                 case ReferenceFrameType.Hybrid:

--- a/service/SpaceCenter/src/Services/Vessel.cs
+++ b/service/SpaceCenter/src/Services/Vessel.cs
@@ -394,7 +394,7 @@ namespace KRPC.SpaceCenter.Services
         /// </summary>
         [KRPCProperty (GameScene = GameScene.Flight)]
         public float Mass {
-            get { return InternalVessel.parts.Sum(part => part.WetMass()); }
+            get { return InternalVessel.WetMass (); }
         }
 
         /// <summary>

--- a/service/SpaceCenter/src/Services/Vessel.cs
+++ b/service/SpaceCenter/src/Services/Vessel.cs
@@ -1081,10 +1081,9 @@ namespace KRPC.SpaceCenter.Services
         [KRPCMethod (GameScene = GameScene.Flight)]
         public Tuple3 AngularVelocity (ReferenceFrame referenceFrame)
         {
-            // FIXME: finding the rigidbody is expensive - cache it
             if (ReferenceEquals (referenceFrame, null))
                 throw new ArgumentNullException (nameof (referenceFrame));
-            return referenceFrame.AngularVelocityFromWorldSpace (InternalVessel.GetComponent<Rigidbody> ().angularVelocity).ToTuple ();
+            return referenceFrame.AngularVelocityFromWorldSpace (InternalVessel.WorldAngularVelocity ()).ToTuple ();
         }
     }
 }

--- a/service/SpaceCenter/test/test_node.py
+++ b/service/SpaceCenter/test/test_node.py
@@ -1,6 +1,5 @@
 import unittest
 
-import krpc
 import krpctest
 from krpctest.geometry import norm, normalize, vector
 
@@ -55,17 +54,17 @@ class TestNode(krpctest.TestCase):
     def test_remove_node(self):
         node = self.control.add_node(self.space_center.ut, 0, 0, 0)
         node.remove()
-        with self.assertRaises(krpc.client.RPCError):
+        with self.assertRaises(RuntimeError):
             node.prograde = 0
 
     def test_remove_nodes(self):
-        self.control.add_node(self.space_center.ut + 15, 4, -2, 1)
-        self.control.add_node(self.space_center.ut + 40, 1, 3, 2)
-        self.control.add_node(self.space_center.ut + 60, 0, 4, 0)
+        node0 = self.control.add_node(self.space_center.ut + 15, 4, -2, 1)
+        node1 = self.control.add_node(self.space_center.ut + 40, 1, 3, 2)
+        node2 = self.control.add_node(self.space_center.ut + 60, 0, 4, 0)
         self.control.remove_nodes()
-        # TODO: don't skip the following
-        # with self.assertRaises (krpc.client.RPCError):
-        #     node.prograde = 0
+        for node in (node0, node1, node2):
+            with self.assertRaises(RuntimeError):
+                node.prograde = 0
 
     def test_get_nodes(self):
         self.assertEqual([], self.control.nodes)

--- a/service/SpaceCenter/test/test_parts_wheel.py
+++ b/service/SpaceCenter/test/test_parts_wheel.py
@@ -159,11 +159,23 @@ class TestPartsWheel(krpctest.TestCase):
         self.assertTrue(wheel.steering_enabled)
         self.assertFalse(wheel.steering_inverted)
 
+    def test_steering_angle_auto(self):
+        wheel = self.powered_wheel
+        # The setting round-trips through the live KSP field
+        default = wheel.steering_angle_auto
+        wheel.steering_angle_auto = not default
+        self.wait()
+        self.assertEqual(not default, wheel.steering_angle_auto)
+        wheel.steering_angle_auto = default
+        self.wait()
+        self.assertEqual(default, wheel.steering_angle_auto)
+
     def test_unsteerable(self):
         wheel = self.fixed_wheel
         self.assertFalse(wheel.steerable)
         self.assertRaises(RuntimeError, getattr, wheel, "steering_enabled")
         self.assertRaises(RuntimeError, getattr, wheel, "steering_inverted")
+        self.assertRaises(RuntimeError, getattr, wheel, "steering_angle_auto")
 
     def test_suspension(self):
         wheel = self.suspension_wheel


### PR DESCRIPTION
A batch of correctness fixes and performance improvements to the SpaceCenter service:

* `RCS.Active` treated any shielded thruster as inactive, but KSP allows a shielded thruster to fire when `shieldedCanThrust` is set (verified against KSP's own `FixedUpdate` gate). This also corrects the RCS torque, force and acceleration values that gate on `Active`.
* `Wheel.SteeringAngleAuto` is wired up as a get/set property (the previous code was an unfinished stub), matching the sibling steering properties.
* Maneuver-node reference frame positions corrected the orbit-space→world-space offset using the active vessel, giving wrong positions for maneuver frames belonging to other vessels; the offset is now measured on the node's own vessel, which the frame already tracks.
* A `Node` object whose maneuver node was removed via `Control.RemoveNodes`, another `Node` object, or manually in the in-game UI silently read from and wrote to the detached node; only `Remove`-then-access threw. All `Node` members now validate the node is still in the vessel's flight plan and raise `InvalidOperationException`, covering every removal path.
* `CommNode.IsVessel`/`Vessel` scanned every vessel in the game; the vessel is now read in O(1) from the node's transform. `Vessel.AngularVelocity` and the reference-frame and attitude-controller angular velocity reads used a per-call `GetComponent<Rigidbody>` lookup; they now read the root part's cached rigidbody. `Flight`'s reference area no longer constructs a vessel wrapper to read its mass.
* The quaternion/euler single-precision round-trip and the `Experiment.Run` reflection are documented as necessary workarounds (KSP's `QuaternionD` euler bindings are stripped at runtime; no public KSP method runs an experiment without the results dialog).

**Testing.** Verified in-game: the comms, flight, vessel, node and docking-port suites, plus the autopilot quick gate (orbital directions on all craft classes, launch and smooth-turn on all launch craft) for the per-tick angular velocity change.
