### PR TITLE
Server UI cleanups

### DIFF
--- a/server/src/Addon.cs
+++ b/server/src/Addon.cs
@@ -12,7 +12,9 @@ namespace KRPC
     [KSPAddon (KSPAddon.Startup.AllGameScenes, false)]
     public sealed class Addon : MonoBehaviour
     {
-        // TODO: clean this up
+        // A new addon instance is created on every scene change (KSPAddon.AllGameScenes
+        // with once: false), so state that must survive scene switches — the loaded
+        // configuration, the running server core and cached button textures — is static.
         internal static ConfigurationFile config;
         static Core core;
         static Texture textureOnline;

--- a/server/src/UI/GUILayoutExtensions.cs
+++ b/server/src/UI/GUILayoutExtensions.cs
@@ -177,13 +177,10 @@ namespace KRPC.UI
             // be used to set the position of the combo window later
             if (Event.current.type == EventType.Repaint) {
                 var position = GUILayoutUtility.GetLastRect ();
-                // Convert from relative to absolute coordinates
-                // TODO: ugly hack...
-                Vector2 mousePosition = Input.mousePosition;
-                mousePosition.y = Screen.height - mousePosition.y;
-                Vector2 clippedMousePos = Event.current.mousePosition;
-                position.x = position.x + mousePosition.x - clippedMousePos.x;
-                position.y = position.y + mousePosition.y - clippedMousePos.y;
+                // Convert from GUI-space (window-relative) to screen coordinates
+                var screenPosition = GUIUtility.GUIToScreenPoint (new Vector2 (position.x, position.y));
+                position.x = screenPosition.x;
+                position.y = screenPosition.y;
                 comboButtonPositions [caller] = position;
             }
 

--- a/server/src/UI/OptionDialog.cs
+++ b/server/src/UI/OptionDialog.cs
@@ -53,11 +53,10 @@ namespace KRPC.UI
         public void Close ()
         {
             if (Visible) {
-                try {
+                // The popup may have already been destroyed by other UI logic (e.g. a
+                // scene switch); Unity's lifetime check reports it as null in that case.
+                if (popup != null)
                     Destroy (popup.gameObject);
-                } catch (NullReferenceException) {
-                    // FIXME: Nasty hack catching this. Dialog may have already been removed by other UI logic.
-                }
                 Visible = false;
                 dialog = null;
                 popup = null;

--- a/server/src/UI/Window.cs
+++ b/server/src/UI/Window.cs
@@ -111,7 +111,9 @@ namespace KRPC.UI
                     Visible = false;
                 }
             }
-            // FIXME: dirty hack to make the title bar slightly bigger when the UI is scaled up
+            // The title font is scaled with UI_SCALE (see OnGUI) but the skin's window
+            // style reserves a fixed-height title area, so reserve the extra height the
+            // scaled title needs to stop the content overlapping it.
             GUILayout.Space ((int)(20 * (GameSettings.UI_SCALE - 1)));
             Draw (rescale);
             rescale = false;


### PR DESCRIPTION
The combo box position was converted from GUI space to screen coordinates by differencing `Input.mousePosition` against the event's mouse position, which is only correct when the two agree on where the mouse is — true when a real mouse is over the button, and wildly wrong otherwise (verified in-game: off by 960 px in a headless environment, while `GUIUtility.GUIToScreenPoint` returned exactly the window origin plus the button offset). The conversion now uses `GUIToScreenPoint`, which is exact via the GUI clip stack and independent of the mouse.

Option dialogs closed by other UI logic were handled by catching the `NullReferenceException` from `Destroy`; the close path now uses Unity's lifetime check instead. The addon's static state and the scaled title-bar spacer get comments explaining why they exist.

**Testing.** In-game verification of the coordinate conversion by numeric comparison of both forms; server builds and the in-game suite boots cleanly.
