### PR TITLE
Build and tooling fixes

### DIFF
--- a/doc/conf.py.tmpl
+++ b/doc/conf.py.tmpl
@@ -92,7 +92,10 @@ toc_object_entries = False
 todo_include_todos = True
 
 spelling_word_list_filename = 'dictionary.txt'
-spelling_ignore_contributor_names = True
+# Not enabled: it scans git history for contributor names, but the docs are built from a source tree
+# with no git repository, so it only ever warns and adds nothing. Names that need allowing go in
+# dictionary.txt. Keeping it off lets the spelling build run with warnings treated as errors.
+spelling_ignore_contributor_names = False
 
 # The changelog page is generated verbatim from the CHANGES.txt files and is
 # dense with API identifiers; exclude it from the spell checker (only -- it is

--- a/tools/build/client_test.bzl
+++ b/tools/build/client_test.bzl
@@ -49,7 +49,10 @@ def _impl(ctx):
         ])
         server_args = '--type=serialio --port="$SERVER_PORT"'
         get_server_settings = [
-            "sleep 1",  # FIXME: hack to ensure serial port is established fully before running tests
+            # The virtual serial link (server PTY <-> socat <-> client PTY) is not always ready the
+            # instant the server reports started, so wait briefly for it to settle before the client
+            # connects.
+            "sleep 1",
             'echo "Server started, port = $SERVER_PORT"',
         ]
         test_env = "PORT=$CLIENT_PORT"

--- a/tools/build/pkg.bzl
+++ b/tools/build/pkg.bzl
@@ -16,16 +16,24 @@ def _apply_path_map(path_map, path):
                 matchlen = len(x)
     return match
 
+# buildifier: disable=function-docstring-header
 def _apply_exclude(exclude, path):
-    """ Apply wildcard exclusion patterns to the path. """
-
-    # TODO: improve this
+    """ Whether the path matches any of the exclusion patterns. A pattern may be an exact path, a
+        leading '*' (suffix match), a trailing '*' (prefix match), or both (substring match); these
+        are the forms the callers use. Patterns with a '*' elsewhere are not supported. """
     for pattern in exclude:
-        if "*" in pattern:
-            if pattern[0] == "*" and path.endswith(pattern[1:]):
+        if "*" not in pattern:
+            if path == pattern:
                 return True
-        else:
-            return path == pattern
+        elif pattern.startswith("*") and pattern.endswith("*"):
+            if pattern[1:-1] in path:
+                return True
+        elif pattern.startswith("*"):
+            if path.endswith(pattern[1:]):
+                return True
+        elif pattern.endswith("*"):
+            if path.startswith(pattern[:-1]):
+                return True
     return False
 
 def _is_executable(mode_map, path):

--- a/tools/build/sphinx.bzl
+++ b/tools/build/sphinx.bzl
@@ -95,18 +95,17 @@ def _spelling_impl(ctx):
     sub_commands = []
 
     sphinx_commands = [
+        # Fail the build if sphinx fails anywhere in the pipe, not just at tee.
+        "set -o pipefail",
         # sphinxcontrib-spelling requires the dictionary to be a readable, writable regular file,
         # but Bazel stages inputs as read-only symlinks. Replace the symlink with a writable copy.
         'cp "`pwd`/doc/srcs/dictionary.txt" "`pwd`/doc/srcs/dictionary.txt.tmp"',
         'rm "`pwd`/doc/srcs/dictionary.txt"',
         'mv "`pwd`/doc/srcs/dictionary.txt.tmp" "`pwd`/doc/srcs/dictionary.txt"',
         "chmod 644 `pwd`/doc/srcs/dictionary.txt",
-        # FIXME: re-add -W flag. Fails currently as it gets a warning looking for contributors
-        "%s -b spelling -E -N -T %s ./out %s 2>&1 | tee stdout" % (sphinx_build.short_path, src_dir, opts),
-        'grep "misspelled words" stdout',
-        "ret=$?",
-        'echo "ret=$ret"',
-        "if [ $ret -eq 0 ]; then exit 1; fi",
+        # -W treats warnings as errors: the spelling builder logs each misspelling as a warning, so
+        # this fails the build (via its exit code) on any misspelling as well as any other warning.
+        "%s -b spelling -E -N -T -W %s ./out %s 2>&1 | tee stdout" % (sphinx_build.short_path, src_dir, opts),
     ]
     sub_commands.append("(" + "; ".join(sphinx_commands) + ")")
 

--- a/tools/build/sphinx.bzl
+++ b/tools/build/sphinx.bzl
@@ -95,12 +95,11 @@ def _spelling_impl(ctx):
     sub_commands = []
 
     sphinx_commands = [
-        # FIXME: following copy is a hack to fix sphinx not being able to read the
-        #        dictionary from a symlink and requiring the file to be writable
+        # sphinxcontrib-spelling requires the dictionary to be a readable, writable regular file,
+        # but Bazel stages inputs as read-only symlinks. Replace the symlink with a writable copy.
         'cp "`pwd`/doc/srcs/dictionary.txt" "`pwd`/doc/srcs/dictionary.txt.tmp"',
         'rm "`pwd`/doc/srcs/dictionary.txt"',
         'mv "`pwd`/doc/srcs/dictionary.txt.tmp" "`pwd`/doc/srcs/dictionary.txt"',
-        # end of hack
         "chmod 644 `pwd`/doc/srcs/dictionary.txt",
         # FIXME: re-add -W flag. Fails currently as it gets a warning looking for contributors
         "%s -b spelling -E -N -T %s ./out %s 2>&1 | tee stdout" % (sphinx_build.short_path, src_dir, opts),

--- a/tools/krpctools/CHANGES.txt
+++ b/tools/krpctools/CHANGES.txt
@@ -2,6 +2,8 @@ v0.6.0
  * Surface deprecated members in generated documentation and client stubs (#904)
  * Fix docgen dropping remarks in service-level documentation
  * Fix cross-service member references not resolving in generated C# and Lua documentation (#897)
+ * Fix member references in generated Python documentation using lowerCamelCase
+   instead of snake_case
 
 v0.5.4
  * Fix incorrect protobuf DLL (#755)

--- a/tools/krpctools/krpctools/clientgen/python.py
+++ b/tools/krpctools/krpctools/clientgen/python.py
@@ -15,7 +15,7 @@ from krpc.utils import snake_case
 from .generator import Generator
 from .docparser import DocParser
 from ..lang.python import PythonLanguage
-from ..utils import lower_camel_case, as_type
+from ..utils import as_type
 
 
 class PythonGenerator(Generator):
@@ -398,10 +398,9 @@ class PythonDocParser(DocParser):
 
     @staticmethod
     def parse_cref(cref):
-        # FIXME: is this correct?
         if cref[0] == "M":
             cref = cref[2:].split(".")
-            member = lower_camel_case(cref[-1])
+            member = snake_case(cref[-1])
             del cref[-1]
             return ".".join(cref) + "#" + member
         if cref[0] == "T":

--- a/tools/krpctools/krpctools/docgen/lua.py
+++ b/tools/krpctools/krpctools/docgen/lua.py
@@ -72,7 +72,8 @@ class LuaDomain(Domain):
             name = ".".join(name)
         return self.shorten_ref(name)
 
-    # FIXME: reference shortening does not work with sphinx-lua
+    # sphinx-lua cannot resolve references written in the shortened, module-relative form the other
+    # domains use, so Lua references are left fully qualified.
     def shorten_ref(self, name, obj=None):
         return name
 


### PR DESCRIPTION
Fixes the Python client-stub generator translating `<see cref="M:..."/>` member references to lowerCamelCase (copied from the Java generator) instead of the Python client's snake_case. Fixes the packaging exclude matcher, which silently never matched a trailing-`*` pattern and returned early on an exact match before checking the remaining patterns; it now handles exact, prefix, suffix and infix patterns and tests every pattern.

Re-enables `-W` (warnings as errors) on the spelling build: it previously failed because `spelling_ignore_contributor_names` scanned git history, which only warns in the repo-less sandbox; that is disabled (names belong in the dictionary file) and `pipefail` added so a misspelling fails the build. Verified in both directions. The spelling dictionary copy, the serial test's startup delay and the Lua reference shortening no-op are documented as deliberate.

**Testing.** krpctools tests and lint pass; the docs build is green, and a deliberately introduced misspelling fails it.
