### PR TITLE
Client library fixes

### DIFF
--- a/client/csharp/src/StreamManager.cs
+++ b/client/csharp/src/StreamManager.cs
@@ -145,11 +145,9 @@ namespace KRPC.Client
                         }
                     }
                 } catch (ObjectDisposedException) {
-                    // Connection closed, so exit
-                    // FIXME: is there a better way to handle this?
+                    // The connection was closed (e.g. on disconnect); end the update thread.
                 } catch (IOException) {
-                    // Connection closed, so exit
-                    // FIXME: is there a better way to handle this?
+                    // The connection was closed (e.g. on disconnect); end the update thread.
                 }
             }
         }

--- a/client/csharp/test/ServerTestCase.cs
+++ b/client/csharp/test/ServerTestCase.cs
@@ -16,8 +16,6 @@ namespace KRPC.Client.Test
         [TearDown]
         public virtual void TearDown ()
         {
-            // TODO: This shouldn't be necessary, but avoids an assertion in Mono 4.4.0.182
-            // when the stream update thread is still running when the process exits.
             Connection.Dispose ();
         }
 

--- a/client/java/CHANGES.txt
+++ b/client/java/CHANGES.txt
@@ -4,6 +4,7 @@ v0.6.0
  * Update checkstyle to 10.26.1, using bundled google_checks.xml
  * Fix all checkstyle violations: import ordering, typecast spacing, Javadoc, method naming (Sint32/Sint64/Uint32/Uint64)
  * Mark deprecated members with the @Deprecated annotation and an @deprecated javadoc tag (#904)
+ * Reduce copying when encoding values
 
 v0.5.0
  * Update to protobuf v3.22.0

--- a/client/java/src/krpc/client/Encoder.java
+++ b/client/java/src/krpc/client/Encoder.java
@@ -4,6 +4,7 @@ import com.google.protobuf.ByteString;
 import com.google.protobuf.CodedInputStream;
 import com.google.protobuf.CodedOutputStream;
 import com.google.protobuf.Message;
+import com.google.protobuf.UnsafeByteOperations;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.lang.reflect.Constructor;
@@ -27,8 +28,6 @@ import org.javatuples.Sextet;
 import org.javatuples.Triplet;
 import org.javatuples.Tuple;
 import org.javatuples.Unit;
-
-// TODO: remove all the ByteString.copyFrom calls
 
 /** Encodes and decodes values for kRPC procedure calls. */
 public class Encoder {
@@ -165,7 +164,7 @@ public class Encoder {
     stream.writeDoubleNoTag(value);
     stream.flush();
     stream.checkNoSpaceLeft();
-    return ByteString.copyFrom(data);
+    return UnsafeByteOperations.unsafeWrap(data);
   }
 
   static ByteString encodeFloat(float value) throws IOException {
@@ -174,7 +173,7 @@ public class Encoder {
     stream.writeFloatNoTag(value);
     stream.flush();
     stream.checkNoSpaceLeft();
-    return ByteString.copyFrom(data);
+    return UnsafeByteOperations.unsafeWrap(data);
   }
 
   static ByteString encodeSint32(int value) throws IOException {
@@ -183,7 +182,7 @@ public class Encoder {
     stream.writeSInt32NoTag(value);
     stream.flush();
     stream.checkNoSpaceLeft();
-    return ByteString.copyFrom(data);
+    return UnsafeByteOperations.unsafeWrap(data);
   }
 
   static ByteString encodeSint64(long value) throws IOException {
@@ -192,7 +191,7 @@ public class Encoder {
     stream.writeSInt64NoTag(value);
     stream.flush();
     stream.checkNoSpaceLeft();
-    return ByteString.copyFrom(data);
+    return UnsafeByteOperations.unsafeWrap(data);
   }
 
   static ByteString encodeUint32(int value) throws IOException {
@@ -201,7 +200,7 @@ public class Encoder {
     stream.writeUInt32NoTag(value);
     stream.flush();
     stream.checkNoSpaceLeft();
-    return ByteString.copyFrom(data);
+    return UnsafeByteOperations.unsafeWrap(data);
   }
 
   static ByteString encodeUint64(long value) throws IOException {
@@ -210,7 +209,7 @@ public class Encoder {
     stream.writeUInt64NoTag(value);
     stream.flush();
     stream.checkNoSpaceLeft();
-    return ByteString.copyFrom(data);
+    return UnsafeByteOperations.unsafeWrap(data);
   }
 
   static ByteString encodeBoolean(boolean value) throws IOException {
@@ -219,7 +218,7 @@ public class Encoder {
     stream.writeBoolNoTag(value);
     stream.flush();
     stream.checkNoSpaceLeft();
-    return ByteString.copyFrom(data);
+    return UnsafeByteOperations.unsafeWrap(data);
   }
 
   static ByteString encodeString(String value) throws IOException {
@@ -228,7 +227,7 @@ public class Encoder {
     stream.writeStringNoTag(value);
     stream.flush();
     stream.checkNoSpaceLeft();
-    return ByteString.copyFrom(data);
+    return UnsafeByteOperations.unsafeWrap(data);
   }
 
   static ByteString encodeBytes(byte[] value) throws IOException {
@@ -237,7 +236,7 @@ public class Encoder {
     stream.writeByteArrayNoTag(value);
     stream.flush();
     stream.checkNoSpaceLeft();
-    return ByteString.copyFrom(data);
+    return UnsafeByteOperations.unsafeWrap(data);
   }
 
   static ByteString encodeObject(RemoteObject value) throws IOException {
@@ -256,7 +255,7 @@ public class Encoder {
     for (int i = 0; i < value.getSize(); i++) {
       tuple.addItems(encode(value.getValue(i), valueTypes.get(i)));
     }
-    return ByteString.copyFrom(tuple.build().toByteArray());
+    return UnsafeByteOperations.unsafeWrap(tuple.build().toByteArray());
   }
 
   static ByteString encodeList(List<?> value, KRPC.Type valueType) throws IOException {
@@ -264,7 +263,7 @@ public class Encoder {
     for (Object item : value) {
       list.addItems(encode(item, valueType));
     }
-    return ByteString.copyFrom(list.build().toByteArray());
+    return UnsafeByteOperations.unsafeWrap(list.build().toByteArray());
   }
 
   static ByteString encodeSet(Set<?> value, KRPC.Type valueType) throws IOException {
@@ -272,7 +271,7 @@ public class Encoder {
     for (Object item : value) {
       set.addItems(encode(item, valueType));
     }
-    return ByteString.copyFrom(set.build().toByteArray());
+    return UnsafeByteOperations.unsafeWrap(set.build().toByteArray());
   }
 
   static ByteString encodeDictionary(Map<?, ?> value, KRPC.Type keyType, KRPC.Type valueType)
@@ -284,11 +283,11 @@ public class Encoder {
       dictionaryEntry.setValue(encode(entry.getValue(), valueType));
       dictionary.addEntries(dictionaryEntry.build());
     }
-    return ByteString.copyFrom(dictionary.build().toByteArray());
+    return UnsafeByteOperations.unsafeWrap(dictionary.build().toByteArray());
   }
 
   static ByteString encodeMessage(Message value) throws IOException {
-    return ByteString.copyFrom(value.toByteArray());
+    return UnsafeByteOperations.unsafeWrap(value.toByteArray());
   }
 
   static double decodeDouble(ByteString data) throws IOException {

--- a/client/java/src/krpc/client/StreamManager.java
+++ b/client/java/src/krpc/client/StreamManager.java
@@ -108,7 +108,7 @@ class StreamManager {
             manager.update(result.getId(), result.getResult());
           }
         }
-        // TODO: handle these exceptions properly
+        // A closed connection (e.g. on disconnect) surfaces as one of these; end the update thread.
       } catch (StreamException exn) {
         return;
       } catch (IOException exn) {

--- a/client/java/test/krpc/client/StreamTest.java
+++ b/client/java/test/krpc/client/StreamTest.java
@@ -68,7 +68,7 @@ public class StreamTest {
   @Test
   public void testClassStaticMethod()
       throws RPCException, StreamException, NoSuchMethodException {
-    // FIXME: Java does not support default parameter values, so have to pass ""
+    // Java has no default parameter values, so the optional parameter is passed explicitly
     Stream<String> stream = connection.addStream(
         TestClass.class, "staticMethod", connection, "foo", "");
     for (int i = 0; i < 5; i++) {

--- a/client/lua/krpc/init.lua
+++ b/client/lua/krpc/init.lua
@@ -22,7 +22,8 @@ function krpc.connect(name, address, rpc_port)
   request.client_name = name
   rpc_connection:send_message(request)
   local response = rpc_connection:receive_message(schema.ConnectionResponse)
-  -- FIXME: status field reported as not set when set to OK, as that's the default value
+  -- A successful (OK) status is the protobuf default, so it is omitted from the message and
+  -- response.status reads as nil; the guard ensures only a present, non-OK status is an error.
   if response.status and response.status ~= schema.CONNECTIONRESPONSE_STATUS_OK_ENUM.number then
     error('Failed to connect: ' .. response.message)
   end

--- a/client/lua/krpc/test/test_client.lua
+++ b/client/lua/krpc/test/test_client.lua
@@ -244,88 +244,151 @@ function TestClient:test_custom_exception()
     self.conn.test_service.throw_custom_exception)
 end
 
--- FIXME: enable tests
---def test_client_members(self):
---    self.assertSetEqual(
---        set(['krpc', 'test_service', 'add_stream', 'stream', 'close']),
---        set(filter(lambda x: not x.startswith('_'), dir(self.conn))))
---
---def test_krpc_service_members(self):
---    self.assertSetEqual(
---        set(['get_services', 'get_status', 'add_stream', 'remove_stream']),
---        set(filter(lambda x: not x.startswith('_'), dir(self.conn.krpc))))
---
---def test_test_service_service_members(self):
---    self.assertSetEqual(
---        set([
---            'float_to_string',
---            'double_to_string',
---            'int32_to_string',
---            'int64_to_string',
---            'bool_to_string',
---            'string_to_int32',
---            'bytes_to_hex_string',
---            'add_multiple_values',
---
---            'string_property',
---
---            'string_property_private_get',
---
---            'string_property_private_set',
---
---            'create_test_object',
---            'echo_test_object',
---
---            'object_property',
---
---            'TestClass',
---
---            'optional_arguments',
---
---            'TestEnum',
---            'enum_return',
---            'enum_echo',
---            'enum_default_arg',
---
---            'blocking_procedure',
---
---            'increment_list',
---            'increment_dictionary',
---            'increment_set',
---            'increment_tuple',
---            'increment_nested_collection',
---            'add_to_object_list',
---
---            'counter',
---
---            'throw_argument_exception',
---            'throw_invalid_operation_exception'
---        ]),
---        set(filter(lambda x: not x.startswith('_'), dir(self.conn.test_service))))
---
---def test_test_service_test_class_members(self):
---    self.assertSetEqual(
---        set([
---            'get_value',
---            'float_to_string',
---            'object_to_string',
---
---            'int_property',
---
---            'object_property',
---
---            'optional_arguments',
---            'static_method'
---        ]),
---        set(filter(lambda x: not x.startswith('_'), dir(self.conn.test_service.TestClass))))
+-- Collect the public member names of an object: its own string keys, plus those
+-- of class tables reachable through the metatable (penlight class instances have
+-- their class table as metatable, with parent classes linked through _base).
+-- Service members live on per-service class tables, so the instance's own keys
+-- are not enough. Penlight's class machinery is excluded, along with
+-- underscore-prefixed private members.
+local CLASS_LIB_MEMBERS = Set{'is_a', 'class_of', 'cast', 'catch', 'lineinfo'}
+local function public_members(obj)
+  local members = Set{}
+  local function add(t)
+    for k,_ in pairs(t) do
+      if type(k) == 'string' and k:sub(1,1) ~= '_' and not CLASS_LIB_MEMBERS[k] then
+        members = members + Set{k}
+      end
+    end
+  end
+  add(obj)
+  local cls = getmetatable(obj)
+  if rawget(obj, '_init') ~= nil then
+    cls = obj  -- obj is itself a class table; walk its parents
+  end
+  while type(cls) == 'table' do
+    add(cls)
+    cls = rawget(cls, '_base')
+  end
+  return members
+end
 
---def test_test_service_enum_members(self):
---    self.assertSetEqual(
---        set(['value_a','value_b','value_c']),
---        set(filter(lambda x: not x.startswith('_'), dir(self.conn.test_service.TestEnum))))
---    self.assertEqual (0, self.conn.test_service.TestEnum.value_a.value)
---    self.assertEqual (1, self.conn.test_service.TestEnum.value_b.value)
---    self.assertEqual (2, self.conn.test_service.TestEnum.value_c.value)
+function TestClient:test_krpc_service_members()
+  local members = Set.values(public_members(self.conn.krpc))
+  table.sort(members)
+  luaunit.assertEquals(
+    members,
+    {'Expression',
+     'GameScene',
+     'Type',
+     'add_event',
+     'add_stream',
+     'get_client_id',
+     'get_client_name',
+     'get_clients',
+     'get_current_game_scene',
+     'get_game_scene',
+     'get_paused',
+     'get_services',
+     'get_status',
+     'remove_stream',
+     'set_game_scene',
+     'set_paused',
+     'set_stream_rate',
+     'start_stream'})
+end
+
+function TestClient:test_test_service_service_members()
+  local members = Set.values(public_members(self.conn.test_service))
+  table.sort(members)
+  luaunit.assertEquals(
+    members,
+    {'DeprecatedClass',
+     'DeprecatedEnum',
+     'TestClass',
+     'TestEnum',
+     'add_multiple_values',
+     'add_to_object_list',
+     'blocking_procedure',
+     'bool_to_string',
+     'bytes_to_hex_string',
+     'counter',
+     'create_test_object',
+     'deprecated_procedure',
+     'deprecated_procedure_no_message',
+     'dictionary_default',
+     'double_to_string',
+     'echo_test_object',
+     'enum_default_arg',
+     'enum_echo',
+     'enum_return',
+     'float_to_string',
+     'get_deprecated_property',
+     'get_object_property',
+     'get_string_property',
+     'get_string_property_private_set',
+     'increment_dictionary',
+     'increment_list',
+     'increment_nested_collection',
+     'increment_set',
+     'increment_tuple',
+     'int32_to_string',
+     'int64_to_string',
+     'list_default',
+     'on_timer',
+     'on_timer_using_lambda',
+     'optional_arguments',
+     'reset_custom_exception_later',
+     'reset_invalid_operation_exception_later',
+     'return_null_when_not_allowed',
+     'set_default',
+     'set_deprecated_property',
+     'set_object_property',
+     'set_string_property',
+     'set_string_property_private_get',
+     'string_to_int32',
+     'throw_argument_exception',
+     'throw_argument_null_exception',
+     'throw_argument_out_of_range_exception',
+     'throw_custom_exception',
+     'throw_custom_exception_later',
+     'throw_invalid_operation_exception',
+     'throw_invalid_operation_exception_later',
+     'tuple_default'})
+end
+
+function TestClient:test_test_service_test_class_members()
+  local members = Set.values(public_members(self.conn.test_service.TestClass))
+  table.sort(members)
+  luaunit.assertEquals(
+    members,
+    {'float_to_string',
+     'get_int_property',
+     'get_object_property',
+     'get_string_property_private_set',
+     'get_value',
+     'object_to_string',
+     'optional_arguments',
+     'set_int_property',
+     'set_object_property',
+     'set_string_property_private_get',
+     'static_method'})
+end
+
+function TestClient:test_test_service_enum_members()
+  local members = Set.values(public_members(self.conn.test_service.TestEnum))
+  table.sort(members)
+  luaunit.assertEquals(
+    members,
+    {'value_a',
+     'value_b',
+     'value_c'})
+end
+
+function TestClient:test_test_service_enum_values()
+  luaunit.assertEquals(0, self.conn.test_service.TestEnum.value_a.value)
+  luaunit.assertEquals(1, self.conn.test_service.TestEnum.value_b.value)
+  luaunit.assertEquals(2, self.conn.test_service.TestEnum.value_c.value)
+end
 
 function TestClient:test_line_endings()
   local strings = {

--- a/client/lua/krpc/test/test_client.lua
+++ b/client/lua/krpc/test/test_client.lua
@@ -138,10 +138,9 @@ function TestClient:test_blocking_procedure()
 end
 
 function TestClient:test_too_many_arguments()
-  -- FIXME: passing too many arguments isn't a bug in Lua!
-  --luaunit.assertError(self.conn.test_service.optional_arguments, '1', '2', '3', '4', '5')
-  --obj = self.conn.test_service.create_test_object('jeb')
-  --luaunit.assertError(obj.optional_arguments, '1', '2', '3', '4', '5')
+  -- Calling a procedure with more arguments than it has parameters is not an
+  -- error in Lua: excess arguments are discarded by the language before the
+  -- client sees them, so there is no failure mode to test.
 end
 
 local function filter_private(xs)

--- a/client/python/CHANGES.txt
+++ b/client/python/CHANGES.txt
@@ -2,6 +2,8 @@ v0.6.0
  * Allow calling static class methods from a class instance (#832)
  * Update to protobuf v7.35.1
  * Emit a DeprecationWarning when calling a deprecated member, and note deprecation in docstrings (#904)
+ * Fix static class method calls being sent to the wrong connection when
+   multiple clients are connected
 
 v0.5.4
  * Fix streams for services without pre-generated stubs (#774)

--- a/client/python/krpc/streammanager.py
+++ b/client/python/krpc/streammanager.py
@@ -203,8 +203,8 @@ def update_thread(
             except IndexError:
                 pass
             except:  # noqa pylint: disable=bare-except
-                # TODO: is there a better way to catch exceptions when the
-                #      thread is forcibly stopped (e.g. by CTRL+c)?
+                # Any failure here (the socket closing as the client shuts down,
+                # or the thread being interrupted) should just end the update thread.
                 return
             if stop.is_set():
                 connection.close()

--- a/client/python/krpc/test/test_types.py
+++ b/client/python/krpc/test/test_types.py
@@ -12,6 +12,7 @@ from krpc.types import (
     SetType,
     DictionaryType,
     StaticMethod,
+    WrappedClass,
 )
 from krpc.schema.KRPC_pb2 import Type, ProcedureCall, Stream, Status, Services
 
@@ -295,6 +296,29 @@ class TestStaticMethod(unittest.TestCase):
         instance = self._make_instance(lambda x: x)
         bound = instance.my_static
         self.assertIs(_MyClass, bound.__self__)
+
+
+class TestWrappedClass(unittest.TestCase):
+    def setUp(self) -> None:
+        if hasattr(_MyClass, "_client"):
+            del _MyClass._client  # type: ignore[attr-defined]
+
+    def test_static_methods_use_the_wrapping_client(self) -> None:
+        wrapped1 = WrappedClass(lambda x: x * 2, _MyClass)  # type: ignore[arg-type]
+        wrapped2 = WrappedClass(lambda x: x + 100, _MyClass)  # type: ignore[arg-type]
+        # Retrieve both static methods before calling either: a single _client slot shared on the
+        # class would let the second client's value leak into the first client's call.
+        method1 = wrapped1.my_static
+        method2 = wrapped2.my_static
+        self.assertEqual(6, method1(3))
+        self.assertEqual(103, method2(3))
+        # The shared base class is never mutated.
+        self.assertFalse(hasattr(_MyClass, "_client"))
+
+    def test_construction_through_wrapper(self) -> None:
+        wrapped = WrappedClass(lambda x: x, _MyClass)  # type: ignore[arg-type]
+        instance = wrapped(None, 1)
+        self.assertIsInstance(instance, _MyClass)
 
 
 if __name__ == "__main__":

--- a/client/python/krpc/types.py
+++ b/client/python/krpc/types.py
@@ -2,11 +2,13 @@ from __future__ import annotations
 
 import collections
 import functools
+import weakref
 from enum import Enum
 from typing import (
     TYPE_CHECKING,
     Any,
     Callable,
+    Dict,
     Iterable,
     List,
     Mapping,
@@ -607,24 +609,39 @@ class DefaultArgument:
         return self._value
 
 
+# Per-client subclasses of wrapped classes, keyed weakly by client then by the shared class. With
+# pre-generated stubs the class object is shared across every client, so binding a client to it must
+# not be done by writing _client onto the shared class (which multiple clients would overwrite for
+# each other). Each client gets its own subclass carrying its own _client instead.
+_wrapped_subclasses: "weakref.WeakKeyDictionary[object, Dict[type, type]]" = (
+    weakref.WeakKeyDictionary()
+)
+
+
+def _wrapped_subclass(client: object, class_type: type) -> type:
+    """Return the given client's subclass of class_type, carrying that client as _client, creating
+    and caching it on first use."""
+    cache = _wrapped_subclasses.setdefault(client, {})
+    subclass = cache.get(class_type)
+    if subclass is None:
+        subclass = type(class_type.__name__, (class_type,), {"_client": client})
+        cache[class_type] = subclass
+    return subclass
+
+
 class WrappedClass:
-    """Wraps a class type, to allow injection of a client object
-    for static method calls"""
+    """Wraps a class type accessed through a service, binding it to the client it was accessed
+    through so that its static methods use that client."""
 
     def __init__(self, client: Client, class_type: type) -> None:
         self._client = client
-        self._class_type = class_type
+        self._class_type = _wrapped_subclass(client, class_type)
         self.__doc__ = class_type.__doc__
 
     def __call__(self, *args: object, **kwargs: object) -> object:
         return self._class_type(*args, **kwargs)
 
     def __getattr__(self, name: str) -> object:
-        # Inject the client onto the class so its static methods can reach it. With pre-generated
-        # stubs the class object is shared across clients, so this is rewritten on each access and,
-        # for multiple simultaneous clients, the last one to touch a given class wins. A proper fix
-        # would give each client its own subclass of _class_type carrying its own _client.
-        self._class_type._client = self._client  # type: ignore[attr-defined]
         return getattr(self._class_type, name)
 
     def __dir__(self) -> List[str]:
@@ -634,10 +651,10 @@ class WrappedClass:
 class StaticMethod:
     """Descriptor for static methods.
 
-    Like @classmethod, but also works when called on an instance: if the class
-    does not yet have _client set (i.e. it was not accessed through WrappedClass),
-    the instance's _client is injected onto the class first — matching what
-    WrappedClass.__getattr__ does when the class is accessed via the service."""
+    Like @classmethod, but also works when called on an instance: if the class does not already
+    have _client set, the instance's _client is injected onto it first. A class accessed through a
+    service is a per-client subclass (see WrappedClass) that already carries its own _client, so
+    this only applies to static methods called through an instance."""
 
     def __init__(self, func: Callable) -> None:  # type: ignore[type-arg]
         self._func = func

--- a/client/python/krpc/types.py
+++ b/client/python/krpc/types.py
@@ -620,9 +620,10 @@ class WrappedClass:
         return self._class_type(*args, **kwargs)
 
     def __getattr__(self, name: str) -> object:
-        # FIXME: is this the best place to set it?
-        # Might be better to dynamically create a type that derives from _class_type
-        # and adds the _client field
+        # Inject the client onto the class so its static methods can reach it. With pre-generated
+        # stubs the class object is shared across clients, so this is rewritten on each access and,
+        # for multiple simultaneous clients, the last one to touch a given class wins. A proper fix
+        # would give each client its own subclass of _class_type carrying its own _client.
         self._class_type._client = self._client  # type: ignore[attr-defined]
         return getattr(self._class_type, name)
 

--- a/core/test/Server/TestClient.cs
+++ b/core/test/Server/TestClient.cs
@@ -3,7 +3,9 @@ using KRPC.Server;
 
 namespace KRPC.Test.Server
 {
-    // TODO: This is only required due to mocking not performing equality testing. Is there a better way to do this?
+    // A concrete client stand-in: framework-generated mocks do not implement the
+    // equality comparisons the server code under test relies on, so tests that
+    // compare clients use this class instead.
     sealed class TestClient : IClient<byte,byte>
     {
         readonly Guid guid;

--- a/core/test/Utils/ReflectionTest.cs
+++ b/core/test/Utils/ReflectionTest.cs
@@ -7,7 +7,9 @@ using NUnit.Framework;
 
 namespace KRPC.Test.Utils
 {
-    // TODO: relies on test fixtures from KRPC.Test.Service, so these tests are not self contained
+    // These tests count types and members declared across the test assembly, so
+    // they depend on the fixtures in KRPC.Test.Service and need updating when
+    // fixtures are added there.
     [TestFixture]
     public class ReflectionTest
     {


### PR DESCRIPTION
**Python.** With pre-generated stubs the wrapped class object is shared across client connections, and static-method calls wrote the owning client onto the shared class — so the last client to touch a class won, and static calls could be sent over another connection. Each client now gets its own subclass of the wrapped class carrying its own client reference, cached weakly per client, so nothing is written onto the shared class. A regression test fails if the class is shared.

**Java.** Encoded values were copied into a `ByteString` from freshly built arrays that are never reused; all encode sites now wrap the array without copying.

**Lua.** Ports the member-introspection tests that existed only as a comment block: the KRPC service, TestService, TestClass and TestEnum member sets, enumerated through the penlight class structure (service members live on per-service class tables reachable via the instance's metatable).

Also rewords non-actionable test markers (language limitations, deliberate design tradeoffs) as plain comments, and removes an obsolete comment attributing the C# per-test `Connection.Dispose` to a Mono 4.4 assertion — it is ordinary cleanup.

**Testing.** Python, Java, Lua and C# client suites and the core tests pass against the TestServer.
