### PR TITLE
Add RemoteTech availability and antenna negative-path tests

### DIFF
--- a/service/RemoteTech/test/test_antenna.py
+++ b/service/RemoteTech/test/test_antenna.py
@@ -49,6 +49,34 @@ class TestAntenna(krpctest.TestCase):
         self.wait()
         self.antenna.target = self.rt.Target.none
 
+    def test_target_invalid_setter_raises(self):
+        # Only none and active_vessel can be assigned directly; other targets
+        # are set via the typed target_body/target_ground_station/target_vessel
+        # setters
+        self.assertEqual(self.rt.Target.none, self.antenna.target)
+        with self.assertRaises(ValueError):
+            self.antenna.target = self.rt.Target.celestial_body
+
+    def test_target_body_getter_wrong_type_raises(self):
+        self.assertEqual(self.rt.Target.none, self.antenna.target)
+        with self.assertRaises(RuntimeError):
+            _ = self.antenna.target_body
+
+    def test_target_ground_station_getter_wrong_type_raises(self):
+        self.assertEqual(self.rt.Target.none, self.antenna.target)
+        with self.assertRaises(RuntimeError):
+            _ = self.antenna.target_ground_station
+
+    def test_target_vessel_getter_wrong_type_raises(self):
+        self.assertEqual(self.rt.Target.none, self.antenna.target)
+        with self.assertRaises(RuntimeError):
+            _ = self.antenna.target_vessel
+
+    def test_target_unknown_ground_station_raises(self):
+        self.assertEqual(self.rt.Target.none, self.antenna.target)
+        with self.assertRaises(ValueError):
+            self.antenna.target_ground_station = "Nowhere"
+
     def test_target_vessel(self):
         self.assertEqual("RemoteTech Ship", self.other_vessel.name)
         self.assertEqual(self.rt.Target.none, self.antenna.target)

--- a/service/RemoteTech/test/test_remotetech.py
+++ b/service/RemoteTech/test/test_remotetech.py
@@ -10,6 +10,9 @@ class TestRemoteTech(krpctest.TestCase):
         cls.new_save()
         cls.rt = cls.connect().remote_tech
 
+    def test_available(self):
+        self.assertTrue(self.rt.available)
+
     def test_ground_stations(self):
         self.assertCountEqual(self.rt.ground_stations, ["Mission Control"])
 


### PR DESCRIPTION
The RemoteTech integration tests never asserted `RemoteTech.Available` and only exercised the antenna target API's happy paths. This adds a test that `Available` is true when the mod is installed, and covers the antenna error paths: assigning a target kind that can only be set via the typed setters, reading a typed target getter (`TargetBody`/`TargetGroundStation`/`TargetVessel`) while the target is none, and setting an unknown ground station. The setter errors surface on the client as `ValueError` (`ArgumentException`) and the getter errors as `RuntimeError` (`InvalidOperationException`).

**Testing.** Test-only change, no behaviour altered; the full RemoteTech suite (12 tests) passes in-game against RemoteTech 1.9.12 on KSP 1.12.5.