### PR TITLE
Deferred-state fixes: ResourceHarvester.Active during deploy, ThrustReverser.Reversed, control input docs

### DIFF
--- a/service/Drawing/test/test_line.py
+++ b/service/Drawing/test/test_line.py
@@ -23,7 +23,6 @@ class TestLine(krpctest.TestCase):
         self.assertEqual((1, 1, 1), line.color)
         self.assertEqual("Legacy Shaders/Particles/Additive", line.material)
         self.assertAlmostEqual(0.1, line.thickness)
-        self.wait()
         line.remove()
         self.assertRaises(ValueError, line.remove)
 
@@ -34,7 +33,6 @@ class TestLine(krpctest.TestCase):
         line.visible = True
         self.assertTrue(line.visible)
         self.assertEqual((1, 0, 0), line.color)
-        self.wait()
         line.remove()
 
     def test_thickness(self):
@@ -44,7 +42,6 @@ class TestLine(krpctest.TestCase):
         line.visible = True
         self.assertTrue(line.visible)
         self.assertAlmostEqual(1.234, line.thickness)
-        self.wait()
         line.remove()
 
 

--- a/service/Drawing/test/test_polygon.py
+++ b/service/Drawing/test/test_polygon.py
@@ -25,7 +25,6 @@ class TestPolygon(krpctest.TestCase):
         self.assertEqual((1, 1, 1), polygon.color)
         self.assertEqual("Legacy Shaders/Particles/Additive", polygon.material)
         self.assertAlmostEqual(0.1, polygon.thickness)
-        self.wait()
         polygon.remove()
         self.assertRaises(ValueError, polygon.remove)
 
@@ -36,7 +35,6 @@ class TestPolygon(krpctest.TestCase):
         polygon.visible = True
         self.assertTrue(polygon.visible)
         self.assertEqual((1, 0, 0), polygon.color)
-        self.wait()
         polygon.remove()
 
     def test_thickness(self):
@@ -46,7 +44,6 @@ class TestPolygon(krpctest.TestCase):
         polygon.visible = True
         self.assertTrue(polygon.visible)
         self.assertAlmostEqual(1.234, polygon.thickness)
-        self.wait()
         polygon.remove()
 
 

--- a/service/Drawing/test/test_text.py
+++ b/service/Drawing/test/test_text.py
@@ -36,7 +36,6 @@ class TestText(krpctest.TestCase):
         self.assertEqual(self.alignment.left, text.alignment)
         self.assertEqual(1, text.line_spacing)
         self.assertEqual(self.anchor.upper_left, text.anchor)
-        self.wait()
         text.remove()
         self.assertRaises(ValueError, text.remove)
 
@@ -59,7 +58,6 @@ class TestText(krpctest.TestCase):
         self.assertEqual(self.alignment.right, text.alignment)
         self.assertEqual(2, text.line_spacing)
         self.assertEqual(self.anchor.upper_right, text.anchor)
-        self.wait()
         text.remove()
         self.assertRaises(ValueError, text.remove)
 

--- a/service/SpaceCenter/CHANGES.txt
+++ b/service/SpaceCenter/CHANGES.txt
@@ -5,6 +5,7 @@ v0.6.0
  * Fix Experiment.Reset not clearing the science data stored by DMagic experiments,
    which caused the next call to Run to fail with "Experiment already contains data" (#550)
  * Fix Camera Distance, Pitch, Heading and FoV setters being lost when set during a camera mode switch (#318)
+ * Fix ResourceHarvester.Active being silently ignored when set while the harvester is deploying; the requested state is now applied when the deploy completes
  * Fix Maneuver and ManeuverOrbital reference frame velocity (previously returned zero; now returns the orbital velocity at the node UT)
  * Fix angular velocity for VesselSurface, VesselSurfaceVelocity, CelestialBodyOrbital, Maneuver, ManeuverOrbital, Part, PartCenterOfMass, DockingPort and Thrust reference frames (previously returned zero)
  * Fix ControlSurface.AvailableTorque returning inconsistent signs (ModuleControlSurface negates the roll axis); now normalised to positive/negative torque like other parts

--- a/service/SpaceCenter/src/KRPC.SpaceCenter.csproj
+++ b/service/SpaceCenter/src/KRPC.SpaceCenter.csproj
@@ -92,6 +92,7 @@
     <Compile Include="AutoPilotInfoAddon.cs" />
     <Compile Include="AutoPilotInfoWindow.cs" />
     <Compile Include="PilotAddon.cs" />
+    <Compile Include="ResourceHarvesterAddon.cs" />
     <Compile Include="ResourceTransferAddon.cs" />
     <Compile Include="Services\Alarm.cs" />
     <Compile Include="Services\AlarmManager.cs" />

--- a/service/SpaceCenter/src/ResourceHarvesterAddon.cs
+++ b/service/SpaceCenter/src/ResourceHarvesterAddon.cs
@@ -1,0 +1,95 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace KRPC.SpaceCenter
+{
+    /// <summary>
+    /// Addon that applies a harvester active-state requested while the harvester
+    /// was still deploying.
+    /// </summary>
+    /// <remarks>
+    /// A drill's resource converter can only be started once its deploy animation
+    /// has finished, which takes several seconds. A write to
+    /// <see cref="Services.Parts.ResourceHarvester.Active"/> issued in that window
+    /// (e.g. setting <c>Deployed</c> then <c>Active</c> back to back) cannot be
+    /// applied immediately, so the requested state is recorded here and applied
+    /// when the deploy completes. A request is discarded if the deploy is canceled
+    /// (the drill starts retracting) or the part is destroyed. There is one
+    /// requested state per drill, held in a static table (last writer wins).
+    /// </remarks>
+    [KSPAddon (KSPAddon.Startup.Flight, false)]
+    public sealed class ResourceHarvesterAddon : UnityEngine.MonoBehaviour
+    {
+        sealed class PendingActivation
+        {
+            public ModuleAnimationGroup Animator;
+            public bool Active;
+        }
+
+        static readonly Dictionary<ModuleResourceHarvester, PendingActivation> pending =
+            new Dictionary<ModuleResourceHarvester, PendingActivation> ();
+
+        /// <summary>
+        /// Record the active-state to apply to a harvester once its deploy completes.
+        /// A superseding request for the same harvester overwrites the entry.
+        /// </summary>
+        internal static void Request (ModuleResourceHarvester harvester, ModuleAnimationGroup animator, bool active)
+        {
+            pending [harvester] = new PendingActivation {
+                Animator = animator,
+                Active = active
+            };
+        }
+
+        /// <summary>
+        /// Discard any pending request for a harvester. Called when a request is
+        /// applied directly, so an older deferred write cannot override it later.
+        /// </summary>
+        internal static void Cancel (ModuleResourceHarvester harvester)
+        {
+            pending.Remove (harvester);
+        }
+
+        /// <summary>
+        /// Wake the addon.
+        /// </summary>
+        public void Awake ()
+        {
+            pending.Clear ();
+        }
+
+        /// <summary>
+        /// Destroy the addon.
+        /// </summary>
+        public void OnDestroy ()
+        {
+            pending.Clear ();
+        }
+
+        /// <summary>
+        /// Apply pending activation requests for harvesters whose deploy has completed.
+        /// </summary>
+        public void FixedUpdate ()
+        {
+            if (pending.Count == 0)
+                return;
+            foreach (var harvester in pending.Keys.ToList ()) {
+                var entry = pending [harvester];
+                if (harvester == null || entry.Animator == null || !entry.Animator.isDeployed) {
+                    // The part was destroyed, or the deploy was canceled by a retract.
+                    pending.Remove (harvester);
+                    continue;
+                }
+                var animation = entry.Animator.ActiveAnimation;
+                if (animation != null && animation.isPlaying)
+                    // Still deploying.
+                    continue;
+                if (entry.Active && !harvester.IsActivated)
+                    harvester.StartResourceConverter ();
+                else if (!entry.Active && harvester.IsActivated)
+                    harvester.StopResourceConverter ();
+                pending.Remove (harvester);
+            }
+        }
+    }
+}

--- a/service/SpaceCenter/src/Services/Control.cs
+++ b/service/SpaceCenter/src/Services/Control.cs
@@ -386,6 +386,12 @@ namespace KRPC.SpaceCenter.Services
         /// Unlike the other control inputs, the throttle is not zeroed when the
         /// clients that set it disconnect.
         /// </summary>
+        /// <remarks>
+        /// The getter returns the input currently applied to the vessel, which
+        /// combines the input set by kRPC with any keyboard, SAS and trim input.
+        /// It refreshes one physics tick after a set, so a read immediately after
+        /// a set returns the previously applied value rather than the value just set.
+        /// </remarks>
         [KRPCProperty]
         public float Throttle {
             get { return PilotAddon.Get (InternalVessel).Throttle; }
@@ -411,6 +417,12 @@ namespace KRPC.SpaceCenter.Services
         /// A value between -1 and 1.
         /// Equivalent to the w and s keys.
         /// </summary>
+        /// <remarks>
+        /// The getter returns the input currently applied to the vessel, which
+        /// combines the input set by kRPC with any keyboard, SAS and trim input.
+        /// It refreshes one physics tick after a set, so a read immediately after
+        /// a set returns the previously applied value rather than the value just set.
+        /// </remarks>
         [KRPCProperty]
         public float Pitch {
             get { return PilotAddon.Get (InternalVessel).Pitch; }
@@ -422,6 +434,12 @@ namespace KRPC.SpaceCenter.Services
         /// A value between -1 and 1.
         /// Equivalent to the a and d keys.
         /// </summary>
+        /// <remarks>
+        /// The getter returns the input currently applied to the vessel, which
+        /// combines the input set by kRPC with any keyboard, SAS and trim input.
+        /// It refreshes one physics tick after a set, so a read immediately after
+        /// a set returns the previously applied value rather than the value just set.
+        /// </remarks>
         [KRPCProperty]
         public float Yaw {
             get { return PilotAddon.Get (InternalVessel).Yaw; }
@@ -433,6 +451,12 @@ namespace KRPC.SpaceCenter.Services
         /// A value between -1 and 1.
         /// Equivalent to the q and e keys.
         /// </summary>
+        /// <remarks>
+        /// The getter returns the input currently applied to the vessel, which
+        /// combines the input set by kRPC with any keyboard, SAS and trim input.
+        /// It refreshes one physics tick after a set, so a read immediately after
+        /// a set returns the previously applied value rather than the value just set.
+        /// </remarks>
         [KRPCProperty]
         public float Roll {
             get { return PilotAddon.Get (InternalVessel).Roll; }
@@ -489,6 +513,12 @@ namespace KRPC.SpaceCenter.Services
         /// A value between -1 and 1.
         /// Equivalent to the h and n keys.
         /// </summary>
+        /// <remarks>
+        /// The getter returns the input currently applied to the vessel, which
+        /// combines the input set by kRPC with any keyboard, SAS and trim input.
+        /// It refreshes one physics tick after a set, so a read immediately after
+        /// a set returns the previously applied value rather than the value just set.
+        /// </remarks>
         [KRPCProperty]
         public float Forward {
             get { return PilotAddon.Get (InternalVessel).Forward; }
@@ -500,6 +530,12 @@ namespace KRPC.SpaceCenter.Services
         /// A value between -1 and 1.
         /// Equivalent to the i and k keys.
         /// </summary>
+        /// <remarks>
+        /// The getter returns the input currently applied to the vessel, which
+        /// combines the input set by kRPC with any keyboard, SAS and trim input.
+        /// It refreshes one physics tick after a set, so a read immediately after
+        /// a set returns the previously applied value rather than the value just set.
+        /// </remarks>
         [KRPCProperty]
         public float Up {
             get { return PilotAddon.Get (InternalVessel).Up; }
@@ -511,6 +547,12 @@ namespace KRPC.SpaceCenter.Services
         /// A value between -1 and 1.
         /// Equivalent to the j and l keys.
         /// </summary>
+        /// <remarks>
+        /// The getter returns the input currently applied to the vessel, which
+        /// combines the input set by kRPC with any keyboard, SAS and trim input.
+        /// It refreshes one physics tick after a set, so a read immediately after
+        /// a set returns the previously applied value rather than the value just set.
+        /// </remarks>
         [KRPCProperty]
         public float Right {
             get { return PilotAddon.Get (InternalVessel).Right; }
@@ -523,6 +565,12 @@ namespace KRPC.SpaceCenter.Services
         /// A value of 1 rotates the wheels forwards, a value of -1 rotates
         /// the wheels backwards.
         /// </summary>
+        /// <remarks>
+        /// The getter returns the input currently applied to the vessel, which
+        /// combines the input set by kRPC with any keyboard, SAS and trim input.
+        /// It refreshes one physics tick after a set, so a read immediately after
+        /// a set returns the previously applied value rather than the value just set.
+        /// </remarks>
         [KRPCProperty]
         public float WheelThrottle {
             get { return PilotAddon.Get (InternalVessel).WheelThrottle; }
@@ -534,6 +582,12 @@ namespace KRPC.SpaceCenter.Services
         /// A value between -1 and 1.
         /// A value of 1 steers to the left, and a value of -1 steers to the right.
         /// </summary>
+        /// <remarks>
+        /// The getter returns the input currently applied to the vessel, which
+        /// combines the input set by kRPC with any keyboard, SAS and trim input.
+        /// It refreshes one physics tick after a set, so a read immediately after
+        /// a set returns the previously applied value rather than the value just set.
+        /// </remarks>
         [KRPCProperty]
         public float WheelSteering {
             get { return PilotAddon.Get (InternalVessel).WheelSteer; }

--- a/service/SpaceCenter/src/Services/Parts/Engine.cs
+++ b/service/SpaceCenter/src/Services/Parts/Engine.cs
@@ -665,8 +665,11 @@ namespace KRPC.SpaceCenter.Services.Parts
 
         /// <summary>
         /// Whether the engine's thrust reverser is engaged, reversing the
-        /// direction of thrust. Raises an exception if the engine does not have a
-        /// thrust reverser (see <see cref="CanReverseThrust"/>).
+        /// direction of thrust. While the reverser is still moving, this reports
+        /// the state it is moving to, so a read immediately after a set returns
+        /// the value that was set and setting the same value again has no effect.
+        /// Raises an exception if the engine does not have a thrust reverser
+        /// (see <see cref="CanReverseThrust"/>).
         /// </summary>
         [KRPCProperty]
         public bool ThrustReversed {

--- a/service/SpaceCenter/src/Services/Parts/ResourceHarvester.cs
+++ b/service/SpaceCenter/src/Services/Parts/ResourceHarvester.cs
@@ -98,12 +98,26 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// <summary>
         /// Whether the harvester is actively drilling.
         /// </summary>
+        /// <remarks>
+        /// A value set while the harvester is deploying is applied when the
+        /// deploy completes, so it can be set immediately after setting
+        /// <see cref="Deployed"/> without waiting for the deploy animation.
+        /// Setting it has no effect while the harvester is retracted or
+        /// retracting.
+        /// </remarks>
         [KRPCProperty]
         public bool Active {
             get { return State == ResourceHarvesterState.Active; }
             set {
-                if (!Deployed)
+                if (!Deployed) {
+                    // The converter cannot start until the deploy animation has
+                    // finished; defer the requested state until then rather than
+                    // silently dropping it.
+                    if (State == ResourceHarvesterState.Deploying)
+                        ResourceHarvesterAddon.Request (harvester, animator, value);
                     return;
+                }
+                ResourceHarvesterAddon.Cancel (harvester);
                 if (value && !harvester.IsActivated)
                     harvester.StartResourceConverter ();
                 if (!value && harvester.IsActivated)

--- a/service/SpaceCenter/src/Services/Parts/ThrustReverser.cs
+++ b/service/SpaceCenter/src/Services/Parts/ThrustReverser.cs
@@ -126,7 +126,12 @@ namespace KRPC.SpaceCenter.Services.Parts
         }
 
         public bool Reversed {
-            get { return (animation.animTime > 0.5f) == reversedWhenDeployed; }
+            // animSwitch is false when the animation is at, or playing towards, its
+            // deployed end, so this reads the commanded target state rather than the
+            // animation's progress. Reading progress would make the setter
+            // non-idempotent: a set re-issued while the animation is still short of
+            // its midpoint would toggle a second time and cancel the first.
+            get { return !animation.animSwitch == reversedWhenDeployed; }
             set { if (value != Reversed) animation.Toggle (); }
         }
 

--- a/service/SpaceCenter/test/test_control.py
+++ b/service/SpaceCenter/test/test_control.py
@@ -183,10 +183,8 @@ class ControlMixin:
         speed_mode = self.space_center.SpeedMode
         self.control.speed_mode = speed_mode.orbit
         self.assertEqual(self.control.speed_mode, speed_mode.orbit)
-        self.wait()
         self.control.speed_mode = speed_mode.surface
         self.assertEqual(self.control.speed_mode, speed_mode.surface)
-        self.wait()
         # No target set, so the target mode would be ignored here. It is
         # covered by test_speed_mode_with_target on the active vessel.
 

--- a/service/SpaceCenter/test/test_parts_antenna.py
+++ b/service/SpaceCenter/test/test_parts_antenna.py
@@ -99,10 +99,8 @@ class TestPartsAntenna(krpctest.TestCase):
     def test_allow_partial(self):
         self.assertFalse(self.fixed_antenna.allow_partial)
         self.fixed_antenna.allow_partial = True
-        self.wait()
         self.assertTrue(self.fixed_antenna.allow_partial)
         self.fixed_antenna.allow_partial = False
-        self.wait()
         self.assertFalse(self.fixed_antenna.allow_partial)
 
 

--- a/service/SpaceCenter/test/test_parts_engine.py
+++ b/service/SpaceCenter/test/test_parts_engine.py
@@ -261,12 +261,10 @@ class TestPartsEngine(krpctest.TestCase, EngineTestBase):
         self.assertTrue(engine.has_fuel)
 
     def test_has_no_fuel(self):
+        # has_fuel reads live propellant totals, so it reports correctly
+        # without the engine ever having been activated.
         engine = self.get_engine("liquidEngine3.v2")  # LV-909 "Terrier"
-        # FIXME: have to activate engine for this to work
-        engine.active = True
-        self.wait()
         self.assertFalse(engine.has_fuel)
-        engine.active = False
 
     def test_flameout(self):
         engine = self.get_engine("liquidEngine")  # LV-T30 "Reliant"

--- a/service/SpaceCenter/test/test_parts_engine.py
+++ b/service/SpaceCenter/test/test_parts_engine.py
@@ -553,12 +553,16 @@ class TestPartsEngineReverser(krpctest.TestCase, EngineTestBase):
         self.assertTrue(engine.can_reverse_thrust)
         self.assertFalse(engine.thrust_reversed)
 
-        # Engage the reverser
+        # Engage the reverser. The read-back reflects the commanded state while
+        # the animation is still running, so re-issuing the set mid-animation is
+        # a no-op rather than a second toggle that would cancel the first.
+        engine.thrust_reversed = True
+        self.assertTrue(engine.thrust_reversed)
         engine.thrust_reversed = True
         self.wait(2)  # the reverser animation takes time
         self.assertTrue(engine.thrust_reversed)
 
-        # Setting to the same state is a no-op
+        # Setting to the same state once settled is also a no-op
         engine.thrust_reversed = True
         self.assertTrue(engine.thrust_reversed)
 

--- a/service/SpaceCenter/test/test_parts_resource_harvester.py
+++ b/service/SpaceCenter/test/test_parts_resource_harvester.py
@@ -96,6 +96,31 @@ class TestPartsResourceHarvester(krpctest.TestCase):
         self.assertFalse(self.drill.deployed)
         self.assertFalse(self.drill.active)
 
+    def test_activate_while_deploying(self):
+        # An activation requested during the deploy animation is deferred and
+        # applied when the deploy completes, rather than silently dropped.
+        self.assertEqual(self.state.retracted, self.drill.state)
+        self.drill.deployed = True
+        self.drill.active = True
+        self.wait()
+        self.assertEqual(self.state.deploying, self.drill.state)
+        self.assertFalse(self.drill.active)
+        self.wait_until(
+            lambda: self.drill.state == self.state.active,
+            message="drill to activate after its deploy completes",
+        )
+        self.assertTrue(self.drill.active)
+        # Return the drill to its retracted state for the other tests
+        self.drill.active = False
+        self.wait_until(
+            lambda: self.drill.state == self.state.deployed,
+            message="drill to deactivate",
+        )
+        self.drill.deployed = False
+        self.wait_until(
+            lambda: self.drill.state == self.state.retracted, message="drill to retract"
+        )
+
     def test_control(self):
         for drill in self.drills:
             self.assertEqual(self.state.retracted, drill.state)

--- a/service/SpaceCenter/test/test_parts_wheel.py
+++ b/service/SpaceCenter/test/test_parts_wheel.py
@@ -40,11 +40,9 @@ class TestPartsWheel(krpctest.TestCase):
         wheel = self.fixed_wheel
         self.assertTrue(wheel.auto_friction_control)
         wheel.auto_friction_control = False
-        self.wait()
         self.assertFalse(wheel.auto_friction_control)
         self.assertAlmostEqual(2.0005, wheel.manual_friction_control, places=3)
         wheel.manual_friction_control = 1.2
-        self.wait()
         self.assertAlmostEqual(1.2, wheel.manual_friction_control, places=3)
         wheel.manual_friction_control = 1.0
         wheel.auto_friction_control = True

--- a/service/SpaceCenter/test/test_spacecenter.py
+++ b/service/SpaceCenter/test/test_spacecenter.py
@@ -493,7 +493,6 @@ class TestWarpOnLaunchpad(krpctest.TestCase, WarpTestBase):
         cls.vessel = cls.sc.active_vessel
         cls.maximum_rails_warp_factor = 7
         cls.landed = True
-        cls.wait(1)  # TODO: why is this wait needed?
 
     def test_warp_to_long(self):
         ut = self.sc.ut + (100 * 60 * 60)  # 100 hours in future
@@ -512,7 +511,6 @@ class TestWarpInOrbit(krpctest.TestCase, WarpTestBase):
         cls.vessel = cls.sc.active_vessel
         cls.maximum_rails_warp_factor = 4
         cls.landed = False
-        cls.wait(1)  # TODO: why is this wait needed?
 
 
 class TestWarpInSpace(krpctest.TestCase, WarpTestBase):
@@ -526,7 +524,6 @@ class TestWarpInSpace(krpctest.TestCase, WarpTestBase):
         cls.vessel = cls.sc.active_vessel
         cls.maximum_rails_warp_factor = 7
         cls.landed = False
-        cls.wait(1)  # TODO: why is this wait needed?
 
 
 class TestSpaceCenterCareer(krpctest.TestCase):

--- a/service/SpaceCenter/test/test_vessel.py
+++ b/service/SpaceCenter/test/test_vessel.py
@@ -309,12 +309,6 @@ class TestVesselEngines(krpctest.TestCase):
         engine.active = True
         self.wait(0.5)
 
-        # FIXME: need to run the engines to update their has fuel status
-        self.control.throttle = 0.1
-        self.wait(0.5)
-        self.control.throttle = 0.0
-        self.wait(0.5)
-
         info = self.engine_info[name]
         self.assertAlmostEqual(0, self.vessel.thrust, places=3)
         self.assertAlmostEqual(

--- a/service/UI/test/test_button.py
+++ b/service/UI/test/test_button.py
@@ -16,7 +16,6 @@ class TestButton(krpctest.TestCase):
         self.assertIsNotNone(button.text)
         self.assertEqual("Foo", button.text.content)
         self.assertFalse(button.clicked)
-        self.wait()
         button.remove()
         self.assertRaises(ValueError, button.remove)
 

--- a/service/UI/test/test_input_field.py
+++ b/service/UI/test/test_input_field.py
@@ -16,7 +16,6 @@ class TestInputField(krpctest.TestCase):
         self.assertEqual("", input_field.value)
         self.assertIsNotNone(input_field.text)
         self.assertFalse(input_field.changed)
-        self.wait()
         input_field.remove()
         self.assertRaises(ValueError, input_field.remove)
 

--- a/service/UI/test/test_text.py
+++ b/service/UI/test/test_text.py
@@ -24,7 +24,6 @@ class TestText(krpctest.TestCase):
         self.assertAlmostEqual((0.196, 0.196, 0.196), text.color, places=3)
         self.assertEqual(self.anchor.upper_left, text.alignment)
         self.assertEqual(1, text.line_spacing)
-        self.wait()
         text.remove()
         self.assertRaises(ValueError, text.remove)
 
@@ -43,7 +42,6 @@ class TestText(krpctest.TestCase):
         self.assertEqual((1, 0, 0), text.color)
         self.assertEqual(self.anchor.upper_right, text.alignment)
         self.assertEqual(2, text.line_spacing)
-        self.wait()
         text.remove()
         self.assertRaises(ValueError, text.remove)
 


### PR DESCRIPTION
Follow-ups from an audit of RPCs whose effect is deferred to a later physics tick, where a write issued at the wrong moment was silently lost or a read returned a stale value.

**ResourceHarvester.** Setting `Active` while the harvester was deploying was silently ignored: the underlying `ModuleResourceHarvester` rejects the start event until the deploy animation completes. A new `ResourceHarvesterAddon` records the requested state and applies it once the deploy completes, so the natural deploy-then-activate call sequence now works. A regression test covers this (it fails without the fix).

**ThrustReverser.** `Reversed` read the animation's current position, so reading it back immediately after a set — or setting it twice in quick succession — misbehaved while the animation was still playing. It now reports the commanded state (`animSwitch`), making sets idempotent and reads consistent with what was requested.

**Control input docs.** The nine `Control` input properties (`Pitch`, `Yaw`, `Roll`, `Throttle`, etc.) intentionally read back the input applied to the vessel on the last physics update rather than the pending set value; this get/set asymmetry is kept by design and is now documented on each property.

**Test cleanup.** Removes vestigial `wait()` calls and stale FIXME markers from the integration tests, including three warp-setup waits that are no longer needed.

**Testing.** Verified in-game on KSP 1.12.5: the harvester regression test goes red→green, and the affected suites (117 tests) pass.