### PR TITLE
Add Vessel.PhysicsRange

### DIFF
--- a/doc/order.txt
+++ b/doc/order.txt
@@ -173,6 +173,7 @@ SpaceCenter.Vessel.Type
 SpaceCenter.Vessel.Situation
 SpaceCenter.Vessel.Loaded
 SpaceCenter.Vessel.Packed
+SpaceCenter.Vessel.PhysicsRange
 SpaceCenter.Vessel.Recoverable
 SpaceCenter.Vessel.Recover
 SpaceCenter.Vessel.MET

--- a/service/SpaceCenter/CHANGES.txt
+++ b/service/SpaceCenter/CHANGES.txt
@@ -58,6 +58,10 @@ v0.6.0
    individual part (#459)
  * Add Control.AeroSurfaces to enable/disable pitch, yaw and roll on all control surfaces (#827)
  * Add Vessel.Loaded and Vessel.Packed to report a vessel's loading and on-rails state
+ * Add Vessel.PhysicsRange to set how far from the active vessel a vessel keeps running its
+   physics simulation, so that it stays controllable beyond the game's default range. The
+   range applies to that vessel only, and persists until it is set back to zero or the game
+   is exited
  * Add Engine.Flameout (#311)
  * Add Control.EngineGimbals to enable/disable gimbal on all gimballed engines (#827)
  * Allow Module.HasFieldWithId, GetFieldById, SetFieldIntById, SetFieldFloatById,

--- a/service/SpaceCenter/src/KRPC.SpaceCenter.csproj
+++ b/service/SpaceCenter/src/KRPC.SpaceCenter.csproj
@@ -95,6 +95,7 @@
     <Compile Include="PilotAddon.cs" />
     <Compile Include="ResourceHarvesterAddon.cs" />
     <Compile Include="ResourceTransferAddon.cs" />
+    <Compile Include="VesselPhysicsRangeAddon.cs" />
     <Compile Include="Services\Alarm.cs" />
     <Compile Include="Services\AlarmManager.cs" />
     <Compile Include="Services\AlarmMessageAction.cs" />

--- a/service/SpaceCenter/src/Services/Vessel.cs
+++ b/service/SpaceCenter/src/Services/Vessel.cs
@@ -115,6 +115,44 @@ namespace KRPC.SpaceCenter.Services
         }
 
         /// <summary>
+        /// The distance from the active vessel, in meters, out to which this vessel keeps running
+        /// its physics simulation — and so stays controllable, able to burn its engines and
+        /// respond to its autopilot. Setting this raises the vessel out of the stock physics
+        /// bubble, so that it keeps flying while the active vessel is far away. Set to zero to
+        /// restore the game's default range.
+        /// </summary>
+        /// <remarks>
+        /// This always reports the vessel's live range, so reading it when no range has been set
+        /// gives the game's default for the vessel's current <see cref="Situation" /> — which is
+        /// much shorter than the distance at which the vessel unloads. In orbit a vessel is put
+        /// on rails just 350m away, long before it unloads at 2.5km, and a vessel on rails
+        /// produces no thrust and ignores control input even though it is still loaded.
+        ///
+        /// There is a 10% margin below the range, so that a vessel hovering at the threshold does
+        /// not repeatedly drop out of the simulation and rejoin it. The vessel leaves the
+        /// simulation at the distance set here, and rejoins it at 90% of that distance; in
+        /// between it keeps whichever state it is already in.
+        ///
+        /// The requested range applies in every situation. The game's own defaults are not
+        /// uniform — a vessel flying in atmosphere stays loaded out to 22.5km — so setting a
+        /// small range can shorten the range such a vessel would otherwise have had.
+        ///
+        /// A range lasts until it is set back to zero or the game is exited. Unlike most state a
+        /// client sets, it is not released when that client disconnects, because dropping a
+        /// distant vessel back to the default range would put it on-rails part way through a
+        /// maneuver.
+        ///
+        /// Holding a vessel off-rails a long way from the active vessel costs performance, and
+        /// accumulates positional error that can destroy it. Raise the range on the vessels that
+        /// need it, by as little as they need.
+        /// </remarks>
+        [KRPCProperty (GameScene = GameScene.Flight)]
+        public float PhysicsRange {
+            get { return VesselPhysicsRangeAddon.Get (InternalVessel); }
+            set { VesselPhysicsRangeAddon.Set (InternalVessel, value); }
+        }
+
+        /// <summary>
         /// Whether the vessel is recoverable.
         /// </summary>
         [KRPCProperty]

--- a/service/SpaceCenter/src/VesselPhysicsRangeAddon.cs
+++ b/service/SpaceCenter/src/VesselPhysicsRangeAddon.cs
@@ -1,0 +1,142 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace KRPC.SpaceCenter
+{
+    /// <summary>
+    /// Addon that holds the physics ranges requested through
+    /// <see cref="Services.Vessel.PhysicsRange"/> and keeps them applied.
+    /// </summary>
+    /// <remarks>
+    /// KSP assigns <c>Vessel.vesselRanges</c> only in <c>Vessel.Awake</c>, copying
+    /// <c>PhysicsGlobals.VesselRangesDefault</c>, and never saves it. A vessel rebuilt from its
+    /// protovessel — after a scene change, or when it comes back into loading range — therefore
+    /// starts again at the stock ranges. The requested range is held here, keyed by vessel id so
+    /// that it outlives the vessel object, and re-applied so it survives those rebuilds.
+    ///
+    /// Overrides are deliberately not owned by the client that set them and are not released on
+    /// disconnect: dropping a distant vessel back to the stock bubble because a script exited
+    /// would pack it onto rails mid-flight, which is a worse outcome than an override outliving
+    /// its script. A client releases an override by setting the range to zero; all of them are
+    /// discarded when the game exits.
+    /// </remarks>
+    [KSPAddon (KSPAddon.Startup.Flight, false)]
+    public sealed class VesselPhysicsRangeAddon : MonoBehaviour
+    {
+        sealed class Override
+        {
+            public float Range;
+            public VesselRanges Original;
+        }
+
+        /// <summary>
+        /// The fraction of the requested range at which a vessel is loaded and unpacked. The
+        /// gap between this and the range itself is the hysteresis that stops a vessel sitting
+        /// on the threshold from flapping between states; the ratio matches the stock
+        /// load-to-unload ratio of 2250/2500.
+        /// </summary>
+        const float hysteresis = 0.9f;
+
+        static readonly IDictionary<Guid, Override> overrides = new Dictionary<Guid, Override> ();
+
+        /// <summary>
+        /// The distance beyond which a vessel stops running physics, for its current situation.
+        /// </summary>
+        /// <remarks>
+        /// A vessel is put on rails when it is further away than <c>pack</c>, and also when it is
+        /// further away than <c>unload</c>, because unloading forces it on rails. The smaller of
+        /// the two is therefore the distance out to which it keeps simulating. This reads the
+        /// vessel's live ranges rather than any requested value, so it reports what the game will
+        /// actually do.
+        /// </remarks>
+        internal static float Get (global::Vessel vessel)
+        {
+            var ranges = vessel.vesselRanges.GetSituationRanges (vessel.situation);
+            return Math.Min (ranges.pack, ranges.unload);
+        }
+
+        /// <summary>
+        /// Request a physics range for a vessel, applying it immediately. A range of zero or
+        /// less drops the request and restores the ranges the vessel had when it was made.
+        /// </summary>
+        internal static void Set (global::Vessel vessel, float range)
+        {
+            Override entry;
+            var exists = overrides.TryGetValue (vessel.id, out entry);
+            if (range <= 0) {
+                if (exists) {
+                    Restore (vessel, entry.Original);
+                    overrides.Remove (vessel.id);
+                }
+                return;
+            }
+            if (!exists) {
+                entry = new Override { Original = new VesselRanges (vessel.vesselRanges) };
+                overrides [vessel.id] = entry;
+            }
+            entry.Range = range;
+            Apply (vessel, range);
+        }
+
+        /// <summary>
+        /// Re-apply the requested ranges, so that they survive a vessel being rebuilt from its
+        /// protovessel — on entering the scene, or on coming back into loading range.
+        /// </summary>
+        public void FixedUpdate ()
+        {
+            ApplyAll ();
+        }
+
+        static void ApplyAll ()
+        {
+            if (overrides.Count == 0 || !FlightGlobals.ready)
+                return;
+            foreach (var vessel in FlightGlobals.Vessels) {
+                Override entry;
+                if (overrides.TryGetValue (vessel.id, out entry))
+                    Apply (vessel, entry.Range);
+            }
+        }
+
+        static void Apply (global::Vessel vessel, float range)
+        {
+            var ranges = vessel.vesselRanges;
+            Apply (ranges.prelaunch, range);
+            Apply (ranges.landed, range);
+            Apply (ranges.splashed, range);
+            Apply (ranges.flying, range);
+            Apply (ranges.subOrbital, range);
+            Apply (ranges.orbit, range);
+            Apply (ranges.escaping, range);
+        }
+
+        static void Apply (VesselRanges.Situation situation, float range)
+        {
+            situation.unload = range;
+            situation.pack = range;
+            situation.load = range * hysteresis;
+            situation.unpack = range * hysteresis;
+        }
+
+        static void Restore (global::Vessel vessel, VesselRanges original)
+        {
+            var ranges = vessel.vesselRanges;
+            Restore (ranges.prelaunch, original.prelaunch);
+            Restore (ranges.landed, original.landed);
+            Restore (ranges.splashed, original.splashed);
+            Restore (ranges.flying, original.flying);
+            Restore (ranges.subOrbital, original.subOrbital);
+            Restore (ranges.orbit, original.orbit);
+            Restore (ranges.escaping, original.escaping);
+        }
+
+        static void Restore (VesselRanges.Situation situation, VesselRanges.Situation original)
+        {
+            situation.load = original.load;
+            situation.unload = original.unload;
+            situation.pack = original.pack;
+            situation.unpack = original.unpack;
+        }
+    }
+}

--- a/service/SpaceCenter/test/test_vessel.py
+++ b/service/SpaceCenter/test/test_vessel.py
@@ -37,6 +37,21 @@ class TestVessel(krpctest.TestCase):
     def test_packed(self):
         self.assertFalse(self.vessel.packed)
 
+    def test_physics_range(self):
+        # Defaults to the stock pack distance for the vessel's situation, which in orbit
+        # is far shorter than the 2500m unload distance
+        self.assertEqual(self.Situation.orbiting, self.vessel.situation)
+        self.assertAlmostEqual(350, self.vessel.physics_range, places=1)
+        try:
+            self.vessel.physics_range = 50000
+            self.assertAlmostEqual(50000, self.vessel.physics_range, places=1)
+            self.wait(0.5)
+            # Survives being re-applied by the addon
+            self.assertAlmostEqual(50000, self.vessel.physics_range, places=1)
+        finally:
+            self.vessel.physics_range = 0
+        self.assertAlmostEqual(350, self.vessel.physics_range, places=1)
+
     def test_recoverable(self):
         self.assertFalse(self.vessel.recoverable)
         self.assertRaises(RuntimeError, self.vessel.recover)

--- a/service/SpaceCenter/test/test_vessel_physics_range.py
+++ b/service/SpaceCenter/test/test_vessel_physics_range.py
@@ -1,0 +1,195 @@
+import math
+
+import krpctest
+
+
+def magnitude(vector):
+    return math.sqrt(sum(x * x for x in vector))
+
+
+class TestVesselPhysicsRange(krpctest.TestCase):
+    """Tests Vessel.physics_range against a second vessel held at a controlled distance.
+
+    Both halves of Multi.craft are undocked into two vessels sharing a circular orbit,
+    and the active vessel is teleported along that orbit to place the other one. The
+    thresholds are only evaluated against non-active vessels, so a second vessel is the
+    only way to exercise them.
+    """
+
+    # A vessel is put on rails at 350m in orbit, so it is loaded but frozen well inside
+    # the 2.5km unload distance. This is the distance the tests use to show that.
+    PACKED_DISTANCE = 1000
+    RANGE = 5000
+
+    # Teleporting calls PrepTeleport, which puts vessels on rails and then blocks
+    # unpacking for a countdown of physics frames, so the state needs time to settle.
+    SETTLE = 4
+
+    @classmethod
+    def setUpClass(cls):
+        cls.new_save()
+        cls.launch_vessel_from_vab("Multi")
+        cls.remove_other_vessels()
+        cls.set_circular_orbit("Kerbin", 100000)
+        cls.space_center = cls.connect().space_center
+        next(iter(cls.space_center.active_vessel.parts.docking_ports)).undock()
+        cls.wait(1)
+        cls.vessel = cls.space_center.active_vessel
+        cls.other = next(v for v in cls.space_center.vessels if v != cls.vessel)
+        cls.semi_major_axis = cls.other.orbit.semi_major_axis
+        cls.epoch = cls.other.orbit.epoch
+        cls.anomaly_zero = cls.calibrate()
+
+    def tearDown(self):
+        self.other.physics_range = 0
+
+    @classmethod
+    def set_anomaly(cls, anomaly):
+        cls.set_orbit("Kerbin", cls.semi_major_axis, 0, 0, 0, 0, anomaly, cls.epoch)
+        cls.wait(cls.SETTLE)
+
+    @classmethod
+    def calibrate(cls):
+        """Find the mean anomaly at epoch that puts the active vessel alongside the other
+        one. A circular equatorial orbit is degenerate in its angles - the game reports a
+        non-zero longitude of ascending node and argument of periapsis with the mean
+        anomaly compensating - so the phase cannot be read off the other vessel's
+        elements and is measured instead. The chord between two placements on the same
+        orbit is 2a*sin(offset/2), which gives the size of the offset; a second placement
+        resolves its sign."""
+        cls.set_anomaly(0.0)
+        distance = magnitude(cls.other.position(cls.vessel.reference_frame))
+        offset = 2 * math.asin(min(1.0, distance / (2 * cls.semi_major_axis)))
+        cls.set_anomaly(offset)
+        if magnitude(cls.other.position(cls.vessel.reference_frame)) > distance:
+            offset = -offset
+        return offset
+
+    def place_at(self, distance):
+        """Teleport the active vessel so the other vessel sits at roughly the given
+        distance, and return the distance actually achieved."""
+        self.set_anomaly(self.anomaly_zero + distance / self.semi_major_axis)
+        return self.distance()
+
+    def distance(self):
+        return magnitude(self.other.position(self.vessel.reference_frame))
+
+    def assert_state(self, loaded, packed, message):
+        """Assert the other vessel's loaded and packed state, and check the game's
+        invariant that an unpacked vessel is always loaded."""
+        self.assertEqual(loaded, self.other.loaded, "loaded, " + message)
+        self.assertEqual(packed, self.other.packed, "packed, " + message)
+        if not self.other.packed:
+            self.assertTrue(self.other.loaded, "unpacked but not loaded, " + message)
+
+    def rcs_speed_change(self):
+        """Run the other vessel's RCS at full forward translation and return the change
+        in its orbital speed. A packed vessel has kinematic rigidbodies and discards all
+        forces, so this is zero however successfully the commands are issued."""
+        before = self.other.orbit.speed
+        self.other.control.rcs = True
+        self.other.control.forward = 1.0
+        self.wait(5)
+        after = self.other.orbit.speed
+        self.other.control.forward = 0.0
+        self.other.control.rcs = False
+        return abs(after - before)
+
+    def test_default_is_the_pack_distance(self):
+        # In orbit the game packs a vessel at 350m, long before it unloads at 2500m, so
+        # the physics range is the much shorter of the two.
+        self.assertEqual(
+            self.space_center.VesselSituation.orbiting, self.other.situation
+        )
+        self.assertAlmostEqual(350, self.other.physics_range, places=1)
+
+    def test_set_and_clear(self):
+        self.other.physics_range = self.RANGE
+        self.assertAlmostEqual(self.RANGE, self.other.physics_range, places=1)
+        # The addon re-applies the range every physics tick; it must survive that.
+        self.wait(1)
+        self.assertAlmostEqual(self.RANGE, self.other.physics_range, places=1)
+        self.other.physics_range = 0
+        self.assertAlmostEqual(350, self.other.physics_range, places=1)
+
+    def test_stock_vessel_is_packed_within_loading_range(self):
+        # Loaded but on rails: the state the physics range exists to avoid.
+        self.place_at(self.PACKED_DISTANCE)
+        self.assert_state(True, True, "stock ranges at ~1km")
+
+    def test_override_keeps_vessel_in_physics(self):
+        # The whole point of the feature. Same vessel, same distance, and the only
+        # difference is the physics range: without it the vessel is frozen and ignores
+        # its controls, with it the vessel is live and its RCS actually moves it.
+        self.place_at(self.PACKED_DISTANCE)
+        self.assert_state(True, True, "stock ranges at ~1km")
+        self.assertEqual(
+            self.space_center.ControlState.full,
+            self.other.control.state,
+            "a packed vessel still reports itself fully controllable",
+        )
+        self.assertLess(
+            self.rcs_speed_change(),
+            0.01,
+            "a packed vessel accepts control input but does not move",
+        )
+
+        self.other.physics_range = self.RANGE
+        self.wait(self.SETTLE)
+        self.assert_state(True, False, "physics range raised at ~1km")
+        self.assertGreater(
+            self.rcs_speed_change(),
+            0.5,
+            "an unpacked vessel responds to control input",
+        )
+
+    def test_override_moves_the_thresholds(self):
+        # The range is applied as pack = unload = range, and load = unpack = 0.9 * range,
+        # so well inside it the vessel runs physics and well outside it unloads.
+        self.other.physics_range = self.RANGE
+        self.wait(self.SETTLE)
+        self.place_at(3000)
+        self.assert_state(True, False, "inside a raised physics range")
+        self.place_at(int(self.RANGE * 1.5))
+        self.assert_state(False, True, "outside a raised physics range")
+        # Coming back inside restores it, so the range survives an unload/load cycle.
+        self.place_at(3000)
+        self.assert_state(True, False, "back inside a raised physics range")
+
+
+class TestVesselPhysicsRangeSceneChange(krpctest.TestCase):
+    """A scene change destroys the vessels and rebuilds them from their protovessels,
+    and a rebuilt vessel re-copies the game's default ranges in Vessel.Awake. The range
+    has to be re-applied for it to survive, which is what the addon is for. Uses the
+    active vessel, the one vessel guaranteed to survive the round trip."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.new_save()
+        cls.launch_vessel_from_vab("Basic")
+        cls.remove_other_vessels()
+        cls.set_circular_orbit("Kerbin", 100000)
+        cls.space_center = cls.connect().space_center
+
+    def test_survives_scene_change(self):
+        krpc = self.connect().krpc
+        self.space_center.active_vessel.physics_range = 5000
+
+        krpc.game_scene = krpc.GameScene.space_center
+        self.wait_until(
+            lambda: krpc.game_scene == krpc.GameScene.space_center,
+            message="never reached the space center",
+        )
+        krpc.game_scene = krpc.GameScene.flight
+        self.wait_until(
+            lambda: krpc.game_scene == krpc.GameScene.flight,
+            message="never returned to flight",
+        )
+        self.wait(3)
+
+        vessel = self.space_center.active_vessel
+        # physics_range reads the vessel's live ranges rather than the requested value,
+        # so this only passes if the range really was re-applied to the rebuilt vessel.
+        self.assertAlmostEqual(5000, vessel.physics_range, places=1)
+        vessel.physics_range = 0
+        self.assertAlmostEqual(350, vessel.physics_range, places=1)


### PR DESCRIPTION
Adds `Vessel.PhysicsRange`, letting a script keep one vessel running its physics simulation beyond the game's default range so that, for example, an upper stage flying under autopilot control stays flyable while the camera is elsewhere. Requested by a user who was otherwise reaching for PhysicsRangeExtender, which raises the range for every vessel in the game and is a well known source of instability.

**Background.** The familiar "2.5km bubble" is the *loading* distance. In orbit KSP puts a non-active vessel on rails at 350m, long before it unloads at 2500m, and a vessel on rails produces no thrust (`ModuleEngines.FixedUpdate` returns early on `part.packed`) and silently discards control input (`Vessel.FeedInputFeed` invokes the fly-by-wire callbacks and then returns before `propagateControlUpdate`), while still reporting itself fully controllable. So the distance that actually matters here is an order of magnitude shorter than the one users quote.

**Implementation.** The range is applied to all seven situations as `pack = unload = range` and `load = unpack = 0.9 * range`. Setting `pack` is the point — keeping the vessel merely loaded is useless — and `unload` has to move with it because unloading forces the vessel on rails. The 10% margin is hysteresis; keeping `load` below `unload` matters because `Vessel.Update` tests them with two sequential `if`s rather than an `if`/`else`, so an inverted pair would unload and reload every part every frame. The getter returns `min(pack, unload)` read from the vessel's live ranges, which is the distance at which it stops simulating, and round-trips exactly with the setter.

`Vessel.vesselRanges` is assigned only in `Vessel.Awake`, copied from `PhysicsGlobals.VesselRangesDefault`, and is never saved. A vessel rebuilt from its protovessel after a scene change therefore starts again at the defaults, so `VesselPhysicsRangeAddon` holds the requested ranges keyed by vessel id and re-applies them. They are deliberately not owned by the client that set them and are not released on disconnect: dropping a distant vessel back to the default range because a script exited would pack it onto rails mid-flight, which is a worse failure than an override outliving its script. A range is released by setting it to zero, and all of them are discarded when the game exits.

**Testing.** New in-game tests in `test_vessel_physics_range.py` undock `Multi.craft` into two vessels and teleport the active vessel along its orbit to place the other at controlled distances. The decisive case is the same vessel at the same distance with and without a range set: at ~1km stock it is loaded, packed, reports `ControlState.full`, and full RCS for five seconds changes its orbital speed by 0.0001 m/s; with the range raised it is unpacked and the same input changes its speed by 1.13 m/s. Also covered: the default reporting the pack distance rather than the unload distance, set and clear surviving the addon's re-application, the raised thresholds including a vessel unloading and coming back, and a Flight to Space Center and back round trip proving the range is genuinely re-applied to the rebuilt vessel.

Thresholds were confirmed against the running game with throwaway probes before the tests were written: stock `unpack` 200 bracketed at 188-234, stock `pack` 350 measured at 341.6 and 339.5 under continuous drift, stock `load` 2250 at 2044-2244, stock `unload` 2500 at 2131-2530, and with `physics_range = 5000` the `unpack` and `unload` thresholds at 4269-4668 and 4868-5468 against the predicted 4500 and 5000.

**Note.** The range applies in every situation, and the stock defaults are not uniform — a vessel flying in atmosphere stays loaded out to 22500m — so a small range can shorten the range such a vessel would otherwise have had. This is documented on the property rather than clamped, since clamping would leave the getter unable to report what was set.
