### PR TITLE
Enforce the SAS auto-pilot guard on both SAS properties

### DIFF
--- a/service/SpaceCenter/CHANGES.txt
+++ b/service/SpaceCenter/CHANGES.txt
@@ -10,6 +10,9 @@ v0.6.0
    Active; use ResourceHarvester.Active to check whether the harvester is drilling. The
    ResourceHarvesterState enumeration is removed and its values renumbered, so clients
    using it must be regenerated
+ * **Breaking:** Control.SAS now throws an exception when set to true while the autopilot is
+   engaged, matching AutoPilot.SAS. Previously the write was accepted and the autopilot
+   silently switched SAS back off on the next physics tick (#492)
  * Fix RoboticRotation.CurrentAngle and RoboticRotor.CurrentRPM returning stale values in
    flight (the KSP fields they read are only refreshed while the part action window is open)
  * Add SpaceCenter.Expansions to report the installed KSP expansions

--- a/service/SpaceCenter/src/Services/AutoPilot.cs
+++ b/service/SpaceCenter/src/Services/AutoPilot.cs
@@ -63,15 +63,15 @@ namespace KRPC.SpaceCenter.Services
         /// <summary>
         /// The state of SAS.
         /// </summary>
-        /// <remarks>Equivalent to <see cref="Control.SAS"/></remarks>
+        /// <remarks>
+        /// Equivalent to <see cref="Control.SAS"/>.
+        /// Throws an exception if set to <c>true</c> while the auto-pilot is engaged, as the
+        /// auto-pilot holds SAS off for as long as it is flying the vessel.
+        /// </remarks>
         [KRPCProperty]
         public bool SAS {
             get { return GetSAS (InternalVessel); }
-            set {
-                if (value && Engaged)
-                    throw new InvalidOperationException ("SAS cannot be enabled when the auto-pilot is engaged");
-                SetSAS (InternalVessel, value);
-            }
+            set { SetSAS (InternalVessel, value); }
         }
 
         internal static bool GetSAS (global::Vessel vessel)
@@ -79,9 +79,26 @@ namespace KRPC.SpaceCenter.Services
             return vessel.ActionGroups.groups [BaseAction.GetGroupIndex (KSPActionGroup.SAS)];
         }
 
+        /// <summary>
+        /// Sets the SAS action group, refusing to enable it while the auto-pilot is engaged.
+        /// The guard lives here rather than in the properties so that every route to SAS
+        /// enforces it and reports the same error.
+        /// </summary>
         internal static void SetSAS (global::Vessel vessel, bool value)
         {
+            if (value && IsAutoPilotEngaged (vessel))
+                throw new InvalidOperationException ("SAS cannot be enabled when the auto-pilot is engaged");
             vessel.ActionGroups.SetGroup (KSPActionGroup.SAS, value);
+        }
+
+        /// <summary>
+        /// Whether the vessel's auto-pilot is currently engaged. Uses the non-creating lookup,
+        /// so merely querying SAS does not allocate a controller for a vessel that has none.
+        /// </summary>
+        static bool IsAutoPilotEngaged (global::Vessel vessel)
+        {
+            var controller = PilotAddon.FindAttitudeController (vessel.id);
+            return controller != null && controller.Engaged;
         }
 
         /// <summary>

--- a/service/SpaceCenter/src/Services/Control.cs
+++ b/service/SpaceCenter/src/Services/Control.cs
@@ -76,7 +76,11 @@ namespace KRPC.SpaceCenter.Services
         /// <summary>
         /// The state of SAS.
         /// </summary>
-        /// <remarks>Equivalent to <see cref="AutoPilot.SAS"/></remarks>
+        /// <remarks>
+        /// Equivalent to <see cref="AutoPilot.SAS"/>.
+        /// Throws an exception if set to <c>true</c> while the auto-pilot is engaged, as the
+        /// auto-pilot holds SAS off for as long as it is flying the vessel.
+        /// </remarks>
         [KRPCProperty]
         public bool SAS {
             get { return AutoPilot.GetSAS (InternalVessel); }

--- a/service/SpaceCenter/test/test_autopilot.py
+++ b/service/SpaceCenter/test/test_autopilot.py
@@ -2237,6 +2237,10 @@ class TestAutoPilotRevertToLaunch(krpctest.TestCase):
         # is a ground-independent signal that the engaged handle is wired to the vessel's
         # live controller — a revert leaves the craft on the launch pad, where it cannot be
         # slewed to a target, so this checks the drive path rather than actual rotation.
+        #
+        # SAS can only be enabled while the auto-pilot is disengaged, so the sequence is
+        # disengage, arm SAS, then engage and watch the pilot loop clear it.
+        auto_pilot.engaged = False
         auto_pilot.reference_frame = vessel.surface_reference_frame
         auto_pilot.target_pitch_and_heading(0, 90)
         vessel.control.sas = True

--- a/service/SpaceCenter/test/test_control.py
+++ b/service/SpaceCenter/test/test_control.py
@@ -179,6 +179,26 @@ class ControlMixin:
         self.assertEqual(self.control.sas_mode, sas_mode.stability_assist)
         self.control.sas = False
 
+    def test_sas_cannot_be_enabled_while_autopilot_engaged(self):
+        # Control.sas and AutoPilot.sas are documented as equivalent, so both must
+        # refuse to enable SAS while the auto-pilot is engaged. Control.sas used to
+        # accept the write and let the pilot loop silently clear SAS a tick later.
+        self.control.sas = False
+        self.auto_pilot.reference_frame = self.vessel.surface_reference_frame
+        self.auto_pilot.target_pitch_and_heading(0, 90)
+        self.auto_pilot.engaged = True
+        try:
+            self.assertRaises(RuntimeError, setattr, self.control, "sas", True)
+            self.assertRaises(RuntimeError, setattr, self.auto_pilot, "sas", True)
+            # The refused writes left SAS off rather than enabling it for a tick.
+            self.wait()
+            self.assertFalse(self.control.sas)
+            # Disabling SAS is always allowed, engaged or not.
+            self.control.sas = False
+            self.auto_pilot.sas = False
+        finally:
+            self.auto_pilot.engaged = False
+
     def test_speed_mode(self):
         speed_mode = self.space_center.SpeedMode
         self.control.speed_mode = speed_mode.orbit


### PR DESCRIPTION
`AutoPilot.SAS` and `Control.SAS` are documented as equivalent — each carries a `<remarks>Equivalent to ...</remarks>` pointing at the other — but only the former refused to enable SAS while the auto-pilot is engaged. `Control.SAS` called the shared `internal AutoPilot.SetSAS` helper directly and skipped the check.

**Root cause.** This is the other half of #492, which reported that enabling SAS under an engaged auto-pilot silently resets it to off and asked for the setter to throw. The fix for it, `bcd117289` (v0.4.8), added the guard to `AutoPilot.cs` and touched no other file, so `Control.SAS` has shown the originally-reported behaviour ever since. The issue is left closed; this completes it.

**Impact.** Both paths end in the same vessel state, because `AttitudeController.Fly` clears the SAS action group on every physics tick while engaged. They differ in feedback. Via `AutoPilot.SAS` the client gets an immediate, explicit error; via `Control.SAS` the write is accepted, the getter reads back `true`, and SAS then flips off a tick later with no indication why. The silent path is the one most scripts use, since `Control` is where every other control input lives.

**Fix.** The guard moves into `SetSAS`, so both properties enforce it and report the same error. Engaged-ness is read through `PilotAddon.FindAttitudeController`, the non-creating lookup, so querying SAS no longer allocates a controller for a vessel that has none. The other routes to the SAS action group were audited: `AttitudeController.Fly` writes it directly rather than through `SetSAS` and only ever writes `false`, so the hold-off cannot trip its own guard, and the generic action-group RPCs map only to `Custom01`–`Custom10`. Those two properties are the only ways in. `SASMode` is deliberately untouched — both properties already route through `SetSASMode`, and it never enables SAS.

This is a narrow breaking change: `Control.SAS = True` under an engaged auto-pilot used to return without error and now raises. Anything relying on that was relying on a silent no-op. The changelog entry is marked accordingly.

**Testing.** New `test_sas_cannot_be_enabled_while_autopilot_engaged` in `ControlMixin`, so it covers both the active and non-active vessel. It asserts that both properties raise, that SAS stays off rather than flickering on for a tick, and that disabling SAS still works while engaged. Verified red→green: against the pre-fix source it fails with `RuntimeError not raised by setattr` on the `Control.SAS` assertion, and passes with the fix. Full `test_control.py` plus `TestAutoPilotSAS` is green (49 passed), as are the headless `//service/SpaceCenter:test` and `:lint` gates and `//doc:spelling`.

One existing test changed. `TestAutoPilotRevertToLaunch.assert_pilot_loop_drives` set `vessel.control.sas = True` on an already-engaged auto-pilot, so it depended on the bypass. It now disengages, arms SAS, then engages and watches the pilot loop clear it. The #958 regression coverage is preserved: before that fix the re-engage would still bind the orphaned controller, SAS would never clear, and the `wait_until` would still time out.
