### PR TITLE
Remove Module.AllFieldsById

### DIFF
--- a/doc/order.txt
+++ b/doc/order.txt
@@ -743,7 +743,6 @@ SpaceCenter.Module.EventList
 SpaceCenter.Module.ActionList
 SpaceCenter.Module.Fields
 SpaceCenter.Module.FieldsById
-SpaceCenter.Module.AllFieldsById
 SpaceCenter.Module.HasField
 SpaceCenter.Module.HasFieldWithId
 SpaceCenter.Module.GetField

--- a/service/SpaceCenter/CHANGES.txt
+++ b/service/SpaceCenter/CHANGES.txt
@@ -55,8 +55,6 @@ v0.6.0
  * Add Vessel.Loaded and Vessel.Packed to report a vessel's loading and on-rails state
  * Add Engine.Flameout (#311)
  * Add Control.EngineGimbals to enable/disable gimbal on all gimballed engines (#827)
- * Add Module.AllFieldsById to expose all part module field values, including those not
-   visible in the UI (#858)
  * Allow Module.HasFieldWithId, GetFieldById, SetFieldIntById, SetFieldFloatById,
    SetFieldStringById, SetFieldBoolById and ResetFieldById to also access fields not
    visible in the UI (#858)

--- a/service/SpaceCenter/src/Services/Parts/Module.cs
+++ b/service/SpaceCenter/src/Services/Parts/Module.cs
@@ -204,25 +204,6 @@ namespace KRPC.SpaceCenter.Services.Parts
         }
 
         /// <summary>
-        /// The modules field identifiers and their associated values, as a dictionary.
-        /// This is the same as <see cref="FieldsById"/>, except that it also includes
-        /// fields that are not visible in the right-click menu of the part.
-        /// </summary>
-        /// <remarks>
-        /// Throws an exception if there is more than one field with the same identifier.
-        /// </remarks>
-        [Obsolete("Use <see cref='FieldList'/> instead.")]
-        [KRPCProperty]
-        public IDictionary<string,string> AllFieldsById {
-            get {
-                var result = new Dictionary<string,string> ();
-                foreach (var f in AllBaseFields)
-                    result.Add (f.name, f.GetValue (module).ToString ());
-                return result;
-            }
-        }
-
-        /// <summary>
         /// Returns <c>true</c> if the module has a field with the given name.
         /// </summary>
         /// <param name="name">Name of the field.</param>


### PR DESCRIPTION
`Module.AllFieldsById` returned every field of a part module — including those not visible in the right-click menu — as a name-to-string dictionary. The object-oriented part field API added in #859 supersedes it: `Module.FieldList` exposes every field of a module, visible or not, as `PartField` objects, with typed access instead of stringified values.

`AllFieldsById` was added after v0.5.4 (#858) and has never appeared in a release, so there is nothing to deprecate and no compatibility window to observe — the member and its changelog entry are removed outright. The related change from #858 that widened `HasFieldWithId`, `GetFieldById` and the `SetField*ById`/`ResetFieldById` setters to reach fields not visible in the UI is unaffected and keeps its changelog entry.

**Testing.** No references to the member remain anywhere in the repository (server, clients, tests, docs); `doc/order.txt` is updated to match the reduced API surface.
