### PR TITLE
Send the game scenes a procedure is available in

### DIFF
--- a/core/CHANGES.txt
+++ b/core/CHANGES.txt
@@ -5,6 +5,9 @@ v0.6.0
  * Rename KRPC.CurrentGameScene to KRPC.GameScene and make it settable to switch the current game scene (#897)
  * Add AstronautComplex, MissionControl, ResearchAndDevelopment, Administration and MissionBuilder game scenes (#897)
  * **Deprecated:** KRPC.CurrentGameScene, kept as a read-only alias of KRPC.GameScene (#897)
+ * Fix the game scenes a procedure is available in never being sent by GetServices; the
+   game_scenes field of every procedure was empty, which the protocol defines as meaning
+   the procedure is available in all game scenes
  * Reduce copying and allocation when receiving messages: protobuf messages are
    now parsed directly from the receive buffer, without allocating intermediate
    buffers or streams

--- a/core/src/Server/ProtocolBuffers/MessageExtensions.cs
+++ b/core/src/Server/ProtocolBuffers/MessageExtensions.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using KRPC.Service;
 using KRPC.Service.Messages;
@@ -95,9 +96,31 @@ namespace KRPC.Server.ProtocolBuffers
             if (procedure.ReturnType != null)
                 result.ReturnType = procedure.ReturnType.ToProtobufMessage ();
             result.ReturnIsNullable = procedure.ReturnIsNullable;
+            result.GameScenes.Add (ToProtobufMessage (procedure.GameScene));
             result.Documentation = procedure.Documentation;
             result.Deprecated = procedure.Deprecated;
             result.DeprecatedReason = procedure.DeprecatedReason;
+            return result;
+        }
+
+        /// <summary>
+        /// Convert a game scene mask into wire enumeration values. Scenes are matched by the
+        /// same names used by the JSON service definitions, so the wire enumeration only needs
+        /// its values to be named consistently to stay in step; any scene it does not name is
+        /// omitted. A procedure available in every scene encodes as an empty list, which the
+        /// protocol defines to mean all scenes.
+        /// </summary>
+        static IList<Schema.KRPC.Procedure.Types.GameScene> ToProtobufMessage (GameScene scenes)
+        {
+            var result = new List<Schema.KRPC.Procedure.Types.GameScene> ();
+            if (scenes == GameScene.All)
+                return result;
+            var descriptor = Schema.KRPC.Procedure.Descriptor.EnumTypes.Single ();
+            foreach (var name in GameSceneUtils.Serialize (scenes)) {
+                var value = descriptor.FindValueByName (name);
+                if (value != null)
+                    result.Add ((Schema.KRPC.Procedure.Types.GameScene)value.Number);
+            }
             return result;
         }
 

--- a/core/test/KRPC.Core.Test.csproj
+++ b/core/test/KRPC.Core.Test.csproj
@@ -43,6 +43,7 @@
     <Compile Include="Server\HTTP\RequestTest.cs" />
     <Compile Include="Server\HTTP\ResponseTest.cs" />
     <Compile Include="Server\ProtocolBuffers\EncoderTest.cs" />
+    <Compile Include="Server\ProtocolBuffers\MessageExtensionsTest.cs" />
     <Compile Include="Server\ProtocolBuffers\RPCServerTest.cs" />
     <Compile Include="Server\ProtocolBuffers\RPCStreamTest.cs" />
     <Compile Include="Server\ProtocolBuffers\SchemaTest.cs" />

--- a/core/test/Server/ProtocolBuffers/MessageExtensionsTest.cs
+++ b/core/test/Server/ProtocolBuffers/MessageExtensionsTest.cs
@@ -1,0 +1,41 @@
+using KRPC.Server.ProtocolBuffers;
+using KRPC.Service;
+using KRPC.Service.Messages;
+using NUnit.Framework;
+using WireGameScene = KRPC.Schema.KRPC.Procedure.Types.GameScene;
+
+namespace KRPC.Test.Server.ProtocolBuffers
+{
+    [TestFixture]
+    public class MessageExtensionsTest
+    {
+        static Schema.KRPC.Procedure Encode (GameScene scenes)
+        {
+            var procedure = new Procedure ("ProcedureName");
+            procedure.GameScene = scenes;
+            return procedure.ToProtobufMessage ();
+        }
+
+        [Test]
+        public void EncodeProcedureGameScenes ()
+        {
+            CollectionAssert.AreEqual (
+                new [] { WireGameScene.Flight }, Encode (GameScene.Flight).GameScenes);
+            CollectionAssert.AreEqual (
+                new [] { WireGameScene.EditorVab, WireGameScene.EditorSph },
+                Encode (GameScene.Editor).GameScenes);
+            CollectionAssert.AreEqual (
+                new [] { WireGameScene.SpaceCenter, WireGameScene.TrackingStation },
+                Encode (GameScene.SpaceCenter | GameScene.TrackingStation).GameScenes);
+            CollectionAssert.AreEqual (
+                new [] { WireGameScene.SpaceCenter, WireGameScene.AstronautComplex },
+                Encode (GameScene.SpaceCenter | GameScene.AstronautComplex).GameScenes);
+        }
+
+        [Test]
+        public void EncodeProcedureGameScenesAll ()
+        {
+            CollectionAssert.IsEmpty (Encode (GameScene.All).GameScenes);
+        }
+    }
+}

--- a/doc/src/communication-protocols/messages.rst
+++ b/doc/src/communication-protocols/messages.rst
@@ -643,7 +643,14 @@ follows:
      EDITOR_VAB = 3;
      EDITOR_SPH = 4;
      MISSION_BUILDER = 5;
+     ASTRONAUT_COMPLEX = 6;
+     MISSION_CONTROL = 7;
+     RESEARCH_AND_DEVELOPMENT = 8;
+     ADMINISTRATION = 9;
    };
+
+The astronaut complex, mission control, research and development and administration scenes are
+facilities that open within the space center scene.
 
 .. _communication-protocol-proxy-objects:
 

--- a/protobuf/krpc.proto
+++ b/protobuf/krpc.proto
@@ -112,6 +112,10 @@ message Procedure {
     EDITOR_VAB = 3;
     EDITOR_SPH = 4;
     MISSION_BUILDER = 5;
+    ASTRONAUT_COMPLEX = 6;
+    MISSION_CONTROL = 7;
+    RESEARCH_AND_DEVELOPMENT = 8;
+    ADMINISTRATION = 9;
   };
 }
 


### PR DESCRIPTION
**Problem.** The `Procedure` message has carried a `game_scenes` field since the game scene mask was introduced, and the protocol documents it as reporting which game scenes a procedure can be called from, but the protobuf encoder never populated it. Every procedure was sent with an empty list, which the protocol defines as meaning the procedure is available in all game scenes — so clients had no way to tell which procedures were actually scene-restricted.

**Fix.** Encode the mask in `MessageExtensions.ToProtobufMessage`, looking up the wire enumeration values by the same names the JSON service definitions use so the two representations stay in step as scenes are added. A mask covering every scene is still sent as an empty list, matching the protocol's definition. The wire enumeration itself only named the original six scenes, so the astronaut complex, mission control, research and development and administration scenes had no value to encode to; those are added to `krpc.proto` and listed in the protocol documentation.

**Testing.** New `MessageExtensionsTest` covers encoding a single scene, a multi-scene mask (`Editor` expanding to VAB and SPH), a mask spanning an original and a newly added scene, and the all-scenes case encoding as empty.
