### PR TITLE
Packaging fixes

### DIFF
--- a/client/csharp/BUILD.bazel
+++ b/client/csharp/BUILD.bazel
@@ -40,7 +40,7 @@ nuget_package(
     project_url = "https://github.com/krpc/krpc",
     version = nuget_version,
     deps = {
-        "Google.Protobuf": "3.22.0",
+        "Google.Protobuf": "3.35.1",
     },
 )
 

--- a/client/python/pyproject.toml
+++ b/client/python/pyproject.toml
@@ -12,7 +12,7 @@ description = "Client library for kRPC, a Remote Procedure Call server for Kerba
 readme = "README.txt"
 license = "LGPL-3.0-only"
 requires-python = ">=3.10"
-dependencies = ["protobuf >= 3.6"]
+dependencies = ["protobuf >= 7.35.1"]
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: End Users/Desktop",

--- a/core/BUILD.bazel
+++ b/core/BUILD.bazel
@@ -107,6 +107,20 @@ service_definitions(
     visibility = ["//visibility:public"],
 )
 
+# The XML documentation file of the net8.0 build, for packaging beside
+# KRPC.Core.dll in published tools: the server and the ServiceDefinitions tool
+# read API documentation from the XML file next to the assembly at runtime.
+genrule(
+    name = "KRPC.Core.net8-xmldoc",
+    srcs = [":KRPC.Core.net8"],
+    outs = ["xmldoc-net8/KRPC.Core.xml"],
+    cmd = 'for f in $(SRCS); do case "$$f" in *.xml) cp "$$f" "$@";; esac; done',
+    visibility = [
+        "//tools/TestServer:__pkg__",
+        "//tools/krpctools:__pkg__",
+    ],
+)
+
 csharp_assembly_info(
     name = "TestAssemblyInfo",
     cls_compliant = False,

--- a/tools/TestServer/BUILD.bazel
+++ b/tools/TestServer/BUILD.bazel
@@ -43,15 +43,19 @@ pkg_zip(
     exclude = ["*.pdb"],
     files = [
         ":README.md",
+        ":TestServer-xmldoc",
         ":publish",
         "//:version",
+        "//core:KRPC.Core.net8-xmldoc",
         "//tools/build/protobuf:LICENSE",
     ],
     mode_map = {
         "TestServer": "755",
     },
     path_map = {
+        "core/xmldoc-net8/": "",
         "tools/TestServer/publish/publish/linux-x64/": "",
+        "tools/TestServer/xmldoc/": "",
         "tools/TestServer/": "",
         "tools/build/protobuf/LICENSE": "LICENSE.protobuf",
     },
@@ -70,6 +74,15 @@ csharp_binary(
     visibility = ["//visibility:public"],
     warning_level = 4,
     deps = exe_deps,
+)
+
+# The server reads API documentation from the XML doc file next to each
+# assembly at runtime, so the release archive ships it beside the binaries.
+genrule(
+    name = "TestServer-xmldoc",
+    srcs = [":TestServer"],
+    outs = ["xmldoc/TestServer.xml"],
+    cmd = 'for f in $(SRCS); do case "$$f" in *.xml) cp "$$f" "$@";; esac; done',
 )
 
 # Published (framework-dependent) layout of TestServer for the release

--- a/tools/krpctools/BUILD.bazel
+++ b/tools/krpctools/BUILD.bazel
@@ -51,6 +51,7 @@ py_sdist(
         "//:COPYING",
         "//:python_version",
         "//:version",
+        "//core:KRPC.Core.net8-xmldoc",
         "//tools/ServiceDefinitions:publish",
         "//tools/TestServer:ServiceDefinitions",
         "//tools/TestServer:archive",
@@ -63,6 +64,7 @@ py_sdist(
     ]),
     path_map = {
         "version.py": "krpctools/version.py",
+        "core/xmldoc-net8/": "krpctools/bin/",
         "tools/krpctools/": "",
         "tools/ServiceDefinitions/publish/publish/linux-x64/": "krpctools/bin/",
         "tools/TestServer/TestService.json": "krpctools/test/TestService.json",

--- a/tools/update-arduino-library.sh
+++ b/tools/update-arduino-library.sh
@@ -4,9 +4,11 @@ set -e
 VERSION=`tools/krpc-version.sh`
 COMMIT=`git rev-parse HEAD`
 
-# Build cnano library
+# Build cnano library, and fetch the nanopb runtime that the Arduino library
+# vendors (the cnano archive itself takes nanopb as an external dependency)
 echo 'Building library...'
-bazel build //client/cnano
+bazel build //client/cnano @c_nanopb//:srcs
+nanopb=`pwd`/bazel-krpc/external/+http_archive+c_nanopb
 
 # Clone arduino library repository
 arduino=`pwd`/bazel-bin/client/cnano/arduino
@@ -25,8 +27,11 @@ unzip -q krpc-cnano-$VERSION.zip
 # Restructure files
 mv krpc-cnano-$VERSION/include/* ./
 mv krpc-cnano-$VERSION/src/*.c ./
-rm Makefile.*
 rm -rf krpc-cnano-$VERSION krpc-cnano-$VERSION.zip
+# Vendor the nanopb runtime: headers beside the other krpc_cnano headers
+# (they are included as <krpc_cnano/pb.h>), sources at the top level
+cp $nanopb/pb.h $nanopb/pb_common.h $nanopb/pb_encode.h $nanopb/pb_decode.h krpc_cnano/
+cp $nanopb/pb_common.c $nanopb/pb_encode.c $nanopb/pb_decode.c ./
 # Rename .c to .cpp for arduino builder
 for file in *.c; do
   mv "$file" "$(basename "$file" .c).cpp"


### PR DESCRIPTION
Three packaging fixes found while checking what the release artifacts actually contain.

**XML documentation.** The server and the `ServiceDefinitions` tool read API documentation from the XML file sitting next to each assembly at runtime, but neither the TestServer nor the krpctools package shipped those files, so TestServer served empty documentation and `krpc-servicedefs` emitted definitions without docs. `TestServer.xml` and the net8.0 `KRPC.Core.xml` are now extracted from the builds and packaged beside the published binaries.

**Arduino library.** The C-nano archive takes nanopb as an external dependency and no longer bundles its runtime or any autotools files, so `update-arduino-library.sh` now copies the pinned nanopb sources out of the `@c_nanopb` Bazel external instead — headers beside the other `krpc_cnano` headers and sources at the top level, matching the layout the published library has always used.

**Client dependency floors.** The Python package declared `protobuf >= 3.6` while its generated schema code requires the 7.35 runtime line, so an install satisfying the declared floor could fail on import. The C# nupkg declared `Google.Protobuf 3.22.0` while the assembly is compiled against 3.35.1, so NuGet could restore a version that fails assembly binding at runtime. Both floors now match the versions the packages are built with.
