### PR TITLE
Make behavior independent of the machine's locale

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -19,6 +19,16 @@ build:macos --cxxopt=-Wno-unused-command-line-argument --host_cxxopt=-Wno-unused
 
 build --java_runtime_version=remotejdk_11
 
+# Pin the locale for build actions and tests. Several tools change behaviour with
+# it: the code generators read and write UTF-8 sources, C and Lua case folding and
+# number formatting go through the C library, and .NET formats numbers using the
+# ambient culture. Without this the output depends on whoever runs the build, and
+# CI (which has no LANG set, so runs under POSIX) disagrees with a developer
+# machine that does.
+build --action_env=LC_ALL=C.UTF-8
+build --host_action_env=LC_ALL=C.UTF-8
+test --test_env=LC_ALL=C.UTF-8
+
 # Windows: rules_dotnet (and the symlink-based staging rules) need real symlinks
 # and runfiles trees. The startup flag is a no-op off Windows; the windows config
 # group is auto-selected on Windows hosts (and CI also passes --config=windows).

--- a/client/csharp/src/Encoder.cs
+++ b/client/csharp/src/Encoder.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -98,12 +99,12 @@ namespace KRPC.Client
         {
             var encodedTuple = new Schema.KRPC.Tuple ();
             var valueTypes = type.GetGenericArguments ().ToArray ();
-            var genericType = Type.GetType ("System.Tuple`" + valueTypes.Length.ToString ());
+            var genericType = Type.GetType ("System.Tuple`" + valueTypes.Length.ToString (CultureInfo.InvariantCulture));
             var tupleType = genericType.MakeGenericType (valueTypes);
             using (var internalBuffer = new MemoryStream ()) {
                 var internalStream = new CodedOutputStream (internalBuffer);
                 for (int i = 0; i < valueTypes.Length; i++) {
-                    var property = tupleType.GetProperty ("Item" + (i + 1).ToString ());
+                    var property = tupleType.GetProperty ("Item" + (i + 1).ToString (CultureInfo.InvariantCulture));
                     var item = property.GetGetMethod ().Invoke (value, null);
                     encodedTuple.Items.Add (EncodeObject (item, valueTypes [i], internalBuffer, internalStream));
                 }
@@ -217,7 +218,7 @@ namespace KRPC.Client
         {
             var encodedTuple = Schema.KRPC.Tuple.Parser.ParseFrom (stream);
             var valueTypes = type.GetGenericArguments ().ToArray ();
-            var genericType = Type.GetType ("System.Tuple`" + valueTypes.Length.ToString ());
+            var genericType = Type.GetType ("System.Tuple`" + valueTypes.Length.ToString (CultureInfo.InvariantCulture));
             var values = new object[valueTypes.Length];
             for (int i = 0; i < valueTypes.Length; i++) {
                 var item = encodedTuple.Items [i];

--- a/client/csharp/test/TestingTools.cs
+++ b/client/csharp/test/TestingTools.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Globalization;
 using System.Linq;
 using Google.Protobuf;
 
@@ -8,7 +9,7 @@ namespace KRPC.Client.Test
     {
         public static string ToHexString (this byte[] data)
         {
-            return BitConverter.ToString (data).Replace ("-", string.Empty).ToLower ();
+            return BitConverter.ToString (data).Replace ("-", string.Empty).ToLowerInvariant ();
         }
 
         public static string ToHexString (this ByteString data)

--- a/client/lua/CHANGES.txt
+++ b/client/lua/CHANGES.txt
@@ -1,5 +1,7 @@
 v0.6.0
  * Fix attributes module to always return boolean for is_a_class_member and is_a_class_property_accessor
+ * Fix service, method and property names being converted to snake case using the machine's
+   locale, which renamed every member the client exposes under Turkish locales
 
 v0.5.0
  * Update to protobuf v3.22.0

--- a/client/lua/krpc/service.lua
+++ b/client/lua/krpc/service.lua
@@ -15,11 +15,21 @@ local regex_multi_uppercase = '([A-Z]+)([A-Z][a-z0-9])'
 local regex_single_uppercase = '([a-z0-9])([A-Z])'
 local regex_underscores = '(.)_'
 
+-- Lower case the ASCII letters in a string. string.lower goes through the C
+-- library and so follows LC_CTYPE, which in Turkish locales maps I onto a
+-- dotless i. These names have to match the identifiers the server sends
+-- exactly, so the fold must not depend on the locale.
+local function ascii_lower(str)
+  return (str:gsub('[A-Z]', function(char)
+    return string.char(string.byte(char) + 32)
+  end))
+end
+
 --- Convert camel case to snake case, e.g. GetServices -> get_services
 function service.to_snake_case(camel_case)
   local result = camel_case:gsub(regex_underscores, '%1__')
   result = result:gsub(regex_single_uppercase, '%1_%2')
-  return result:gsub(regex_multi_uppercase, '%1_%2'):lower()
+  return ascii_lower(result:gsub(regex_multi_uppercase, '%1_%2'))
 end
 
 local KEYWORDS = Set{

--- a/core/CHANGES.txt
+++ b/core/CHANGES.txt
@@ -15,6 +15,9 @@ v0.6.0
    across multiple reads; requests are now buffered until complete
  * Fix websocket connection URL query parameter parsing: parameters are now
    found in any position and are percent-decoded
+ * Fix type codes in the service description, and HTTP and websocket protocol tokens, being
+   case converted using the machine's locale; under Turkish locales this produced values that
+   clients could not match
 
 v0.5.4
  * Initial version, split off from KRPC.dll

--- a/core/src/Server/HTTP/Request.cs
+++ b/core/src/Server/HTTP/Request.cs
@@ -58,7 +58,7 @@ namespace KRPC.Server.HTTP
                     throw new MalformedRequestException ("Request line malformed");
                 if (requestLineParts [0].Length == 0)
                     throw new MalformedRequestException ("Invalid or unsupported method");
-                request.Method = requestLineParts [0].ToLower ();
+                request.Method = requestLineParts [0].ToLowerInvariant ();
                 try {
                     var baseUri = new Uri ("http://localhost/");
                     request.URI = new Uri (baseUri, requestLineParts [1]);
@@ -67,7 +67,7 @@ namespace KRPC.Server.HTTP
                 }
                 if (requestLineParts [2].Length == 0)
                     throw new MalformedRequestException ("Invalid or unsupported protocol");
-                request.Protocol = requestLineParts [2].ToLower ();
+                request.Protocol = requestLineParts [2].ToLowerInvariant ();
 
                 // Parse header fields
                 if (!line.MoveNext ())
@@ -77,7 +77,7 @@ namespace KRPC.Server.HTTP
                     var i = line.Current.IndexOf (':');
                     if (i == -1)
                         throw new MalformedRequestException ("Header field malformed");
-                    var key = line.Current.Substring (0, i).Trim ().ToLower ();
+                    var key = line.Current.Substring (0, i).Trim ().ToLowerInvariant ();
                     var value = line.Current.Substring (i + 1).Trim ();
                     if (key.Length == 0)
                         throw new MalformedRequestException ("Header field key empty");

--- a/core/src/Server/ProtocolBuffers/RPCServer.cs
+++ b/core/src/Server/ProtocolBuffers/RPCServer.cs
@@ -39,7 +39,7 @@ namespace KRPC.Server.ProtocolBuffers
                 if (request == null)
                     return null;
                 if (request.Type != Type.Rpc) {
-                    var name = request.Type.ToString ().ToLower ();
+                    var name = request.Type.ToString ().ToLowerInvariant ();
                     WriteErrorConnectionResponse (client, Status.WrongType,
                         "Connection request was for the " + name + " server, but this is the rpc server. " +
                         "Did you connect to the wrong port number?");

--- a/core/src/Server/ProtocolBuffers/StreamServer.cs
+++ b/core/src/Server/ProtocolBuffers/StreamServer.cs
@@ -38,7 +38,7 @@ namespace KRPC.Server.ProtocolBuffers
                 if (request == null)
                     return null;
                 if (request.Type != Type.Stream) {
-                    var name = request.Type.ToString ().ToLower ();
+                    var name = request.Type.ToString ().ToLowerInvariant ();
                     WriteErrorConnectionResponse (Status.WrongType,
                         "Connection request was for the " + name + " server, but this is the stream server. " +
                         "Did you connect to the wrong port number?", stream);

--- a/core/src/Server/SerialIO/RPCServer.cs
+++ b/core/src/Server/SerialIO/RPCServer.cs
@@ -45,7 +45,7 @@ namespace KRPC.Server.SerialIO
                         client, Status.MalformedMessage, "Expected a ConnectionRequest message");
                 }
                 if (connectionRequest.Type != Type.Rpc) {
-                    var name = connectionRequest.Type.ToString().ToLower ();
+                    var name = connectionRequest.Type.ToString().ToLowerInvariant ();
                     WriteErrorConnectionResponse(
                         client, Status.WrongType,
                         "Connection request was for a " + name + " server, " +

--- a/core/src/Server/TCP/TCPServer.cs
+++ b/core/src/Server/TCP/TCPServer.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Net;
 using System.Net.Sockets;
 using System.Threading;
@@ -237,7 +238,7 @@ namespace KRPC.Server.TCP
                     return anyClientText;
                 try {
                     var subnet = NetworkInformation.GetSubnetMask (ListenAddress);
-                    return string.Format (subnetAllowedText, subnet);
+                    return string.Format (CultureInfo.InvariantCulture, subnetAllowedText, subnet);
                 } catch (NotImplementedException) {
                 } catch (ArgumentException) {
                 } catch (DllNotFoundException) {

--- a/core/src/Server/WebSockets/ConnectionRequest.cs
+++ b/core/src/Server/WebSockets/ConnectionRequest.cs
@@ -132,7 +132,7 @@ namespace KRPC.Server.WebSockets
                 throw new HandshakeException (Response.CreateBadRequest ("Host field not set."));
 
             // Check upgrade field
-            if (!request.Headers.ContainsKey ("upgrade") || request.Headers ["upgrade"].SingleOrDefault ().ToLower () != "websocket")
+            if (!request.Headers.ContainsKey ("upgrade") || request.Headers ["upgrade"].SingleOrDefault ().ToLowerInvariant () != "websocket")
                 throw new HandshakeException (Response.CreateBadRequest ("Upgrade field not set to websocket."));
 
             // Check connection field

--- a/core/src/Service/KRPC/Expression.cs
+++ b/core/src/Service/KRPC/Expression.cs
@@ -519,7 +519,7 @@ namespace KRPC.Service.KRPC
             if (ReferenceEquals (arg, null))
                 throw new ArgumentNullException (nameof (arg));
             var argType = arg.Type;
-            if (argType.Name.StartsWith("Tuple`", StringComparison.CurrentCulture)) {
+            if (argType.Name.StartsWith("Tuple`", StringComparison.Ordinal)) {
                 var tupleIndex = LinqExpression.Lambda<Func<int>> (index).Compile () ();
                 var property = argType.GetProperty ("Item" + (tupleIndex + 1));
                 if (property == null)

--- a/core/src/Service/TypeUtils.cs
+++ b/core/src/Service/TypeUtils.cs
@@ -102,7 +102,7 @@ namespace KRPC.Service
         /// </summary>
         public static bool IsATupleCollectionType (Type type)
         {
-            return type.Name.StartsWith("Tuple`", StringComparison.CurrentCulture) &&
+            return type.Name.StartsWith("Tuple`", StringComparison.Ordinal) &&
             type.GetGenericArguments().All(IsAValidType);
         }
 
@@ -626,7 +626,7 @@ namespace KRPC.Service
                         snakeCase += camelCase[i];
                 }
                 snakeCase += camelCase[camelCase.Length-1];
-                result["code"] = snakeCase.ToUpper();
+                result["code"] = snakeCase.ToUpperInvariant();
             }
             if (!result.ContainsKey("code"))
                 throw new ArgumentException ("Type " + type + " is not a valid kRPC type");

--- a/core/src/Utils/Logger.cs
+++ b/core/src/Utils/Logger.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Globalization;
 
 namespace KRPC.Utils
 {
@@ -73,7 +74,7 @@ namespace KRPC.Utils
         public static void WriteLine (string message, Severity severity = Severity.Info)
         {
             if (ShouldLog (severity))
-                Writer (string.Format (format, DateTime.Now, severity, message), severity);
+                Writer (string.Format (CultureInfo.InvariantCulture, format, DateTime.Now, severity, message), severity);
         }
 
         internal static bool ShouldLog (Severity severity)

--- a/core/test/TestingTools.cs
+++ b/core/test/TestingTools.cs
@@ -8,7 +8,7 @@ namespace KRPC.Test
     {
         public static string ToHexString (this byte[] data)
         {
-            return BitConverter.ToString (data).Replace ("-", string.Empty).ToLower ();
+            return BitConverter.ToString (data).Replace ("-", string.Empty).ToLowerInvariant ();
         }
 
         public static string ToHexString (this ByteString data)

--- a/service/SpaceCenter/CHANGES.txt
+++ b/service/SpaceCenter/CHANGES.txt
@@ -13,6 +13,11 @@ v0.6.0
  * **Breaking:** Control.SAS now throws an exception when set to true while the autopilot is
    engaged, matching AutoPilot.SAS. Previously the write was accepted and the autopilot
    silently switched SAS back off on the next physics tick (#492)
+ * **Breaking:** RoboticController.AddAxis, AddKeyFrame and ClearAxis now identify an axis by
+   the name of its field, for example targetAngle, instead of by the label shown in the part's
+   menu, for example "Target Angle". The names now match those returned by
+   RoboticController.Axes, which previously could not be passed back in, and no longer change
+   with the language the game is running in
  * Fix RoboticRotation.CurrentAngle and RoboticRotor.CurrentRPM returning stale values in
    flight (the KSP fields they read are only refreshed while the part action window is open)
  * Add SpaceCenter.Expansions to report the installed KSP expansions
@@ -181,6 +186,19 @@ v0.6.0
  * Add Parachute.SafeState reporting whether it is currently safe to deploy the
    parachute (safe, risky, unsafe, or not applicable)
  * Add Contract.DateAccepted, DateDeadline, DateExpire and DateFinished
+ * Fix DockingPort.Undock doing nothing when the game is not running in English
+ * Fix Fairing.Jettison doing nothing, and Fairing.Jettisoned always reporting true, when the
+   game is not running in English
+ * Fix CargoBay.Open neither opening nor closing the bay when the game is not running in English
+ * Fix ResourceConverter.State only ever reporting Running when the game is not running in
+   English, leaving MissingResource, StorageFull and Capacity unreachable
+ * Fix DockingPort.State reporting Shielded instead of Moving while a shield is opening or
+   closing, when the game is not running in English
+ * Fix CargoBay.State reporting Deployed for a closed cargo ramp, and reporting a resting
+   state while the bay was still moving
+ * Fix part module field values being formatted using the machine's locale, so that
+   Module.Fields, Module.GetField and PartField.Value returned numbers that clients running
+   under a locale that writes decimals with a comma could not parse
 
 v0.5.4
  * Fix vessel recovery (#782)

--- a/service/SpaceCenter/src/ExtensionMethods/BaseFieldExtensions.cs
+++ b/service/SpaceCenter/src/ExtensionMethods/BaseFieldExtensions.cs
@@ -1,0 +1,22 @@
+using System.Globalization;
+
+namespace KRPC.SpaceCenter.ExtensionMethods
+{
+    static class BaseFieldExtensions
+    {
+        /// <summary>
+        /// Get the value of a part module field as a string.
+        /// </summary>
+        /// <remarks>
+        /// The value is formatted using the invariant culture, so that a numeric field is
+        /// rendered the same way whatever locale the game is running under. Clients parse these
+        /// values, so a decimal comma would make them unreadable.
+        /// </remarks>
+        public static string GetValueString (this BaseField field, PartModule module)
+        {
+            if (field == null)
+                return null;
+            return System.Convert.ToString (field.GetValue (module), CultureInfo.InvariantCulture);
+        }
+    }
+}

--- a/service/SpaceCenter/src/ExtensionMethods/PartModuleExtensions.cs
+++ b/service/SpaceCenter/src/ExtensionMethods/PartModuleExtensions.cs
@@ -5,14 +5,15 @@ namespace KRPC.SpaceCenter.ExtensionMethods
     static class PartModuleExtensions
     {
         /// <summary>
-        /// Try invoking a named event for a part module. Returns true if an event is found
-        /// and invoked.
+        /// Try invoking an event for a part module, identified by its id -- the name of the
+        /// method implementing it, which the game does not translate, unlike the display name.
+        /// Returns true if an event is found and invoked.
         /// </summary>
-        public static bool InvokeEvent (this PartModule module, string eventName)
+        public static bool InvokeEvent (this PartModule module, string eventId)
         {
             var e = module.Events
                 .Where (x => x != null && (HighLogic.LoadedSceneIsEditor ? x.guiActiveEditor : x.guiActive) && x.active)
-                .FirstOrDefault (x => x.guiName == eventName);
+                .FirstOrDefault (x => x.name == eventId);
             if (e != null) {
                 e.Invoke ();
                 return true;

--- a/service/SpaceCenter/src/KRPC.SpaceCenter.csproj
+++ b/service/SpaceCenter/src/KRPC.SpaceCenter.csproj
@@ -50,6 +50,7 @@
     <Compile Include="ExtensionMethods\AlarmTypeExtensions.cs" />
     <Compile Include="ExtensionMethods\AlarmWarpActionExtensions.cs" />
     <Compile Include="ExtensionMethods\AutoPilotModeExtensions.cs" />
+    <Compile Include="ExtensionMethods\BaseFieldExtensions.cs" />
     <Compile Include="ExtensionMethods\CelestialBodyExtensions.cs" />
     <Compile Include="ExtensionMethods\ColorExtensions.cs" />
     <Compile Include="ExtensionMethods\ContractStateExtensions.cs" />

--- a/service/SpaceCenter/src/Services/Parts/CargoBay.cs
+++ b/service/SpaceCenter/src/Services/Parts/CargoBay.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Linq;
 using KRPC.Service.Attributes;
 using KRPC.SpaceCenter.ExtensionMethods;
 using KRPC.Utils;
@@ -68,12 +67,17 @@ namespace KRPC.SpaceCenter.Services.Parts
             get {
                 if (bay.ClosedAndLocked ())
                     return DeployableState.Retracted;
-                else if (!animation.IsMoving ())
+                if (!animation.IsMoving ())
                     return DeployableState.Deployed;
-                else if (!animation.animSwitch)
-                    return animation.startEventGUIName == "Open" ? DeployableState.Deploying : DeployableState.Retracting;
-                else
-                    return animation.startEventGUIName == "Close" ? DeployableState.Deploying : DeployableState.Retracting;
+                // The animation plays forwards, towards a scalar of 1, while animSwitch is false,
+                // and backwards towards 0 while it is true. closedPosition is the scalar at which
+                // the bay is closed, so which direction opens the bay depends on which end of the
+                // animation that is.
+                var playingForwards = !animation.animSwitch;
+                var opensForwards = bay.closedPosition < 0.5f;
+                return playingForwards == opensForwards
+                    ? DeployableState.Deploying
+                    : DeployableState.Retracting;
             }
         }
 
@@ -87,28 +91,27 @@ namespace KRPC.SpaceCenter.Services.Parts
                 return state == DeployableState.Deployed || state == DeployableState.Deploying;
             }
             set {
-                var openEvent = OpenEvent;
-                var closeEvent = CloseEvent;
-                if (value && openEvent != null)
-                    openEvent.Invoke ();
-                else if (!value && closeEvent != null)
-                    closeEvent.Invoke ();
+                if (value == Open)
+                    return;
+                var toggle = ToggleEvent;
+                if (toggle != null)
+                    toggle.Invoke ();
             }
         }
 
-        BaseEvent OpenEvent {
+        /// <summary>
+        /// The event that opens or closes the bay, whichever it currently offers. It is looked up
+        /// by id -- the name of the method implementing it -- which the game does not translate,
+        /// unlike the display name on the button. Null when the bay cannot currently be toggled,
+        /// for example while it is shielded from the airstream.
+        /// </summary>
+        BaseEvent ToggleEvent {
             get {
-                return animation.Events
-                    .Where (x => x != null && (HighLogic.LoadedSceneIsEditor ? x.guiActiveEditor : x.guiActive))
-                    .FirstOrDefault (x => x.guiName == "Open");
-            }
-        }
-
-        BaseEvent CloseEvent {
-            get {
-                return animation.Events
-                    .Where (x => x != null && (HighLogic.LoadedSceneIsEditor ? x.guiActiveEditor : x.guiActive))
-                    .FirstOrDefault (x => x.guiName == "Close");
+                var toggle = animation.Events ["Toggle"];
+                if (toggle == null)
+                    return null;
+                var available = HighLogic.LoadedSceneIsEditor ? toggle.guiActiveEditor : toggle.guiActive;
+                return available ? toggle : null;
             }
         }
     }

--- a/service/SpaceCenter/src/Services/Parts/CargoBay.cs
+++ b/service/SpaceCenter/src/Services/Parts/CargoBay.cs
@@ -59,25 +59,23 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// The state of the cargo bay.
         /// </summary>
         /// <remarks>
+        /// This describes where the bay's doors are, which is not the same as whether the parts
+        /// inside are sheltered: a bay whose open end has nothing attached to it never shelters
+        /// anything, however tightly shut it is. Use <see cref="Part.Shielded"/> for that.
+        ///
         /// A cargo bay is never <see cref="DeployableState.Broken" />, as the game
         /// does not track damage for them.
         /// </remarks>
         [KRPCProperty]
         public DeployableState State {
             get {
-                if (bay.ClosedAndLocked ())
-                    return DeployableState.Retracted;
-                if (!animation.IsMoving ())
-                    return DeployableState.Deployed;
-                // The animation plays forwards, towards a scalar of 1, while animSwitch is false,
-                // and backwards towards 0 while it is true. closedPosition is the scalar at which
-                // the bay is closed, so which direction opens the bay depends on which end of the
-                // animation that is.
-                var playingForwards = !animation.animSwitch;
-                var opensForwards = bay.closedPosition < 0.5f;
-                return playingForwards == opensForwards
-                    ? DeployableState.Deploying
-                    : DeployableState.Retracting;
+                if (animation.IsMoving ())
+                    return OpeningOrOpen
+                        ? DeployableState.Deploying
+                        : DeployableState.Retracting;
+                return OpeningOrOpen
+                    ? DeployableState.Deployed
+                    : DeployableState.Retracted;
             }
         }
 
@@ -86,17 +84,32 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         [KRPCProperty]
         public bool Open {
-            get {
-                var state = State;
-                return state == DeployableState.Deployed || state == DeployableState.Deploying;
-            }
+            get { return OpeningOrOpen; }
             set {
-                if (value == Open)
+                if (value == OpeningOrOpen)
                     return;
                 var toggle = ToggleEvent;
                 if (toggle != null)
                     toggle.Invoke ();
             }
+        }
+
+        /// <summary>
+        /// Whether the bay is open, or travelling that way.
+        /// </summary>
+        /// <remarks>
+        /// The animation runs forwards, towards a scalar of 1, while animSwitch is false, and
+        /// backwards towards 0 while it is true. closedPosition is the scalar at which the bay is
+        /// shut, so which of those opens it depends on which end of the animation that is.
+        ///
+        /// A bay that is not moving is sitting at whichever end it last travelled to, so the same
+        /// answer covers a moving and a stationary bay alike. Reading the direction rather than
+        /// the position matters: the animation stops fractionally short of its end, so comparing
+        /// the scalar against closedPosition reports a shut bay as open for as long as it takes
+        /// the last frame to land.
+        /// </remarks>
+        bool OpeningOrOpen {
+            get { return !animation.animSwitch == (bay.closedPosition < 0.5f); }
         }
 
         /// <summary>

--- a/service/SpaceCenter/src/Services/Parts/DockingPort.cs
+++ b/service/SpaceCenter/src/Services/Parts/DockingPort.cs
@@ -130,9 +130,11 @@ namespace KRPC.SpaceCenter.Services.Parts
             var dockedPort = dockedPart != null ? dockedPart.Module<ModuleDockingNode> () : null;
             var preVesselIds = FlightGlobals.Vessels.Select (v => v.id).ToList ();
 
-            // Try calling "Decouple Node" or "Undock" on this part and on the port we are docked to, if any
-            if (port.InvokeEvent ("Decouple Node") || port.InvokeEvent ("Undock") ||
-                (dockedPort != null && (dockedPort.InvokeEvent ("Decouple Node") || dockedPort.InvokeEvent ("Undock")))) {
+            // Try decoupling or undocking this part, and then the port we are docked to, if any.
+            // Decouple detaches a port that was attached in the editor, Undock separates two ports
+            // that docked in flight; a given port only ever offers one of them.
+            if (port.InvokeEvent ("Decouple") || port.InvokeEvent ("Undock") ||
+                (dockedPort != null && (dockedPort.InvokeEvent ("Decouple") || dockedPort.InvokeEvent ("Undock")))) {
                 return PartSeparation.NewVessel (preVesselIds, () => State != DockingPortState.Docked);
             }
 
@@ -176,13 +178,11 @@ namespace KRPC.SpaceCenter.Services.Parts
                 // Don't do anything if we are aren't in a state where the shield can be opened or closed
                 if (state != DockingPortState.Shielded && state != DockingPortState.Ready)
                     return;
-                // Open the shield if we are shielded, and value is false
-                var shielded = Shielded;
-                if (!value && shielded)
-                    shield.Events.First (e => e.guiName == shield.startEventGUIName).Invoke ();
-                // Close the shield if we are not shielded, and value is true
-                else if (value && !shielded)
-                    shield.Events.First (e => e.guiName == shield.endEventGUIName).Invoke ();
+                // A single event toggles the shield open or closed. It is looked up by id -- the
+                // name of the method implementing it -- which the game does not translate, unlike
+                // the display name shown on the button.
+                if (value != Shielded)
+                    shield.Events ["Toggle"].Invoke ();
             }
         }
 
@@ -336,10 +336,12 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         static DockingPortState IndividualState (ModuleDockingNode node)
         {
+            // These are the names of the port's finite state machine states, which the game
+            // does not translate, unlike the status text shown in the right-click menu.
             var state = node.state;
             if (state == "Ready")
                 return DockingPortState.Ready;
-            if (state.StartsWith ("Docked", StringComparison.CurrentCulture) || state == "PreAttached")
+            if (state.StartsWith ("Docked", StringComparison.Ordinal) || state == "PreAttached")
                 return DockingPortState.Docked;
             if (state.Contains ("Acquire"))
                 return DockingPortState.Docking;
@@ -349,7 +351,8 @@ namespace KRPC.SpaceCenter.Services.Parts
                 var shieldModule = node.part.Module<ModuleAnimateGeneric> ();
                 if (shieldModule == null)
                     throw new InvalidOperationException ("Docking port state is '" + node.state + "', but it does not have a shield!");
-                return shieldModule.status.StartsWith ("Moving", StringComparison.CurrentCulture) ? DockingPortState.Moving : DockingPortState.Shielded;
+                return shieldModule.aniState == ModuleAnimateGeneric.animationStates.MOVING
+                    ? DockingPortState.Moving : DockingPortState.Shielded;
             }
             throw new ArgumentException ("Unknown docking port state '" + node.state + "'");
         }

--- a/service/SpaceCenter/src/Services/Parts/Fairing.cs
+++ b/service/SpaceCenter/src/Services/Parts/Fairing.cs
@@ -70,10 +70,12 @@ namespace KRPC.SpaceCenter.Services.Parts
         {
             if (!Jettisoned) {
                 if (fairing != null) {
-                    fairing.TriggerVisibleEvent("Deploy");
+                    fairing.TriggerVisibleEventById("DeployFairing");
                 } else {
-                    // Note: older versions of ProceduralFairings have the "Jettison" event,
-                    // newer versions have the "Jettison Fairing" event
+                    // Older versions of ProceduralFairings have the "Jettison" event, newer
+                    // versions have the "Jettison Fairing" event. These match the display name
+                    // rather than the event id, as the mod's method names are not known here;
+                    // the mod does not appear to translate them.
                     foreach (var e in proceduralFairing.VisibleEventNames) {
                         if (e == "Jettison")
                             proceduralFairing.TriggerVisibleEvent("Jettison");
@@ -92,10 +94,12 @@ namespace KRPC.SpaceCenter.Services.Parts
         {
             get {
                 if (fairing != null) {
-                    return !fairing.HasVisibleEvent("Deploy");
+                    return !fairing.HasVisibleEventById("DeployFairing");
                 } else {
-                    // Note: older versions of ProceduralFairings have the "Jettison" event,
-                    // newer versions have the "Jettison Fairing" event
+                    // Older versions of ProceduralFairings have the "Jettison" event, newer
+                    // versions have the "Jettison Fairing" event. These match the display name
+                    // rather than the event id, as the mod's method names are not known here;
+                    // the mod does not appear to translate them.
                     return !(proceduralFairing.HasVisibleEvent("Jettison") ||
                              proceduralFairing.HasVisibleEvent("Jettison Fairing"));
                 }

--- a/service/SpaceCenter/src/Services/Parts/Module.cs
+++ b/service/SpaceCenter/src/Services/Parts/Module.cs
@@ -126,6 +126,10 @@ namespace KRPC.SpaceCenter.Services.Parts
             get { return module.Actions; }
         }
 
+        // The following three helpers match on the display name, which the game translates.
+        // They exist to serve the guiName-keyed public API and must not be used to identify a
+        // known event from within kRPC -- use the ById helpers below for that.
+
         internal IEnumerable<string> VisibleEventNames {
             get { return AllEvents.Select (x => x.guiName); }
         }
@@ -138,6 +142,19 @@ namespace KRPC.SpaceCenter.Services.Parts
         internal void TriggerVisibleEvent (string name)
         {
             AllEvents.First (x => x.guiName == name).Invoke ();
+        }
+
+        // Events are identified by their id -- the name of the method implementing them -- which
+        // the game does not translate, unlike the display name.
+
+        internal bool HasVisibleEventById (string id)
+        {
+            return AllEvents.Any (x => x.name == id);
+        }
+
+        internal void TriggerVisibleEventById (string id)
+        {
+            AllEvents.First (x => x.name == id).Invoke ();
         }
 
         /// <summary>

--- a/service/SpaceCenter/src/Services/Parts/Module.cs
+++ b/service/SpaceCenter/src/Services/Parts/Module.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using KRPC.Service.Attributes;
+using KRPC.SpaceCenter.ExtensionMethods;
 using KRPC.Utils;
 
 namespace KRPC.SpaceCenter.Services.Parts
@@ -200,7 +201,7 @@ namespace KRPC.SpaceCenter.Services.Parts
             get {
                 var result = new Dictionary<string,string> ();
                 foreach (var f in VisibleFields)
-                    result.Add (f.guiName, f.GetValue (module).ToString ());
+                    result.Add (f.guiName, f.GetValueString (module));
                 return result;
             }
         }
@@ -215,7 +216,7 @@ namespace KRPC.SpaceCenter.Services.Parts
             get {
                 var result = new Dictionary<string,string> ();
                 foreach (var f in VisibleFields)
-                    result.Add (f.name, f.GetValue (module).ToString ());
+                    result.Add (f.name, f.GetValueString (module));
                 return result;
             }
         }
@@ -260,7 +261,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         [KRPCMethod]
         public string GetField (string name)
         {
-            return GetBaseFieldByName (name).GetValue (module).ToString ();
+            return GetBaseFieldByName (name).GetValueString (module);
         }
 
         /// <summary>
@@ -271,7 +272,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         [KRPCMethod]
         public string GetFieldById (string id)
         {
-            return GetBaseFieldById (id).GetValue (module).ToString ();
+            return GetBaseFieldById (id).GetValueString (module);
         }
 
         /// <summary>

--- a/service/SpaceCenter/src/Services/Parts/PartField.cs
+++ b/service/SpaceCenter/src/Services/Parts/PartField.cs
@@ -1,5 +1,6 @@
 using System;
 using KRPC.Service.Attributes;
+using KRPC.SpaceCenter.ExtensionMethods;
 using KRPC.Utils;
 
 namespace KRPC.SpaceCenter.Services.Parts
@@ -126,7 +127,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </remarks>
         [KRPCProperty]
         public string Value {
-            get { return baseField.GetValue (Module.InternalModule).ToString (); }
+            get { return baseField.GetValueString (Module.InternalModule); }
             set { Assign (value); }
         }
 

--- a/service/SpaceCenter/src/Services/Parts/ResourceConverter.cs
+++ b/service/SpaceCenter/src/Services/Parts/ResourceConverter.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using KRPC.Service.Attributes;
 using KRPC.SpaceCenter.ExtensionMethods;
 using KRPC.Utils;
+using KSP.Localization;
 
 namespace KRPC.SpaceCenter.Services.Parts
 {
@@ -130,14 +131,43 @@ namespace KRPC.SpaceCenter.Services.Parts
             var status = converter.status;
             if (status == null)
                 return ResourceConverterState.Unknown;
-            else if (status.Contains ("missing") || status.IndexOf("insufficient", StringComparison.OrdinalIgnoreCase) >= 0)
+            if (StatusMatches (status, MissingResourceMessages))
                 return ResourceConverterState.MissingResource;
-            else if (status.Contains ("full"))
+            if (StatusMatches (status, StorageFullMessages))
                 return ResourceConverterState.StorageFull;
-            else if (status.Contains ("cap"))
+            if (StatusMatches (status, CapacityMessages))
                 return ResourceConverterState.Capacity;
-            else
-                return ResourceConverterState.Running;
+            return ResourceConverterState.Running;
+        }
+
+        // The messages the game builds a converter's status out of. It reports the status
+        // already translated, so these are the tags for the same messages rather than the
+        // English text, which only matches when the game is running in English.
+        static readonly string[] MissingResourceMessages = {
+            "#autoLOC_261263", "#autoLOC_261304", // missing <resource>
+            "#autoLOC_258451", "#autoLOC_259933"  // insufficient power
+        };
+        static readonly string[] StorageFullMessages = { "#autoLOC_261334" };
+        static readonly string[] CapacityMessages = { "#autoLOC_261332" };
+
+        /// <summary>
+        /// Whether a converter's status is one of the given messages.
+        /// </summary>
+        /// <remarks>
+        /// The messages carry a resource name or amount in a placeholder, so only their
+        /// fixed part can be matched. Comparison follows the language the game is running
+        /// in, which is the one case where that is what is wanted: both sides are text the
+        /// game has translated.
+        /// </remarks>
+        static bool StatusMatches (string status, string[] tags)
+        {
+            foreach (var tag in tags) {
+                var message = Localizer.Format (tag, new [] { string.Empty }).Trim ();
+                if (message.Length > 0 &&
+                    status.IndexOf (message, StringComparison.CurrentCultureIgnoreCase) >= 0)
+                    return true;
+            }
+            return false;
         }
 
         /// <summary>

--- a/service/SpaceCenter/src/Services/Parts/RoboticController.cs
+++ b/service/SpaceCenter/src/Services/Parts/RoboticController.cs
@@ -144,6 +144,9 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// <summary>
         /// Add an axis to the controller.
         /// </summary>
+        /// <param name="module">The part module that the axis belongs to.</param>
+        /// <param name="fieldName">The name of the axis field, as returned by
+        /// <see cref="Axes"/>.</param>
         /// <returns>Returns <c>true</c> if the axis is added successfully.</returns>
         [KRPCMethod]
         public bool AddAxis(Module module, string fieldName)
@@ -152,25 +155,21 @@ namespace KRPC.SpaceCenter.Services.Parts
                 throw new ArgumentNullException (nameof (module));
             var internalPart = module.Part.InternalPart;
             var internalModule = internalPart.Modules[module.Name];
-            foreach (var field in internalModule.Fields)
-            {
-                if (field.guiName == fieldName)
-                {
-                    var axisField = (BaseAxisField)internalModule.Fields[field.name];
-                    if (axisField != null)
-                    {
-                        controller.AddPartAxis(internalPart, internalModule, axisField);
-                        return true;
-                    }
-                    return false;
-                }
-            }
-            return false;
+            var axisField = internalModule.Fields[fieldName] as BaseAxisField;
+            if (axisField == null)
+                return false;
+            controller.AddPartAxis(internalPart, internalModule, axisField);
+            return true;
         }
 
         /// <summary>
         /// Add key frame value for controller axis.
         /// </summary>
+        /// <param name="module">The part module that the axis belongs to.</param>
+        /// <param name="fieldName">The name of the axis field, as returned by
+        /// <see cref="Axes"/>.</param>
+        /// <param name="time">The time of the key frame.</param>
+        /// <param name="value">The value of the key frame.</param>
         /// <returns>Returns <c>true</c> if the key frame is added successfully.</returns>
         [KRPCMethod]
         public bool AddKeyFrame(Module module, string fieldName, float time, float value)
@@ -182,7 +181,7 @@ namespace KRPC.SpaceCenter.Services.Parts
 
             foreach (var axis in controller.ControlledAxes)
             {
-                if (internalModule == axis.Module && fieldName == axis.AxisField.guiName)
+                if (internalModule == axis.Module && fieldName == axis.AxisField.name)
                 {
                     Expansions.Serenity.ControlledAxis outAxis;
                     controller.TryGetPartAxisField(axis.Part, axis.AxisField, out outAxis);
@@ -200,6 +199,9 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// <summary>
         /// Clear axis.
         /// </summary>
+        /// <param name="module">The part module that the axis belongs to.</param>
+        /// <param name="fieldName">The name of the axis field, as returned by
+        /// <see cref="Axes"/>.</param>
         /// <returns>Returns <c>true</c> if the axis is cleared successfully.</returns>
         [KRPCMethod]
         public bool ClearAxis(Module module, string fieldName)
@@ -211,7 +213,7 @@ namespace KRPC.SpaceCenter.Services.Parts
 
             foreach (var axis in controller.ControlledAxes)
             {
-                if (internalModule == axis.Module && fieldName == axis.AxisField.guiName)
+                if (internalModule == axis.Module && fieldName == axis.AxisField.name)
                 {
                     Expansions.Serenity.ControlledAxis outAxis;
                     controller.TryGetPartAxisField(axis.Part, axis.AxisField, out outAxis);

--- a/service/SpaceCenter/src/Services/Parts/Sensor.cs
+++ b/service/SpaceCenter/src/Services/Parts/Sensor.cs
@@ -63,7 +63,10 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         /// <remarks>
         /// This is the same readout string shown in the part's right-click menu
-        /// in-game. For programmatic access to the underlying quantities, consider
+        /// in-game, and is intended for display rather than for parsing. Both its
+        /// units and the way it formats numbers follow the language the game is
+        /// running in, so it is not stable across locales. For programmatic access
+        /// to the underlying quantities, use
         /// <see cref="Part.Temperature"/> (temperature sensors),
         /// <see cref="Flight.GForce"/> (accelerometers) or
         /// <see cref="Flight.StaticPressure"/> (barometers).

--- a/service/SpaceCenter/src/Services/WaypointManager.cs
+++ b/service/SpaceCenter/src/Services/WaypointManager.cs
@@ -93,7 +93,7 @@ namespace KRPC.SpaceCenter.Services
             get {
                 if (icons == null) {
                     icons = GameDatabase.Instance.databaseTexture
-                        .Where (t => t.name.StartsWith ("Squad/Contracts/Icons/", StringComparison.CurrentCulture))
+                        .Where (t => t.name.StartsWith ("Squad/Contracts/Icons/", StringComparison.Ordinal))
                         .Select (texInfo => texInfo.name.Replace ("Squad/Contracts/Icons/", string.Empty))
                         .ToList ();
                 }

--- a/service/SpaceCenter/test/test_parts_cargo_bay.py
+++ b/service/SpaceCenter/test/test_parts_cargo_bay.py
@@ -41,14 +41,9 @@ class TestPartsCargoBay(krpctest.TestCase):
         self.assertEqual(bay.state, self.state.retracting)
         self.assertFalse(bay.open)
 
-        # After the close animation stops, ModuleCargoBay can take an extra
-        # frame or two to register as closed-and-locked; until it does, the
-        # state reads back as open (not moving, not yet locked). Wait for the
-        # terminal closed state rather than just "no longer closing", so the
-        # assertion doesn't race that lock-lag (seen on mk3CargoBayS).
         self.wait_while(
-            lambda: bay.state in (self.state.retracting, self.state.deployed),
-            message="cargo bay to close and lock",
+            lambda: bay.state == self.state.retracting,
+            message="cargo bay to finish closing",
         )
 
         self.assertEqual(bay.state, self.state.retracted)

--- a/service/SpaceCenter/test/test_parts_robotic.py
+++ b/service/SpaceCenter/test/test_parts_robotic.py
@@ -181,11 +181,17 @@ class TestPartsRobotic(krpctest.TestCase):
         module = next(
             m for m in hinge.part.modules if m.name == "ModuleRoboticServoHinge"
         )
-        self.assertTrue(controller.add_axis(module, "Target Angle"))
+        # Axes are named by field name, not by the label shown in the part's
+        # menu, so that the names round trip through axes() and do not change
+        # with the language the game is running in
+        self.assertTrue(controller.add_axis(module, "targetAngle"))
         self.assertTrue(controller.has_part(hinge.part))
-        self.assertTrue(controller.add_key_frame(module, "Target Angle", 0, 0))
-        self.assertGreater(len(controller.axes()), 0)
-        self.assertTrue(controller.clear_axis(module, "Target Angle"))
+        self.assertTrue(controller.add_key_frame(module, "targetAngle", 0, 0))
+        self.assertIn("targetAngle", [axis[1] for axis in controller.axes()])
+        self.assertTrue(controller.clear_axis(module, "targetAngle"))
+
+        # The display name is not accepted
+        self.assertFalse(controller.add_axis(module, "Target Angle"))
 
 
 if __name__ == "__main__":

--- a/service/UI/CHANGES.txt
+++ b/service/UI/CHANGES.txt
@@ -1,3 +1,7 @@
+v0.6.0
+ * Fix UI.Message showing its size tag as literal text when the size is not a whole number
+   and the machine's locale writes decimals with a comma
+
 v0.3.5
  * Add Canvas class (#281)
  * Add UI.StockCanvas to get the stock KSP UI canvas and UI.AddCanvas to create additional canvases

--- a/service/UI/src/UI.cs
+++ b/service/UI/src/UI.cs
@@ -83,7 +83,7 @@ namespace KRPC.UI
             float size = 20)
         {
             var htmlColor = "#" + ColorUtility.ToHtmlStringRGB(color.ToColor());
-            var message = "<color=" + htmlColor + "><size=" + size.ToString() + ">" + content + "</size></color>";
+            var message = "<color=" + htmlColor + "><size=" + size.ToString(CultureInfo.InvariantCulture) + ">" + content + "</size></color>";
             ScreenMessages.PostScreenMessage(message, duration, position.ToScreenMessageStyle());
         }
 

--- a/service/UI/src/UI.cs
+++ b/service/UI/src/UI.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using KRPC.Service;
 using KRPC.Service.Attributes;
 using KRPC.SpaceCenter.ExtensionMethods;

--- a/tools/TestServer/src/TestService.cs
+++ b/tools/TestServer/src/TestService.cs
@@ -56,7 +56,7 @@ namespace TestServer
         [KRPCProcedure]
         public static string BytesToHexString (byte[] value)
         {
-            return BitConverter.ToString (value).Replace ("-", string.Empty).ToLower ();
+            return BitConverter.ToString (value).Replace ("-", string.Empty).ToLowerInvariant ();
         }
 
         [KRPCProcedure]

--- a/tools/build/image.bzl
+++ b/tools/build/image.bzl
@@ -7,7 +7,12 @@ def _impl(ctx):
         inputs = [input],
         outputs = [output],
         progress_message = "Generating PNG image %s" % output.short_path,
+        # The default shell environment supplies PATH, needed to find rsvg-convert.
+        # LC_ALL is set on top of it so that text shaping in the rendered image does
+        # not vary with whoever runs the build; unlike the inherited variables it
+        # also forms part of the action key.
         use_default_shell_env = True,
+        env = {"LC_ALL": "C.UTF-8"},
         command = "rsvg-convert --format=png -o %s %s" % (output.path, input.path),
     )
 

--- a/tools/build/protobuf/run_protoc.py
+++ b/tools/build/protobuf/run_protoc.py
@@ -66,10 +66,10 @@ def main():
 
     for spec in opts.rewrite:
         dst, pattern, repl = spec.split("=", 2)
-        with open(dst) as handle:
+        with open(dst, encoding="utf-8") as handle:
             text = handle.read()
         text = re.sub(pattern, repl, text)
-        with open(dst, "w") as handle:
+        with open(dst, "w", encoding="utf-8") as handle:
             handle.write(text)
 
     return 0

--- a/tools/build/sphinx.bzl
+++ b/tools/build/sphinx.bzl
@@ -67,7 +67,12 @@ def _build_impl(ctx):
         outputs = [out],
         progress_message = "Generating %s documentation" % builder,
         command = " && \\\n".join(sub_commands),
+        # The default shell environment supplies PATH, needed to find make and the
+        # LaTeX toolchain. LC_ALL is set on top of it so that hyphenation, sorting
+        # and date formatting do not vary with whoever runs the build; unlike the
+        # inherited variables it also forms part of the action key.
         use_default_shell_env = True,
+        env = {"LC_ALL": "C.UTF-8"},
     )
 
 sphinx_build = rule(

--- a/tools/krpctools/CHANGES.txt
+++ b/tools/krpctools/CHANGES.txt
@@ -4,6 +4,8 @@ v0.6.0
  * Fix cross-service member references not resolving in generated C# and Lua documentation (#897)
  * Fix member references in generated Python documentation using lowerCamelCase
    instead of snake_case
+ * Fix generating client stubs and documentation from a KSP install failing when the machine's
+   locale is not UTF-8 and a service's documentation contains non-ASCII characters
 
 v0.5.4
  * Fix incorrect protobuf DLL (#755)

--- a/tools/krpctools/krpctools/clientgen/__init__.py
+++ b/tools/krpctools/krpctools/clientgen/__init__.py
@@ -91,7 +91,7 @@ def main():
                 )
             defs = servicedefs(args.ksp, args.service, inputs)
             if args.output_defs:
-                with open(args.output_defs, "w") as fp:
+                with open(args.output_defs, "w", encoding="utf-8") as fp:
                     fp.write(defs)
             defs = json.loads(defs)
 
@@ -146,7 +146,7 @@ def load_generator(path):
     sys.path.append(dirpath)
     module = importlib.import_module(modulepath)
     generator = module.generator
-    with open(module.tmpl, "r") as fp:
+    with open(module.tmpl, "r", encoding="utf-8") as fp:
         macro_template = "".join(fp.readlines()).decode("utf-8")
     return generator, macro_template
 

--- a/tools/krpctools/krpctools/servicedefs/__init__.py
+++ b/tools/krpctools/krpctools/servicedefs/__init__.py
@@ -43,7 +43,7 @@ def main():
         return 1
 
     if args.output:
-        with open(args.output, "w") as fp:
+        with open(args.output, "w", encoding="utf-8") as fp:
             fp.write(defs)
     else:
         print(defs)
@@ -102,7 +102,7 @@ def servicedefs(ksp, service, assemblies):
         shutil.rmtree(bindir)
         raise RuntimeError(ex.output) from ex
 
-    with open(tmpout, "r") as fp:
+    with open(tmpout, "r", encoding="utf-8") as fp:
         return fp.read()
 
     shutil.rmtree(bindir)


### PR DESCRIPTION
kRPC runs inside the game on the player's machine, so the ambient culture follows their operating system, and values formatted, compared or case folded under it reach clients written in other languages. This branch is a codebase-wide audit of that, and the fixes it turned up.

**Part module events were matched by translated display name.** `Undock()`, `Fairing.Jettison()` and `CargoBay.Open` looked up a `PartModule` event by the label shown in the part's menu, which the game translates. For anyone not playing in English they matched nothing and were silent no-ops. They now match on `BaseEvent.name`, which is stable. `ResourceConverter.State` had the same problem from the other direction, comparing a translated status string against English words, so every active converter reported `Running` and the missing-resource, storage-full and capacity states were unreachable; it now asks the game to translate the same messages it builds that status from and compares against those.

**Values crossing the wire were formatted with the ambient culture.** Part module field values were stringified locally, so a player whose locale uses a decimal comma sent `"92,5"` to clients that then failed to parse it as a number. The type codes in the service description were upper cased with the ambient culture, which under a Turkish locale maps `i` onto a dotted capital `I` and produces codes no client can match — a protocol break. Both now use the invariant culture, as do the log timestamps, the subnet message, the indices the C# client builds tuple type names from, and the size tag in `UI.Message`. `Sensor.Value` is deliberately left alone: it reproduces the game's own readout, which the game itself formats with the ambient culture, so matching it is the point, and its docstring now says it is for display rather than parsing.

**The build and the code generators were locale dependent.** The generators read the service definitions the C# side writes as UTF-8 but opened them at the locale default, which fails outright under a POSIX or Latin-1 locale because several services' doc comments contain degree signs and dashes, and silently mangles them on Windows. The Lua client folded case through the C library when converting names to snake case, which under a Turkish locale would rename every method it exposes. `LC_ALL` is now pinned for build actions and tests, and set explicitly on the two actions that inherit the caller's environment — variables inherited via `use_default_shell_env` do not form part of the action key, so a divergent result would otherwise be cached against the same key.

**Two fixes that came out of the audit rather than the locale itself.** `CargoBay.State` asked `ModuleCargoBay.ClosedAndLocked()` whether the bay was shut, which answers whether the parts inside are sheltered, not where the doors are — it requires every connected bay to be shut and the bay to be end capped, so a shut cargo ramp reported itself deployed. It also raced, checking that before the moving check, which is what made `test_service_bay` intermittently read `Retracted` where it expected `Retracting`. Both now read the direction of the bay's animation, which covers the moving and resting cases with one answer. Airstream shielding is still available as `Part.Shielded`.

**Breaking.** `RoboticController.AddAxis`, `AddKeyFrame` and `ClearAxis` now identify an axis by the name of its field, for example `targetAngle`, rather than by the label shown in the part's menu, for example `"Target Angle"`. The names now match those returned by `RoboticController.Axes`, which previously could not be passed back in, and no longer change with the language the game is running in.

**Testing.** Full `bazel build //...`, `//:test` and `//:lint` are green. The in-game suites covering the changed surfaces pass.
