### PR TITLE
Stop float in the Python docs linking to SpaceCenter.FieldType.float

### DIFF
--- a/doc/conf.py.tmpl
+++ b/doc/conf.py.tmpl
@@ -245,3 +245,30 @@ nitpick_ignore = [
     ('py:class', 'krpc.schema.KRPC.Status'),
     ('py:class', 'krpc.schema.KRPC.Stream')
 ]
+
+# The builtin type names above are meant to render as plain text, since there
+# is nothing in these docs to link them to. The python domain resolves the type
+# of a :param:/:rtype: field in "refspecific" mode, which falls back to a fuzzy
+# suffix search over every documented attribute when the exact name is unknown,
+# so an unqualified builtin can match an unrelated member that happens to share
+# its name: "float" matched the SpaceCenter.FieldType.float enumeration value
+# and every float parameter and return type in the Python API linked to it.
+# Refusing to resolve these names keeps them plain text.
+PY_BUILTIN_TYPES = frozenset(
+    target for domain, target in nitpick_ignore
+    if domain == 'py:class' and '.' not in target
+)
+
+
+def setup(app):
+    from sphinx.domains.python import PythonDomain
+
+    class KRPCPythonDomain(PythonDomain):
+        def resolve_xref(self, env, fromdocname, builder, typ, target, node,
+                         contnode):
+            if typ == 'class' and target in PY_BUILTIN_TYPES:
+                return None
+            return super().resolve_xref(env, fromdocname, builder, typ, target,
+                                        node, contnode)
+
+    app.add_domain(KRPCPythonDomain, override=True)


### PR DESCRIPTION
**Root cause.** `docgen` emits Python types into Sphinx doc fields as bare text (`:rtype: float`, `:param float value:`). Sphinx's Python domain resolves the type of such a field in *refspecific* mode, which falls back to a fuzzy suffix search over every documented object when the exact name is unknown, retried as `data` and then `attr` — a fallback intended for type aliases. Nothing in these docs documents the builtin `float` (there is no intersphinx mapping to the Python docs), so the search matched the only object ending in `.float`: the `SpaceCenter.FieldType.float` enumeration value, which is documented as a Python attribute. Every `float` parameter and return type across the Python API — 892 links — rendered as a link to that enumeration value. It went unnoticed because the reference resolved successfully, so no nitpick warning was emitted, even though `('py:class', 'float')` is already listed in `nitpick_ignore` to declare that the name should stay plain text. Only `float` was affected: the enumeration's other values are `boolean`, `integer`, `double`, `string` and `unknown`, none of which collide with a type name the Python documentation generator emits.

**Fix.** Override the Python domain's `resolve_xref` to refuse `:class:` targets that are unqualified builtin type names, taken from the `py:class` entries already in `nitpick_ignore`. Those names then render as plain text, exactly as `int`, `str` and `bool` already did.

**Testing.** Rebuilt `//doc:html` (which runs with `-W`) and scanned the generated pages: no link anywhere in the Python documentation now has a builtin type name as its text, down from 892; `float` renders as plain text alongside `str`; links to kRPC types such as `SpaceCenter.Flight` still resolve; and the `SpaceCenter.FieldType.float` definition anchor is unchanged.