### PR TITLE
Fix stale code snippet line ranges and indentation in the docs

### DIFF
--- a/doc/src/cnano/client.rst
+++ b/doc/src/cnano/client.rst
@@ -78,48 +78,48 @@ Compilation Options
 The following options control how the library operates. They must be specified at compile time as an
 argument to the compiler.
 
- * Error handling
+* Error handling
 
-   * ``KRPC_ERROR_CHECK_RETURN`` (the default) -- when a remote procedure call gets an error, it
-     returns the error code.
-   * ``KRPC_ERROR_CHECK_EXIT`` -- terminates the program (by calling ``exit()``) when an error
-     occurs in a remote procedure call.
-   * ``KRPC_ERROR_CHECK_ASSERT`` -- fails a debug assertion (by calling ``assert()``) when an error
-     occurs in a remote procedure call.
-   * ``KRPC_ERROR_CHECK_FN`` -- specifies the ``krpc_error_handler`` function should be called when
-     an error occurs in a remote procedure call. This should be set to a pointer to a function that
-     takes a single parameter of type ``krpc_error_t``.
+  * ``KRPC_ERROR_CHECK_RETURN`` (the default) -- when a remote procedure call gets an error, it
+    returns the error code.
+  * ``KRPC_ERROR_CHECK_EXIT`` -- terminates the program (by calling ``exit()``) when an error
+    occurs in a remote procedure call.
+  * ``KRPC_ERROR_CHECK_ASSERT`` -- fails a debug assertion (by calling ``assert()``) when an error
+    occurs in a remote procedure call.
+  * ``KRPC_ERROR_CHECK_FN`` -- specifies the ``krpc_error_handler`` function should be called when
+    an error occurs in a remote procedure call. This should be set to a pointer to a function that
+    takes a single parameter of type ``krpc_error_t``.
 
-   * ``KRPC_PRINT_ERRORS_TO_STDERR`` -- enables printing of a descriptive error message to stderr
-     when an error occurs
-   * ``PB_NO_ERRMSG`` -- disables error messages in the nanopb library, which kRPC uses to
-     communicate with the server. Enabled by default in the Arduino version of the library.
+  * ``KRPC_PRINT_ERRORS_TO_STDERR`` -- enables printing of a descriptive error message to stderr
+    when an error occurs
+  * ``PB_NO_ERRMSG`` -- disables error messages in the nanopb library, which kRPC uses to
+    communicate with the server. Enabled by default in the Arduino version of the library.
 
- * Communication
+* Communication
 
-   * ``KRPC_COMMUNICATION_POSIX`` -- Specifies that the library should be built to communicate over
-     a serial port using POSIX read/write functions communication mechanisms. This is the default
-     when no other platform is detected.
-   * ``KRPC_COMMUNICATION_WINDOWS`` -- Specifies that the library should be built to communicate
-     over a serial port using the Windows API. The Windows platform will be auto-detected so you do
-     not need to specify this manually.
-   * ``KRPC_COMMUNICATION_ARDUINO`` -- Specifies that the library should be built using Arduino
-     serial communication mechanisms. The Arduino platform will be auto-detected so you do not need
-     to specify this manually.
-   * ``KRPC_COMMUNICATION_CUSTOM`` -- Allows you to provide your own implementation for the
-     communication mechanism.
+  * ``KRPC_COMMUNICATION_POSIX`` -- Specifies that the library should be built to communicate over
+    a serial port using POSIX read/write functions communication mechanisms. This is the default
+    when no other platform is detected.
+  * ``KRPC_COMMUNICATION_WINDOWS`` -- Specifies that the library should be built to communicate
+    over a serial port using the Windows API. The Windows platform will be auto-detected so you do
+    not need to specify this manually.
+  * ``KRPC_COMMUNICATION_ARDUINO`` -- Specifies that the library should be built using Arduino
+    serial communication mechanisms. The Arduino platform will be auto-detected so you do not need
+    to specify this manually.
+  * ``KRPC_COMMUNICATION_CUSTOM`` -- Allows you to provide your own implementation for the
+    communication mechanism.
 
- * Memory allocation
+* Memory allocation
 
-   * ``KRPC_ALLOC_BLOCK_SIZE`` -- The size of collections (lists, sets, etc.) are not know ahead of
-     time, so when they are received from the server they are decoded into dynamically allocated
-     memory on the heap. This option controls how many items to increase the capacity of the
-     collection by when its space is exhausted. Setting this to 1 will consume the least amount of
-     heap memory, but will require one heap allocation call per item. Setting this to a higher value
-     will consume more memory, but require fewer allocations.
-   * ``KRPC_CUSTOM_MEMORY_ALLOC`` -- Disables the default implementation of memory allocation
-     functions ``krpc_malloc``, ``krpc_calloc``, ``krpc_recalloc`` and krpc_free so that you can
-     provide your own implementation.
+  * ``KRPC_ALLOC_BLOCK_SIZE`` -- The size of collections (lists, sets, etc.) are not know ahead of
+    time, so when they are received from the server they are decoded into dynamically allocated
+    memory on the heap. This option controls how many items to increase the capacity of the
+    collection by when its space is exhausted. Setting this to 1 will consume the least amount of
+    heap memory, but will require one heap allocation call per item. Setting this to a higher value
+    will consume more memory, but require fewer allocations.
+  * ``KRPC_CUSTOM_MEMORY_ALLOC`` -- Disables the default implementation of memory allocation
+    functions ``krpc_malloc``, ``krpc_calloc``, ``krpc_recalloc`` and krpc_free so that you can
+    provide your own implementation.
 
 .. note::
 

--- a/doc/src/communication-protocols.rst
+++ b/doc/src/communication-protocols.rst
@@ -3,10 +3,10 @@ Communication Protocols
 
 kRPC provides three communication protocols:
 
- * :doc:`communication-protocols/tcpip` for languages that can communicate over a
-   TCP/IP socket.
- * :doc:`communication-protocols/websockets` for web browsers.
- * :doc:`communication-protocols/serialio` for Arduino and similar.
+* :doc:`communication-protocols/tcpip` for languages that can communicate over a
+  TCP/IP socket.
+* :doc:`communication-protocols/websockets` for web browsers.
+* :doc:`communication-protocols/serialio` for Arduino and similar.
 
 In each protocol, clients invoke remote procedure calls by :doc:`sending and receiving protobuf
 messages <communication-protocols/messages>`.

--- a/doc/src/communication-protocols/messages.rst
+++ b/doc/src/communication-protocols/messages.rst
@@ -129,15 +129,15 @@ error.
 
 The fields of an error message are:
 
- * ``service`` - If the error was caused by an exception, this is the name of the service in which the
-   exception type is defined.
+* ``service`` - If the error was caused by an exception, this is the name of the service in which the
+  exception type is defined.
 
- * ``name`` - If the error was caused by an exception, this is the name of the exception type.
+* ``name`` - If the error was caused by an exception, this is the name of the exception type.
 
- * ``description`` - A human readable description of the error
+* ``description`` - A human readable description of the error
 
- * ``stack_trace`` - If the error was caused by an exception, this is a server-side stack trace for
-   the exception.
+* ``stack_trace`` - If the error was caused by an exception, this is a server-side stack trace for
+  the exception.
 
 Example RPC invocation
 ^^^^^^^^^^^^^^^^^^^^^^
@@ -412,14 +412,14 @@ The fields are:
 * ``parameters`` - A list of ``Parameter`` messages containing details of the
   procedure's parameters, with the following fields:
 
-   * ``name`` - The name of the parameter, to allow parameter passing by name.
+  * ``name`` - The name of the parameter, to allow parameter passing by name.
 
-   * ``type`` - The :ref:`type <communication-protocol-type>` of the parameter.
+  * ``type`` - The :ref:`type <communication-protocol-type>` of the parameter.
 
-   * ``default_value`` - The value of the default value of the parameter, if any, :ref:`encoded
-     using Protocol Buffer format <communication-protocol-protobuf-encoding>`.
+  * ``default_value`` - The value of the default value of the parameter, if any, :ref:`encoded
+    using Protocol Buffer format <communication-protocol-protobuf-encoding>`.
 
-   * ``nullable`` - If the parameter has a class type, indicates whether null can be passed.
+  * ``nullable`` - If the parameter has a class type, indicates whether null can be passed.
 
 * ``return_type`` - The :ref:`return type <communication-protocol-type>` of the procedure. If the
   procedure does not return anything its type is set to ``NONE``.
@@ -548,13 +548,13 @@ Procedure Names
 Procedures names are CamelCase. Whether a procedure is a service procedure, class method, class
 property, and what class (if any) it belongs to is determined by its name:
 
- * ``ProcedureName`` - a standard procedure that is just part of a service.
- * ``get_PropertyName`` - a procedure that returns the value of a property in a service.
- * ``set_PropertyName`` - a procedure that sets the value of a property in a service.
- * ``ClassName_MethodName`` - a class method.
- * ``ClassName_static_StaticMethodName`` - a static class method.
- * ``ClassName_get_PropertyName`` - a class property getter.
- * ``ClassName_set_PropertyName`` - a class property setter.
+* ``ProcedureName`` - a standard procedure that is just part of a service.
+* ``get_PropertyName`` - a procedure that returns the value of a property in a service.
+* ``set_PropertyName`` - a procedure that sets the value of a property in a service.
+* ``ClassName_MethodName`` - a class method.
+* ``ClassName_static_StaticMethodName`` - a static class method.
+* ``ClassName_get_PropertyName`` - a class property getter.
+* ``ClassName_set_PropertyName`` - a class property setter.
 
 Only letters and numbers are permitted in class, method and property names. Underscores can
 therefore be used to split the name into its constituent parts.
@@ -617,10 +617,10 @@ fields are empty.
 
 For collection types the ``types`` repeated field will contain the sub-types:
 
- * ``TUPLE`` types contain 1 or more types in the ``types`` field.
- * ``LIST`` and ``SET`` types contain a single type in the ``types`` field.
- * ``DICTIONARY`` types contain a 2 types in the ``types`` field - the key and value types, in that
-   order.
+* ``TUPLE`` types contain 1 or more types in the ``types`` field.
+* ``LIST`` and ``SET`` types contain a single type in the ``types`` field.
+* ``DICTIONARY`` types contain a 2 types in the ``types`` field - the key and value types, in that
+  order.
 
 For all other types the ``types`` field is empty.
 

--- a/doc/src/communication-protocols/serialio.rst
+++ b/doc/src/communication-protocols/serialio.rst
@@ -24,17 +24,17 @@ size, in bytes, encoded as a Protocol Buffers varint.
 
 To send a message to the server:
 
- 1. Encode the message using the Protocol Buffers format.
- 2. Get the length of the encoded message data (in bytes) and encode that as a Protocol Buffers
-    varint.
- 3. Write the encoded length followed by the encoded message data to the serial port.
+1. Encode the message using the Protocol Buffers format.
+2. Get the length of the encoded message data (in bytes) and encode that as a Protocol Buffers
+   varint.
+3. Write the encoded length followed by the encoded message data to the serial port.
 
 To receive a message from the server, do the reverse:
 
- 1. Read the size of the message as a Protocol Buffers encoded varint from the serial port.
- 2. Decode the message size.
- 3. Read message size bytes of message data from the serial port.
- 4. Decode the message data.
+1. Read the size of the message as a Protocol Buffers encoded varint from the serial port.
+2. Decode the message size.
+3. Read message size bytes of message data from the serial port.
+4. Decode the message data.
 
 Unlike the TCP/IP and WebSockets protocols, all messages sent to the server after the initial
 connection handshake are wrapped in a ``MultiplexedRequest`` message, and all messages received
@@ -58,45 +58,45 @@ Connecting to the Server
 There is a single serial port connection for both RPC calls and stream updates. To establish a
 connection, a client must do the following:
 
- 1. Open a connection to the serial port.
+1. Open a connection to the serial port.
 
- 2. Send a ``MultiplexedRequest`` message to the server with its ``connection_request`` field
-    populated. The ``ConnectionRequest`` message is defined as:
+2. Send a ``MultiplexedRequest`` message to the server with its ``connection_request`` field
+   populated. The ``ConnectionRequest`` message is defined as:
 
-    .. code-block:: protobuf
+   .. code-block:: protobuf
 
-       message ConnectionRequest {
-         Type type = 1;
-         string client_name = 2;
-         bytes client_identifier = 3;
-         enum Type {
-           RPC = 0;
-           STREAM = 1;
-         };
-       }
+      message ConnectionRequest {
+        Type type = 1;
+        string client_name = 2;
+        bytes client_identifier = 3;
+        enum Type {
+          RPC = 0;
+          STREAM = 1;
+        };
+      }
 
-    The ``type`` field should be set to ``ConnectionRequest.RPC`` and the ``client_name`` field can
-    be set to the name of the client to display on the in-game UI. The ``client_identifier`` should
-    be left blank.
+   The ``type`` field should be set to ``ConnectionRequest.RPC`` and the ``client_name`` field can
+   be set to the name of the client to display on the in-game UI. The ``client_identifier`` should
+   be left blank.
 
- 3. Receive a ``ConnectionResponse`` message from the server. This message is defined as:
+3. Receive a ``ConnectionResponse`` message from the server. This message is defined as:
 
-    .. code-block:: protobuf
+   .. code-block:: protobuf
 
-       message ConnectionResponse {
-         Status status = 1;
-         enum Status {
-           OK = 0;
-           MALFORMED_MESSAGE = 1;
-           TIMEOUT = 2;
-           WRONG_TYPE = 3;
-         }
-         string message = 2;
-         bytes client_identifier = 3;
-       }
+      message ConnectionResponse {
+        Status status = 1;
+        enum Status {
+          OK = 0;
+          MALFORMED_MESSAGE = 1;
+          TIMEOUT = 2;
+          WRONG_TYPE = 3;
+        }
+        string message = 2;
+        bytes client_identifier = 3;
+      }
 
-    If the ``status`` field is set to ``ConnectionResponse.OK`` then the connection was successful.
-    If not, the ``message`` field contains a description of what went wrong.
+   If the ``status`` field is set to ``ConnectionResponse.OK`` then the connection was successful.
+   If not, the ``message`` field contains a description of what went wrong.
 
 Receiving Stream Updates
 ------------------------

--- a/doc/src/communication-protocols/tcpip.rst
+++ b/doc/src/communication-protocols/tcpip.rst
@@ -16,17 +16,17 @@ size, in bytes, encoded as a Protocol Buffers varint.
 
 To send a message to the server:
 
- 1. Encode the message using the Protocol Buffers format.
- 2. Get the length of the encoded message data (in bytes) and encode that as a Protocol Buffers
-    varint.
- 3. Send the encoded length followed by the encoded message data.
+1. Encode the message using the Protocol Buffers format.
+2. Get the length of the encoded message data (in bytes) and encode that as a Protocol Buffers
+   varint.
+3. Send the encoded length followed by the encoded message data.
 
 To receive a message from the server, do the reverse:
 
- 1. Receive the size of the message as a Protocol Buffers encoded varint.
- 2. Decode the message size.
- 3. Receive message size bytes of message data.
- 4. Decode the message data.
+1. Receive the size of the message as a Protocol Buffers encoded varint.
+2. Decode the message size.
+3. Receive message size bytes of message data.
+4. Decode the message data.
 
 Connecting to the RPC Server
 ----------------------------
@@ -34,48 +34,48 @@ Connecting to the RPC Server
 A client invokes remote procedures by communicating with the *RPC server*. To establish a
 connection, a client must do the following:
 
- 1. Open a TCP socket to the server on its RPC port (which defaults to 50000).
+1. Open a TCP socket to the server on its RPC port (which defaults to 50000).
 
- 2. Send a ``ConnectionRequest`` message to the server. This message is defined as:
+2. Send a ``ConnectionRequest`` message to the server. This message is defined as:
 
-    .. code-block:: protobuf
+   .. code-block:: protobuf
 
-       message ConnectionRequest {
-         Type type = 1;
-         string client_name = 2;
-         bytes client_identifier = 3;
-         enum Type {
-           RPC = 0;
-           STREAM = 1;
-         };
-       }
+      message ConnectionRequest {
+        Type type = 1;
+        string client_name = 2;
+        bytes client_identifier = 3;
+        enum Type {
+          RPC = 0;
+          STREAM = 1;
+        };
+      }
 
-    The ``type`` field should be set to ``ConnectionRequest.RPC`` and the ``client_name`` field can
-    be set to the name of the client to display on the in-game UI. The ``client_identifier`` should
-    be left blank.
+   The ``type`` field should be set to ``ConnectionRequest.RPC`` and the ``client_name`` field can
+   be set to the name of the client to display on the in-game UI. The ``client_identifier`` should
+   be left blank.
 
- 3. Receive a `ConnectionResponse` message from the server. This message is defined as:
+3. Receive a `ConnectionResponse` message from the server. This message is defined as:
 
-    .. code-block:: protobuf
+   .. code-block:: protobuf
 
-       message ConnectionResponse {
-         Status status = 1;
-         enum Status {
-           OK = 0;
-           MALFORMED_MESSAGE = 1;
-           TIMEOUT = 2;
-           WRONG_TYPE = 3;
-         }
-         string message = 2;
-         bytes client_identifier = 3;
-       }
+      message ConnectionResponse {
+        Status status = 1;
+        enum Status {
+          OK = 0;
+          MALFORMED_MESSAGE = 1;
+          TIMEOUT = 2;
+          WRONG_TYPE = 3;
+        }
+        string message = 2;
+        bytes client_identifier = 3;
+      }
 
-    If the ``status`` field is set to ``ConnectionResponse.OK`` then the connection was
-    successful. If not, the ``message`` field contains a description of what went wrong.
+   If the ``status`` field is set to ``ConnectionResponse.OK`` then the connection was
+   successful. If not, the ``message`` field contains a description of what went wrong.
 
-    When the connection is successful, the ``client_identifier`` contains a unique 16-byte
-    identifier for the client. This is required when connecting to the stream server (described
-    below).
+   When the connection is successful, the ``client_identifier`` contains a unique 16-byte
+   identifier for the client. This is required when connecting to the stream server (described
+   below).
 
 Connecting to the Stream Server
 -------------------------------
@@ -112,12 +112,12 @@ from the response.
 To send and receive messages to the server, they need to be encoded and decoded from their binary
 format:
 
- * The ``encode_varint`` and ``decode_varint`` functions convert between Python integers and
-   Protocol Buffer varint encoded integers.
- * ``send_message`` encodes a message, sends the length of the message to the server as a Protocol
-   Buffer varint encoded integer, and then sends the message data.
- * ``recv_message`` receives the size of the message, decodes it, receives the message data, and
-   decodes it.
+* The ``encode_varint`` and ``decode_varint`` functions convert between Python integers and
+  Protocol Buffer varint encoded integers.
+* ``send_message`` encodes a message, sends the length of the message to the server as a Protocol
+  Buffer varint encoded integer, and then sends the message data.
+* ``recv_message`` receives the size of the message, decodes it, receives the message data, and
+  decodes it.
 
 .. literalinclude:: /scripts/communication-protocol-rpc.py
    :language: python

--- a/doc/src/communication-protocols/websockets.rst
+++ b/doc/src/communication-protocols/websockets.rst
@@ -38,14 +38,14 @@ protobuf binary format.
 
 To send a message to the server:
 
- 1. Encode the message using the Protocol Buffers format.
- 2. Send a binary websockets message to the server, with payload containing the encoded message
-    data.
+1. Encode the message using the Protocol Buffers format.
+2. Send a binary websockets message to the server, with payload containing the encoded message
+   data.
 
 To receive a message from the server, do the reverse:
 
- 1. Receive a binary websockets message from the server.
- 2. Decode the messages payload using the Protocol Buffers format.
+1. Receive a binary websockets message from the server.
+2. Decode the messages payload using the Protocol Buffers format.
 
 Invoking Remote Procedures
 --------------------------

--- a/doc/src/getting-started.rst
+++ b/doc/src/getting-started.rst
@@ -97,16 +97,14 @@ Run KSP and start the server with the default settings. Then run the following p
 
 
 .. code-block:: python
-   :linenos:
 
    import krpc
    conn = krpc.connect(name='Hello World')
    vessel = conn.space_center.active_vessel
    print(vessel.name)
 
-This does the following: line 1 loads the kRPC python module, line 2 opens a new connection to the
-server, line 3 gets the active vessel and line 4 prints out the name of the vessel. You should see
-something like the following:
+This loads the kRPC python module, opens a new connection to the server, gets the active vessel and
+prints out the name of the vessel. You should see something like the following:
 
 .. image:: /images/getting-started/hello-world.png
 

--- a/doc/src/getting-started.rst
+++ b/doc/src/getting-started.rst
@@ -14,10 +14,10 @@ Installation
 
 1. Download and install the kRPC server plugin from one of these locations:
 
- * `Github <https://github.com/krpc/krpc/releases>`_
- * `SpaceDock <https://spacedock.info/mod/69/kRPC>`_
- * `Curse <https://mods.curse.com/ksp-mods/kerbal/220219-krpc-control-the-game-using-c-c-java-lua-python>`_
- * Or the install it using `CKAN <https://forum.kerbalspaceprogram.com/index.php?/topic/90246-the-comprehensive-kerbal-archive-network-ckan-package-manager-v1180-19-june-2016/>`_
+   * `Github <https://github.com/krpc/krpc/releases>`_
+   * `SpaceDock <https://spacedock.info/mod/69/kRPC>`_
+   * `Curse <https://mods.curse.com/ksp-mods/kerbal/220219-krpc-control-the-game-using-c-c-java-lua-python>`_
+   * Or the install it using `CKAN <https://forum.kerbalspaceprogram.com/index.php?/topic/90246-the-comprehensive-kerbal-archive-network-ckan-package-manager-v1180-19-june-2016/>`_
 
 2. Start up KSP and load a save game.
 
@@ -113,10 +113,10 @@ Congratulations! You've written your first script that communicates with KSP.
 Going further...
 ----------------
 
- * For some more interesting examples of what you can do with kRPC, check out the
-   :doc:`tutorials <tutorials>`.
- * Client libraries are available for other languages too, including :doc:`C# <csharp/client>`,
-   :doc:`C++ <cpp/client>`, :doc:`C <cnano/client>`, :doc:`Java <java/client>` and
-   :doc:`Lua <lua/client>`.
- * It is also possible to :doc:`communicate with the server manually <communication-protocols>` from
-   any language you like.
+* For some more interesting examples of what you can do with kRPC, check out the
+  :doc:`tutorials <tutorials>`.
+* Client libraries are available for other languages too, including :doc:`C# <csharp/client>`,
+  :doc:`C++ <cpp/client>`, :doc:`C <cnano/client>`, :doc:`Java <java/client>` and
+  :doc:`Lua <lua/client>`.
+* It is also possible to :doc:`communicate with the server manually <communication-protocols>` from
+  any language you like.

--- a/doc/src/getting-started.rst
+++ b/doc/src/getting-started.rst
@@ -115,9 +115,6 @@ Going further...
 
  * For some more interesting examples of what you can do with kRPC, check out the
    :doc:`tutorials <tutorials>`.
- * A script is not limited to the game scene it connected in: setting ``KRPC.GameScene``
-   switches the current game scene, for example from the space center to the tracking
-   station, and can open and close space center facilities such as mission control.
  * Client libraries are available for other languages too, including :doc:`C# <csharp/client>`,
    :doc:`C++ <cpp/client>`, :doc:`C <cnano/client>`, :doc:`Java <java/client>` and
    :doc:`Lua <lua/client>`.

--- a/doc/src/java/client.rst
+++ b/doc/src/java/client.rst
@@ -197,29 +197,29 @@ Client API Reference
       :param int stream_port: The port number of the Stream Server. Defaults to 50001. This should
                               match the stream port number of the server you want to connect to.
 
-  .. method:: Stream<T> addStream(Class<?> clazz, String method, Object... args)
+   .. method:: Stream<T> addStream(Class<?> clazz, String method, Object... args)
 
-     Create a stream for a static method call to the given class.
+      Create a stream for a static method call to the given class.
 
-  .. method:: Stream<T> addStream(RemoteObject instance, String method, Object... args)
+   .. method:: Stream<T> addStream(RemoteObject instance, String method, Object... args)
 
-     Create a stream for a method call to the given remote object.
+      Create a stream for a method call to the given remote object.
 
-  .. method:: krpc.schema.KRPC.ProcedureCall getCall(Class<?> clazz, String method, Object... args)
+   .. method:: krpc.schema.KRPC.ProcedureCall getCall(Class<?> clazz, String method, Object... args)
 
-     Returns a procedure call message for the given static method call. This allows descriptions of
-     procedure calls to be passed to the server, for example when constructing custom events. See
-     :rst:ref:`java-client-events`.
+      Returns a procedure call message for the given static method call. This allows descriptions of
+      procedure calls to be passed to the server, for example when constructing custom events. See
+      :rst:ref:`java-client-events`.
 
-  .. method:: krpc.schema.KRPC.ProcedureCall getCall(RemoteObject instance, String method, Object... args)
+   .. method:: krpc.schema.KRPC.ProcedureCall getCall(RemoteObject instance, String method, Object... args)
 
-     Returns a procedure call message for the given method call. This allows descriptions of
-     procedure calls to be passed to the server, for example when constructing custom events. See
-     :rst:ref:`java-client-events`.
+      Returns a procedure call message for the given method call. This allows descriptions of
+      procedure calls to be passed to the server, for example when constructing custom events. See
+      :rst:ref:`java-client-events`.
 
-  .. method:: void close()
+   .. method:: void close()
 
-     Close the connection.
+      Close the connection.
 
 .. type:: class Stream<T>
 

--- a/doc/src/third-party.rst
+++ b/doc/src/third-party.rst
@@ -9,32 +9,32 @@ page, please feel free to ask `on the forum
 Clients
 -------
 
- * `Ruby client <https://github.com/TeWu/krpc-rb>`_
- * `Haskell client <https://github.com/Cahu/krpc-hs>`_
- * `Node.js client <https://github.com/eXigentCoder/krpc-node>`_
- * `Julia client <https://github.com/BenChung/kRPC.jl>`_
- * `Rust client <https://github.com/Cahu/krpc-mars>`_
- * `Another Rust client <https://github.com/kladd/krpc-client>`_ -- "dynamic", so doesn't require
-   generated service stubs.
- * `Go client <https://github.com/nathan-boulestin/krpc/tree/main/client/go>`_
- * `Using the plugin in F# <http://fssnip.net/7Pi>`_
+* `Ruby client <https://github.com/TeWu/krpc-rb>`_
+* `Haskell client <https://github.com/Cahu/krpc-hs>`_
+* `Node.js client <https://github.com/eXigentCoder/krpc-node>`_
+* `Julia client <https://github.com/BenChung/kRPC.jl>`_
+* `Rust client <https://github.com/Cahu/krpc-mars>`_
+* `Another Rust client <https://github.com/kladd/krpc-client>`_ -- "dynamic", so doesn't require
+  generated service stubs.
+* `Go client <https://github.com/nathan-boulestin/krpc/tree/main/client/go>`_
+* `Using the plugin in F# <http://fssnip.net/7Pi>`_
 
 Services
 --------
 
- * `kRPC.MechJeb <https://genhis.github.io/KRPC.MechJeb>`_ -- remote procedures to interact with
-   MechJeb (an up-to-date service based on `krpcmj <https://github.com/artwhaley/krpcmj>`_)
+* `kRPC.MechJeb <https://genhis.github.io/KRPC.MechJeb>`_ -- remote procedures to interact with
+  MechJeb (an up-to-date service based on `krpcmj <https://github.com/artwhaley/krpcmj>`_)
 
 Scripts/Tools/Libraries etc.
 ----------------------------
 
- * `kIPC <https://forum.kerbalspaceprogram.com/index.php?/topic/142979-113-kipc-inter-processor-communication-between-kos-and-krpc-v020-beta-now-available/>`_ -
-   Inter-Process(or) Communication between kOS and KRPC
- * `kautopilly <https://github.com/Cheaterman/kautopilly>`_ -- an autopilot primarily intended for planes.
- * `KNav <https://github.com/Vivero/KNav>`_ -- a flexible platform for implementing computer-assisted navigation and control of vessels.
- * `wernher <https://github.com/theodoregoetz/wernher>`_ -- a toolkit for flight control and orbit analysis.
- * `A small logging script. <https://gist.github.com/fat-lobyte/4326afa551fa04dd028f>`_
- * `Universal Powered Guidance <https://github.com/denebwang/ksp_UPG>`_
- * `Flight control software for rockets and torchships <https://github.com/object-Object/kRPC-or-Bust>`_
- * `MechPeste <https://github.com/Pesterenan/MechPeste-Java>`_ -- a java app for controlling
-   rockets.
+* `kIPC <https://forum.kerbalspaceprogram.com/index.php?/topic/142979-113-kipc-inter-processor-communication-between-kos-and-krpc-v020-beta-now-available/>`_ -
+  Inter-Process(or) Communication between kOS and KRPC
+* `kautopilly <https://github.com/Cheaterman/kautopilly>`_ -- an autopilot primarily intended for planes.
+* `KNav <https://github.com/Vivero/KNav>`_ -- a flexible platform for implementing computer-assisted navigation and control of vessels.
+* `wernher <https://github.com/theodoregoetz/wernher>`_ -- a toolkit for flight control and orbit analysis.
+* `A small logging script. <https://gist.github.com/fat-lobyte/4326afa551fa04dd028f>`_
+* `Universal Powered Guidance <https://github.com/denebwang/ksp_UPG>`_
+* `Flight control software for rockets and torchships <https://github.com/object-Object/kRPC-or-Bust>`_
+* `MechPeste <https://github.com/Pesterenan/MechPeste-Java>`_ -- a java app for controlling
+  rockets.

--- a/doc/src/tutorials/launch-into-orbit.rst
+++ b/doc/src/tutorials/launch-into-orbit.rst
@@ -25,28 +25,28 @@ bunch of streams to get flight telemetry then prepares the rocket for launch.
 
       .. literalinclude:: /scripts/tutorials/launch-into-orbit/LaunchIntoOrbit.c
          :language: c
-         :lines: 1-44
+         :lines: 1-42
          :linenos:
 
    .. group-tab:: C#
 
       .. literalinclude:: /scripts/tutorials/launch-into-orbit/LaunchIntoOrbit.cs
          :language: csharp
-         :lines: 1-39
+         :lines: 1-40
          :linenos:
 
    .. group-tab:: C++
 
       .. literalinclude:: /scripts/tutorials/launch-into-orbit/LaunchIntoOrbit.cpp
          :language: cpp
-         :lines: 1-35
+         :lines: 1-36
          :linenos:
 
    .. group-tab:: Java
 
       .. literalinclude:: /scripts/tutorials/launch-into-orbit/LaunchIntoOrbit.java
          :language: java
-         :lines: 1-50
+         :lines: 1-51
          :linenos:
 
    .. group-tab:: Lua
@@ -75,32 +75,32 @@ close to the target apoapsis.
 
       .. literalinclude:: /scripts/tutorials/launch-into-orbit/LaunchIntoOrbit.c
          :language: c
-         :lines: 46-77
-         :lineno-start: 46
+         :lines: 44-79
+         :lineno-start: 44
          :linenos:
 
    .. group-tab:: C#
 
       .. literalinclude:: /scripts/tutorials/launch-into-orbit/LaunchIntoOrbit.cs
          :language: csharp
-         :lines: 41-78
-         :lineno-start: 41
+         :lines: 42-79
+         :lineno-start: 42
          :linenos:
 
    .. group-tab:: C++
 
       .. literalinclude:: /scripts/tutorials/launch-into-orbit/LaunchIntoOrbit.cpp
          :language: cpp
-         :lines: 37-71
-         :lineno-start: 37
+         :lines: 38-72
+         :lineno-start: 38
          :linenos:
 
    .. group-tab:: Java
 
       .. literalinclude:: /scripts/tutorials/launch-into-orbit/LaunchIntoOrbit.java
          :language: java
-         :lines: 52-89
-         :lineno-start: 52
+         :lines: 53-90
+         :lineno-start: 53
          :linenos:
 
    .. group-tab:: Lua
@@ -115,7 +115,7 @@ close to the target apoapsis.
 
       .. literalinclude:: /scripts/tutorials/launch-into-orbit/LaunchIntoOrbit.py
          :language: python
-         :lines: 33-62
+         :lines: 33-63
          :lineno-start: 33
          :linenos:
 
@@ -128,32 +128,32 @@ the rocket has left Kerbin's atmosphere.
 
       .. literalinclude:: /scripts/tutorials/launch-into-orbit/LaunchIntoOrbit.c
          :language: c
-         :lines: 79-95
-         :lineno-start: 79
+         :lines: 81-97
+         :lineno-start: 81
          :linenos:
 
    .. group-tab:: C#
 
       .. literalinclude:: /scripts/tutorials/launch-into-orbit/LaunchIntoOrbit.cs
          :language: csharp
-         :lines: 80-90
-         :lineno-start: 80
+         :lines: 81-91
+         :lineno-start: 81
          :linenos:
 
    .. group-tab:: C++
 
       .. literalinclude:: /scripts/tutorials/launch-into-orbit/LaunchIntoOrbit.cpp
          :language: cpp
-         :lines: 73-83
-         :lineno-start: 73
+         :lines: 74-84
+         :lineno-start: 74
          :linenos:
 
    .. group-tab:: Java
 
       .. literalinclude:: /scripts/tutorials/launch-into-orbit/LaunchIntoOrbit.java
          :language: java
-         :lines: 91-101
-         :lineno-start: 91
+         :lines: 92-102
+         :lineno-start: 92
          :linenos:
 
    .. group-tab:: Lua
@@ -168,8 +168,8 @@ the rocket has left Kerbin's atmosphere.
 
       .. literalinclude:: /scripts/tutorials/launch-into-orbit/LaunchIntoOrbit.py
          :language: python
-         :lines: 64-74
-         :lineno-start: 64
+         :lines: 65-75
+         :lineno-start: 65
          :linenos:
 
 It is now time to plan the circularization burn. First, we calculate the delta-v
@@ -191,32 +191,32 @@ time needed to achieve this delta-v, using the `Tsiolkovsky rocket equation
 
       .. literalinclude:: /scripts/tutorials/launch-into-orbit/LaunchIntoOrbit.c
          :language: c
-         :lines: 97-126
-         :lineno-start: 97
+         :lines: 99-128
+         :lineno-start: 99
          :linenos:
 
    .. group-tab:: C#
 
       .. literalinclude:: /scripts/tutorials/launch-into-orbit/LaunchIntoOrbit.cs
          :language: csharp
-         :lines: 92-110
-         :lineno-start: 92
+         :lines: 93-111
+         :lineno-start: 93
          :linenos:
 
    .. group-tab:: C++
 
       .. literalinclude:: /scripts/tutorials/launch-into-orbit/LaunchIntoOrbit.cpp
          :language: cpp
-         :lines: 85-103
-         :lineno-start: 85
+         :lines: 86-104
+         :lineno-start: 86
          :linenos:
 
    .. group-tab:: Java
 
       .. literalinclude:: /scripts/tutorials/launch-into-orbit/LaunchIntoOrbit.java
          :language: java
-         :lines: 103-121
-         :lineno-start: 103
+         :lines: 104-122
+         :lineno-start: 104
          :linenos:
 
    .. group-tab:: Lua
@@ -231,8 +231,8 @@ time needed to achieve this delta-v, using the `Tsiolkovsky rocket equation
 
       .. literalinclude:: /scripts/tutorials/launch-into-orbit/LaunchIntoOrbit.py
          :language: python
-         :lines: 76-94
-         :lineno-start: 76
+         :lines: 77-94
+         :lineno-start: 77
          :linenos:
 
 Next, we need to rotate the craft and wait until the circularization burn. We
@@ -245,32 +245,32 @@ orientate the ship along the y-axis of the maneuver node's reference frame
 
       .. literalinclude:: /scripts/tutorials/launch-into-orbit/LaunchIntoOrbit.c
          :language: c
-         :lines: 128-141
-         :lineno-start: 128
+         :lines: 130-143
+         :lineno-start: 130
          :linenos:
 
    .. group-tab:: C#
 
       .. literalinclude:: /scripts/tutorials/launch-into-orbit/LaunchIntoOrbit.cs
          :language: csharp
-         :lines: 112-122
-         :lineno-start: 112
+         :lines: 113-123
+         :lineno-start: 113
          :linenos:
 
    .. group-tab:: C++
 
       .. literalinclude:: /scripts/tutorials/launch-into-orbit/LaunchIntoOrbit.cpp
          :language: cpp
-         :lines: 105-115
-         :lineno-start: 105
+         :lines: 106-116
+         :lineno-start: 106
          :linenos:
 
    .. group-tab:: Java
 
       .. literalinclude:: /scripts/tutorials/launch-into-orbit/LaunchIntoOrbit.java
          :language: java
-         :lines: 123-135
-         :lineno-start: 123
+         :lines: 124-136
+         :lineno-start: 124
          :linenos:
 
    .. group-tab:: Lua
@@ -300,32 +300,32 @@ which point the node has been executed).
 
       .. literalinclude:: /scripts/tutorials/launch-into-orbit/LaunchIntoOrbit.c
          :language: c
-         :lines: 143-
-         :lineno-start: 143
+         :lines: 145-
+         :lineno-start: 145
          :linenos:
 
    .. group-tab:: C#
 
       .. literalinclude:: /scripts/tutorials/launch-into-orbit/LaunchIntoOrbit.cs
          :language: csharp
-         :lines: 124-
-         :lineno-start: 124
+         :lines: 125-
+         :lineno-start: 125
          :linenos:
 
    .. group-tab:: C++
 
       .. literalinclude:: /scripts/tutorials/launch-into-orbit/LaunchIntoOrbit.cpp
          :language: cpp
-         :lines: 117-
-         :lineno-start: 115
+         :lines: 118-
+         :lineno-start: 118
          :linenos:
 
    .. group-tab:: Java
 
       .. literalinclude:: /scripts/tutorials/launch-into-orbit/LaunchIntoOrbit.java
          :language: java
-         :lines: 137-
-         :lineno-start: 137
+         :lines: 138-
+         :lineno-start: 138
          :linenos:
 
    .. group-tab:: Lua

--- a/doc/src/tutorials/launch-into-orbit.rst
+++ b/doc/src/tutorials/launch-into-orbit.rst
@@ -26,42 +26,36 @@ bunch of streams to get flight telemetry then prepares the rocket for launch.
       .. literalinclude:: /scripts/tutorials/launch-into-orbit/LaunchIntoOrbit.c
          :language: c
          :lines: 1-42
-         :linenos:
 
    .. group-tab:: C#
 
       .. literalinclude:: /scripts/tutorials/launch-into-orbit/LaunchIntoOrbit.cs
          :language: csharp
          :lines: 1-40
-         :linenos:
 
    .. group-tab:: C++
 
       .. literalinclude:: /scripts/tutorials/launch-into-orbit/LaunchIntoOrbit.cpp
          :language: cpp
          :lines: 1-36
-         :linenos:
 
    .. group-tab:: Java
 
       .. literalinclude:: /scripts/tutorials/launch-into-orbit/LaunchIntoOrbit.java
          :language: java
          :lines: 1-51
-         :linenos:
 
    .. group-tab:: Lua
 
       .. literalinclude:: /scripts/tutorials/launch-into-orbit/LaunchIntoOrbit.lua
          :language: lua
          :lines: 1-28
-         :linenos:
 
    .. group-tab:: Python
 
       .. literalinclude:: /scripts/tutorials/launch-into-orbit/LaunchIntoOrbit.py
          :language: python
          :lines: 1-31
-         :linenos:
 
 The next part of the program launches the rocket. The main loop continuously
 updates the auto-pilot heading to gradually pitch the rocket towards the
@@ -76,48 +70,36 @@ close to the target apoapsis.
       .. literalinclude:: /scripts/tutorials/launch-into-orbit/LaunchIntoOrbit.c
          :language: c
          :lines: 44-79
-         :lineno-start: 44
-         :linenos:
 
    .. group-tab:: C#
 
       .. literalinclude:: /scripts/tutorials/launch-into-orbit/LaunchIntoOrbit.cs
          :language: csharp
          :lines: 42-79
-         :lineno-start: 42
-         :linenos:
 
    .. group-tab:: C++
 
       .. literalinclude:: /scripts/tutorials/launch-into-orbit/LaunchIntoOrbit.cpp
          :language: cpp
          :lines: 38-72
-         :lineno-start: 38
-         :linenos:
 
    .. group-tab:: Java
 
       .. literalinclude:: /scripts/tutorials/launch-into-orbit/LaunchIntoOrbit.java
          :language: java
          :lines: 53-90
-         :lineno-start: 53
-         :linenos:
 
    .. group-tab:: Lua
 
       .. literalinclude:: /scripts/tutorials/launch-into-orbit/LaunchIntoOrbit.lua
          :language: lua
          :lines: 30-64
-         :lineno-start: 30
-         :linenos:
 
    .. group-tab:: Python
 
       .. literalinclude:: /scripts/tutorials/launch-into-orbit/LaunchIntoOrbit.py
          :language: python
          :lines: 33-63
-         :lineno-start: 33
-         :linenos:
 
 Next, the program fine tunes the apoapsis, using 25% thrust, then waits until
 the rocket has left Kerbin's atmosphere.
@@ -129,48 +111,36 @@ the rocket has left Kerbin's atmosphere.
       .. literalinclude:: /scripts/tutorials/launch-into-orbit/LaunchIntoOrbit.c
          :language: c
          :lines: 81-97
-         :lineno-start: 81
-         :linenos:
 
    .. group-tab:: C#
 
       .. literalinclude:: /scripts/tutorials/launch-into-orbit/LaunchIntoOrbit.cs
          :language: csharp
          :lines: 81-91
-         :lineno-start: 81
-         :linenos:
 
    .. group-tab:: C++
 
       .. literalinclude:: /scripts/tutorials/launch-into-orbit/LaunchIntoOrbit.cpp
          :language: cpp
          :lines: 74-84
-         :lineno-start: 74
-         :linenos:
 
    .. group-tab:: Java
 
       .. literalinclude:: /scripts/tutorials/launch-into-orbit/LaunchIntoOrbit.java
          :language: java
          :lines: 92-102
-         :lineno-start: 92
-         :linenos:
 
    .. group-tab:: Lua
 
       .. literalinclude:: /scripts/tutorials/launch-into-orbit/LaunchIntoOrbit.lua
          :language: lua
          :lines: 66-76
-         :lineno-start: 66
-         :linenos:
 
    .. group-tab:: Python
 
       .. literalinclude:: /scripts/tutorials/launch-into-orbit/LaunchIntoOrbit.py
          :language: python
          :lines: 65-75
-         :lineno-start: 65
-         :linenos:
 
 It is now time to plan the circularization burn. First, we calculate the delta-v
 required to circularize the orbit using the `vis-viva equation
@@ -192,48 +162,36 @@ time needed to achieve this delta-v, using the `Tsiolkovsky rocket equation
       .. literalinclude:: /scripts/tutorials/launch-into-orbit/LaunchIntoOrbit.c
          :language: c
          :lines: 99-128
-         :lineno-start: 99
-         :linenos:
 
    .. group-tab:: C#
 
       .. literalinclude:: /scripts/tutorials/launch-into-orbit/LaunchIntoOrbit.cs
          :language: csharp
          :lines: 93-111
-         :lineno-start: 93
-         :linenos:
 
    .. group-tab:: C++
 
       .. literalinclude:: /scripts/tutorials/launch-into-orbit/LaunchIntoOrbit.cpp
          :language: cpp
          :lines: 86-104
-         :lineno-start: 86
-         :linenos:
 
    .. group-tab:: Java
 
       .. literalinclude:: /scripts/tutorials/launch-into-orbit/LaunchIntoOrbit.java
          :language: java
          :lines: 104-122
-         :lineno-start: 104
-         :linenos:
 
    .. group-tab:: Lua
 
       .. literalinclude:: /scripts/tutorials/launch-into-orbit/LaunchIntoOrbit.lua
          :language: lua
          :lines: 78-95
-         :lineno-start: 78
-         :linenos:
 
    .. group-tab:: Python
 
       .. literalinclude:: /scripts/tutorials/launch-into-orbit/LaunchIntoOrbit.py
          :language: python
          :lines: 77-94
-         :lineno-start: 77
-         :linenos:
 
 Next, we need to rotate the craft and wait until the circularization burn. We
 orientate the ship along the y-axis of the maneuver node's reference frame
@@ -246,48 +204,36 @@ orientate the ship along the y-axis of the maneuver node's reference frame
       .. literalinclude:: /scripts/tutorials/launch-into-orbit/LaunchIntoOrbit.c
          :language: c
          :lines: 130-143
-         :lineno-start: 130
-         :linenos:
 
    .. group-tab:: C#
 
       .. literalinclude:: /scripts/tutorials/launch-into-orbit/LaunchIntoOrbit.cs
          :language: csharp
          :lines: 113-123
-         :lineno-start: 113
-         :linenos:
 
    .. group-tab:: C++
 
       .. literalinclude:: /scripts/tutorials/launch-into-orbit/LaunchIntoOrbit.cpp
          :language: cpp
          :lines: 106-116
-         :lineno-start: 106
-         :linenos:
 
    .. group-tab:: Java
 
       .. literalinclude:: /scripts/tutorials/launch-into-orbit/LaunchIntoOrbit.java
          :language: java
          :lines: 124-136
-         :lineno-start: 124
-         :linenos:
 
    .. group-tab:: Lua
 
       .. literalinclude:: /scripts/tutorials/launch-into-orbit/LaunchIntoOrbit.lua
          :language: lua
          :lines: 97-107
-         :lineno-start: 97
-         :linenos:
 
    .. group-tab:: Python
 
       .. literalinclude:: /scripts/tutorials/launch-into-orbit/LaunchIntoOrbit.py
          :language: python
          :lines: 96-106
-         :lineno-start: 96
-         :linenos:
 
 This next part executes the burn. It sets maximum throttle, then throttles down
 to 5% approximately a tenth of a second before the predicted end of the burn. It then
@@ -301,47 +247,35 @@ which point the node has been executed).
       .. literalinclude:: /scripts/tutorials/launch-into-orbit/LaunchIntoOrbit.c
          :language: c
          :lines: 145-
-         :lineno-start: 145
-         :linenos:
 
    .. group-tab:: C#
 
       .. literalinclude:: /scripts/tutorials/launch-into-orbit/LaunchIntoOrbit.cs
          :language: csharp
          :lines: 125-
-         :lineno-start: 125
-         :linenos:
 
    .. group-tab:: C++
 
       .. literalinclude:: /scripts/tutorials/launch-into-orbit/LaunchIntoOrbit.cpp
          :language: cpp
          :lines: 118-
-         :lineno-start: 118
-         :linenos:
 
    .. group-tab:: Java
 
       .. literalinclude:: /scripts/tutorials/launch-into-orbit/LaunchIntoOrbit.java
          :language: java
          :lines: 138-
-         :lineno-start: 138
-         :linenos:
 
    .. group-tab:: Lua
 
       .. literalinclude:: /scripts/tutorials/launch-into-orbit/LaunchIntoOrbit.lua
          :language: lua
          :lines: 109-
-         :lineno-start: 109
-         :linenos:
 
    .. group-tab:: Python
 
       .. literalinclude:: /scripts/tutorials/launch-into-orbit/LaunchIntoOrbit.py
          :language: python
          :lines: 108-
-         :lineno-start: 108
-         :linenos:
 
 The rocket should now be in a circular 150km orbit above Kerbin.

--- a/doc/src/tutorials/suborbital-flight.rst
+++ b/doc/src/tutorials/suborbital-flight.rst
@@ -82,8 +82,8 @@ name for our script that will appear in the server window in game:
 
       .. literalinclude:: /scripts/tutorials/sub-orbital-flight/SubOrbitalFlight.py
          :language: python
-         :lines: 3
-         :lineno-start: 3
+         :lines: 4
+         :lineno-start: 4
          :linenos:
 
 Next we need to get an object representing the active vessel. It's via this object that we will send
@@ -135,8 +135,8 @@ instructions to the rocket:
 
       .. literalinclude:: /scripts/tutorials/sub-orbital-flight/SubOrbitalFlight.py
          :language: python
-         :lines: 5
-         :lineno-start: 5
+         :lines: 6
+         :lineno-start: 6
          :linenos:
 
 We then need to prepare the rocket for launch. The following code sets the throttle to maximum and
@@ -189,8 +189,8 @@ instructs the auto-pilot to hold a pitch and heading of 90° (vertically upwards
 
       .. literalinclude:: /scripts/tutorials/sub-orbital-flight/SubOrbitalFlight.py
          :language: python
-         :lines: 7-10
-         :lineno-start: 7
+         :lines: 8-11
+         :lineno-start: 8
          :linenos:
 
 Part Two: Lift-off!
@@ -244,8 +244,8 @@ We're now ready to launch by activating the first stage (equivalent to pressing 
 
       .. literalinclude:: /scripts/tutorials/sub-orbital-flight/SubOrbitalFlight.py
          :language: python
-         :lines: 12-13
-         :lineno-start: 12
+         :lines: 13-14
+         :lineno-start: 13
          :linenos:
 
 The rocket has a solid fuel stage that will quickly run out, and will need to be jettisoned. We can
@@ -299,8 +299,8 @@ jettison the boosters:
 
       .. literalinclude:: /scripts/tutorials/sub-orbital-flight/SubOrbitalFlight.py
          :language: python
-         :lines: 15-23
-         :lineno-start: 15
+         :lines: 16-24
+         :lineno-start: 16
          :linenos:
 
 In this bit of code, ``vessel.resources`` returns a :class:`Resources` object that is used to get
@@ -360,8 +360,8 @@ following uses an event to wait until the altitude of the rocket reaches 10km:
 
       .. literalinclude:: /scripts/tutorials/sub-orbital-flight/SubOrbitalFlight.py
          :language: python
-         :lines: 25-31
-         :lineno-start: 25
+         :lines: 26-33
+         :lineno-start: 26
          :linenos:
 
 In this bit of code, calling ``vessel.flight()`` returns a :class:`Flight` object that is used to
@@ -417,8 +417,8 @@ this, we simply reconfigure the auto-pilot:
 
       .. literalinclude:: /scripts/tutorials/sub-orbital-flight/SubOrbitalFlight.py
          :language: python
-         :lines: 33-34
-         :lineno-start: 33
+         :lines: 35-36
+         :lineno-start: 35
          :linenos:
 
 Now we wait until the apoapsis reaches 100km (again, using an event), then reduce the throttle to
@@ -439,7 +439,7 @@ zero, jettison the launch stage and turn off the auto-pilot:
       .. literalinclude:: /scripts/tutorials/sub-orbital-flight/SubOrbitalFlight.cs
          :language: csharp
          :lines: 48-62
-         :lineno-start: 32
+         :lineno-start: 48
          :linenos:
 
    .. group-tab:: C++
@@ -470,8 +470,8 @@ zero, jettison the launch stage and turn off the auto-pilot:
 
       .. literalinclude:: /scripts/tutorials/sub-orbital-flight/SubOrbitalFlight.py
          :language: python
-         :lines: 36-48
-         :lineno-start: 36
+         :lines: 38-51
+         :lineno-start: 38
          :linenos:
 
 In this bit of code, ``vessel.orbit`` returns an :class:`Orbit` object that contains all the
@@ -531,8 +531,8 @@ happens - the script will continue to work.
 
       .. literalinclude:: /scripts/tutorials/sub-orbital-flight/SubOrbitalFlight.py
          :language: python
-         :lines: 50-58
-         :lineno-start: 50
+         :lines: 53-61
+         :lineno-start: 53
          :linenos:
 
 The parachutes should have now been deployed. The next bit of code will repeatedly print out the
@@ -584,8 +584,8 @@ altitude of the capsule until its speed reaches zero -- which will happen when i
 
       .. literalinclude:: /scripts/tutorials/sub-orbital-flight/SubOrbitalFlight.py
          :language: python
-         :lines: 60-63
-         :lineno-start: 60
+         :lines: 63-66
+         :lineno-start: 63
          :linenos:
 
 This bit of code uses the ``vessel.flight()`` function, as before, but this time it is passed a

--- a/doc/src/tutorials/suborbital-flight.rst
+++ b/doc/src/tutorials/suborbital-flight.rst
@@ -44,47 +44,36 @@ name for our script that will appear in the server window in game:
       .. literalinclude:: /scripts/tutorials/sub-orbital-flight/SubOrbitalFlight.c
          :language: c
          :lines: 7-9
-         :lineno-start: 7
-         :linenos:
 
    .. group-tab:: C#
 
       .. literalinclude:: /scripts/tutorials/sub-orbital-flight/SubOrbitalFlight.cs
          :language: csharp
          :lines: 10
-         :lineno-start: 10
-         :linenos:
 
    .. group-tab:: C++
 
       .. literalinclude:: /scripts/tutorials/sub-orbital-flight/SubOrbitalFlight.cpp
          :language: cpp
          :lines: 9-11
-         :lineno-start: 9
-         :linenos:
 
    .. group-tab:: Java
 
       .. literalinclude:: /scripts/tutorials/sub-orbital-flight/SubOrbitalFlight.java
          :language: java
          :lines: 20-22
-         :lineno-start: 20
-         :linenos:
 
    .. group-tab:: Lua
 
       .. literalinclude:: /scripts/tutorials/sub-orbital-flight/SubOrbitalFlight.lua
          :language: lua
          :lines: 1-3
-         :linenos:
 
    .. group-tab:: Python
 
       .. literalinclude:: /scripts/tutorials/sub-orbital-flight/SubOrbitalFlight.py
          :language: python
          :lines: 4
-         :lineno-start: 4
-         :linenos:
 
 Next we need to get an object representing the active vessel. It's via this object that we will send
 instructions to the rocket:
@@ -96,48 +85,36 @@ instructions to the rocket:
       .. literalinclude:: /scripts/tutorials/sub-orbital-flight/SubOrbitalFlight.c
          :language: c
          :lines: 11-18
-         :lineno-start: 11
-         :linenos:
 
    .. group-tab:: C#
 
       .. literalinclude:: /scripts/tutorials/sub-orbital-flight/SubOrbitalFlight.cs
          :language: csharp
          :lines: 12
-         :lineno-start: 12
-         :linenos:
 
    .. group-tab:: C++
 
       .. literalinclude:: /scripts/tutorials/sub-orbital-flight/SubOrbitalFlight.cpp
          :language: cpp
          :lines: 13
-         :lineno-start: 13
-         :linenos:
 
    .. group-tab:: Java
 
       .. literalinclude:: /scripts/tutorials/sub-orbital-flight/SubOrbitalFlight.java
          :language: java
          :lines: 24
-         :lineno-start: 24
-         :linenos:
 
    .. group-tab:: Lua
 
       .. literalinclude:: /scripts/tutorials/sub-orbital-flight/SubOrbitalFlight.lua
          :language: lua
          :lines: 5
-         :lineno-start: 5
-         :linenos:
 
    .. group-tab:: Python
 
       .. literalinclude:: /scripts/tutorials/sub-orbital-flight/SubOrbitalFlight.py
          :language: python
          :lines: 6
-         :lineno-start: 6
-         :linenos:
 
 We then need to prepare the rocket for launch. The following code sets the throttle to maximum and
 instructs the auto-pilot to hold a pitch and heading of 90° (vertically upwards). It then waits for
@@ -150,48 +127,36 @@ instructs the auto-pilot to hold a pitch and heading of 90° (vertically upwards
       .. literalinclude:: /scripts/tutorials/sub-orbital-flight/SubOrbitalFlight.c
          :language: c
          :lines: 20-23
-         :lineno-start: 20
-         :linenos:
 
    .. group-tab:: C#
 
       .. literalinclude:: /scripts/tutorials/sub-orbital-flight/SubOrbitalFlight.cs
          :language: csharp
          :lines: 14-17
-         :lineno-start: 14
-         :linenos:
 
    .. group-tab:: C++
 
       .. literalinclude:: /scripts/tutorials/sub-orbital-flight/SubOrbitalFlight.cpp
          :language: cpp
          :lines: 15-18
-         :lineno-start: 15
-         :linenos:
 
    .. group-tab:: Java
 
       .. literalinclude:: /scripts/tutorials/sub-orbital-flight/SubOrbitalFlight.java
          :language: java
          :lines: 26-29
-         :lineno-start: 26
-         :linenos:
 
    .. group-tab:: Lua
 
       .. literalinclude:: /scripts/tutorials/sub-orbital-flight/SubOrbitalFlight.lua
          :language: lua
          :lines: 7-10
-         :lineno-start: 7
-         :linenos:
 
    .. group-tab:: Python
 
       .. literalinclude:: /scripts/tutorials/sub-orbital-flight/SubOrbitalFlight.py
          :language: python
          :lines: 8-11
-         :lineno-start: 8
-         :linenos:
 
 Part Two: Lift-off!
 -------------------
@@ -205,48 +170,36 @@ We're now ready to launch by activating the first stage (equivalent to pressing 
       .. literalinclude:: /scripts/tutorials/sub-orbital-flight/SubOrbitalFlight.c
          :language: c
          :lines: 25-26
-         :lineno-start: 25
-         :linenos:
 
    .. group-tab:: C#
 
       .. literalinclude:: /scripts/tutorials/sub-orbital-flight/SubOrbitalFlight.cs
          :language: csharp
          :lines: 19-20
-         :lineno-start: 19
-         :linenos:
 
    .. group-tab:: C++
 
       .. literalinclude:: /scripts/tutorials/sub-orbital-flight/SubOrbitalFlight.cpp
          :language: cpp
          :lines: 20-21
-         :lineno-start: 20
-         :linenos:
 
    .. group-tab:: Java
 
       .. literalinclude:: /scripts/tutorials/sub-orbital-flight/SubOrbitalFlight.java
          :language: java
          :lines: 31-32
-         :lineno-start: 31
-         :linenos:
 
    .. group-tab:: Lua
 
       .. literalinclude:: /scripts/tutorials/sub-orbital-flight/SubOrbitalFlight.lua
          :language: lua
          :lines: 12-13
-         :lineno-start: 12
-         :linenos:
 
    .. group-tab:: Python
 
       .. literalinclude:: /scripts/tutorials/sub-orbital-flight/SubOrbitalFlight.py
          :language: python
          :lines: 13-14
-         :lineno-start: 13
-         :linenos:
 
 The rocket has a solid fuel stage that will quickly run out, and will need to be jettisoned. We can
 monitor the amount of solid fuel in the rocket using an event that is triggered when there is very
@@ -260,48 +213,36 @@ jettison the boosters:
       .. literalinclude:: /scripts/tutorials/sub-orbital-flight/SubOrbitalFlight.c
          :language: c
          :lines: 28-38
-         :lineno-start: 28
-         :linenos:
 
    .. group-tab:: C#
 
       .. literalinclude:: /scripts/tutorials/sub-orbital-flight/SubOrbitalFlight.cs
          :language: csharp
          :lines: 23-29
-         :lineno-start: 23
-         :linenos:
 
    .. group-tab:: C++
 
       .. literalinclude:: /scripts/tutorials/sub-orbital-flight/SubOrbitalFlight.cpp
          :language: cpp
          :lines: 26-32
-         :lineno-start: 26
-         :linenos:
 
    .. group-tab:: Java
 
       .. literalinclude:: /scripts/tutorials/sub-orbital-flight/SubOrbitalFlight.java
          :language: java
          :lines: 34-47
-         :lineno-start: 34
-         :linenos:
 
    .. group-tab:: Lua
 
       .. literalinclude:: /scripts/tutorials/sub-orbital-flight/SubOrbitalFlight.lua
          :language: lua
          :lines: 15-19
-         :lineno-start: 15
-         :linenos:
 
    .. group-tab:: Python
 
       .. literalinclude:: /scripts/tutorials/sub-orbital-flight/SubOrbitalFlight.py
          :language: python
          :lines: 16-24
-         :lineno-start: 16
-         :linenos:
 
 In this bit of code, ``vessel.resources`` returns a :class:`Resources` object that is used to get
 information about the resources in the rocket. The code creates the expression
@@ -321,48 +262,36 @@ following uses an event to wait until the altitude of the rocket reaches 10km:
       .. literalinclude:: /scripts/tutorials/sub-orbital-flight/SubOrbitalFlight.c
          :language: c
          :lines: 40-47
-         :lineno-start: 40
-         :linenos:
 
    .. group-tab:: C#
 
       .. literalinclude:: /scripts/tutorials/sub-orbital-flight/SubOrbitalFlight.cs
          :language: csharp
          :lines: 36-42
-         :lineno-start: 36
-         :linenos:
 
    .. group-tab:: C++
 
       .. literalinclude:: /scripts/tutorials/sub-orbital-flight/SubOrbitalFlight.cpp
          :language: cpp
          :lines: 39-45
-         :lineno-start: 39
-         :linenos:
 
    .. group-tab:: Java
 
       .. literalinclude:: /scripts/tutorials/sub-orbital-flight/SubOrbitalFlight.java
          :language: java
          :lines: 50-58
-         :lineno-start: 50
-         :linenos:
 
    .. group-tab:: Lua
 
       .. literalinclude:: /scripts/tutorials/sub-orbital-flight/SubOrbitalFlight.lua
          :language: lua
          :lines: 21-23
-         :lineno-start: 21
-         :linenos:
 
    .. group-tab:: Python
 
       .. literalinclude:: /scripts/tutorials/sub-orbital-flight/SubOrbitalFlight.py
          :language: python
          :lines: 26-33
-         :lineno-start: 26
-         :linenos:
 
 In this bit of code, calling ``vessel.flight()`` returns a :class:`Flight` object that is used to
 get all sorts of information about the rocket, such as the direction it is pointing in and its
@@ -378,48 +307,36 @@ this, we simply reconfigure the auto-pilot:
       .. literalinclude:: /scripts/tutorials/sub-orbital-flight/SubOrbitalFlight.c
          :language: c
          :lines: 49-50
-         :lineno-start: 49
-         :linenos:
 
    .. group-tab:: C#
 
       .. literalinclude:: /scripts/tutorials/sub-orbital-flight/SubOrbitalFlight.cs
          :language: csharp
          :lines: 45-46
-         :lineno-start: 45
-         :linenos:
 
    .. group-tab:: C++
 
       .. literalinclude:: /scripts/tutorials/sub-orbital-flight/SubOrbitalFlight.cpp
          :language: cpp
          :lines: 48-49
-         :lineno-start: 48
-         :linenos:
 
    .. group-tab:: Java
 
       .. literalinclude:: /scripts/tutorials/sub-orbital-flight/SubOrbitalFlight.java
          :language: java
          :lines: 61-62
-         :lineno-start: 61
-         :linenos:
 
    .. group-tab:: Lua
 
       .. literalinclude:: /scripts/tutorials/sub-orbital-flight/SubOrbitalFlight.lua
          :language: lua
          :lines: 25-26
-         :lineno-start: 25
-         :linenos:
 
    .. group-tab:: Python
 
       .. literalinclude:: /scripts/tutorials/sub-orbital-flight/SubOrbitalFlight.py
          :language: python
          :lines: 35-36
-         :lineno-start: 35
-         :linenos:
 
 Now we wait until the apoapsis reaches 100km (again, using an event), then reduce the throttle to
 zero, jettison the launch stage and turn off the auto-pilot:
@@ -431,48 +348,36 @@ zero, jettison the launch stage and turn off the auto-pilot:
       .. literalinclude:: /scripts/tutorials/sub-orbital-flight/SubOrbitalFlight.c
          :language: c
          :lines: 52-65
-         :lineno-start: 52
-         :linenos:
 
    .. group-tab:: C#
 
       .. literalinclude:: /scripts/tutorials/sub-orbital-flight/SubOrbitalFlight.cs
          :language: csharp
          :lines: 48-62
-         :lineno-start: 48
-         :linenos:
 
    .. group-tab:: C++
 
       .. literalinclude:: /scripts/tutorials/sub-orbital-flight/SubOrbitalFlight.cpp
          :language: cpp
          :lines: 51-65
-         :lineno-start: 51
-         :linenos:
 
    .. group-tab:: Java
 
       .. literalinclude:: /scripts/tutorials/sub-orbital-flight/SubOrbitalFlight.java
          :language: java
          :lines: 64-81
-         :lineno-start: 64
-         :linenos:
 
    .. group-tab:: Lua
 
       .. literalinclude:: /scripts/tutorials/sub-orbital-flight/SubOrbitalFlight.lua
          :language: lua
          :lines: 28-35
-         :lineno-start: 28
-         :linenos:
 
    .. group-tab:: Python
 
       .. literalinclude:: /scripts/tutorials/sub-orbital-flight/SubOrbitalFlight.py
          :language: python
          :lines: 38-51
-         :lineno-start: 38
-         :linenos:
 
 In this bit of code, ``vessel.orbit`` returns an :class:`Orbit` object that contains all the
 information about the orbit of the rocket.
@@ -492,48 +397,36 @@ happens - the script will continue to work.
       .. literalinclude:: /scripts/tutorials/sub-orbital-flight/SubOrbitalFlight.c
          :language: c
          :lines: 67-74
-         :lineno-start: 67
-         :linenos:
 
    .. group-tab:: C#
 
       .. literalinclude:: /scripts/tutorials/sub-orbital-flight/SubOrbitalFlight.cs
          :language: csharp
          :lines: 64-74
-         :lineno-start: 64
-         :linenos:
 
    .. group-tab:: C++
 
       .. literalinclude:: /scripts/tutorials/sub-orbital-flight/SubOrbitalFlight.cpp
          :language: cpp
          :lines: 67-77
-         :lineno-start: 67
-         :linenos:
 
    .. group-tab:: Java
 
       .. literalinclude:: /scripts/tutorials/sub-orbital-flight/SubOrbitalFlight.java
          :language: java
          :lines: 83-96
-         :lineno-start: 83
-         :linenos:
 
    .. group-tab:: Lua
 
       .. literalinclude:: /scripts/tutorials/sub-orbital-flight/SubOrbitalFlight.lua
          :language: lua
          :lines: 37-40
-         :lineno-start: 37
-         :linenos:
 
    .. group-tab:: Python
 
       .. literalinclude:: /scripts/tutorials/sub-orbital-flight/SubOrbitalFlight.py
          :language: python
          :lines: 53-61
-         :lineno-start: 53
-         :linenos:
 
 The parachutes should have now been deployed. The next bit of code will repeatedly print out the
 altitude of the capsule until its speed reaches zero -- which will happen when it lands:
@@ -545,48 +438,36 @@ altitude of the capsule until its speed reaches zero -- which will happen when i
       .. literalinclude:: /scripts/tutorials/sub-orbital-flight/SubOrbitalFlight.c
          :language: c
          :lines: 76-93
-         :lineno-start: 76
-         :linenos:
 
    .. group-tab:: C#
 
       .. literalinclude:: /scripts/tutorials/sub-orbital-flight/SubOrbitalFlight.cs
          :language: csharp
          :lines: 76-81
-         :lineno-start: 76
-         :linenos:
 
    .. group-tab:: C++
 
       .. literalinclude:: /scripts/tutorials/sub-orbital-flight/SubOrbitalFlight.cpp
          :language: cpp
          :lines: 79-83
-         :lineno-start: 79
-         :linenos:
 
    .. group-tab:: Java
 
       .. literalinclude:: /scripts/tutorials/sub-orbital-flight/SubOrbitalFlight.java
          :language: java
          :lines: 98-103
-         :lineno-start: 98
-         :linenos:
 
    .. group-tab:: Lua
 
       .. literalinclude:: /scripts/tutorials/sub-orbital-flight/SubOrbitalFlight.lua
          :language: lua
          :lines: 42-
-         :lineno-start: 42
-         :linenos:
 
    .. group-tab:: Python
 
       .. literalinclude:: /scripts/tutorials/sub-orbital-flight/SubOrbitalFlight.py
          :language: python
          :lines: 63-66
-         :lineno-start: 63
-         :linenos:
 
 This bit of code uses the ``vessel.flight()`` function, as before, but this time it is passed a
 :class:`ReferenceFrame` parameter. We want to get the vertical speed of the capsule relative to the


### PR DESCRIPTION
The code snippets in the sub-orbital flight and launch into orbit tutorials no longer matched the scripts they quote. The `literalinclude` line ranges had drifted, so the tutorials showed the wrong lines, and in the worst case the first Python snippet on the sub-orbital flight page started on a blank line and rendered as nothing but the line number `3`.

**Root cause.** The Python ranges went stale when the tutorial scripts were reformatted, which shifted `SubOrbitalFlight.py` from 63 to 66 lines and moved the contents of `LaunchIntoOrbit.py`. The ranges for the other languages had drifted separately, by one line in the C#, C++ and Java snippets and by two in the C ones. Nothing detects this: a stale range is still valid reStructuredText, so the docs build stays green and the page quietly shows the wrong code.

**Fix.** All 36 ranges in the launch into orbit tutorial and all 10 Python ranges in the sub-orbital flight tutorial are corrected, so every language shows the same logical chunk in each section. Two consequences worth calling out: the C snippet in the launch into orbit tutorial was skipping the call that engages the auto-pilot entirely, because it fell in the gap between two blocks, and one C# snippet in the sub-orbital flight tutorial was numbered from line 32 when it quotes line 48 onwards.

The line numbers are then removed from the tutorial snippets altogether. They are confusing to read, particularly for the single-line snippets where the number is the most prominent thing in the block, and the remaining tutorials already show their snippets without them. The getting started guide described its example by line number, so that prose is reworded to walk through the statements instead.

Two smaller fixes ride along. The note about switching the game scene is dropped from the getting started guide, as the rest of that list points at the next thing to read rather than at a detail of one particular API. Separately, lists indented by a single space are not top level lists but lists inside a block quote, which the theme renders greyed out and indented; the getting started guide, the third party page, the communication protocol pages and the C-nano client page were all written this way and are dedented to the left margin. The Java client reference had the same problem in a different form, with five of the `Connection` methods indented one space short of their siblings, which put `addStream`, both `getCall` overloads and `close` outside the class they document.

**Testing.** `//doc:html` builds cleanly at each of the four commits, and `bazel test //doc:test //doc:spelling` passes. The rendered HTML was checked directly rather than by eye over the source: the first line of all 46 code blocks across both tutorials now falls on the intended boundary, the site contains no block quotes at all, and the five Java methods render inside the `Connection` class. The indentation commit was verified to be whitespace only by diffing every file against `main` with leading whitespace stripped.
