### PR TITLE
Version dev builds against the release being worked towards

### DIFF
--- a/.github/actions/build-setup/action.yml
+++ b/.github/actions/build-setup/action.yml
@@ -5,13 +5,38 @@ inputs:
 runs:
   using: composite
   steps:
-    # Suffix the version in config.bzl with a build number derived from the
-    # commit sha, followed by the truncated sha. The build number is kept in
-    # 0-65535 to satisfy the .NET assembly version format.
+    # Suffix the version in config.bzl with the number of commits since the
+    # last release, followed by the truncated sha. The count orders one dev
+    # build against another; the sha says which commit it came from.
     - if: ${{ inputs.long-version == 'true' }}
       shell: python
       run: |
         import os
+        import subprocess
+        import sys
+
+        def git(*arguments):
+            return subprocess.run(("git",) + arguments, check=True,
+                                  capture_output=True, text=True).stdout.strip()
+
+        # actions/checkout clones to a depth of one and fetches no tags,
+        # leaving neither history to count nor a release to count it from.
+        # Deepen the clone and fetch the tags, taking no trees or blobs: the
+        # commits are all rev-list needs, and they cost a couple of megabytes
+        # against the ~150MB the full history would pull down.
+        if git("rev-parse", "--is-shallow-repository") == "true":
+            git("fetch", "-q", "--unshallow", "--tags", "--filter=tree:0")
+        # Rather than stamp a wrong build number: a repository still shallow
+        # here counts one commit, so every build would call itself build 1.
+        if git("rev-parse", "--is-shallow-repository") == "true":
+            sys.exit("could not deepen the repository to count its commits")
+
+        # Counting from the last release rather than the root keeps the number
+        # small and restarts it each cycle, well inside the 16-bit build field
+        # the .NET assembly version allows. Releases are tagged vx.y.z; the
+        # pattern excludes the lua client's tags, which are versioned apart.
+        release = git("describe", "--tags", "--abbrev=0", "--match", "v[0-9]*")
+        build = git("rev-list", "--count", release + "..HEAD")
 
         with open("config.bzl", "r") as f:
             lines = f.readlines()
@@ -19,8 +44,7 @@ runs:
             if line.startswith("version = "):
                 version = line.partition("=")[2].strip()[1:-1]
                 sha = os.environ["GITHUB_SHA"][:7]
-                sha_int = int(sha, 16) % 65536
-                version += "-" + str(sha_int) + "-" + sha
+                version += "-" + build + "-" + sha
                 lines[i] = 'version = "%s"\n' % version
                 break
         with open("config.bzl", "w") as f:

--- a/config.bzl
+++ b/config.bzl
@@ -1,7 +1,7 @@
 " global configuration "
 
 author = "djungelorm"
-version = "0.5.4"
+version = "0.6.0"
 ksp_version_max = "1.12.5.3190"
 ksp_version_min = "1.12.3.3173"
 ksp_version_max_parts = ksp_version_max.split(".")
@@ -15,9 +15,9 @@ def get_version_parts(version):
 
 version_parts = get_version_parts(version)
 
-# Python version x.y.z[+w.w]
+# Python version x.y.z[.devw[+sha]]
 python_version = \
-    ".".join(version_parts) if len(version_parts) == 3 else ".".join(version_parts[:3]) + "+" + ".".join(version_parts[3:])
+    ".".join(version_parts) if len(version_parts) == 3 else ".".join(version_parts[:3]) + ".dev" + version_parts[3] + ("+" + ".".join(version_parts[4:]) if len(version_parts) > 4 else "")
 
 # C# assembly version: x.y.z[.w]
 assembly_version = ".".join(version_parts[:4])

--- a/tools/release/70-announcements.py
+++ b/tools/release/70-announcements.py
@@ -26,6 +26,8 @@ def main():
 
     lib.banner(f'Remaining manual steps for {lib.TAG}')
     print(STEPS.format(version=lib.VERSION))
+    print()
+    print('Next, once the release is announced: tools/release/80-bump-version.py')
 
 
 if __name__ == '__main__':

--- a/tools/release/80-bump-version.py
+++ b/tools/release/80-bump-version.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""Sets the version in config.bzl to the one to work towards next.
+
+Run once the release is out. Between releases config.bzl names the version
+being worked towards rather than the last one released, so that a build from
+main is a pre-release of it: CI stamps such a build as x.y.z-<commits>-<sha>,
+which orders after the release just made and below the one set here.
+"""
+
+import re
+from pathlib import Path
+
+import lib
+
+CONFIG = Path('config.bzl')
+
+
+def release_parts(version):
+    """The (x, y, z) of a plain release version, or None if it isn't one."""
+    match = re.fullmatch(r'(\d+)\.(\d+)\.(\d+)', version)
+    return tuple(int(part) for part in match.groups()) if match else None
+
+
+def ask(current):
+    """Ask which version to work towards, suggesting the next patch.
+
+    Only the maintainer knows whether what comes next is a patch or a larger
+    step, so the suggestion is the conservative one and is there to be typed
+    over.
+    """
+    suggestion = '%d.%d.%d' % (current[0], current[1], current[2] + 1)
+    version = input(f'Version to work towards [{suggestion}] ').strip() \
+        or suggestion
+    parts = release_parts(version)
+    if parts is None:
+        raise lib.ReleaseError(f"'{version}' is not an x.y.z version")
+    if parts <= current:
+        raise lib.ReleaseError(f'{version} does not come after {lib.VERSION}')
+    return version
+
+
+def main():
+    lib.require('git')
+    lib.require_clean_tree()
+
+    current = release_parts(lib.VERSION)
+    if current is None:
+        raise lib.ReleaseError(
+            f'config.bzl is at {lib.VERSION}, which is not a release version')
+
+    branch = lib.capture('git', 'rev-parse', '--abbrev-ref', 'HEAD')
+    if branch != 'main':
+        raise lib.ReleaseError(f"on branch '{branch}', expected main")
+
+    # Guards against bumping past a release that was never made: the tag is
+    # created by 30-tag.py, so its absence means this is being run too early
+    if not lib.succeeds('git', 'rev-parse', '-q', '--verify',
+                        f'refs/tags/{lib.TAG}'):
+        raise lib.ReleaseError(
+            f'tag {lib.TAG} does not exist; release {lib.VERSION} first')
+
+    version = ask(current)
+
+    lib.banner(f'Setting the version in {CONFIG} to {version}')
+    text = CONFIG.read_text()
+    bumped = re.sub(r'^version = ".+"$', f'version = "{version}"', text,
+                    count=1, flags=re.MULTILINE)
+    if bumped == text:
+        raise lib.ReleaseError(f'no version line found in {CONFIG}')
+    CONFIG.write_text(bumped)
+    lib.run('git', 'commit', '-m', f'Work towards {version}', str(CONFIG))
+
+    lib.banner('Pushing to GitHub')
+    lib.confirm('Push main to origin?')
+    lib.run('git', 'push', 'origin', 'main')
+
+    lib.banner('Done')
+    print(f'main is working towards {version}. Changelog entries for it go '
+          f'under a v{version} header.')
+
+
+if __name__ == '__main__':
+    lib.main(main)


### PR DESCRIPTION
**Problem.** `config.bzl` named the last release rather than the one being worked towards, so a build from a commit after the 0.5.4 release called itself `0.5.4-<build>-<sha>`. As a SemVer pre-release that sorts *below* 0.5.4, so the nuget package built after the release advertised itself as older than the release it followed, and read as a version it named a release the build was not. The build number compounded it: the first seven hex digits of the commit sha reduced modulo 65536, which is a unique-ish label rather than a sequence, so there was no way to tell which of two dev builds was the later one.

**Change.** The version in `config.bzl` is now the one being worked towards, so a build between releases is a pre-release of the version it leads to. The build number becomes the number of commits since the last release tag, which orders dev builds against each other and restarts each cycle. A commit 938 past `v0.5.4` now stamps as:

 * python `0.6.0.dev938+027ba8c`, where it was `0.5.4+12345.027ba8c`
 * nuget `0.6.0-build938`, where it was `0.5.4-build12345`
 * assembly, lua and cmake `0.6.0.938`, KSP-AVC `0.6.0 build 938`

The python format moves the build number from a local segment to a `.dev` segment as part of this: PEP 440 sorts a local segment *above* the release it hangs off, so `0.6.0+938.027ba8c` would have ordered above the eventual 0.6.0 release rather than below it. The nuget and python formats now both place a dev build after the last release and before the next, which neither did before.

Counting from the last release tag rather than the root keeps the number small and bounded per cycle — 938 rather than 5487 — so it stays well inside the 16-bit build field the .NET assembly version allows. Neither the history nor the tags survive the shallow clone `actions/checkout` makes, so the build-setup action deepens the repository first, with trees and blobs filtered out: the commits are all `rev-list` needs, and they cost ~2MB against the ~150MB the full history would pull down.

**Release process.** With the source tree versioned at the release being worked towards, the bump belongs at the end of a release rather than the start of one. `tools/release/80-bump-version.py` sets `config.bzl` to the version to work towards next, asking which that is and suggesting the next patch, and refuses to run unless the tree is clean, on `main`, and the release it follows is already tagged.

**Testing.** The version-stamping step was run against a shallow, tagless clone to check it deepens correctly and stamps what it should, and the derived formats were checked to order as `0.5.4 < 0.6.0.dev938+027ba8c < 0.6.0` under `packaging`. `bazel build --nobuild //...` analyzes all 810 targets under both a release and a dev version, which covers the derived formats reaching package filenames. The release step's guards and validation were exercised in a scratch clone. There is no changelog entry: this is release infrastructure, with no user-facing change beyond the version string a dev build reports.
</content>
