### PR TITLE
Improve KAC alarm action docs

### DIFF
--- a/service/KerbalAlarmClock/src/AlarmAction.cs
+++ b/service/KerbalAlarmClock/src/AlarmAction.cs
@@ -18,21 +18,20 @@ namespace KRPC.KerbalAlarmClock
         /// Don't do anything, and delete the alarm.
         /// </summary>
         DoNothingDeleteWhenPassed,
-        // TODO: what's the difference between KillWarp and KillWarpOnly?
         /// <summary>
-        /// Drop out of time warp.
+        /// Drop out of time warp and display a message.
         /// </summary>
         KillWarp,
         /// <summary>
-        /// Drop out of time warp.
+        /// Drop out of time warp, without displaying a message.
         /// </summary>
         KillWarpOnly,
         /// <summary>
-        /// Display a message.
+        /// Display a message, without affecting time warp.
         /// </summary>
         MessageOnly,
         /// <summary>
-        /// Pause the game.
+        /// Pause the game and display a message.
         /// </summary>
         PauseGame,
         /// <summary>


### PR DESCRIPTION
Resolves TODO comment.

Makes it clear the difference between the enum items suffixed with "Only"