### PR TITLE
Check C# sources against the .csproj file lists

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,6 +107,8 @@ jobs:
         run: |
           dotnet build KRPC.sln -c Debug -warnaserror
           dotnet build KRPC.sln -c Release -warnaserror
+      - name: test
+        run: bazel test //:csproj-test
 
   build-client-cnano-cmake-linux:
     needs: test-client-cnano

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_python//python:defs.bzl", "py_test")
 load("//:config.bzl", "avc_version", "ksp_avc_version_max", "ksp_avc_version_min", "python_version", "version")
 load("//tools/build:pkg.bzl", "pkg_zip")
 
@@ -173,9 +174,36 @@ pkg_zip(
     },
 )
 
+# The Bazel build globs its C# sources, so it cannot see a source file that is
+# missing from a .csproj -- only a `dotnet build` of KRPC.sln can. This checks the
+# .csproj file lists directly, so the divergence is caught without a .NET SDK.
+py_test(
+    name = "csproj-test",
+    srcs = ["//tools/build:csproj_test.py"],
+    data = [
+        "KRPC.sln",
+        "//client/csharp:csproj-srcs",
+        "//core:csproj-srcs",
+        "//server:csproj-srcs",
+        "//service/DockingCamera:csproj-srcs",
+        "//service/Drawing:csproj-srcs",
+        "//service/InfernalRobotics:csproj-srcs",
+        "//service/KerbalAlarmClock:csproj-srcs",
+        "//service/LiDAR:csproj-srcs",
+        "//service/RemoteTech:csproj-srcs",
+        "//service/SpaceCenter:csproj-srcs",
+        "//service/UI:csproj-srcs",
+        "//tools/ServiceDefinitions:csproj-srcs",
+        "//tools/TestServer:csproj-srcs",
+        "//tools/TestingTools:csproj-srcs",
+    ],
+    main = "csproj_test.py",
+)
+
 test_suite(
     name = "test",
     tests = [
+        "//:csproj-test",
         "//client/cnano:test",
         "//client/cpp:test",
         "//client/csharp:test",

--- a/client/csharp/BUILD.bazel
+++ b/client/csharp/BUILD.bazel
@@ -253,3 +253,13 @@ clientgen_csharp(
         "//:__pkg__",
     ],
 )
+
+# Sources for //:csproj-test, which checks them against the .csproj file lists.
+filegroup(
+    name = "csproj-srcs",
+    srcs = glob([
+        "**/*.cs",
+        "**/*.csproj",
+    ]),
+    visibility = ["//:__pkg__"],
+)

--- a/core/BUILD.bazel
+++ b/core/BUILD.bazel
@@ -157,3 +157,13 @@ csharp_nunit_test(
         "//tools/build/dotnet:System.IO.Ports",
     ],
 )
+
+# Sources for //:csproj-test, which checks them against the .csproj file lists.
+filegroup(
+    name = "csproj-srcs",
+    srcs = glob([
+        "**/*.cs",
+        "**/*.csproj",
+    ]),
+    visibility = ["//:__pkg__"],
+)

--- a/core/test/KRPC.Core.Test.csproj
+++ b/core/test/KRPC.Core.Test.csproj
@@ -81,6 +81,7 @@
     <Compile Include="Service\TestService.cs" />
     <Compile Include="Service\TestService2.cs" />
     <Compile Include="Service\TestService3.cs" />
+    <Compile Include="Service\TestServiceDeprecated.cs" />
     <Compile Include="Service\TestTopLevelClass.cs" />
     <Compile Include="Service\TypeUtilsTest.cs" />
     <Compile Include="Service\ValueUtilsTest.cs" />

--- a/server/BUILD.bazel
+++ b/server/BUILD.bazel
@@ -67,3 +67,13 @@ png_images(
     name = "icons",
     srcs = glob(["src/icons/*.svg"]),
 )
+
+# Sources for //:csproj-test, which checks them against the .csproj file lists.
+filegroup(
+    name = "csproj-srcs",
+    srcs = glob([
+        "**/*.cs",
+        "**/*.csproj",
+    ]),
+    visibility = ["//:__pkg__"],
+)

--- a/service/DockingCamera/BUILD.bazel
+++ b/service/DockingCamera/BUILD.bazel
@@ -53,3 +53,13 @@ service_definitions(
     service = "DockingCamera",
     visibility = ["//visibility:public"],
 )
+
+# Sources for //:csproj-test, which checks them against the .csproj file lists.
+filegroup(
+    name = "csproj-srcs",
+    srcs = glob([
+        "**/*.cs",
+        "**/*.csproj",
+    ]),
+    visibility = ["//:__pkg__"],
+)

--- a/service/Drawing/BUILD.bazel
+++ b/service/Drawing/BUILD.bazel
@@ -81,3 +81,13 @@ py_lint_test(
         "//tools/krpctest:krpctest_lib",
     ],
 )
+
+# Sources for //:csproj-test, which checks them against the .csproj file lists.
+filegroup(
+    name = "csproj-srcs",
+    srcs = glob([
+        "**/*.cs",
+        "**/*.csproj",
+    ]),
+    visibility = ["//:__pkg__"],
+)

--- a/service/InfernalRobotics/BUILD.bazel
+++ b/service/InfernalRobotics/BUILD.bazel
@@ -77,3 +77,13 @@ py_lint_test(
         "//tools/krpctest:krpctest_lib",
     ],
 )
+
+# Sources for //:csproj-test, which checks them against the .csproj file lists.
+filegroup(
+    name = "csproj-srcs",
+    srcs = glob([
+        "**/*.cs",
+        "**/*.csproj",
+    ]),
+    visibility = ["//:__pkg__"],
+)

--- a/service/KerbalAlarmClock/BUILD.bazel
+++ b/service/KerbalAlarmClock/BUILD.bazel
@@ -77,3 +77,13 @@ py_lint_test(
         "//tools/krpctest:krpctest_lib",
     ],
 )
+
+# Sources for //:csproj-test, which checks them against the .csproj file lists.
+filegroup(
+    name = "csproj-srcs",
+    srcs = glob([
+        "**/*.cs",
+        "**/*.csproj",
+    ]),
+    visibility = ["//:__pkg__"],
+)

--- a/service/LiDAR/BUILD.bazel
+++ b/service/LiDAR/BUILD.bazel
@@ -53,3 +53,13 @@ service_definitions(
     service = "LiDAR",
     visibility = ["//visibility:public"],
 )
+
+# Sources for //:csproj-test, which checks them against the .csproj file lists.
+filegroup(
+    name = "csproj-srcs",
+    srcs = glob([
+        "**/*.cs",
+        "**/*.csproj",
+    ]),
+    visibility = ["//:__pkg__"],
+)

--- a/service/RemoteTech/BUILD.bazel
+++ b/service/RemoteTech/BUILD.bazel
@@ -77,3 +77,13 @@ py_lint_test(
         "//tools/krpctest:krpctest_lib",
     ],
 )
+
+# Sources for //:csproj-test, which checks them against the .csproj file lists.
+filegroup(
+    name = "csproj-srcs",
+    srcs = glob([
+        "**/*.cs",
+        "**/*.csproj",
+    ]),
+    visibility = ["//:__pkg__"],
+)

--- a/service/SpaceCenter/BUILD.bazel
+++ b/service/SpaceCenter/BUILD.bazel
@@ -82,3 +82,13 @@ py_lint_test(
         "//tools/krpctest:krpctest_lib",
     ],
 )
+
+# Sources for //:csproj-test, which checks them against the .csproj file lists.
+filegroup(
+    name = "csproj-srcs",
+    srcs = glob([
+        "**/*.cs",
+        "**/*.csproj",
+    ]),
+    visibility = ["//:__pkg__"],
+)

--- a/service/UI/BUILD.bazel
+++ b/service/UI/BUILD.bazel
@@ -78,3 +78,13 @@ py_lint_test(
         "//tools/krpctest:krpctest_lib",
     ],
 )
+
+# Sources for //:csproj-test, which checks them against the .csproj file lists.
+filegroup(
+    name = "csproj-srcs",
+    srcs = glob([
+        "**/*.cs",
+        "**/*.csproj",
+    ]),
+    visibility = ["//:__pkg__"],
+)

--- a/tools/ServiceDefinitions/BUILD.bazel
+++ b/tools/ServiceDefinitions/BUILD.bazel
@@ -40,3 +40,13 @@ csharp_assembly_info(
         "//:__pkg__",  # Make visible to //:csproj-deps so it can copy AssemblyInfo.cs to generated_deps
     ],
 )
+
+# Sources for //:csproj-test, which checks them against the .csproj file lists.
+filegroup(
+    name = "csproj-srcs",
+    srcs = glob([
+        "**/*.cs",
+        "**/*.csproj",
+    ]),
+    visibility = ["//:__pkg__"],
+)

--- a/tools/TestServer/BUILD.bazel
+++ b/tools/TestServer/BUILD.bazel
@@ -128,3 +128,13 @@ csharp_binary(
     warning_level = 4,
     deps = exe_deps,
 )
+
+# Sources for //:csproj-test, which checks them against the .csproj file lists.
+filegroup(
+    name = "csproj-srcs",
+    srcs = glob([
+        "**/*.cs",
+        "**/*.csproj",
+    ]),
+    visibility = ["//:__pkg__"],
+)

--- a/tools/TestingTools/BUILD.bazel
+++ b/tools/TestingTools/BUILD.bazel
@@ -37,3 +37,13 @@ csharp_assembly_info(
         "//:__pkg__",  # Make visible to //:csproj-deps so it can copy AssemblyInfo.cs to generated_deps
     ],
 )
+
+# Sources for //:csproj-test, which checks them against the .csproj file lists.
+filegroup(
+    name = "csproj-srcs",
+    srcs = glob([
+        "**/*.cs",
+        "**/*.csproj",
+    ]),
+    visibility = ["//:__pkg__"],
+)

--- a/tools/build/BUILD.bazel
+++ b/tools/build/BUILD.bazel
@@ -2,6 +2,8 @@ load("@rules_python//python:defs.bzl", "py_binary")
 
 package(default_visibility = ["//visibility:public"])
 
+exports_files(["csproj_test.py"])
+
 py_binary(
     name = "run_and_stamp",
     srcs = ["run_and_stamp.py"],

--- a/tools/build/csproj_test.py
+++ b/tools/build/csproj_test.py
@@ -1,0 +1,92 @@
+"""Check that every C# source file is listed in its project's .csproj.
+
+The Bazel build globs its sources, so a .cs file that is missing from the .csproj
+still builds and tests clean here; only a `dotnet build` of KRPC.sln notices. This
+test closes that gap, and catches the stale entries (a .csproj naming a file that
+no longer exists) that break that build outright.
+
+It compares file lists rather than compiling, so it also catches divergences a
+build cannot see: a test fixture reached only by reflection is a compile-clean
+omission that silently drops the fixture from the solution's test assembly.
+"""
+
+import os
+import re
+import sys
+import xml.etree.ElementTree as ET
+
+# Project paths as listed in the solution, e.g.
+#     Project("{FAE0...}") = "KRPC.Core", "core\src\KRPC.Core.csproj", "{960F...}"
+SLN_PROJECT = re.compile(r'^Project\([^)]*\)\s*=\s*"[^"]*",\s*"([^"]*\.csproj)"', re.MULTILINE)
+
+# Sources outside the project directory: the generated AssemblyInfo.cs, pulled in
+# as $(bazel-bin)\..., and files shared with a sibling project via a relative path.
+# Neither can diverge from a glob of the project directory, so neither is checked.
+EXTERNAL_INCLUDE = re.compile(r"^\$\(|^\.\.")
+
+IGNORED_DIRS = {"obj", "bin"}
+
+
+def compile_includes(csproj):
+    """Return the project-relative paths the .csproj declares as <Compile Include>."""
+    declared = set()
+    for element in ET.parse(csproj).iter():
+        # Strip the MSBuild namespace that ElementTree keeps on the tag.
+        if element.tag.rsplit("}", 1)[-1] != "Compile":
+            continue
+        include = element.get("Include")
+        if include is None or EXTERNAL_INCLUDE.match(include):
+            continue
+        declared.add(os.path.normpath(include.replace("\\", "/")))
+    return declared
+
+
+def sources_on_disk(directory):
+    """Return the paths of the .cs files under a project directory, relative to it."""
+    found = set()
+    for dirpath, dirnames, filenames in os.walk(directory):
+        dirnames[:] = [d for d in dirnames if d not in IGNORED_DIRS]
+        for filename in filenames:
+            if filename.endswith(".cs"):
+                path = os.path.join(dirpath, filename)
+                found.add(os.path.normpath(os.path.relpath(path, directory)))
+    return found
+
+
+def main():
+    with open("KRPC.sln", encoding="utf-8") as f:
+        projects = [p.replace("\\", "/") for p in SLN_PROJECT.findall(f.read())]
+    if not projects:
+        sys.exit("no projects found in KRPC.sln")
+
+    errors = []
+    for csproj in sorted(projects):
+        # The sources reach this test through a per-package filegroup. A project
+        # added to the solution without one would otherwise be skipped silently.
+        if not os.path.exists(csproj):
+            errors.append(
+                "%s: not in the test's inputs -- add the package to the srcs of "
+                "//:csproj-test" % csproj
+            )
+            continue
+        declared = compile_includes(csproj)
+        found = sources_on_disk(os.path.dirname(csproj))
+        for path in sorted(found - declared):
+            errors.append(
+                "%s: %s exists but is not listed -- add "
+                '<Compile Include="%s" />' % (csproj, path, path.replace("/", "\\"))
+            )
+        for path in sorted(declared - found):
+            errors.append("%s: %s is listed but does not exist" % (csproj, path))
+
+    if errors:
+        print("\n".join(errors), file=sys.stderr)
+        sys.exit(
+            "\n%d problem(s) found. The Bazel build globs its sources, so these "
+            "break only `dotnet build KRPC.sln`." % len(errors)
+        )
+    print("checked %d projects" % len(projects))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Every C# project lists its sources explicitly, but the Bazel build globs them, so a source file missing from a `.csproj` builds and tests clean locally and breaks only the `build-csharp-sln` CI job. That job is the sole check, and it is a compile, which turns out not to be enough.

**Root cause.** `core/test/Service/TestServiceDeprecated.cs` has been missing from `KRPC.Core.Test.csproj` since it was added, and nothing noticed. The scanner tests reach that service only by name, through reflection over the assembly, so no code references the type at compile time: the solution builds clean and the CI job passes. The only symptom is that the solution's test assembly silently lacks the fixture, so `ScannerTest` fails two tests when the suite is run from the solution rather than through Bazel.

**Fix.** Add the missing `<Compile Include>`, and add `//:csproj-test` to stop the class of bug rather than this instance. It reads the project list from `KRPC.sln` and diffs each `.csproj` file list against the files on disk, in both directions — a stale entry naming a deleted file breaks the solution build outright, so it is worth catching too. Comparing file lists rather than compiling is the point: it needs no .NET SDK, runs in a tenth of a second, and catches exactly the reflection-only omission above that a build cannot see.

The test is in `//:test`, so it runs locally with everything else, and in `build-csharp-sln` after the build.

**Reaching the sources.** Bazel globs do not descend into subpackages, so a root-level target cannot see `core/src/*.cs` on its own; the sources arrive through a per-package `csproj-srcs` filegroup listed in the test's `data`. That is boilerplate a new C# project has to remember, which is a weaker version of the problem being fixed, so the test enumerates projects from `KRPC.sln` and fails on any whose sources are absent from its inputs rather than skipping it quietly.

**Testing.** Verified the test fails on a missing entry and on a stale one, and passes once both are restored; re-ran it after rebasing onto the current `main`.