### PR TITLE
Add crew-to-part relationships

### DIFF
--- a/doc/order.txt
+++ b/doc/order.txt
@@ -552,6 +552,7 @@ SpaceCenter.CrewMember.Veteran
 SpaceCenter.CrewMember.Trait
 SpaceCenter.CrewMember.Gender
 SpaceCenter.CrewMember.RosterStatus
+SpaceCenter.CrewMember.Part
 SpaceCenter.CrewMember.SuitType
 SpaceCenter.CrewMember.CareerLogFlights
 SpaceCenter.CrewMember.CareerLogTypes
@@ -667,6 +668,8 @@ SpaceCenter.Part.ThermalConvectionFlux
 SpaceCenter.Part.ThermalRadiationFlux
 SpaceCenter.Part.ThermalInternalFlux
 SpaceCenter.Part.ThermalSkinToInternalFlux
+SpaceCenter.Part.CrewCapacity
+SpaceCenter.Part.Crew
 SpaceCenter.Part.AvailableSeats
 SpaceCenter.Part.Resources
 SpaceCenter.Part.Crossfeed

--- a/service/SpaceCenter/CHANGES.txt
+++ b/service/SpaceCenter/CHANGES.txt
@@ -224,6 +224,7 @@ v0.6.0
  * Fix part module field values being formatted using the machine's locale, so that
    Module.Fields, Module.GetField and PartField.Value returned numbers that clients running
    under a locale that writes decimals with a comma could not parse
+ * Add CrewMember.Part and per-part CrewCapacity and Crew properties
 
 v0.5.4
  * Fix vessel recovery (#782)

--- a/service/SpaceCenter/src/Services/CrewMember.cs
+++ b/service/SpaceCenter/src/Services/CrewMember.cs
@@ -1,3 +1,4 @@
+using KRPC.Service;
 using KRPC.Service.Attributes;
 using KRPC.SpaceCenter.ExtensionMethods;
 using KRPC.Utils;
@@ -139,6 +140,29 @@ namespace KRPC.SpaceCenter.Services
         [KRPCProperty]
         public RosterStatus RosterStatus {
             get { return (RosterStatus)InternalCrewMember.rosterStatus; }
+        }
+
+        /// <summary>
+        /// The part containing the crew member. Returns <c>null</c> if the crew member is not
+        /// occupying a part, or the vessel containing the part is not loaded.
+        /// </summary>
+        [KRPCProperty (Nullable = true, GameScene = GameScene.Flight)]
+        public Parts.Part Part {
+            get {
+                var crewMember = InternalCrewMember;
+                if (crewMember == null)
+                    return null;
+                var seat = crewMember.seat;
+                var part = seat == null ? null : seat.part;
+                if (part == null || !part.protoModuleCrew.Contains (crewMember)) {
+                    // The seat is null when the part's IVA model is not instantiated, but the
+                    // part's crew manifest remains available.
+                    part = FlightGlobals.VesselsLoaded
+                        .SelectMany (vessel => vessel.parts)
+                        .FirstOrDefault (candidate => candidate.protoModuleCrew.Contains (crewMember));
+                }
+                return part == null ? null : new Parts.Part (part);
+            }
         }
 
         /// <summary>

--- a/service/SpaceCenter/src/Services/Parts/Part.cs
+++ b/service/SpaceCenter/src/Services/Parts/Part.cs
@@ -403,6 +403,22 @@ namespace KRPC.SpaceCenter.Services.Parts
         }
 
         /// <summary>
+        /// The number of crew members that can occupy the part.
+        /// </summary>
+        [KRPCProperty]
+        public int CrewCapacity {
+            get { return InternalPart.CrewCapacity; }
+        }
+
+        /// <summary>
+        /// The crew members occupying the part.
+        /// </summary>
+        [KRPCProperty]
+        public IList<CrewMember> Crew {
+            get { return InternalPart.protoModuleCrew.Select (x => new CrewMember (x)).ToList (); }
+        }
+
+        /// <summary>
         /// How many open seats the part has.
         /// </summary>
         [KRPCProperty]

--- a/service/SpaceCenter/test/test_vessel.py
+++ b/service/SpaceCenter/test/test_vessel.py
@@ -187,6 +187,16 @@ class TestVessel(krpctest.TestCase):
         self.assertTrue(crew_member.name.endswith(" Kerman"))
         self.assertEqual(self.space_center.CrewMemberType.crew, crew_member.type)
         self.assertTrue(crew_member.on_mission)
+        part = crew_member.part
+        self.assertIsNotNone(part)
+        self.assertEqual(1, part.crew_capacity)
+        self.assertEqual([crew_member], part.crew)
+        crewless_part = next(
+            candidate
+            for candidate in self.vessel.parts.all
+            if candidate.crew_capacity == 0
+        )
+        self.assertEqual([], crewless_part.crew)
         # pylint: disable=pointless-statement
         crew_member.courage
         # pylint: disable=pointless-statement


### PR DESCRIPTION
This makes it easier to determine exactly where crew members are located within a vessel, rather than only seeing the vessel-wide crew list.

It adds:
- `CrewMember.Part`, returning the containing part when available
- `Part.CrewCapacity`
- `Part.Crew`, listing the crew currently occupying the part

It also includes integration coverage for crewed and crewless parts.

## Suggested Changelog Entry

* Add CrewMember.Part and per-part CrewCapacity and Crew properties