### PR TITLE
Cnano client fixes

### DIFF
--- a/client/cnano/BUILD.bazel
+++ b/client/cnano/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test")
 load("//:config.bzl", "cmake_version", "version")
 load("//tools/build:client_test.bzl", "client_test")
 load("//tools/build:cpp.bzl", "clang_format_test", "clang_tidy_test")
@@ -152,9 +152,33 @@ cc_library(
 test_suite(
     name = "test",
     tests = [
+        ":arduino",
         ":client",
         ":lint",
     ],
+)
+
+# Builds the Arduino communication backend for the host, against a stand-in for the Arduino
+# HardwareSerial class, so it can be tested without hardware. It deliberately does not depend
+# on krpc_cnano, whose copy of communication.c is built for the host platform instead and
+# defines the same functions.
+cc_test(
+    name = "arduino",
+    size = "small",
+    srcs = [
+        "include/krpc_cnano/communication.h",
+        "include/krpc_cnano/error.h",
+        "src/communication.c",
+        "test/arduino/HardwareSerial.h",
+        "test/arduino/test_communication_arduino.cpp",
+    ],
+    copts = ["-xc++"],
+    includes = [
+        "include",
+        "test/arduino",
+    ],
+    local_defines = ["ARDUINO"],
+    deps = ["@cpp_googletest//:gtest"],
 )
 
 client_test(

--- a/client/cnano/BUILD.bazel
+++ b/client/cnano/BUILD.bazel
@@ -198,12 +198,25 @@ test_srcs = glob([
     "test/*.hpp",
 ]) + [":services-test-service"]
 
+# The tests are built with server error messages enabled, so that they cover decoding them. The
+# default build, with them disabled, is covered by the krpc_cnano library itself.
+cc_library(
+    name = "krpc_cnano_error_messages",
+    testonly = True,
+    srcs = srcs + [":protobuf"],
+    hdrs = hdrs + [":protobuf"],
+    defines = ["KRPC_ERROR_MESSAGES"],
+    includes = ["include"],
+    deps = ["@c_nanopb//:nanopb"],
+)
+
 cc_binary(
     name = "cnanotest",
+    testonly = True,
     srcs = test_srcs,
     includes = ["test"],
     deps = [
-        ":krpc_cnano",
+        ":krpc_cnano_error_messages",
         "@cpp_googletest//:gmock",
         "@cpp_googletest//:gtest",
     ],

--- a/client/cnano/CHANGES.txt
+++ b/client/cnano/CHANGES.txt
@@ -12,6 +12,15 @@ v0.6.0
  * Mark deprecated functions with the KRPC_DEPRECATED attribute macro (#904)
  * Generated functions are now defined as static inline, so the generated
    service headers can be safely included from multiple translation units
+ * **Breaking:** On Arduino, a read now fails with KRPC_ERROR_EOF when the serial timeout
+   elapses without a single byte being received, instead of retrying forever and hanging the
+   sketch when the server goes away. The timeout applies to each byte, so a slow but
+   progressing reply is unaffected; use Serial.setTimeout to control how long to wait
+ * Add the KRPC_ERROR_MESSAGES option, which captures the message describing an error returned
+   by the server so that it can be read using krpc_get_error_message. Without it every server
+   error is indistinguishable, as they all return KRPC_ERROR_RPC_FAILED
+ * Fix corruption of received data on POSIX systems when a serial read returns fewer bytes than
+   were asked for
 
 v0.5.2
  * The arduino compatible version of the library now uses the same "krpc_cnano/..." include directory as the version released on GitHub.

--- a/client/cnano/include/krpc_cnano/error.h
+++ b/client/cnano/include/krpc_cnano/error.h
@@ -22,6 +22,24 @@ typedef enum {
 /* Convert an error code to a string */
 const char* krpc_get_error(krpc_error_t error);
 
+/* Messages describing errors returned by the server.
+ * When KRPC_ERROR_MESSAGES is defined, an error returned by the server is captured into a fixed
+ * size buffer as it is decoded, and can be retrieved using krpc_get_error_message. This costs
+ * KRPC_ERROR_MESSAGE_LENGTH bytes of static storage. When it is not defined nothing is stored
+ * and the message is discarded as it is decoded, so every server error is only distinguishable
+ * as KRPC_ERROR_RPC_FAILED.
+ */
+#ifdef KRPC_ERROR_MESSAGES
+#ifndef KRPC_ERROR_MESSAGE_LENGTH
+#define KRPC_ERROR_MESSAGE_LENGTH 256
+#endif
+
+/* Get the message for the most recent error returned by the server, or an empty string if there
+ * has not been one. Formatted as "service.name: description", followed by the stack trace when
+ * the server is sending them, and truncated to fit KRPC_ERROR_MESSAGE_LENGTH. */
+const char* krpc_get_error_message(void);
+#endif
+
 /* Print an error message when it occurs */
 #if !defined(KRPC_PRINT_ERROR)
 #ifdef KRPC_PRINT_ERRORS_TO_STDERR

--- a/client/cnano/src/communication.c
+++ b/client/cnano/src/communication.c
@@ -103,11 +103,17 @@ krpc_error_t krpc_close(krpc_connection_t connection) {
 }
 
 krpc_error_t krpc_read(krpc_connection_t connection, uint8_t* buf, size_t count) {
-  size_t read = 0;
-  while (true) {
-    read += connection->readBytes(buf + read, count - read);
-    if (read == count) return KRPC_OK;
+  size_t total = 0;
+  while (total < count) {
+    // A serial link has no end-of-file, so the only sign the peer has gone is silence.
+    // readBytes waits up to the serial timeout for each byte, so it returns nothing only
+    // when not a single byte arrived in that time; a slow but progressing stream keeps
+    // going. Use Serial.setTimeout to control how long to wait before giving up.
+    size_t result = connection->readBytes(buf + total, count - total);
+    if (result == 0) KRPC_RETURN_ERROR(EOF, "eof received");
+    total += result;
   }
+  return KRPC_OK;
 }
 
 krpc_error_t krpc_write(krpc_connection_t connection, const uint8_t* buf, size_t count) {

--- a/client/cnano/src/communication.c
+++ b/client/cnano/src/communication.c
@@ -23,7 +23,7 @@ krpc_error_t krpc_close(krpc_connection_t connection) {
 krpc_error_t krpc_read(krpc_connection_t connection, uint8_t* buf, size_t count) {
   size_t total = 0;
   while (total < count) {
-    ssize_t result = read(connection, buf, count);
+    ssize_t result = read(connection, buf + total, count - total);
     if (result == -1) {
       KRPC_RETURN_ERROR(IO, "read failed");
     } else if (result == 0) {

--- a/client/cnano/src/krpc.c
+++ b/client/cnano/src/krpc.c
@@ -6,6 +6,9 @@
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
+#ifdef KRPC_ERROR_MESSAGES
+#include <string.h>
+#endif
 
 static bool write_callback(pb_ostream_t *stream, const uint8_t *buf, size_t count);
 static bool read_callback(pb_istream_t *stream, uint8_t *buf, size_t count);
@@ -45,10 +48,60 @@ krpc_error_t krpc_connect(krpc_connection_t connection, const char *client_name)
   return KRPC_OK;
 }
 
+#ifdef KRPC_ERROR_MESSAGES
+
+static char krpc_error_message[KRPC_ERROR_MESSAGE_LENGTH];
+
+const char *krpc_get_error_message(void) { return krpc_error_message; }
+
+/* Append to the error message, discarding whatever does not fit */
+static void krpc_append_error_message(const char *str, size_t length) {
+  size_t used = strlen(krpc_error_message);
+  size_t space = KRPC_ERROR_MESSAGE_LENGTH - used - 1;
+  if (length > space) length = space;
+  memcpy(krpc_error_message + used, str, length);
+  krpc_error_message[used + length] = '\0';
+}
+
+/* Decode one of the string fields of an error message onto the end of the error message,
+ * preceded by the separator passed as arg. The separator is skipped when nothing has been
+ * appended yet, so that fields the server left empty do not leave stray punctuation behind.
+ * The string is copied in chunks to avoid needing a buffer as large as the field. */
+static bool krpc_decode_callback_error_string(pb_istream_t *stream, const pb_field_t *field,
+                                              void **arg) {
+  (void)field;
+  if (stream->bytes_left == 0) return true;
+  if (krpc_error_message[0] != '\0') {
+    const char *separator = (const char *)(*arg);
+    krpc_append_error_message(separator, strlen(separator));
+  }
+  char chunk[32];
+  while (stream->bytes_left > 0) {
+    size_t size = stream->bytes_left < sizeof(chunk) ? stream->bytes_left : sizeof(chunk);
+    if (!pb_read(stream, (pb_byte_t *)chunk, size))
+      KRPC_CALLBACK_RETURN_STREAM_ERROR("failed to decode error message field", stream);
+    krpc_append_error_message(chunk, size);
+  }
+  return true;
+}
+
+#endif
+
 static bool krpc_decode_callback_error(pb_istream_t *stream, const pb_field_t *field, void **arg) {
   krpc_error_t *error_code = (krpc_error_t *)(*arg);
   *error_code = KRPC_ERROR_RPC_FAILED;
   krpc_schema_Error error = krpc_schema_Error_init_default;
+#ifdef KRPC_ERROR_MESSAGES
+  krpc_error_message[0] = '\0';
+  error.service.funcs.decode = &krpc_decode_callback_error_string;
+  error.service.arg = (void *)"";
+  error.name.funcs.decode = &krpc_decode_callback_error_string;
+  error.name.arg = (void *)".";
+  error.description.funcs.decode = &krpc_decode_callback_error_string;
+  error.description.arg = (void *)": ";
+  error.stack_trace.funcs.decode = &krpc_decode_callback_error_string;
+  error.stack_trace.arg = (void *)"\nServer stack trace:\n";
+#endif
   if (!pb_decode(stream, krpc_schema_Error_fields, &error))
     KRPC_RETURN_STREAM_ERROR(DECODING_FAILED, "failed to decode error message", stream);
   return true;
@@ -87,7 +140,13 @@ krpc_error_t krpc_invoke(krpc_connection_t connection, krpc_schema_ProcedureResu
     if (!pb_decode_delimited(&istream, krpc_schema_MultiplexedResponse_fields, &m_response))
       KRPC_RETURN_STREAM_ERROR(DECODING_FAILED, "failed to decode response message", &istream);
 
-    if (rpc_error != KRPC_OK) KRPC_RETURN_ERROR(RPC_FAILED, "rpc returned an error");
+    if (rpc_error != KRPC_OK) {
+#ifdef KRPC_ERROR_MESSAGES
+      KRPC_RETURN_ERROR(RPC_FAILED, krpc_get_error_message());
+#else
+      KRPC_RETURN_ERROR(RPC_FAILED, "rpc returned an error");
+#endif
+    }
 
     // Extract the procedure result message from the response
     krpc_schema_Response *response = &m_response.response;

--- a/client/cnano/test/arduino/HardwareSerial.h
+++ b/client/cnano/test/arduino/HardwareSerial.h
@@ -1,0 +1,53 @@
+#pragma once
+
+#include <stddef.h>
+#include <stdint.h>
+
+#define SERIAL_8N1 0x06
+
+/* Minimal stand-in for the Arduino HardwareSerial class, enough to exercise the Arduino
+   communication backend on the host. Reads are scripted: data holds the bytes available to be
+   read and chunks gives the number of them each successive call to readBytes hands back, where
+   0 means the serial timeout expired without a single byte arriving.
+
+   Kept free of the C++ standard library, as this header is included by the backend itself when
+   it is compiled, and as the Arduino platform does not provide it either. */
+class HardwareSerial {
+ public:
+  HardwareSerial(const uint8_t* data, size_t data_size, const size_t* chunks, size_t num_chunks)
+      : data(data), data_size(data_size), chunks(chunks), num_chunks(num_chunks) {}
+
+  void begin(uint32_t speed, uint8_t config) {
+    (void)speed;
+    (void)config;
+  }
+
+  void end() {}
+
+  operator bool() const { return true; }
+
+  size_t readBytes(uint8_t* buf, size_t count) {
+    size_t n = chunk < num_chunks ? chunks[chunk++] : 0;
+    if (n > count) n = count;
+    if (n > data_size - position) n = data_size - position;
+    for (size_t i = 0; i < n; i++) buf[i] = data[position++];
+    return n;
+  }
+
+  size_t write(const uint8_t* buf, size_t count) {
+    for (size_t i = 0; i < count && num_written < sizeof(written); i++)
+      written[num_written++] = buf[i];
+    return count;
+  }
+
+  uint8_t written[64];
+  size_t num_written = 0;
+
+ private:
+  const uint8_t* data;
+  size_t data_size;
+  const size_t* chunks;
+  size_t num_chunks;
+  size_t position = 0;
+  size_t chunk = 0;
+};

--- a/client/cnano/test/arduino/test_communication_arduino.cpp
+++ b/client/cnano/test/arduino/test_communication_arduino.cpp
@@ -1,0 +1,44 @@
+#include <krpc_cnano/communication.h>
+
+#include "gtest/gtest.h"
+
+static const uint8_t data[] = {1, 2, 3, 4, 5, 6, 7, 8};
+
+TEST(test_communication_arduino, test_read) {
+  const size_t chunks[] = {8};
+  HardwareSerial serial(data, sizeof(data), chunks, 1);
+
+  uint8_t buf[8] = {0};
+  ASSERT_EQ(KRPC_OK, krpc_read(&serial, buf, sizeof(buf)));
+  for (size_t i = 0; i < sizeof(buf); i++) ASSERT_EQ(data[i], buf[i]);
+}
+
+// A read that returns fewer bytes than requested must resume at the point the previous one
+// finished, rather than restarting at the beginning of the buffer.
+TEST(test_communication_arduino, test_read_partial) {
+  const size_t chunks[] = {3, 5};
+  HardwareSerial serial(data, sizeof(data), chunks, 2);
+
+  uint8_t buf[8] = {0};
+  ASSERT_EQ(KRPC_OK, krpc_read(&serial, buf, sizeof(buf)));
+  for (size_t i = 0; i < sizeof(buf); i++) ASSERT_EQ(data[i], buf[i]);
+}
+
+// A read that returns nothing means the serial timeout elapsed without a single byte
+// arriving, which is as close to a disconnect as a serial link gets. It must fail rather than
+// retry forever.
+TEST(test_communication_arduino, test_read_timeout) {
+  const size_t chunks[] = {2, 0};
+  HardwareSerial serial(data, sizeof(data), chunks, 2);
+
+  uint8_t buf[4] = {0};
+  ASSERT_EQ(KRPC_ERROR_EOF, krpc_read(&serial, buf, sizeof(buf)));
+}
+
+TEST(test_communication_arduino, test_write) {
+  HardwareSerial serial(data, sizeof(data), NULL, 0);
+
+  ASSERT_EQ(KRPC_OK, krpc_write(&serial, data, sizeof(data)));
+  ASSERT_EQ(sizeof(data), serial.num_written);
+  for (size_t i = 0; i < sizeof(data); i++) ASSERT_EQ(data[i], serial.written[i]);
+}

--- a/client/cnano/test/server_test.hpp
+++ b/client/cnano/test/server_test.hpp
@@ -1,6 +1,19 @@
 #pragma once
 
+#include <gmock/gmock.h>
 #include <krpc_cnano.h>
+
+// Check the message for the last error returned by the server, when the client is built with
+// support for them. Only the start of the message is compared, as the server also sends a stack
+// trace, which is truncated to fit the message buffer.
+#ifdef KRPC_ERROR_MESSAGES
+#define ASSERT_ERROR_MESSAGE(expected) \
+  ASSERT_THAT(krpc_get_error_message(), testing::StartsWith(expected))
+#else
+#define ASSERT_ERROR_MESSAGE(expected) \
+  do {                                 \
+  } while (false)
+#endif
 
 class server_test : public ::testing::Test {
  public:

--- a/client/cnano/test/test_client.cpp
+++ b/client/cnano/test/test_client.cpp
@@ -389,25 +389,30 @@ TEST_F(test_client, test_collections_of_objects) {
 TEST_F(test_client, test_invalid_operation_exception) {
   int32_t value;
   ASSERT_EQ(KRPC_ERROR_RPC_FAILED, krpc_TestService_ThrowInvalidOperationException(conn, &value));
+  ASSERT_ERROR_MESSAGE("KRPC.InvalidOperationException: Invalid operation");
 }
 
 TEST_F(test_client, test_argument_exception) {
   int32_t value;
   ASSERT_EQ(KRPC_ERROR_RPC_FAILED, krpc_TestService_ThrowArgumentException(conn, &value));
+  ASSERT_ERROR_MESSAGE("KRPC.ArgumentException: Invalid argument");
 }
 
 TEST_F(test_client, test_argument_null_exception) {
   int32_t value;
   ASSERT_EQ(KRPC_ERROR_RPC_FAILED, krpc_TestService_ThrowArgumentNullException(conn, &value, ""));
+  ASSERT_ERROR_MESSAGE("KRPC.ArgumentNullException: ");
 }
 
 TEST_F(test_client, test_argument_out_of_range_exception) {
   int32_t value;
   ASSERT_EQ(KRPC_ERROR_RPC_FAILED,
             krpc_TestService_ThrowArgumentOutOfRangeException(conn, &value, 0));
+  ASSERT_ERROR_MESSAGE("KRPC.ArgumentOutOfRangeException: ");
 }
 
 TEST_F(test_client, test_custom_exception) {
   int32_t value;
   ASSERT_EQ(KRPC_ERROR_RPC_FAILED, krpc_TestService_ThrowCustomException(conn, &value));
+  ASSERT_ERROR_MESSAGE("TestService.CustomException: A custom kRPC exception");
 }

--- a/client/cnano/test/test_communication.cpp
+++ b/client/cnano/test/test_communication.cpp
@@ -1,0 +1,49 @@
+#include <krpc_cnano/communication.h>
+
+#include "gtest/gtest.h"
+
+#if defined(KRPC_COMMUNICATION_POSIX)
+
+#include <unistd.h>
+
+#include <chrono>
+#include <thread>
+
+// A read that returns fewer bytes than requested must resume at the point the previous one
+// finished, rather than restarting at the beginning of the buffer.
+TEST(test_communication, test_read_partial) {
+  int fds[2];
+  ASSERT_EQ(0, pipe(fds));
+
+  const uint8_t data[] = {1, 2, 3, 4, 5, 6, 7, 8};
+  ASSERT_EQ(3, write(fds[1], data, 3));
+
+  // Supply the remainder only once the reader is blocked, so that the first read is short
+  std::thread writer([&fds, &data]() {
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    EXPECT_EQ(5, write(fds[1], data + 3, 5));
+  });
+
+  uint8_t buf[8] = {0};
+  krpc_error_t error = krpc_read(fds[0], buf, sizeof(buf));
+  writer.join();
+  close(fds[0]);
+  close(fds[1]);
+
+  ASSERT_EQ(KRPC_OK, error);
+  for (size_t i = 0; i < sizeof(buf); i++) ASSERT_EQ(data[i], buf[i]);
+}
+
+TEST(test_communication, test_read_eof) {
+  int fds[2];
+  ASSERT_EQ(0, pipe(fds));
+  close(fds[1]);
+
+  uint8_t buf[4] = {0};
+  krpc_error_t error = krpc_read(fds[0], buf, sizeof(buf));
+  close(fds[0]);
+
+  ASSERT_EQ(KRPC_ERROR_EOF, error);
+}
+
+#endif

--- a/doc/src/cnano/client.rst
+++ b/doc/src/cnano/client.rst
@@ -92,6 +92,12 @@ argument to the compiler.
 
   * ``KRPC_PRINT_ERRORS_TO_STDERR`` -- enables printing of a descriptive error message to stderr
     when an error occurs
+  * ``KRPC_ERROR_MESSAGES`` -- captures the message describing an error returned by the server,
+    which can then be read using :func:`krpc_get_error_message`. Without this every server error
+    is indistinguishable, as they all return :macro:`KRPC_ERROR_RPC_FAILED`. Enabling it costs
+    ``KRPC_ERROR_MESSAGE_LENGTH`` bytes of static storage.
+  * ``KRPC_ERROR_MESSAGE_LENGTH`` -- the size of the buffer used to store the message described
+    above, defaulting to 256 bytes. Longer messages are truncated to fit.
   * ``PB_NO_ERRMSG`` -- disables error messages in the nanopb library, which kRPC uses to
     communicate with the server. Enabled by default in the Arduino version of the library.
 
@@ -305,3 +311,14 @@ Client API Reference
 .. function:: const char * krpc_get_error(krpc_error_t error)
 
    Returns a descriptive string for the given error code.
+
+.. function:: const char * krpc_get_error_message(void)
+
+   Returns the message describing the most recent error returned by the server, or an empty
+   string if there has not been one. It is formatted as ``service.name: description``, for
+   example ``SpaceCenter.InvalidOperationException: Vessel does not exist``, followed by the
+   server stack trace when the server is configured to send one, and is truncated to fit
+   ``KRPC_ERROR_MESSAGE_LENGTH``.
+
+   This function is only available when the library is built with ``KRPC_ERROR_MESSAGES``
+   defined, as storing the message is not free.

--- a/doc/src/cnano/client.rst
+++ b/doc/src/cnano/client.rst
@@ -243,6 +243,14 @@ Client API Reference
      config.config = SERIAL_5N1;
      krpc_open(&conn, &config);
 
+   .. note::
+
+     A serial connection has no end-of-file, so on Arduino a read fails with
+     :macro:`KRPC_ERROR_EOF` when the serial timeout elapses without a single byte arriving.
+     This timeout is one second by default and applies to each byte, so a slow but progressing
+     reply never trips it. If the server can take longer than this to start replying, raise the
+     timeout with ``Serial.setTimeout`` before calling :func:`krpc_open`.
+
 .. function:: krpc_error_t krpc_connect(krpc_connection_t connection, const char * name)
 
    Connect to a kRPC server.


### PR DESCRIPTION
Three independent fixes to the cnano client.

**Short reads on POSIX.** The POSIX `krpc_read` loop passed the whole buffer and count to every `read()` call, so a read returning fewer bytes than requested restarted at the beginning of the buffer, overwriting bytes already received, while the running total counted them as progress. The Windows backend already offsets correctly. Fixed by advancing the buffer pointer and remaining count as bytes arrive.

**Arduino reads never giving up.** The Arduino `krpc_read` looped until it had every byte it asked for, with no exit for a read that returned nothing, so a server that went away left the sketch spinning until reset. A serial link has no end-of-file, but `readBytes` waits up to the serial timeout for each byte, so returning nothing means nothing arrived in that time, while a slow but progressing reply keeps going. That case now returns `KRPC_ERROR_EOF`, matching the POSIX and Windows backends and the other clients. This is a behavior change for sketches relying on the old wait-forever behavior, hence the breaking marker in the changelog; `Serial.setTimeout` controls how long to wait and is now documented.

**Server error messages.** The decoded `Error` message was discarded in full, collapsing every server-side failure to `KRPC_ERROR_RPC_FAILED` with no way to tell any two apart. Surfacing it unconditionally is not wanted on a memory constrained target, so it is opt-in: defining `KRPC_ERROR_MESSAGES` captures the error into a static buffer of `KRPC_ERROR_MESSAGE_LENGTH` bytes, formatted as `service.name: description` plus the stack trace when the server sends one, and readable using `krpc_get_error_message`. The fields are copied in chunks as they are decoded, so nothing scales with the size of the message. Left undefined, the string field callbacks stay null and the message is skipped exactly as before.

**Testing.** New unit tests cover each fix: a short read forced over a pipe by supplying the remainder only once the reader has blocked, plus the EOF path; the Arduino backend built for the host against a stand-in for `HardwareSerial`, covering reads, short reads, the timeout and writes; and assertions on the captured message for each of the exceptions the test service throws, with the client tests built with `KRPC_ERROR_MESSAGES` enabled.
