### PR TITLE
Lua client fixes

### DIFF
--- a/client/lua/CHANGES.txt
+++ b/client/lua/CHANGES.txt
@@ -2,6 +2,11 @@ v0.6.0
  * Fix attributes module to always return boolean for is_a_class_member and is_a_class_property_accessor
  * Fix service, method and property names being converted to snake case using the machine's
    locale, which renamed every member the client exposes under Turkish locales
+ * Calling a procedure with an argument that needs coercing no longer leaves a global named
+   ok behind (#1003)
+ * Remove encoder.client_name, which raised an error whatever it was passed, as the length it
+   padded names to was never defined. It was a leftover from before the protocol used
+   protocol buffers (#1003)
 
 v0.5.0
  * Update to protobuf v3.22.0

--- a/client/lua/krpc/client.lua
+++ b/client/lua/krpc/client.lua
@@ -75,6 +75,9 @@ function Client:_build_request(service, procedure, args, param_names, param_type
       valid = typ.lua_type:class_of(value)
     end
     if not valid then
+      -- Only ok is declared here; value is the loop variable and must stay so, as the
+      -- coerced value is read below, outside this block
+      local ok
       ok,value = pcall(self._types.coerce_to, self._types, value, typ)
       if not ok then
         error(string.format('%s.%s() argument %d must be a %s, got a %s', service, procedure, i, typ.lua_type, type(value)))

--- a/client/lua/krpc/encoder.lua
+++ b/client/lua/krpc/encoder.lua
@@ -68,12 +68,6 @@ local function _encode_value(x, typ)
   error('Failed to encode data')
 end
 
-function encoder.client_name(name)
-  name = name or ''
-  name = name:sub(1, encoder.CLIENT_NAME_LENGTH)
-  return name .. string.rep('\0', encoder.CLIENT_NAME_LENGTH - name:len())
-end
-
 function encoder.encode(x, typ)
   if typ:is_a(Types.MessageType) then
     return x:SerializeToString()

--- a/client/lua/krpc/test/test_client.lua
+++ b/client/lua/krpc/test/test_client.lua
@@ -187,6 +187,14 @@ function TestClient:test_collections()
   luaunit.assertError(self.conn.test_service.increment_dictionary, Types.none)
 end
 
+function TestClient:test_coercion_does_not_leak_a_global()
+  -- Coercing an argument, as passing a plain table where a list is expected does, must
+  -- not leave the status of its pcall behind in the global namespace
+  rawset(_G, 'ok', nil)
+  luaunit.assertEquals(List{1,2,3}, self.conn.test_service.increment_list({0,1,2}))
+  luaunit.assertNil(rawget(_G, 'ok'))
+end
+
 function TestClient:test_nested_collections()
   luaunit.assertEquals(Map{}, self.conn.test_service.increment_nested_collection(Map{}))
   luaunit.assertEquals(Map{a=List{1, 2}, b=List{}, c=List{3}},

--- a/client/lua/krpc/types.lua
+++ b/client/lua/krpc/types.lua
@@ -349,7 +349,7 @@ function Types.EnumerationType:_init(protobuf_type)
 end
 
 function Types.EnumerationType:set_values(values)
-  self.lua_type = _create_enum_type(self._service_name, self._enum_name, values)
+  self.lua_type = _create_enum_type(self._service_name, self._class_name, values)
 end
 
 Types.TupleType = class(Types.TypeBase)


### PR DESCRIPTION
Three unrelated defects in the Lua client, each fixed in its own commit.

**Global leak when coercing an argument.** The result of the pcall that coerces an argument was assigned to an undeclared `ok`, making it a global, so every call needing a coercion wrote to and left a value in the global namespace. Only `ok` is now declared local: the value it is assigned alongside is the loop variable holding the argument and has to stay that way, since declaring both would scope a new local to the branch and the coerced value is read after it — the argument would then be silently sent uncoerced. A comment records this.

**Broken `encoder.client_name`.** It padded a name to `encoder.CLIENT_NAME_LENGTH`, which is never defined, so the function raised an error whatever it was passed. It is a leftover from before the protocol used protocol buffers and nothing calls it, so it is removed.

**Enumeration name never passed to its Lua type.** `set_values` passed `self._enum_name`, which is never assigned; the field set when the type is constructed is `_class_name`, so the name reaching `_create_enum_type` was always nil. This is harmless today only because that function ignores the service and class names it is given and uses only the values, hence no changelog entry.

**Testing.** New `test_coercion_does_not_leak_a_global` in the Lua client tests passes a plain table where a list is expected, which is a coercion that succeeds, and asserts no global `ok` is left behind. Passing a list where a tuple is expected does not exercise this, as a tuple's Lua type is `List`, so the argument is already considered valid and no coercion is attempted.