### PR TITLE
Fix stream handling and error reporting in the Java client

### DIFF
--- a/client/java/CHANGES.txt
+++ b/client/java/CHANGES.txt
@@ -3,6 +3,18 @@ v0.6.0
  * Update dependencies: guava 33.4.8-jre, antlr4-runtime 4.13.2
  * Mark deprecated members with the @Deprecated annotation and an @deprecated javadoc tag (#904)
  * Reduce copying when encoding values
+ * Fix Stream.getRate always returning zero, whatever the rate had been set to (#1004)
+ * Fix looking up the method to stream or call: a method name built at runtime is now matched
+   the same as a literal one, and the arguments are checked against the parameters of each
+   candidate, so a mismatch is reported instead of resolving to any method taking the same
+   number of arguments and failing later while encoding (#1004)
+ * An exception thrown by a stream or event callback no longer ends the stream update thread,
+   which stopped every stream and event on the connection from updating again. It is passed to
+   the thread's uncaught exception handler and the remaining callbacks still run (#1004)
+ * Fix a deadlock between the stream update thread and a thread waiting for an update while
+   holding a stream or event condition, as waiting for one requires (#1004)
+ * An error from a service with no generated stubs loaded now raises an RPCException describing
+   it, instead of a NullPointerException raised while building the exception for it (#1004)
 
 v0.5.0
  * Update to protobuf v3.22.0

--- a/client/java/src/krpc/client/Connection.java
+++ b/client/java/src/krpc/client/Connection.java
@@ -301,13 +301,21 @@ public class Connection implements AutoCloseable {
         throw new IndexOutOfBoundsException(message);
       }
       Class<?> exnType = exceptionTypes.get(key);
-      Constructor<?>[] ctors = exnType.getDeclaredConstructors();
       Constructor<?> ctor = null;
-      for (int i = 0; i < ctors.length; i++) {
-        ctor = ctors[i];
-        if (ctor.getParameterTypes().length == 1) {
-          break;
+      if (exnType != null) {
+        for (Constructor<?> candidate : exnType.getDeclaredConstructors()) {
+          if (candidate.getParameterTypes().length == 1) {
+            ctor = candidate;
+            break;
+          }
         }
+      }
+      if (ctor == null) {
+        // The type is unknown here if the service it belongs to has no generated stubs loaded,
+        // and has no usable constructor if it was not generated as an exception type. Report
+        // the error itself, named by its type on the server, rather than the failure to build
+        // an exception for it, which would say nothing about what actually went wrong.
+        throw new RPCException(key + ": " + message);
       }
       try {
         ctor.setAccessible(true);

--- a/client/java/src/krpc/client/Connection.java
+++ b/client/java/src/krpc/client/Connection.java
@@ -24,6 +24,19 @@ public class Connection implements AutoCloseable {
   private CodedInputStream rpcInputStream;
   StreamManager streamManager;
 
+  private static final Map<Class<?>, Class<?>> WRAPPER_TYPES = new HashMap<Class<?>, Class<?>>();
+
+  static {
+    WRAPPER_TYPES.put(boolean.class, Boolean.class);
+    WRAPPER_TYPES.put(byte.class, Byte.class);
+    WRAPPER_TYPES.put(char.class, Character.class);
+    WRAPPER_TYPES.put(short.class, Short.class);
+    WRAPPER_TYPES.put(int.class, Integer.class);
+    WRAPPER_TYPES.put(long.class, Long.class);
+    WRAPPER_TYPES.put(float.class, Float.class);
+    WRAPPER_TYPES.put(double.class, Double.class);
+  }
+
   private static String EMPTY_NAME = "";
   private static InetAddress DEFAULT_ADDRESS = InetAddress.getLoopbackAddress();
   private static int DEFAULT_RPC_PORT = 50000;
@@ -443,16 +456,21 @@ public class Connection implements AutoCloseable {
       throws RPCException {
     Method[] methods = clazz.getMethods();
     for (Method method : methods) {
-      if (method.getName() == methodName) {
-        Class<?>[] paramTypes = method.getParameterTypes();
-        if (args.length != paramTypes.length) {
-          continue;
+      if (!method.getName().equals(methodName)) {
+        continue;
+      }
+      Class<?>[] paramTypes = method.getParameterTypes();
+      if (args.length != paramTypes.length) {
+        continue;
+      }
+      boolean matches = true;
+      for (int i = 0; i < args.length; i++) {
+        if (!isArgumentAssignable(paramTypes[i], args[i])) {
+          matches = false;
+          break;
         }
-        for (int i = 0; i < args.length; i++) {
-          if (!paramTypes[i].isAssignableFrom(args.getClass())) {
-            continue;
-          }
-        }
+      }
+      if (matches) {
         return method;
       }
     }
@@ -461,9 +479,20 @@ public class Connection implements AutoCloseable {
       if (i > 0) {
         params += ",";
       }
-      params += args[i].getClass().toString();
+      params += args[i] == null ? "null" : args[i].getClass().toString();
     }
     throw new RPCException(
       "Method " + clazz.getName() + "." + methodName + "(" + params + ") not found.");
+  }
+
+  // Whether an argument can be passed as a parameter of the given type. Arguments arrive boxed,
+  // having been passed through an Object..., so a primitive parameter type is compared against
+  // its wrapper type. Null is accepted by any parameter that is not a primitive.
+  private static boolean isArgumentAssignable(Class<?> paramType, Object arg) {
+    if (arg == null) {
+      return !paramType.isPrimitive();
+    }
+    Class<?> type = paramType.isPrimitive() ? WRAPPER_TYPES.get(paramType) : paramType;
+    return type.isAssignableFrom(arg.getClass());
   }
 }

--- a/client/java/src/krpc/client/StreamImpl.java
+++ b/client/java/src/krpc/client/StreamImpl.java
@@ -52,6 +52,7 @@ class StreamImpl {
 
   public void setRate(float rate) throws RPCException {
     KRPC.newInstance(connection).setStreamRate(id, rate);
+    this.rate = rate;
   }
 
   public Object getValue() throws StreamException {

--- a/client/java/src/krpc/client/StreamManager.java
+++ b/client/java/src/krpc/client/StreamManager.java
@@ -4,7 +4,9 @@ import com.google.protobuf.ByteString;
 import com.google.protobuf.CodedInputStream;
 import java.io.IOException;
 import java.net.Socket;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
 import krpc.client.services.KRPC;
@@ -66,33 +68,41 @@ class StreamManager {
   }
 
   void update(long id, ProcedureResult result) throws StreamException {
+    StreamImpl stream;
+    Object value;
+    List<Consumer<Object>> callbacks;
+    // The update lock is held only to find the stream and decode its new value, and is released
+    // before the stream's condition is taken. A thread waiting for an update holds the condition
+    // and then needs the update lock -- Event.waitFor resets the stream value while holding it,
+    // as its documented use requires -- so taking the two in the opposite order here deadlocks.
+    // The callbacks are copied for the same reason: they run below without the lock held.
     synchronized (updateLock) {
       if (!streams.containsKey(id)) {
         return;
       }
-      StreamImpl stream = streams.get(id);
-      Object value;
+      stream = streams.get(id);
       if (!result.hasError()) {
         value = Encoder.decode(result.getValue(), stream.getReturnType(), connection);
       } else {
         value = result.getError();
       }
-      Object condition = stream.getCondition();
-      synchronized (condition) {
-        stream.setValue(value);
-        condition.notifyAll();
-      }
-      for (Consumer<Object> callback : stream.getCallbacks().values()) {
-        try {
-          callback.accept(value);
-        } catch (RuntimeException exn) {
-          // A callback that throws must not stop the remaining callbacks running, nor escape
-          // and end the update thread, which would silently stop every stream on the
-          // connection. There is no caller to propagate it to, so hand it to the thread's
-          // uncaught exception handler, which by default reports it on stderr.
-          Thread thread = Thread.currentThread();
-          thread.getUncaughtExceptionHandler().uncaughtException(thread, exn);
-        }
+      callbacks = new ArrayList<Consumer<Object>>(stream.getCallbacks().values());
+    }
+    Object condition = stream.getCondition();
+    synchronized (condition) {
+      stream.setValue(value);
+      condition.notifyAll();
+    }
+    for (Consumer<Object> callback : callbacks) {
+      try {
+        callback.accept(value);
+      } catch (RuntimeException exn) {
+        // A callback that throws must not stop the remaining callbacks running, nor escape
+        // and end the update thread, which would silently stop every stream on the
+        // connection. There is no caller to propagate it to, so hand it to the thread's
+        // uncaught exception handler, which by default reports it on stderr.
+        Thread thread = Thread.currentThread();
+        thread.getUncaughtExceptionHandler().uncaughtException(thread, exn);
       }
     }
   }

--- a/client/java/src/krpc/client/StreamManager.java
+++ b/client/java/src/krpc/client/StreamManager.java
@@ -90,7 +90,16 @@ class StreamManager {
     }
     Object condition = stream.getCondition();
     synchronized (condition) {
-      stream.setValue(value);
+      synchronized (updateLock) {
+        // The stream can be removed while its new value is being decoded, in which case
+        // remove() has already stored the error saying so and this value must not overwrite
+        // it - the stream is gone from the registry, so nothing would ever replace it and it
+        // would be returned as though the stream were still live.
+        if (!streams.containsKey(id)) {
+          return;
+        }
+        stream.setValue(value);
+      }
       condition.notifyAll();
     }
     for (Consumer<Object> callback : callbacks) {

--- a/client/java/src/krpc/client/StreamManager.java
+++ b/client/java/src/krpc/client/StreamManager.java
@@ -83,7 +83,16 @@ class StreamManager {
         condition.notifyAll();
       }
       for (Consumer<Object> callback : stream.getCallbacks().values()) {
-        callback.accept(value);
+        try {
+          callback.accept(value);
+        } catch (RuntimeException exn) {
+          // A callback that throws must not stop the remaining callbacks running, nor escape
+          // and end the update thread, which would silently stop every stream on the
+          // connection. There is no caller to propagate it to, so hand it to the thread's
+          // uncaught exception handler, which by default reports it on stderr.
+          Thread thread = Thread.currentThread();
+          thread.getUncaughtExceptionHandler().uncaughtException(thread, exn);
+        }
       }
     }
   }

--- a/client/java/test/krpc/client/ConnectionTest.java
+++ b/client/java/test/krpc/client/ConnectionTest.java
@@ -230,6 +230,25 @@ public class ConnectionTest {
     assertEquals("value=bob", list.get(1).getValue());
   }
 
+  // A method name is matched by value, so one assembled at runtime resolves the same as a
+  // literal, which is interned and so happened to work when the two were compared by identity.
+  @Test
+  public void testGetCallWithNonInternedMethodName() throws RPCException {
+    String name = new StringBuilder("floatToString").toString();
+    assertEquals(
+        connection.getCall(TestService.class, "floatToString", 3.14159f),
+        connection.getCall(TestService.class, name, 3.14159f));
+  }
+
+  // Arguments of the wrong type do not match, rather than any method of the same name taking
+  // the same number of arguments.
+  @Test
+  public void testGetCallWithWrongArgumentType() {
+    RPCException e = assertThrows(RPCException.class,
+        () -> connection.getCall(TestService.class, "floatToString", "not a float"));
+    assertTrue(e.getMessage().contains("not found"));
+  }
+
   @Test
   public void testInvalidOperationException() {
     UnsupportedOperationException e = assertThrows(UnsupportedOperationException.class,

--- a/client/java/test/krpc/client/ConnectionTest.java
+++ b/client/java/test/krpc/client/ConnectionTest.java
@@ -17,6 +17,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
 import krpc.client.services.KRPC;
 import krpc.client.services.TestService;
+import krpc.schema.KRPC.Error;
 import krpc.schema.KRPC.Status;
 import org.javatuples.Pair;
 import org.junit.Before;
@@ -247,6 +248,20 @@ public class ConnectionTest {
     RPCException e = assertThrows(RPCException.class,
         () -> connection.getCall(TestService.class, "floatToString", "not a float"));
     assertTrue(e.getMessage().contains("not found"));
+  }
+
+  // An error naming a type this client has no stubs for still reports what went wrong, rather
+  // than failing while trying to construct the exception for it.
+  @Test
+  public void testUnknownExceptionType() {
+    Error error = Error.newBuilder()
+        .setService("NotAService")
+        .setName("NotAnException")
+        .setDescription("something went wrong")
+        .build();
+    RPCException e = assertThrows(RPCException.class, () -> connection.throwException(error));
+    assertTrue(e.getMessage().contains("NotAService.NotAnException"));
+    assertTrue(e.getMessage().contains("something went wrong"));
   }
 
   @Test

--- a/client/java/test/krpc/client/StreamTest.java
+++ b/client/java/test/krpc/client/StreamTest.java
@@ -418,6 +418,37 @@ public class StreamTest {
     assertEquals(testCallbackValue, 5);
   }
 
+  private volatile int testCallbackThrowsCount = 0;
+  private volatile boolean testCallbackThrowsStop = false;
+
+  // A callback that throws must not take the update thread down with it, which would stop
+  // every stream on the connection. The timeout catches that, as the loop below would
+  // otherwise never see another update.
+  @Test(timeout = 30000)
+  public void testCallbackThrows()
+      throws RPCException, StreamException {
+    Stream<Integer> stream = connection.addStream(
+        TestService.class, "counter", "StreamTest.testCallbackThrows", 10);
+    stream.addCallback(
+        (Integer value) -> {
+          throw new IllegalStateException("callback failed");
+      });
+    stream.addCallback(
+        (Integer value) -> {
+          if (value > 5) {
+            testCallbackThrowsStop = true;
+          } else {
+            testCallbackThrowsCount++;
+          }
+      });
+    stream.start();
+    while (!testCallbackThrowsStop) {
+    }
+    stream.remove();
+    // The callback registered after the one that threw still ran
+    assertTrue(testCallbackThrowsCount > 0);
+  }
+
   private volatile boolean testRemoveCallbackCalled1 = false;
   private volatile boolean testRemoveCallbackCalled2 = false;
 

--- a/client/java/test/krpc/client/StreamTest.java
+++ b/client/java/test/krpc/client/StreamTest.java
@@ -418,6 +418,24 @@ public class StreamTest {
     assertEquals(testCallbackValue, 5);
   }
 
+  // The update thread must not hold the update lock while waiting for a stream's condition. A
+  // caller holding that condition -- which is how waiting for an update is documented to work --
+  // otherwise blocks forever on anything needing the update lock, and the update thread blocks
+  // on the condition, deadlocking both. The timeout catches it, as it hangs the test outright.
+  @Test(timeout = 30000)
+  public void testRemoveWhileHoldingCondition()
+      throws RPCException, StreamException, InterruptedException {
+    Stream<Integer> stream = connection.addStream(
+        TestService.class, "counter", "StreamTest.testRemoveWhileHoldingCondition", 1);
+    stream.start();
+    synchronized (stream.getCondition()) {
+      stream.waitForUpdate();
+      // Let the update thread reach the next update and block on this condition
+      Thread.sleep(200);
+      stream.remove();
+    }
+  }
+
   private volatile int testCallbackThrowsCount = 0;
   private volatile boolean testCallbackThrowsStop = false;
 

--- a/client/java/test/krpc/client/StreamTest.java
+++ b/client/java/test/krpc/client/StreamTest.java
@@ -478,6 +478,19 @@ public class StreamTest {
   }
 
   @Test
+  public void testGetRate()
+      throws RPCException, StreamException {
+    Stream<Integer> stream = connection.addStream(
+        TestService.class, "counter", "StreamTest.testGetRate", 1);
+    assertEquals(0, stream.getRate(), 0.0001);
+    stream.setRate(5);
+    assertEquals(5, stream.getRate(), 0.0001);
+    stream.setRate(0);
+    assertEquals(0, stream.getRate(), 0.0001);
+    stream.remove();
+  }
+
+  @Test
   public void testEquality()
       throws RPCException, StreamException {
     Stream<Integer> stream0 = connection.addStream(


### PR DESCRIPTION
Six independent fixes to the Java client, mostly in stream handling, each in its own commit.

**Stream rate.** `Stream.getRate` returned a field that `setRate` never assigned, so it always reported zero however the rate had been set. It is now assigned once the server has accepted the new rate, matching the Python client.

**Method lookup.** Methods to stream or call were matched on an identity comparison of their names, which worked only because a literal and the name held in a class file are both interned; a name assembled at runtime never matched and the method was reported as not found. The argument check could not reject anything either — it compared each parameter against the class of the argument array rather than of the argument, and its `continue` restarted the loop it was already in rather than moving to the next candidate. Overloads therefore resolved on argument count alone and a mismatch surfaced much later as a `ClassCastException` from the encoder. Names are now compared by value and each argument against its own parameter, boxing primitive parameter types first since arguments arrive boxed through the varargs.

**Callbacks ending the update thread.** A stream or event callback that threw propagated out of the stream update thread and ended it, so one misbehaving callback silently stopped every stream and event on the connection. Callbacks now run in isolation and anything thrown goes to the thread's uncaught exception handler, which reports it on stderr by default. The update thread has no caller to propagate to, and swallowing it outright would hide a broken callback completely.

**Lock ordering.** The update thread took the update lock and then, still holding it, the condition of the stream being updated. A thread waiting for updates takes these in the opposite order: it holds the condition, as the documented way to wait requires, then reaches for the update lock through `Event.waitFor` resetting the stream value, or through removing a stream or callback. Both threads blocked on each other and every stream stopped. The update lock is now held only to look the stream up and decode its value, with the condition taken after releasing it. Since that leaves a window in which the stream could be removed between decoding and storing — overwriting the error `remove()` recorded, with nothing left in the registry to ever replace it — the registration is re-checked before storing.

**Unknown exception types.** An error naming a service whose generated stubs are not loaded found no registered exception type, and the null went straight into a reflective lookup, so a `NullPointerException` replaced the error being reported. A type registered without a single-argument constructor passed the last constructor it found to `newInstance` and failed similarly. Both cases now fall back to an `RPCException` carrying the description and the type name from the server.

**Testing.** `bazel test //client/java:test` passes, with new tests covering the rate, method lookup, throwing callbacks and unknown exception types. The removed-during-decode re-check is untested: the equivalent Python test injects the removal by replacing a module-level decoder and there is no comparable seam here.
