### PR TITLE
Fix several defects in the C# client

### DIFF
--- a/client/csharp/CHANGES.txt
+++ b/client/csharp/CHANGES.txt
@@ -2,6 +2,15 @@ v0.6.0
  * Requires .NET Framework 4.7.2 or later
  * Update to protobuf v3.35.1
  * Mark deprecated members with the [Obsolete] attribute (#904)
+ * Disposing a connection now stops and joins the stream update thread, instead of leaving it
+   to end by itself when its socket was closed underneath it (#1005)
+ * An error from a service whose exception types were never registered now raises an
+   RPCException describing it, instead of a KeyNotFoundException naming the missing type
+   (#1005)
+ * An exception thrown by a stream or event callback no longer escapes the stream update
+   thread, which ended the process, and the remaining callbacks still run (#1005)
+ * Fix a deadlock between the stream update thread and a thread waiting for an update while
+   holding a stream or event condition, as waiting for one requires (#1005)
 
 v0.5.0
  * Update to protobuf v3.22.0

--- a/client/csharp/src/Connection.cs
+++ b/client/csharp/src/Connection.cs
@@ -103,6 +103,13 @@ namespace KRPC.Client
                     rpcClient.Close ();
                     if (streamClient != null)
                         streamClient.Close ();
+                    // Join the update thread, so that it has ended by the time this returns
+                    // rather than at some later point of its own choosing. This has to come
+                    // after the sockets are closed: the thread spends its time blocked in a
+                    // read that does not observe the stop event, and closing the socket
+                    // underneath it is what releases it.
+                    if (StreamManager != null)
+                        StreamManager.Dispose ();
                 }
                 disposed = true;
             }

--- a/client/csharp/src/Connection.cs
+++ b/client/csharp/src/Connection.cs
@@ -381,7 +381,14 @@ namespace KRPC.Client
                     return new ArgumentNullException (string.Empty, message);
                 if (key == "KRPC.ArgumentOutOfRangeException")
                     return new ArgumentOutOfRangeException (string.Empty, message);
-                var exnType = exceptionTypes [key];
+                System.Type exnType;
+                if (!exceptionTypes.TryGetValue (key, out exnType)) {
+                    // The type is unknown here if the service it belongs to was never
+                    // registered. Report the error itself, named by its type on the server,
+                    // rather than the failure to build an exception for it, which would say
+                    // nothing about what actually went wrong.
+                    return new RPCException (key + ": " + message);
+                }
                 return (System.Exception)Activator.CreateInstance (exnType, new [] { message });
             }
             return new RPCException (message);

--- a/client/csharp/src/StreamManager.cs
+++ b/client/csharp/src/StreamManager.cs
@@ -89,31 +89,47 @@ namespace KRPC.Client
 
         void Update (ulong id, ProcedureResult result)
         {
+            StreamImpl stream;
+            object value;
+            IList<Action<object>> callbacks;
+            // The update lock is held only to find the stream and decode its new value, and is
+            // released before the stream's condition is taken. A thread waiting for an update
+            // holds the condition and then needs the update lock -- Event.Wait resets the
+            // stream value while holding it, as its documented use requires -- so taking the
+            // two in the opposite order here deadlocks. The callbacks are copied for the same
+            // reason: they run below without the lock held.
             lock (updateLock) {
                 if (!streams.ContainsKey (id))
                     return;
-                var stream = streams [id];
-                object value;
+                stream = streams [id];
                 if (result.Error == null)
                     value = Encoder.Decode (result.Value, stream.ReturnType, connection);
                 else
                     value = connection.GetException (result.Error);
-                var condition = stream.Condition;
-                lock (condition) {
+                callbacks = new List<Action<object>> (stream.Callbacks.Values);
+            }
+            var condition = stream.Condition;
+            lock (condition) {
+                lock (updateLock) {
+                    // The stream can be removed while its new value is being decoded, in which
+                    // case Remove has already stored the error saying so and this value must
+                    // not overwrite it. The stream is gone from the registry, so nothing would
+                    // ever replace it and it would be returned as though still live.
+                    if (!streams.ContainsKey (id))
+                        return;
                     stream.Value = value;
-                    Monitor.PulseAll (condition);
                 }
-                foreach (var callback in stream.Callbacks.Values) {
-                    try {
-                        callback (value);
-                    } catch (System.Exception exn) {
-                        // A callback that throws must not stop the remaining callbacks
-                        // running, nor escape and end the update thread. On .NET that ends
-                        // the process outright, taking down every stream and the application
-                        // with it. There is no caller to propagate it to, so report it and
-                        // carry on.
-                        Console.Error.WriteLine ("Exception in kRPC stream callback: " + exn);
-                    }
+                Monitor.PulseAll (condition);
+            }
+            foreach (var callback in callbacks) {
+                try {
+                    callback (value);
+                } catch (System.Exception exn) {
+                    // A callback that throws must not stop the remaining callbacks running,
+                    // nor escape and end the update thread, which would silently stop every
+                    // stream on the connection. There is no caller to propagate it to, so
+                    // report it and carry on.
+                    Console.Error.WriteLine ("Exception in kRPC stream callback: " + exn);
                 }
             }
         }

--- a/client/csharp/src/StreamManager.cs
+++ b/client/csharp/src/StreamManager.cs
@@ -103,8 +103,18 @@ namespace KRPC.Client
                     stream.Value = value;
                     Monitor.PulseAll (condition);
                 }
-                foreach (var callback in stream.Callbacks.Values)
-                    callback (value);
+                foreach (var callback in stream.Callbacks.Values) {
+                    try {
+                        callback (value);
+                    } catch (System.Exception exn) {
+                        // A callback that throws must not stop the remaining callbacks
+                        // running, nor escape and end the update thread. On .NET that ends
+                        // the process outright, taking down every stream and the application
+                        // with it. There is no caller to propagate it to, so report it and
+                        // carry on.
+                        Console.Error.WriteLine ("Exception in kRPC stream callback: " + exn);
+                    }
+                }
             }
         }
 

--- a/client/csharp/test/ConnectionTest.cs
+++ b/client/csharp/test/ConnectionTest.cs
@@ -252,6 +252,22 @@ namespace KRPC.Client.Test
         }
 
         [Test]
+        public void UnknownExceptionType ()
+        {
+            // An error naming a type this client has no registered types for still reports
+            // what went wrong, rather than failing while constructing the exception for it
+            var error = new KRPC.Schema.KRPC.Error {
+                Service = "NotAService",
+                Name = "NotAnException",
+                Description = "something went wrong"
+            };
+            var exn = Connection.GetException (error);
+            Assert.IsInstanceOf<RPCException> (exn);
+            Assert.That (exn.Message, Does.Contain ("NotAService.NotAnException"));
+            Assert.That (exn.Message, Does.Contain ("something went wrong"));
+        }
+
+        [Test]
         public void InvalidOperationException ()
         {
             var exn = Assert.Throws<System.InvalidOperationException> (() => Connection.TestService ().ThrowInvalidOperationException ());

--- a/client/csharp/test/StreamTest.cs
+++ b/client/csharp/test/StreamTest.cs
@@ -348,6 +348,32 @@ namespace KRPC.Client.Test
         }
 
         [Test]
+        public void TestRemoveWhileWaitingOnCondition () {
+            // The update thread must not hold the update lock while waiting for a stream's
+            // condition. A caller holding that condition -- which is how waiting for an
+            // update is documented to work -- otherwise blocks forever on anything needing
+            // the update lock, and the update thread blocks on the condition, deadlocking
+            // both. Run on a thread so a regression fails here instead of hanging the suite.
+            var done = new ManualResetEvent (false);
+            var thread = new Thread (() => {
+                var s = Connection.AddStream (
+                    () => Connection.TestService ().Counter (
+                        "StreamTest.TestRemoveWhileWaitingOnCondition", 1));
+                s.Start ();
+                lock (s.Condition) {
+                    s.Wait ();
+                    // Let the update thread reach the next update and block on this condition
+                    Thread.Sleep (200);
+                    s.Remove ();
+                }
+                done.Set ();
+            });
+            thread.IsBackground = true;
+            thread.Start ();
+            Assert.IsTrue (done.WaitOne (30000));
+        }
+
+        [Test]
         public void TestRemoveCallback () {
             var stop = new ManualResetEvent (false);
             var called1 = false;

--- a/client/csharp/test/StreamTest.cs
+++ b/client/csharp/test/StreamTest.cs
@@ -325,6 +325,29 @@ namespace KRPC.Client.Test
         }
 
         [Test]
+        public void TestCallbackThatThrows () {
+            // A callback that throws must not take the update thread down with it, which
+            // would stop every stream on the connection. The timeout catches that, as the
+            // wait below would otherwise never be satisfied.
+            var stop = new ManualResetEvent (false);
+            var called = false;
+            var s = Connection.AddStream (
+                () => Connection.TestService ().Counter ("StreamTest.TestCallbackThatThrows", 10));
+            s.AddCallback ((int x) => {
+                called = true;
+                throw new System.InvalidOperationException ("callback failed");
+            });
+            s.AddCallback ((int x) => {
+                if (x > 5)
+                    stop.Set ();
+            });
+            s.Start ();
+            Assert.IsTrue (stop.WaitOne (30000));
+            s.Remove ();
+            Assert.IsTrue (called);
+        }
+
+        [Test]
         public void TestRemoveCallback () {
             var stop = new ManualResetEvent (false);
             var called1 = false;


### PR DESCRIPTION
Four independent defects in the C# client, one per commit.

**Disposal.** Disposing a connection closed both sockets but left the stream manager, and so the update thread, to notice on its own. The thread ended only by way of the exception raised when its socket was closed under it, at no point the caller could rely on, so a disposed connection could still be running a thread and invoking callbacks. The stream manager is now disposed, which stops and joins the thread. This has to happen after the sockets are closed: the thread blocks in a read that only checks the stop event once the read returns, so closing the socket is what releases it, and joining first deadlocks.

**Unknown exception types.** An error naming a service whose exception types were never registered was looked up with an unguarded indexer, so a KeyNotFoundException naming the missing key replaced the error being reported. It now falls back to an RPCException carrying the description and the name of the type on the server.

**Callback exceptions.** A callback that threw propagated out of the stream update thread. On .NET an unhandled exception on a background thread ends the process, so one misbehaving callback did not merely stop every stream on the connection, as the same defect does in the Java and Python clients, but terminated the application. Each callback now runs in isolation, with anything it throws reported on standard error, matching what the other clients do by default.

**Lock ordering.** The update thread took the update lock and then, still holding it, the condition of the stream it was updating. A thread waiting for updates takes these in the opposite order: it holds the condition, as the documented way to wait requires, and then reaches for the update lock through Event.Wait resetting the stream value, or through removing a stream or a callback. Both threads then block on each other and every stream on the connection stops. The update lock is now held only to find the stream and decode its value, with the condition taken after it is released, so the two are always acquired in the same order. The callbacks are copied under the lock, as they now run without it held, and the stream is checked to still be registered before its value is stored: releasing the lock in between opens a window in which the stream is removed, and the value would otherwise overwrite the error recording that. This mirrors the same fix already made in the Java and Python clients.

**Testing.** Each fix has a test: the unknown exception type in ConnectionTest, and the callback that throws and the deadlock in StreamTest. The deadlock test runs its wait on a separate thread with a timeout, so a regression fails rather than hanging the suite.
