### PR TITLE
Load the docs footer commit sha at page-load time

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -82,6 +82,14 @@ jobs:
           mkdir -p "gh-pages/${SUBPATH}"
           (cd "gh-pages/${SUBPATH}" && unzip -q "${GITHUB_WORKSPACE}/bazel-bin/doc/html.zip")
 
+          # The commit a dev build came from, read at page-load time by
+          # build-info.js to fill in the footer link. Keeping it out of the HTML
+          # means republishing /dev/ rewrites this file alone rather than every
+          # page. Release builds are frozen and carry no such footer.
+          if [ "$SUBPATH" = "dev" ]; then
+            printf '{"commit": "%s"}\n' "$GITHUB_SHA" > "gh-pages/${SUBPATH}/build-info.json"
+          fi
+
           # Regenerate the runtime dropdown list and the root redirect.
           doc/gen_docs_index.py gh-pages
 

--- a/doc/BUILD.bazel
+++ b/doc/BUILD.bazel
@@ -33,6 +33,7 @@ stage_files(
         "src/scripts/**/*.py",
         "src/scripts/**/*.js",
     ]) + [
+        "src/_static/build-info.js",
         "src/_static/custom.css",
         "src/_static/external-links.js",
         "src/_templates/build-info.html",
@@ -131,10 +132,11 @@ genrule(
     name = "conf",
     srcs = ["conf.py.tmpl"],
     outs = ["src/conf.py"],
-    # %VERSION%/%SUBPATH% get the channel ('dev' or the release number);
-    # %BUILDVERSION% keeps the full version, including a dev build's commit-sha
-    # suffix, which conf.py turns into the footer commit link.
-    cmd = "sed -e 's/%VERSION%/" + docs_version + "/g' -e 's/%SUBPATH%/" + docs_version + "/g' -e 's/%BUILDVERSION%/" + version + "/g' \"$<\" > \"$@\"",
+    # %VERSION%/%SUBPATH% get the channel ('dev' or the release number). The
+    # commit sha is deliberately not substituted in: it reaches a dev build's
+    # footer at page-load time via build-info.json, keeping the HTML identical
+    # from one commit to the next.
+    cmd = "sed -e 's/%VERSION%/" + docs_version + "/g' -e 's/%SUBPATH%/" + docs_version + "/g' \"$<\" > \"$@\"",
 )
 
 sphinx_build(

--- a/doc/conf.py.tmpl
+++ b/doc/conf.py.tmpl
@@ -30,16 +30,15 @@ htmlhelp_basename = 'krpc-doc'
 html_static_path = ['crafts', 'scripts', '_static']
 templates_path = ['_templates']
 html_css_files = ['custom.css']
-html_js_files = ['external-links.js']
+html_js_files = ['external-links.js', 'build-info.js']
 
-# A dev build's version carries a "-<build>-<sha>" suffix (set-version.py); a
-# release version does not. Surface that commit sha as a footer link so a dev
-# page shows which commit it was built from. %BUILDVERSION% is the full
-# config.bzl version, substituted by the :conf genrule.
-build_version = '%BUILDVERSION%'
-html_context = {}
-if '-' in build_version:
-    html_context['build_commit'] = build_version.rsplit('-', 1)[-1]
+# A dev build is published under /dev/ and overwritten on every merge to main.
+# Its footer names the commit it was built from, but the sha is not baked into
+# the pages: build-info.js fetches it from build-info.json, written alongside
+# the HTML by the publish step, so a rebuild leaves every page byte-identical
+# and the published commits stay small. Only dev builds carry the footer, so
+# the pages need to know the channel rather than the commit.
+html_context = {'build_info': '%SUBPATH%' == 'dev'}
 
 # Per-version publishing. %SUBPATH% is
 # the path this build is published under: a release version (e.g. '0.5.4') or

--- a/doc/src/_static/build-info.js
+++ b/doc/src/_static/build-info.js
@@ -1,0 +1,29 @@
+// Fill in the footer's "built from commit" line for dev builds. The commit sha
+// lives in build-info.json next to the HTML rather than in the pages
+// themselves, so republishing the dev docs rewrites one file instead of every
+// page. The placeholder stays empty if the fetch fails or the file is absent.
+document.addEventListener("DOMContentLoaded", function () {
+  var el = document.querySelector(".build-info[data-build-info-url]");
+  if (!el) {
+    return;
+  }
+  fetch(el.dataset.buildInfoUrl)
+    .then(function (response) {
+      return response.ok ? response.json() : null;
+    })
+    .then(function (info) {
+      if (!info || !info.commit) {
+        return;
+      }
+      var link = document.createElement("a");
+      link.href = "https://github.com/krpc/krpc/commit/" + info.commit;
+      link.textContent = info.commit;
+      // external-links.js has already run by the time the fetch resolves, so
+      // this link opts into the new tab itself.
+      link.target = "_blank";
+      link.rel = "noopener";
+      el.appendChild(document.createTextNode("Built from commit "));
+      el.appendChild(link);
+    })
+    .catch(function () {});
+});

--- a/doc/src/_templates/build-info.html
+++ b/doc/src/_templates/build-info.html
@@ -1,6 +1,3 @@
-{%- if build_commit %}
-<p class="build-info">
-  Built from commit
-  <a href="https://github.com/krpc/krpc/commit/{{ build_commit }}">{{ build_commit }}</a>
-</p>
+{%- if build_info %}
+<p class="build-info" data-build-info-url="{{ pathto('build-info.json', 1) }}"></p>
 {%- endif %}


### PR DESCRIPTION
**Problem.** A dev build's version carries a `-<build>-<sha>` suffix, and `conf.py` turned that sha into `html_context['build_commit']`, which `_templates/build-info.html` rendered into the footer of every page. Since the publish step replaces the whole `dev/` subtree, every merge to main rewrote every HTML file in it — the gh-pages history is dominated by commits that change nothing but the footer.

**Fix.** Keep the sha out of the pages. `build-info.html` now emits an empty placeholder carrying a relative URL to `build-info.json`, and a new `_static/build-info.js` fetches that file on load and builds the commit link. The publish step writes `dev/build-info.json` from `GITHUB_SHA` after unpacking the HTML. This is the same approach the version switcher already uses, and for the same reason: data that changes per publish lives in one small file rather than in every page.

`%BUILDVERSION%` is dropped from `conf.py.tmpl` and the `:conf` genrule — nothing else used it, so `//doc:html` output no longer depends on the commit and caches across them. The footer is gated on the channel (`dev`) rather than on the presence of a sha; release builds are frozen and carry no footer, exactly as before.

The commit link sets its own `target=\"_blank\"`, because `external-links.js` runs on `DOMContentLoaded` and has finished by the time the fetch resolves.

**Testing.** Built `//doc:html` twice at differing dev versions (`0.6.0-42-aaaaaaa` and `0.6.0-43-bbbbbbb`) and compared the unpacked trees: `diff -rq` reports no differences, confirming both that the sha was the only source of churn and that the rest of the output is already deterministic. Served the tree to headless Chrome to check the runtime behavior: a nested page resolves `../build-info.json` and renders the commit link; with the JSON absent the placeholder stays empty; a release build emits no placeholder and the script is a no-op.

The first publish after this merges still rewrites every page once, to strip the baked-in sha. Subsequent publishes touch `dev/build-info.json` alone.