### PR TITLE
Fix C++ client error handling around unknown exceptions, stream callbacks and thrower registration

### DIFF
--- a/client/cpp/CHANGES.txt
+++ b/client/cpp/CHANGES.txt
@@ -1,5 +1,13 @@
 v0.6.0
  * Distribute via vcpkg
+ * An error from a service whose generated header is not included now throws an RPCError
+   describing it, instead of running off the end of the exception thrower map (#1007)
+ * An exception thrown by a stream or event callback no longer escapes the stream update
+   thread, which ended the process, and the remaining callbacks still run. Callbacks are not
+   invoked for an update carrying an error, as there is no value to give them; reading the
+   stream still reports the error (#1007)
+ * Fix a data race on the exception thrower map between constructing a service and handling an
+   error (#1007)
  * Update to protobuf v35.1
  * Update to ASIO 1.38.0
  * Drop autotools build; CMake is now the only supported build system

--- a/client/cpp/include/krpc/client.hpp
+++ b/client/cpp/include/krpc/client.hpp
@@ -79,6 +79,11 @@ class Client {
   std::shared_ptr<std::mutex> lock;
   std::map<std::pair<std::string, std::string>, std::function<void(std::string)>>
       exception_throwers;
+  // Guards exception_throwers. Services register their throwers as they are constructed,
+  // which can happen on any thread and at any time, while errors are turned into exceptions
+  // on both the calling thread and the stream update thread. Held by shared pointer as the
+  // client is copyable and a mutex is not.
+  std::shared_ptr<std::mutex> exception_throwers_lock;
 };
 
 }  // namespace krpc

--- a/client/cpp/src/client.cpp
+++ b/client/cpp/src/client.cpp
@@ -15,11 +15,11 @@ namespace krpc {
 
 class StreamImpl;
 
-Client::Client() : lock(new std::mutex) {}
+Client::Client() : lock(new std::mutex), exception_throwers_lock(new std::mutex) {}
 
 Client::Client(const std::string& name, const std::string& address, unsigned int rpc_port,
                unsigned int stream_port)
-    : lock(new std::mutex) {
+    : lock(new std::mutex), exception_throwers_lock(new std::mutex) {
   // Connect to RPC server
   rpc_connection = std::make_shared<Connection>(address, rpc_port);
   rpc_connection->connect();
@@ -109,12 +109,14 @@ schema::ProcedureCall Client::build_call(const std::string& service, const std::
 
 void Client::add_exception_thrower(const std::string& service, const std::string& name,
                                    const std::function<void(std::string)>& thrower) {
+  std::lock_guard<std::mutex> guard(*exception_throwers_lock);
   exception_throwers[std::make_pair(service, name)] = thrower;
 }
 
 void Client::throw_exception(const schema::Error& error) const {
   if (!error.service().empty() && !error.name().empty()) {
     auto key = std::make_pair(error.service(), error.name());
+    std::unique_lock<std::mutex> guard(*exception_throwers_lock);
     auto thrower = exception_throwers.find(key);
     if (thrower == exception_throwers.end()) {
       // The type is unknown here if the generated header for its service was never
@@ -123,7 +125,11 @@ void Client::throw_exception(const schema::Error& error) const {
       // the end of the map.
       throw RPCError(error.service() + "." + error.name() + ": " + error.description());
     }
-    thrower->second(error.description());
+    // Copy the thrower and release the lock before calling it: it throws, and it must not
+    // be holding this lock while the exception propagates out through the caller.
+    auto fn = thrower->second;
+    guard.unlock();
+    fn(error.description());
   } else {
     throw RPCError(error.description());
   }

--- a/client/cpp/src/client.cpp
+++ b/client/cpp/src/client.cpp
@@ -115,8 +115,15 @@ void Client::add_exception_thrower(const std::string& service, const std::string
 void Client::throw_exception(const schema::Error& error) const {
   if (!error.service().empty() && !error.name().empty()) {
     auto key = std::make_pair(error.service(), error.name());
-    auto thrower = exception_throwers.find(key)->second;
-    thrower(error.description());
+    auto thrower = exception_throwers.find(key);
+    if (thrower == exception_throwers.end()) {
+      // The type is unknown here if the generated header for its service was never
+      // instantiated in this translation unit, so nothing registered a thrower for it.
+      // Report the error itself, named by its type on the server, rather than dereferencing
+      // the end of the map.
+      throw RPCError(error.service() + "." + error.name() + ": " + error.description());
+    }
+    thrower->second(error.description());
   } else {
     throw RPCError(error.description());
   }

--- a/client/cpp/src/stream_manager.cpp
+++ b/client/cpp/src/stream_manager.cpp
@@ -4,6 +4,7 @@
 #include <cstddef>
 #include <exception>
 #include <functional>
+#include <iostream>
 #include <memory>
 #include <string>
 #include <utility>
@@ -80,7 +81,22 @@ void StreamManager::update(uint64_t id, const schema::ProcedureResult& result) {
     }
   }
   stream->get_condition().notify_all();
-  for (const auto& callback : stream->get_callbacks()) callback.second(stream->get_data());
+  // A stream in an error state has no value to give a callback: a callback takes the encoded
+  // value and there is nowhere to put an exception, so reading the stream would rethrow the
+  // error into this thread. Skip them for such an update. Anything a callback itself throws
+  // is contained here too, as an exception leaving the update thread calls std::terminate and
+  // ends the process.
+  if (!result.has_error()) {
+    for (const auto& callback : stream->get_callbacks()) {
+      try {
+        callback.second(stream->get_data());
+      } catch (const std::exception& exn) {
+        std::cerr << "kRPC: exception thrown by a stream callback: " << exn.what() << "\n";
+      } catch (...) {
+        std::cerr << "kRPC: unknown exception thrown by a stream callback\n";
+      }
+    }
+  }
 }
 
 void StreamManager::freeze() {

--- a/client/cpp/test/test_client.cpp
+++ b/client/cpp/test/test_client.cpp
@@ -294,6 +294,21 @@ TEST_F(test_client, test_test_service_enum_members) {
   ASSERT_EQ(2, static_cast<int>(krpc::services::TestService::TestEnum::value_c));
 }
 
+// An error naming a service whose generated header was never instantiated has no registered
+// thrower, and must be reported rather than looked up past the end of the map. This client
+// deliberately never constructs the TestService object, so nothing registers its exceptions.
+TEST_F(test_client, test_unknown_exception_type) {
+  krpc::Client client = krpc::connect("C++ClientTestUnknownExceptionType", "localhost",
+                                      get_rpc_port(), get_stream_port());
+  try {
+    client.invoke("TestService", "ThrowCustomException");
+    FAIL() << "expected an exception";
+  } catch (const krpc::RPCError& exn) {
+    ASSERT_THAT(std::string(exn.what()), testing::HasSubstr("TestService.CustomException"));
+    ASSERT_THAT(std::string(exn.what()), testing::HasSubstr("A custom kRPC exception"));
+  }
+}
+
 TEST_F(test_client, test_invalid_operation_exception) {
   ASSERT_THROW(test_service.throw_invalid_operation_exception(),
                krpc::services::KRPC::InvalidOperationException);

--- a/client/cpp/test/test_stream.cpp
+++ b/client/cpp/test/test_stream.cpp
@@ -347,6 +347,45 @@ TEST_F(test_stream, test_callback) {
   ASSERT_EQ(test_callback_value, 5);
 }
 
+// A callback that throws must not escape the update thread: an exception leaving it calls
+// std::terminate and ends the process, not merely the stream updates.
+TEST_F(test_stream, test_callback_that_throws) {
+  std::atomic_flag called;
+  called.test_and_set();
+  std::atomic_flag stop;
+  stop.test_and_set();
+
+  auto x = test_service.counter_stream("test_stream.test_callback_that_throws", 10);
+  x.add_callback([&called](int value) {
+    called.clear();
+    throw std::runtime_error("callback failed");
+  });
+  x.add_callback([&stop](int value) {
+    if (value > 5) stop.clear();
+  });
+  x.start();
+  while (stop.test_and_set()) {
+  }
+  x.remove();
+  ASSERT_FALSE(called.test_and_set());
+}
+
+// An errored stream has no value to give a callback, and reading one rethrows the error. That
+// must not escape the update thread either.
+TEST_F(test_stream, test_callback_on_errored_stream) {
+  std::atomic_flag called;
+  called.test_and_set();
+
+  auto x = test_service.throw_invalid_operation_exception_stream();
+  x.add_callback([&called](int value) { called.clear(); });
+  x.start(false);
+  for (int i = 0; i < 5; i++) wait();
+
+  // The stream still reports its error to a reader, and the callback was never given a value
+  ASSERT_THROW(x(), krpc::services::KRPC::InvalidOperationException);
+  ASSERT_TRUE(called.test_and_set());
+}
+
 TEST_F(test_stream, test_remove_callback) {
   std::atomic_flag called1;
   called1.test_and_set();


### PR DESCRIPTION
Three fixes to the C++ client's error handling, all found by inspection rather than by a reported failure.

**Unknown exception types.** The exception thrower map is populated by generated service headers as each service is constructed, so an error from a service the program does not include has no entry. The lookup ran off the end of the map and dereferenced garbage; it now throws an `RPCError` carrying the service, name and description the server sent.

**Stream callbacks.** Callbacks ran on the stream update thread with no exception barrier, and were passed a value read through `get_data`, which rethrows the stored error for a stream in an error state. Anything thrown — by a callback or by that read — left the thread and called `std::terminate`. Callbacks now run in isolation, with what they throw reported on standard error, and the remaining callbacks still run. An update carrying an error skips callbacks entirely, since a callback takes the encoded value and there is nowhere for it to receive an exception; a reader of the stream still sees the error.

**Data race.** Services register throwers from whatever thread constructs them, while errors are converted to exceptions on both the calling thread and the stream update thread. Neither side locked the map. It is now guarded by a mutex held by shared pointer, as the client is copyable, matching how the existing RPC lock is held.

**Testing.** New tests cover the unknown-exception path and the stream callback cases. The data race has no deterministic test.
