### PR TITLE
Fix stream, connection and decoding bugs in the Python client

### DIFF
--- a/client/python/CHANGES.txt
+++ b/client/python/CHANGES.txt
@@ -5,6 +5,26 @@ v0.6.0
  * Emit a DeprecationWarning when calling a deprecated member, and note deprecation in docstrings (#904)
  * Fix static class method calls being sent to the wrong connection when
    multiple clients are connected
+ * An exception raised by a stream or event callback no longer ends the stream update thread,
+   which stopped every stream and event on the connection from updating again. It is reported
+   through the thread excepthook and the remaining callbacks still run (#1008)
+ * Fix a deadlock between the stream update thread and a thread waiting for an update while
+   holding a stream or event condition, as waiting for one requires (#1008)
+ * An error from a service this client does not know about now raises an RPCError describing
+   it, instead of a RuntimeError about the exception that could not be built (#1008)
+ * Fix decoding of sint64 values at or above 2**62, which were returned with the wrong sign;
+   long.MaxValue decoded as -1 and long.MinValue as 0. Encoding was unaffected (#1008)
+ * A closed connection is now reported instead of being mistaken for no data having arrived
+   yet. Both loops reading a message size retried it at full speed indefinitely, so losing the
+   server left the client spinning with streams frozen and no error raised, and on the RPC
+   connection it did so holding the connection lock, blocking every other thread. Denying a
+   connection in the in-game dialog left krpc.connect spinning rather than reporting it (#1008)
+ * Removing a stream, or closing the client, now wakes threads waiting for an update on it,
+   which previously waited for an update that could never arrive (#1008)
+ * The client can now be closed from a stream or event callback, which raised RuntimeError and
+   left the client half closed (#1008)
+ * Fix a stream returning None rather than its value, or the error saying it has none, when
+   read as its first update was being stored (#1008)
 
 v0.5.4
  * Fix streams for services without pre-generated stubs (#774)

--- a/client/python/krpc/client.py
+++ b/client/python/krpc/client.py
@@ -89,6 +89,9 @@ class Client(krpc.services.Client):
         if self._stream_thread is not None:
             self._stream_thread_stop.set()
             self._stream_thread.join()
+        # No further updates will arrive, so wake anything waiting for one rather than
+        # leaving it blocked for good
+        self._stream_manager.notify_closed()
 
     def __enter__(self) -> Client:
         return self

--- a/client/python/krpc/client.py
+++ b/client/python/krpc/client.py
@@ -88,7 +88,10 @@ class Client(krpc.services.Client):
         self._rpc_connection.close()
         if self._stream_thread is not None:
             self._stream_thread_stop.set()
-            self._stream_thread.join()
+            # Callbacks run on the update thread, so a client closed from one would be
+            # joining the thread it is running on, which raises
+            if threading.current_thread() is not self._stream_thread:
+                self._stream_thread.join()
         # No further updates will arrive, so wake anything waiting for one rather than
         # leaving it blocked for good
         self._stream_manager.notify_closed()

--- a/client/python/krpc/client.py
+++ b/client/python/krpc/client.py
@@ -264,15 +264,18 @@ class Client(krpc.services.Client):
         if error.service and error.name:
             service_name = snake_case(error.service)
             type_name = error.name
+            # The service is missing here if it is not one this client knows about, and the
+            # type is missing if it is not one the service declares as an exception. Report
+            # the error itself, named by its type on the server, rather than the failure to
+            # build an exception for it, which would say nothing about what went wrong.
             if not hasattr(self, service_name):
-                raise RuntimeError(
-                    "Error building exception; service '%s' not found" % service_name
+                return RPCError(
+                    "%s.%s: %s" % (error.service, type_name, self._error_message(error))
                 )
             service = getattr(self, service_name)
             if not hasattr(service, type_name):
-                raise RuntimeError(
-                    "Error building exception; type '%s.%s' not found"
-                    % (service_name, type_name)
+                return RPCError(
+                    "%s.%s: %s" % (error.service, type_name, self._error_message(error))
                 )
             if error.service == "KRPC" and error.name in EXCEPTION_TYPES:
                 # Use a built-in exception type if it's in the mapping

--- a/client/python/krpc/connection.py
+++ b/client/python/krpc/connection.py
@@ -71,12 +71,19 @@ class Connection:
         return data
 
     def partial_receive(self, length: int, timeout: float = 0.01) -> bytes:
-        """Receive up to length bytes of data from the connection."""
+        """Receive up to length bytes of data from the connection.
+        Returns no data if none arrived within the timeout."""
         assert length > 0
         try:
             ready = select.select([self._socket], [], [], timeout)
         except ValueError as exn:
             raise socket.error("Connection closed") from exn
         if ready[0]:
-            return self._socket.recv(length)
+            data = self._socket.recv(length)
+            # A readable socket that yields nothing has reached end of file. Reporting it
+            # as no data would be indistinguishable from nothing having arrived yet, and
+            # callers retry that immediately and forever.
+            if not data:
+                raise socket.error("Connection closed")
+            return data
         return b""

--- a/client/python/krpc/decoder.py
+++ b/client/python/krpc/decoder.py
@@ -137,7 +137,10 @@ class _ValueDecoder:
 
     @classmethod
     def _decode_signed_varint(cls, data: bytes) -> int:
-        value = protobuf_decoder._DecodeSignedVarint(data, 0)[0]  # type: ignore[attr-defined]
+        # The zigzag payload is an unsigned varint. Reading it as a signed one would sign
+        # extend it as two's complement first, which corrupts anything from 2**62 up once
+        # the payload sets bit 63 - long.MaxValue would decode as -1.
+        value = protobuf_decoder._DecodeVarint(data, 0)[0]  # type: ignore[attr-defined]
         return cast(int, protobuf_wire_format.ZigZagDecode(value))  # type: ignore[no-untyped-call]
 
     @classmethod

--- a/client/python/krpc/streammanager.py
+++ b/client/python/krpc/streammanager.py
@@ -110,8 +110,12 @@ class StreamImpl:
 
     def remove(self) -> None:
         self._client._stream_manager.remove_stream(self._stream_id)
-        with self._update_lock:
-            self._value = StreamError("Stream does not exist")
+        with self._condition:
+            with self._update_lock:
+                self._value = StreamError("Stream does not exist")
+            # No further update will ever arrive for this stream, so anything waiting on it
+            # has to be woken here or it waits forever. It sees the error above on waking.
+            self._condition.notify_all()
 
 
 class StreamManager:
@@ -171,6 +175,17 @@ class StreamManager:
         with self._update_lock:
             self._callbacks = [x for x in self._callbacks if x != callback]
             return self._callbacks
+
+    def notify_closed(self) -> None:
+        """Wake everything waiting for a stream update, after the connection has closed and
+        no further update can arrive."""
+        with self._update_lock:
+            streams = list(self._streams.values())
+        for stream in streams:
+            with stream.condition:
+                stream.condition.notify_all()
+        with self._condition:
+            self._condition.notify_all()
 
     def update(self, results: Iterable[KRPC.StreamResult]) -> None:
         # The update lock is held only to find the streams and decode their new values, and

--- a/client/python/krpc/streammanager.py
+++ b/client/python/krpc/streammanager.py
@@ -173,34 +173,42 @@ class StreamManager:
             return self._callbacks
 
     def update(self, results: Iterable[KRPC.StreamResult]) -> None:
+        # The update lock is held only to find the streams and decode their new values, and
+        # is released before any stream condition is taken. A thread waiting for an update
+        # holds a condition and then needs the update lock - Event.wait resets the stream
+        # value while holding it, as its documented use requires - so taking the two in the
+        # opposite order here deadlocks. The callbacks are read under the lock for the same
+        # reason: they run below without it held.
+        decoded = []
         with self._update_lock:
             for result in results:
                 if result.id not in self._streams:
                     continue
 
                 # Check for an error response
+                stream = self._streams[result.id]
                 if result.result.HasField("error"):
-                    self._update_stream(
-                        result.id, self._client._build_error(result.result.error)
+                    value = self._client._build_error(result.result.error)
+                else:
+                    # Decode the return value
+                    value = Decoder.decode(
+                        self._client, result.result.value, stream.return_type
                     )
-                    continue
+                decoded.append((stream, value, stream.callbacks))
+            update_callbacks = self._callbacks
 
-                # Decode the return value and store it in the cache
-                typ = self._streams[result.id].return_type
-                value = Decoder.decode(self._client, result.result.value, typ)
-                self._update_stream(result.id, value)
-            with self._condition:
-                self._condition.notify_all()
-            for fn in self._callbacks:
-                _invoke_callback(fn)
+        # Store each value in the cache and notify anything waiting on it
+        for stream, value, callbacks in decoded:
+            with stream.condition:
+                stream.value = value
+                stream.condition.notify_all()
+            for fn in callbacks:
+                _invoke_callback(fn, value)
 
-    def _update_stream(self, stream_id: int, value: object) -> None:
-        stream = self._streams[stream_id]
-        with stream.condition:
-            stream.value = value
-            stream.condition.notify_all()
-        for fn in stream.callbacks:
-            _invoke_callback(fn, value)
+        with self._condition:
+            self._condition.notify_all()
+        for fn in update_callbacks:
+            _invoke_callback(fn)
 
 
 def update_thread(

--- a/client/python/krpc/streammanager.py
+++ b/client/python/krpc/streammanager.py
@@ -77,8 +77,11 @@ class StreamImpl:
     @value.setter
     def value(self, value: object) -> None:
         with self._update_lock:
-            self._updated = True
+            # Set the value before the flag that says there is one. A reader checks the
+            # flag first and takes no lock, so the other order lets it see the flag set
+            # and read the value that has not been stored yet.
             self._value = value
+            self._updated = True
 
     @property
     def updated(self) -> bool:

--- a/client/python/krpc/streammanager.py
+++ b/client/python/krpc/streammanager.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from typing import cast, Callable, Iterable, List, Optional, TYPE_CHECKING
+import sys
 import threading
 from krpc.stream import Stream
 from krpc.types import TypeBase
@@ -10,6 +11,20 @@ import krpc.schema.KRPC_pb2 as KRPC
 
 if TYPE_CHECKING:
     from krpc.client import Client
+
+
+def _invoke_callback(fn: Callable[..., None], *args: object) -> None:
+    """Run a stream callback, reporting anything it raises rather than letting it
+    propagate. It runs on the update thread, which has no caller to propagate to and
+    would end if it escaped, stopping every stream on the connection from updating
+    again. Report it through the thread excepthook, so it is visible by default and an
+    application can route it elsewhere."""
+    try:
+        fn(*args)
+    except Exception:  # pylint: disable=broad-except
+        threading.excepthook(
+            threading.ExceptHookArgs(sys.exc_info() + (threading.current_thread(),))
+        )
 
 
 class StreamImpl:
@@ -177,7 +192,7 @@ class StreamManager:
             with self._condition:
                 self._condition.notify_all()
             for fn in self._callbacks:
-                fn()
+                _invoke_callback(fn)
 
     def _update_stream(self, stream_id: int, value: object) -> None:
         stream = self._streams[stream_id]
@@ -185,7 +200,7 @@ class StreamManager:
             stream.value = value
             stream.condition.notify_all()
         for fn in stream.callbacks:
-            fn(value)
+            _invoke_callback(fn, value)
 
 
 def update_thread(

--- a/client/python/krpc/streammanager.py
+++ b/client/python/krpc/streammanager.py
@@ -194,13 +194,20 @@ class StreamManager:
                     value = Decoder.decode(
                         self._client, result.result.value, stream.return_type
                     )
-                decoded.append((stream, value, stream.callbacks))
+                decoded.append((result.id, stream, value, stream.callbacks))
             update_callbacks = self._callbacks
 
         # Store each value in the cache and notify anything waiting on it
-        for stream, value, callbacks in decoded:
+        for stream_id, stream, value, callbacks in decoded:
             with stream.condition:
-                stream.value = value
+                with self._update_lock:
+                    # The stream can be removed while its new value is being decoded, in
+                    # which case remove() has already stored the error saying so and this
+                    # value must not overwrite it - the stream is gone from the registry,
+                    # so nothing would ever replace it and it would be returned forever.
+                    if stream_id not in self._streams:
+                        continue
+                    stream.value = value
                 stream.condition.notify_all()
             for fn in callbacks:
                 _invoke_callback(fn, value)

--- a/client/python/krpc/test/test_client.py
+++ b/client/python/krpc/test/test_client.py
@@ -4,6 +4,8 @@ import threading
 import warnings
 from typing import Callable
 import krpc
+import krpc.schema.KRPC_pb2 as KRPC
+from krpc.error import RPCError
 from krpc.test.servertestcase import ServerTestCase
 
 
@@ -343,6 +345,20 @@ class TestClient(ServerTestCase, unittest.TestCase):
         self.assertEqual(
             {1: False, 2: True}, self.conn.test_service.dictionary_default()
         )
+
+    def test_unknown_exception_type(self) -> None:
+        # An error naming a service or type this client does not know about still reports
+        # what went wrong, rather than failing while building the exception for it
+        for service, name in (
+            ("NotAService", "NotAnException"),
+            ("KRPC", "NotAnException"),
+        ):
+            error = KRPC.Error(
+                service=service, name=name, description="something went wrong"
+            )
+            exn = self.conn._build_error(error)
+            self.assertIsInstance(exn, RPCError)
+            self.assertEqual("%s.%s: something went wrong" % (service, name), str(exn))
 
     def test_invalid_operation_exception(self) -> None:
         with self.assertRaises(RuntimeError) as cm:

--- a/client/python/krpc/test/test_connection.py
+++ b/client/python/krpc/test/test_connection.py
@@ -1,6 +1,7 @@
 import unittest
 import threading
 import socket
+import krpc.schema.KRPC_pb2 as KRPC
 from krpc.connection import Connection
 
 
@@ -90,9 +91,31 @@ class TestConnection(unittest.TestCase):
         self.assertRaises(socket.error, conn.receive, 1)
 
     def test_partial_receive_on_remote_closed_connection(self) -> None:
+        # Reports end of file, as receive does. Returning no data here would be
+        # indistinguishable from nothing having arrived yet, and callers retry that
+        # immediately and forever.
         conn = self.connect()
         self.server_close_connection(conn)
-        self.assertEqual(b"", conn.partial_receive(1))
+        self.assertRaises(socket.error, conn.partial_receive, 1)
+
+    def test_receive_message_on_remote_closed_connection(self) -> None:
+        # The loop reading the message size must give up rather than retry a closed
+        # connection at full speed forever. Run on a thread so a regression fails here
+        # instead of hanging the suite.
+        conn = self.connect()
+        self.server_close_connection(conn)
+        raised = []
+
+        def run() -> None:
+            try:
+                conn.receive_message(KRPC.Response)
+            except socket.error as exn:
+                raised.append(exn)
+
+        thread = threading.Thread(target=run, daemon=True)
+        thread.start()
+        thread.join(10)
+        self.assertEqual(1, len(raised))
 
     def test_send_on_closed_connection(self) -> None:
         conn = self.connect()

--- a/client/python/krpc/test/test_encodedecode.py
+++ b/client/python/krpc/test/test_encodedecode.py
@@ -74,6 +74,11 @@ class TestEncodeDecode(unittest.TestCase):
             (300, "d804"),
             (1234567890000, "a091d89fee47"),
             (-33, "41"),
+            # Values from 2**62 up set bit 63 of the zigzag payload, which must not be
+            # read as a sign bit
+            (4611686018427387904, "80808080808080808001"),
+            (9223372036854775807, "feffffffffffffffff01"),
+            (-9223372036854775808, "ffffffffffffffffff01"),
         ]
         self._run_test_encode_value(self.types.sint64_type, cases)
         self._run_test_decode_value(self.types.sint64_type, cases)

--- a/client/python/krpc/test/test_stream.py
+++ b/client/python/krpc/test/test_stream.py
@@ -2,7 +2,10 @@ import threading
 import time
 import unittest
 
+import krpc.schema.KRPC_pb2 as KRPC
 from krpc.error import StreamError
+from krpc import streammanager
+from krpc.streammanager import StreamManager
 from krpc.test.servertestcase import ServerTestCase
 
 
@@ -344,6 +347,34 @@ class TestStream(ServerTestCase, unittest.TestCase):
         self.assertTrue(stop.is_set())
         self.assertFalse(error.is_set())
         self.assertEqual(self.test_callback_value, 5)
+
+    def test_update_does_not_resurrect_a_removed_stream(self) -> None:
+        # A value decoded before the stream was removed must not overwrite the error that
+        # remove() stored. The stream is gone from the registry, so nothing would ever
+        # replace that value and it would be returned as though still live.
+        manager = StreamManager(None)
+        stream = manager.get_stream(self.conn._types.string_type, 1)
+        # Stands in for the error remove() stores to mark the stream as gone
+        stream.value = StreamError("Stream does not exist")
+
+        # Remove the stream midway through the update, while its value is being decoded
+        class RemovingDecoder:
+            # pylint: disable=unused-argument
+            @staticmethod
+            def decode(client: object, data: bytes, typ: object) -> str:
+                del manager._streams[1]
+                return "a stale value"
+
+        result = KRPC.StreamResult(id=1)
+        result.result.value = b"whatever"
+        decoder = streammanager.Decoder
+        streammanager.Decoder = RemovingDecoder  # type: ignore[misc]
+        try:
+            manager.update([result])
+        finally:
+            streammanager.Decoder = decoder  # type: ignore[misc]
+
+        self.assertIsInstance(stream.value, StreamError)
 
     def test_remove_while_holding_condition(self) -> None:
         # The update thread must not hold the update lock while waiting for a stream's

--- a/client/python/krpc/test/test_stream.py
+++ b/client/python/krpc/test/test_stream.py
@@ -345,6 +345,35 @@ class TestStream(ServerTestCase, unittest.TestCase):
         self.assertFalse(error.is_set())
         self.assertEqual(self.test_callback_value, 5)
 
+    def test_remove_while_holding_condition(self) -> None:
+        # The update thread must not hold the update lock while waiting for a stream's
+        # condition. A caller holding that condition - which is how waiting for an update
+        # is documented to work - otherwise blocks forever on anything needing the update
+        # lock, and the update thread blocks on the condition, deadlocking both.
+        done = threading.Event()
+        # Uses its own connection, so that a regression deadlocks only this test rather
+        # than stalling every later test sharing the class connection
+        conn = self.connect()
+
+        def run() -> None:
+            x = conn.add_stream(
+                conn.test_service.counter,
+                "TestStream.test_remove_while_holding_condition",
+                1,
+            )
+            x.start()
+            with x.condition:
+                x.wait()
+                # Let the update thread reach the next update and block on this condition
+                time.sleep(0.2)
+                x.remove()
+            done.set()
+
+        thread = threading.Thread(target=run, daemon=True)
+        thread.start()
+        thread.join(10)
+        self.assertTrue(done.is_set())
+
     def test_callback_that_raises(self) -> None:
         # A callback that raises must not end the update thread, which would stop every
         # stream on the connection from updating again

--- a/client/python/krpc/test/test_stream.py
+++ b/client/python/krpc/test/test_stream.py
@@ -348,6 +348,48 @@ class TestStream(ServerTestCase, unittest.TestCase):
         self.assertFalse(error.is_set())
         self.assertEqual(self.test_callback_value, 5)
 
+    def test_remove_wakes_a_waiting_thread(self) -> None:
+        # Nothing further will update a removed stream, so a thread waiting on it has to be
+        # woken by the removal or it waits forever. The value streamed here never changes,
+        # so the server sends nothing more after the first update and the removal is the
+        # only thing that can wake the waiter.
+        conn = self.connect()
+        try:
+            x = conn.add_stream(conn.test_service.int32_to_string, 42)
+            self.assertEqual("42", x())
+            woke = threading.Event()
+
+            def wait_for_update() -> None:
+                with x.condition:
+                    x.wait()
+                woke.set()
+
+            thread = threading.Thread(target=wait_for_update, daemon=True)
+            thread.start()
+            time.sleep(0.2)
+            x.remove()
+            self.assertTrue(woke.wait(10))
+        finally:
+            conn.close()
+
+    def test_close_wakes_a_waiting_thread(self) -> None:
+        # Same for closing the client, which stops every stream at once
+        conn = self.connect()
+        x = conn.add_stream(conn.test_service.int32_to_string, 43)
+        self.assertEqual("43", x())
+        woke = threading.Event()
+
+        def wait_for_update() -> None:
+            with x.condition:
+                x.wait()
+            woke.set()
+
+        thread = threading.Thread(target=wait_for_update, daemon=True)
+        thread.start()
+        time.sleep(0.2)
+        conn.close()
+        self.assertTrue(woke.wait(10))
+
     def test_update_does_not_resurrect_a_removed_stream(self) -> None:
         # A value decoded before the stream was removed must not overwrite the error that
         # remove() stored. The stream is gone from the registry, so nothing would ever

--- a/client/python/krpc/test/test_stream.py
+++ b/client/python/krpc/test/test_stream.py
@@ -390,6 +390,23 @@ class TestStream(ServerTestCase, unittest.TestCase):
         conn.close()
         self.assertTrue(woke.wait(10))
 
+    def test_close_from_a_callback(self) -> None:
+        # Callbacks run on the update thread, so closing the client from one must not try
+        # to join that thread, which would raise and leave the client half closed
+        conn = self.connect()
+        closed = threading.Event()
+
+        def callback(x: int) -> None:  # pylint: disable=unused-argument
+            conn.close()
+            closed.set()
+
+        stream = conn.add_stream(
+            conn.test_service.counter, "TestStream.test_close_from_a_callback", 1
+        )
+        stream.add_callback(callback)
+        stream.start()
+        self.assertTrue(closed.wait(10))
+
     def test_update_does_not_resurrect_a_removed_stream(self) -> None:
         # A value decoded before the stream was removed must not overwrite the error that
         # remove() stored. The stream is gone from the registry, so nothing would ever

--- a/client/python/krpc/test/test_stream.py
+++ b/client/python/krpc/test/test_stream.py
@@ -345,6 +345,32 @@ class TestStream(ServerTestCase, unittest.TestCase):
         self.assertFalse(error.is_set())
         self.assertEqual(self.test_callback_value, 5)
 
+    def test_callback_that_raises(self) -> None:
+        # A callback that raises must not end the update thread, which would stop every
+        # stream on the connection from updating again
+        called = threading.Event()
+        stop = threading.Event()
+
+        def failing_callback(x: int) -> None:  # pylint: disable=unused-argument
+            called.set()
+            raise RuntimeError("callback failed")
+
+        def callback(x: int) -> None:
+            if x > 5:
+                stop.set()
+
+        with self.conn.stream(
+            self.conn.test_service.counter, "TestStream.test_callback_that_raises", 10
+        ) as x:
+            x.add_callback(failing_callback)
+            x.add_callback(callback)
+            x.start()
+            stop.wait(10)
+
+        self.assertTrue(called.is_set())
+        # Updates kept arriving, and the callback added after the one that raised ran
+        self.assertTrue(stop.is_set())
+
     def test_remove_callback(self) -> None:
         called1 = threading.Event()
         called2 = threading.Event()


### PR DESCRIPTION
A set of independent fixes to the Python client, found while going over its stream and connection handling. Each is in its own commit with the detail; the summary below is by area.

**Streams.** Several ways existed for streams to stop updating, or to report the wrong thing, on a connection that was otherwise healthy. A callback that raised propagated out of the update thread and ended it, silently freezing every stream and event on the connection. The update thread took the update lock and then each stream's condition, the opposite order to a thread waiting for an update — which holds the condition and then reaches for the update lock, as the documented way to wait requires — so the two could deadlock. A stream removed while its next value was being decoded had the error marking it as gone overwritten by that value, and since it was no longer in the registry nothing would ever replace it. Nothing woke a thread waiting on a stream when the stream was removed or the client closed, so it waited for an update that could never arrive. A stream's value was stored after the flag saying it had one, which the getter reads without the lock, so a reader could see the flag and get `None`. Closing the client from a callback joined the thread it was running on and raised, leaving the client half shut down.

**Connections.** `partial_receive` returned no data both when nothing had arrived yet and when the peer had closed, and both loops reading a message size retry immediately on no data. Losing the server therefore left the client spinning at roughly 400,000 iterations a second with streams frozen and no error ever raised; on the RPC connection the spin held the connection lock, blocking every other thread making a call, with no way out of the loop at all. This was reachable from the game — denying a connection in the in-game dialog closes the socket without a response, leaving `krpc.connect` spinning rather than reporting the refusal. It now raises on end of file, as `receive` and `send` already do.

**Decoding.** The zigzag payload of a signed varint was read with protobuf's signed varint decoder, which sign extends it before it is zigzag decoded. From 2**62 up, where the payload sets bit 63, the result was wrong with no error raised: `long.MaxValue` decoded as `-1` and `long.MinValue` as `0`. Only the receive direction was affected — the encoder was already correct, so the client disagreed with itself, with the server and with every other client.

**Errors.** An error naming a service this client does not know about, or a type that service does not declare as an exception, raised a `RuntimeError` about the exception that could not be built and discarded the description, so nothing reaching the caller said what had gone wrong. It now returns an `RPCError` carrying the description and the type name from the server.

**Testing.** Each fix adds a test covering it. The ones for the deadlock and the spinning receive loop run on their own thread or connection, so a regression fails the test rather than hanging the suite.
