### PR TITLE
Documentation version display and frozen-docs tooling

### DIFF
--- a/client/cnano/CHANGELOG.md
+++ b/client/cnano/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [0.6.0] - unreleased
+## [v0.6.0] - unreleased
 - Distribute via vcpkg (#874)
 - **Breaking:** Drop autotools build; CMake is now the only supported build system (#870)
 - **Breaking:** Modernize CMake build: require CMake 3.15+, target-based usage requirements (#834)
@@ -18,32 +18,32 @@
 - Fix corruption of received data on POSIX systems when a serial read returns fewer bytes than
   were asked for (#1002)
 
-## [0.5.2]
+## [v0.5.2]
 - The arduino compatible version of the library now uses the same "krpc_cnano/..." include directory as the version released on GitHub.
 
-## [0.5.0]
+## [v0.5.0]
 - Update to protobuf 22.0
 - Update to nanopb 0.4.7
 - Rename `KRPC_COMMS_CUSTOM` to `KRPC_COMMUNICATION_CUSTOM`
 
-## [0.4.8]
+## [v0.4.8]
 - Update to protobuf v3.6.1
 - Change second parameter of `krpc_open` to be a configuration parameter of type `krpc_connection_config_t` to allow additional configuration options to be passed, such as baud rate for Arduino serial port (#487)
 - Fix encoding issue in procedure call messages that was causing compilation on Arduino Due to fail
 
-## [0.4.7]
+## [v0.4.7]
 - Fix include paths on Arduino (#482)
 
-## [0.4.6]
+## [v0.4.6]
 - Include directory and main header now suffixed with "_cnano" to avoid name clashes with C++ client
 
-## [0.4.5]
+## [v0.4.5]
 - Fix connection timing out on Arduino when connecting to a server with new client confirmation enabled (#446)
 
-## [0.4.3]
+## [v0.4.3]
 - Remove `KRPC_NO_PRINT_ERRORS` option (now enabled by default) and replace with `KRPC_PRINT_ERRORS_TO_STDERR`
 - Enable `PB_NO_ERRMSG` by default in Arduino version of library
 - Invoke remote procedures using service and produce identifiers instead of names to reduce code size and communication overhead
 
-## [0.4.1]
+## [v0.4.1]
 - Initial version

--- a/client/cpp/CHANGELOG.md
+++ b/client/cpp/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [0.6.0] - unreleased
+## [v0.6.0] - unreleased
 - Update to protobuf v35.1 (#850)
 - Update to ASIO 1.38.0 (#850)
 - Distribute via vcpkg (#874)
@@ -18,79 +18,79 @@
   `Client::wait_for_stream_update` sleeping through the update it was waiting for (#974)
 - Fix `Client::freeze_streams` blocking forever when no stream is producing updates (#974)
 
-## [0.5.2]
+## [v0.5.2]
 - Use protobuf-lite
 - Roll back to protobuf v3.21.12 to avoid absl dependency
 
-## [0.5.0]
+## [v0.5.0]
 - Update to protobuf v3.22.0
 - Update to ASIO 1.24.0
 - Fix include path to ASIO header in CMake build scripts
 - Fix CMake build scripts not building a static library with MSVC on Windows
 
-## [0.4.8]
+## [v0.4.8]
 - Update to protobuf v3.6.1
 - Update to ASIO 1.12.1
 - Add condition variable and callbacks that are called when a stream update message is processed (#473)
 - Fix compilation issue on MacOS
 - Fix cmake configuration detection of protoc binary
 
-## [0.4.7]
+## [v0.4.7]
 - Ensure .lib files are generated when building using CMake with MSVC (#474)
 
-## [0.4.6]
+## [v0.4.6]
 - Add methods to remove callbacks from streams and events (#451)
 - Improve Autotools and CMake build scripts to regenerate the protobuf source if protoc is installed
 
-## [0.4.5]
+## [v0.4.5]
 - Update to protobuf v3.5.1
 
-## [0.4.4.post1]
+## [v0.4.4.post1]
 - Add missing files to build scripts
 
-## [0.4.3]
+## [v0.4.3]
 - Add rate control for streams (#116, #141)
 
-## [0.4.0]
+## [v0.4.0]
 - Updated protocol in line with server changes
 - Remove connection retries. Client will now fail fast if it fails to connect to the server.
 - Add support for RPCs and streams to throw exceptions
 
-## [0.3.11]
+## [v0.3.11]
 - Update to protobuf v3.4.1
 
-## [0.3.10]
+## [v0.3.10]
 - Set `ASIO_STANDLONE` in build script instead of source code so that configure script can find the header correctly
 - Add support for building using Cygwin
 - Update to protobuf v3.4.0
 
-## [0.3.9]
+## [v0.3.9]
 - Update to protobuf v3.3.0
 
-## [0.3.8]
+## [v0.3.8]
 - Update to protobuf v3.2.0
 - Update build scripts to check for protobuf >= 3.2 (#374)
 - Move `krpc::connect` into client constructor to allow use of smart pointers
 - Fix bug in `StreamManager` when client is not set
 
-## [0.3.7]
+## [v0.3.7]
 - Add missing header to automake script
 - Add stream freezing (#357)
 - Make stream objects default and copy constructible (#358)
 
-## [0.3.6]
+## [v0.3.6]
 - Fix configure script
 
-## [0.3.4]
+## [v0.3.4]
 - Update to protobuf v3.0.0-beta-3
 
-## [0.2.3]
+## [v0.2.3]
 - Make client thread safe
 - Add checks for `asio.hpp` and protobuf library to cmake script
 - Add Windows with MSVC support to cmake script
 - Fix compiler warnings reported by MSVC
 
-## [0.2.2]
+## [v0.2.2]
 - Add support for streams (#175)
 - Add documentation to service header files
 - Add autotools and cmake build scripts
@@ -98,12 +98,12 @@
 - Remove support for protobuf enumeration and custom protobuf messages
 - Add comparison operations for remote objects
 
-## [0.2.1]
+## [v0.2.1]
 - Remove dependency on boost
 - Use standalone ASIO library for network communication
 
-## [0.2.0]
+## [v0.2.0]
 - Update to protobuf 3.0.0-beta-2
 
-## [0.1.12]
+## [v0.1.12]
 - Initial version

--- a/client/csharp/CHANGELOG.md
+++ b/client/csharp/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [0.6.0] - unreleased
+## [v0.6.0] - unreleased
 - **Breaking:** Requires .NET Framework 4.7.2 or later (#948)
 - Update to protobuf v3.35.1 (#850)
 - Mark deprecated members with the `[Obsolete]` attribute (#904)
@@ -8,61 +8,61 @@
 - An exception thrown by a stream or event callback no longer escapes the stream update thread (#1005)
 - Fix a deadlock between the stream update thread and a thread waiting for an update (#1005)
 
-## [0.5.0]
+## [v0.5.0]
 - Update to protobuf v3.22.0
 - Drop support for net35
 
-## [0.4.8]
+## [v0.4.8]
 - Update to protobuf v3.6.1
 
-## [0.4.6]
+## [v0.4.6]
 - Add methods to remove callbacks from streams and events (#451)
 
-## [0.4.5]
+## [v0.4.5]
 - Update to protobuf v3.5.1
 
-## [0.4.3]
+## [v0.4.3]
 - Add rate control for streams (#116, #141)
 
-## [0.4.0]
+## [v0.4.0]
 - Updated protocol in line with server changes
 - Add support for RPCs and streams to throw exceptions
 
-## [0.3.11]
+## [v0.3.11]
 - Update to protobuf v3.4.1
 
-## [0.3.10]
+## [v0.3.10]
 - Add support for .NET 3.5 (allows use of the client from within KSP itself)
 - Update to protobuf v3.4.0
 
-## [0.3.9]
+## [v0.3.9]
 - Update to protobuf v3.3.0
 
-## [0.3.8]
+## [v0.3.8]
 - Update to protobuf v3.2.0
 
-## [0.3.7]
+## [v0.3.7]
 - Update to protobuf v3.1.0
 - Remove pre-release flag from nuget version
 
-## [0.3.5]
+## [v0.3.5]
 - Fix race condition where the connection constructor returns before the stream server connection has been established
 - Make `Connection` and `StreamManager` disposable so that they clean up resources correctly
 - Fix issue where network streams are closed prematurely
 - Fix issue with receiving partial protobuf messages
 
-## [0.3.4]
+## [v0.3.4]
 - Update to protobuf v3.0.0-beta-3
 
-## [0.2.3]
+## [v0.2.3]
 - Make client thread safe
 
-## [0.2.2]
+## [v0.2.2]
 - Remove support for protobuf enumeration and custom protobuf messages
 
-## [0.2.1]
+## [v0.2.1]
 - Add documentation to generated service code
 - Add support for streams
 
-## [0.2.0]
+## [v0.2.0]
 - Initial version

--- a/client/java/CHANGELOG.md
+++ b/client/java/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [0.6.0] - unreleased
+## [v0.6.0] - unreleased
 - Update to protobuf v4.35.1, guava 33.4.8-jre, antlr4-runtime 4.13.2 (#850)
 - Mark deprecated members with the `@Deprecated` annotation and an `@deprecated` javadoc tag (#904)
 - Reduce copying when encoding values (#979)
@@ -8,23 +8,23 @@
 - Fix a deadlock between the stream update thread and a thread waiting for an update (#1004)
 - An error from a service with no generated stubs loaded now raises an `RPCException` describing it (#1004)
 
-## [0.5.0]
+## [v0.5.0]
 - Update to protobuf v3.22.0
 
-## [0.4.8]
+## [v0.4.8]
 - Make `Connection` class implement `AutoClosable` (#491)
 - Update to protobuf v3.6.1
 
-## [0.4.6]
+## [v0.4.6]
 - Add methods to remove callbacks from streams and events (#451)
 
-## [0.4.5]
+## [v0.4.5]
 - Update to protobuf v3.5.1
 
-## [0.4.3]
+## [v0.4.3]
 - Add rate control for streams (#116, #141)
 
-## [0.4.0]
+## [v0.4.0]
 - Updated protocol in line with server changes
 - Add support for RPCs and streams to throw exceptions
 - Clean up error reporting:
@@ -34,21 +34,21 @@
     as these errors should not occur as a result of user input.
 - Minor code clean up, and source now checked with CheckStyle
 
-## [0.3.10]
+## [v0.3.10]
 - Update to protobuf v3.4.0
 
-## [0.3.9]
+## [v0.3.9]
 - Update to protobuf v3.3.0
 
-## [0.3.8]
+## [v0.3.8]
 - Update to protobuf v3.2.0
 
-## [0.3.4]
+## [v0.3.4]
 - Update to protobuf v3.0.0-beta-3
 
-## [0.2.3]
+## [v0.2.3]
 - Make client thread safe
 - Support JDK 1.7+
 
-## [0.2.2]
+## [v0.2.2]
 - Initial version

--- a/client/lua/CHANGELOG.md
+++ b/client/lua/CHANGELOG.md
@@ -1,42 +1,42 @@
-## [0.6.0] - unreleased
+## [v0.6.0] - unreleased
 - Fix `attributes` module to always return boolean for `is_a_class_member` and `is_a_class_property_accessor` (#850)
 - Fix service, method and property names being converted to snake case using the machine's locale (#993)
 - Calling a procedure with an argument that needs coercing no longer leaves a global named
   `ok` behind (#1003)
 - Remove `encoder.client_name`; a leftover from before the protocol used protocol buffers (#1003)
 
-## [0.5.0]
+## [v0.5.0]
 - Update to protobuf v3.22.0
 
-## [0.4.8]
+## [v0.4.8]
 - Update to protobuf v3.6.1
 
-## [0.4.5]
+## [v0.4.5]
 - Update to protobuf v3.5.1
 
-## [0.4.0]
+## [v0.4.0]
 - Updated protocol in line with server changes
 
-## [0.3.10]
+## [v0.3.10]
 - Update to protobuf v3.4.0
 
-## [0.3.9]
+## [v0.3.9]
 - Update to protobuf v3.3.0
 
-## [0.3.8]
+## [v0.3.8]
 - Update to protobuf v3.2.0
 
-## [0.2.2]
+## [v0.2.2]
 - Remove support for protobuf enumeration and custom protobuf messages
 
-## [0.2.1]
+## [v0.2.1]
 - None
 
-## [0.2.0]
+## [v0.2.0]
 - Update to protobuf 3.0.0-beta-2
 
-## [0.1.12]
+## [v0.1.12]
 - None, bumped version number
 
-## [0.1.11]
+## [v0.1.11]
 - Initial version

--- a/client/python/CHANGELOG.md
+++ b/client/python/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [0.6.0] - unreleased
+## [v0.6.0] - unreleased
 - **Breaking:** Requires Python 3.10+ (#837)
 - Update to protobuf v7.35.1 (#850)
 - Allow calling static class methods from a class instance (#832)
@@ -17,37 +17,37 @@
 - Fix a stream returning `None` rather than its value, or the error saying it has none, when
   read as its first update was being stored (#1008)
 
-## [0.5.4]
+## [v0.5.4]
 - Fix streams for services without pre-generated stubs (#774)
 
-## [0.5.3]
+## [v0.5.3]
 - Fix assertion error when connecting to a server with third party services installed (#754)
 
-## [0.5.2]
+## [v0.5.2]
 - Requires Python 3.7+
 - Add type hints (#703)
 - Pre-generated stubs now include implementation of services as well as type hints
 - Fix various type hint bugs in generated stubs
 - Allow importing types from a service using, for example "`from krpc.services.spacecenter import Vessel`"
 
-## [0.5.0]
+## [v0.5.0]
 - Fix protobuf requirement to be >=3.6 (#506, #510)
 - Update to protobuf v4.22.0
 
-## [0.4.8]
+## [v0.4.8]
 - Update to protobuf v3.6.1
 - Add condition variable and callbacks that are called when a stream update message is processed (#473)
 
-## [0.4.6]
+## [v0.4.6]
 - Add methods to remove callbacks from streams and events (#451)
 
-## [0.4.5]
+## [v0.4.5]
 - Update to protobuf v3.5.1
 
-## [0.4.3]
+## [v0.4.3]
 - Add rate control for streams (#116, #141)
 
-## [0.4.0]
+## [v0.4.0]
 - Updated protocol in line with server changes
 - Remove connection retries. Client will now fail fast if it fails to connect to the server
 - Reorder parameters to `krpc.connect()` so that name is first - to be consistent with other client libraries
@@ -56,70 +56,70 @@
 - Add support for events
 - Don't execute an initial RPC when a stream is created, wait for the first update instead
 
-## [0.3.10]
+## [v0.3.10]
 - Update to protobuf v3.4.0
 
-## [0.3.9.post1]
+## [v0.3.9.post1]
 - Fix compatibility with protobuf v3.4.0
 
-## [0.3.9]
+## [v0.3.9]
 - Update to protobuf v3.3.0
 
-## [0.3.8.post1]
+## [v0.3.8.post1]
 - Rename protobuf generated files to `*_pb2.py` to fix issue with protobuf 3.2.0 (#378, #376)
 - Relax package requirements to protobuf >= 3
 
-## [0.3.8]
+## [v0.3.8]
 - Clean up code to meet PEP 8 guidelines
 - Update to protobuf v3.2.0
 - Change package requirements to protobuf >= 3.2
 
-## [0.3.7]
+## [v0.3.7]
 - Fix bug parsing nested collection types
 
-## [0.3.6]
+## [v0.3.6]
 - Fix values not being documented in generated enumeration classes
 
-## [0.3.5]
+## [v0.3.5]
 - Add check for number of elements in a tuple before invoking an RPC (#276)
 - Fix unicode issue (#284)
 
-## [0.3.4]
+## [v0.3.4]
 - Update protobuf to v3.0.0-beta-3
 
-## [0.2.2]
+## [v0.2.2]
 - Fix exception when stream thread shuts down (#197)
 - Remove support for protobuf enumeration and custom protobuf messages
 - Add comparison methods to remote objects so that they are sortable
 
-## [0.2.1]
+## [v0.2.1]
 - Fix bug with `setup.py` on Windows
 - Add version number to python module
 
-## [0.2.0]
+## [v0.2.0]
 - Update protobuf 3.0.0-beta-2
 - Fix bug in keyword arg handling (#168)
 - Removed `TestServer.exe` and associated binaries from release archive
 
-## [0.1.12]
+## [v0.1.12]
 - Server connection method now retries 10 times every 0.1 seconds
 
-## [0.1.11]
+## [v0.1.11]
 - Docstrings generated from documentation returned by `KRPC.GetServices` (#31)
 
-## [0.1.10]
+## [v0.1.10]
 - Bump version number
 
-## [0.1.9]
+## [v0.1.9]
 - Bump version number
 
-## [0.1.8]
+## [v0.1.8]
 - Improved dynamic creation of service methods
 - Support for static class methods (#106)
 - Improve enums: return an `Enum` object instead of an `int`
 - Fix bug with types across multiple connections (#110)
 
-## [0.1.7]
+## [v0.1.7]
 - Support for Python 3
 - Upgrade to Protocol Buffers 3.0.0-alpha-1
 - Checking of address and port parameters before connecting
@@ -127,25 +127,25 @@
 - Improve detection of protobuf message and enum types and improve support for 3rd party types (#38)
 - Fix unicode decoding/encoding bugs (#104)
 
-## [0.1.6]
+## [v0.1.6]
 - None, bumped version to match server version
 
-## [0.1.5]
+## [v0.1.5]
 - Add `Client.close()`
 
-## [0.1.4]
+## [v0.1.4]
 - Improved network code to fix bugs and make it more robust
 - Add python version checks
 - Make connections thread safe
 
-## [0.1.3]
+## [v0.1.3]
 - Fix bug with encoding/decoding of infinities and NaNs
 
-## [0.1.2]
+## [v0.1.2]
 - Convert parameter names to snake_case
 
-## [0.1.1]
+## [v0.1.1]
 - Update example script
 
-## [0.1.0]
+## [v0.1.0]
 - Initial pre-release

--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [0.6.0] - unreleased
+## [v0.6.0] - unreleased
 - Add `Version` property to `Core`, set by the server plugin on startup (#848)
 - Enable `TCP_NODELAY` on client TCP connections, reducing RPC round-trip latency (#879)
 - Surface deprecated members (annotated with `[Obsolete]`) in the service definition and over the wire (#904)
@@ -12,5 +12,5 @@
 - Fix websocket connection URL query parameter parsing (#973)
 - Fix locale issues with type codes in the service description, and HTTP and websocket protocol tokens (#993)
 
-## [0.5.4]
+## [v0.5.4]
 - Initial version, split off from `KRPC.dll`

--- a/doc/BUILD.bazel
+++ b/doc/BUILD.bazel
@@ -137,11 +137,12 @@ genrule(
     srcs = ["conf.py.tmpl"],
     outs = ["src/conf.py"],
     # %VERSION%/%SUBPATH% get the channel ('dev' or the release number) and
-    # %GITHUB_REF% the source ref (main or vX.Y.Z). The commit sha is
-    # deliberately not substituted in: it reaches a dev build's footer at
-    # page-load time via build-info.json, keeping the HTML identical from one
-    # commit to the next.
-    cmd = "sed -e 's/%VERSION%/" + docs_version + "/g' -e 's/%SUBPATH%/" + docs_version + "/g' -e 's/%GITHUB_REF%/" + github_ref + "/g' \"$<\" > \"$@\"",
+    # %GITHUB_REF% the source ref (main or vX.Y.Z). %FULL_VERSION% gets the
+    # untruncated config.bzl version (the client artifacts' version), for
+    # examples that name a built jar. The commit sha is deliberately not
+    # substituted in: it reaches a dev build's footer at page-load time via
+    # build-info.json, keeping the HTML identical from one commit to the next.
+    cmd = "sed -e 's/%VERSION%/" + docs_version + "/g' -e 's/%SUBPATH%/" + docs_version + "/g' -e 's/%FULL_VERSION%/" + version + "/g' -e 's/%GITHUB_REF%/" + github_ref + "/g' \"$<\" > \"$@\"",
 )
 
 sphinx_build(

--- a/doc/conf.py.tmpl
+++ b/doc/conf.py.tmpl
@@ -7,6 +7,14 @@ release = version
 # Browser-tab title on every page. Set explicitly so the version carries a `v`
 # prefix (Sphinx's default title would show the bare 'kRPC X.Y.Z documentation').
 html_title = f'kRPC v{release} documentation'
+
+# version/release above are the published docs channel: 'dev' for a dev build,
+# the release number otherwise. This is the full config.bzl version (dev suffix
+# included), which is what the client artifacts are named after; exposed to
+# reStructuredText as |jar-version| so download/compile examples can name the
+# exact jar this build produced.
+jar_version = '%FULL_VERSION%'
+rst_epilog = '.. |jar-version| replace:: %s' % jar_version
 # End year is the build year, so the footer stays current without edits.
 copyright = '2015-%d, kRPC Org' % datetime.date.today().year
 author = ''

--- a/doc/conf.py.tmpl
+++ b/doc/conf.py.tmpl
@@ -4,6 +4,9 @@ import os
 project = 'kRPC'
 version = '%VERSION%'
 release = version
+# Browser-tab title on every page. Set explicitly so the version carries a `v`
+# prefix (Sphinx's default title would show the bare 'kRPC X.Y.Z documentation').
+html_title = f'kRPC v{release} documentation'
 # End year is the build year, so the footer stays current without edits.
 copyright = '2015-%d, kRPC Org' % datetime.date.today().year
 author = ''
@@ -49,7 +52,7 @@ html_baseurl = 'https://krpc.github.io/krpc/%SUBPATH%/'
 
 html_theme_options = {
     # Brand text in the header. The theme otherwise shows the full docstitle
-    # ("kRPC X.Y.Z documentation"); the version switcher already exposes the
+    # ("kRPC vX.Y.Z documentation"); the version switcher already exposes the
     # version, so keep it out of the header.
     'logo': {'text': 'kRPC Documentation'},
     # Runtime version switcher. Each version's HTML is built once and frozen, so

--- a/doc/gen_docs_index.py
+++ b/doc/gen_docs_index.py
@@ -69,16 +69,18 @@ def build_entries(releases, has_dev):
     """Entries in pydata-sphinx-theme's switcher.json format: `version` is
     matched against the theme's version_match (the subpath a build was
     published under), `name` is the dropdown label, and `preferred` marks the
-    newest release (used by the old-version warning banner)."""
+    newest release (used by the old-version warning banner). The `name` label
+    carries a `v` prefix for display; `version` and `url` stay bare because they
+    are matched against the subpath each build was published under."""
     entries = []
     for i, version in enumerate(releases):
         entry = {
-            "name": version,
+            "name": "v%s" % version,
             "version": version,
             "url": "%s/%s/" % (SITE, version),
         }
         if i == 0:
-            entry["name"] = "%s (stable)" % version
+            entry["name"] = "v%s (stable)" % version
             entry["preferred"] = True
         entries.append(entry)
     if has_dev:

--- a/doc/gen_docs_index.py
+++ b/doc/gen_docs_index.py
@@ -2,8 +2,10 @@
 """Regenerate switcher.json and the root index.html for the versioned docs site.
 
 Scans a gh-pages working tree for per-version subdirectories, semver-sorts them
-newest-first, marks the newest full release as preferred, and appends a `dev`
-entry if a dev/ build is present. Writes, into the same directory:
+newest-first, marks the newest full release as preferred, and — if a dev/ build
+is present — puts a dev entry at the top of the list (labelled with the version
+it is working towards, e.g. `v0.6.0 (dev)`, without making it the default).
+Writes, into the same directory:
 
   * switcher.json -- the runtime version list read by pydata-sphinx-theme's
                      version switcher (the `switcher` entry in html_theme_options)
@@ -49,6 +51,22 @@ def version_key(version):
     return (tuple(nums), 0, pre_parts)
 
 
+def planned_version():
+    """The version the /dev/ build is working towards, read from config.bzl and
+    stripped of any build-stamp suffix (e.g. `0.6.0-3-abcdef` -> `0.6.0`). It is
+    known ahead of the release, so the dev entry can name it rather than showing
+    a bare `dev`."""
+    config = os.path.join(
+        os.path.dirname(os.path.abspath(__file__)), os.pardir, "config.bzl"
+    )
+    with open(config, encoding="utf-8") as fp:
+        for line in fp:
+            match = re.match(r'^version\s*=\s*"([^"]+)"', line)
+            if match:
+                return match.group(1).partition("-")[0]
+    raise RuntimeError("no version found in %s" % config)
+
+
 def discover_versions(root):
     releases = []
     has_dev = False
@@ -65,14 +83,26 @@ def discover_versions(root):
     return releases, has_dev
 
 
-def build_entries(releases, has_dev):
+def build_entries(releases, dev_version):
     """Entries in pydata-sphinx-theme's switcher.json format: `version` is
     matched against the theme's version_match (the subpath a build was
     published under), `name` is the dropdown label, and `preferred` marks the
     newest release (used by the old-version warning banner). The `name` label
     carries a `v` prefix for display; `version` and `url` stay bare because they
-    are matched against the subpath each build was published under."""
+    are matched against the subpath each build was published under.
+
+    `dev_version` is the version the /dev/ build is working towards, or None if
+    there is no dev build. The dev entry leads the list as the newest line, but
+    is not marked preferred, so the newest release stays the default."""
     entries = []
+    if dev_version is not None:
+        entries.append(
+            {
+                "name": "v%s (dev)" % dev_version,
+                "version": "dev",
+                "url": "%s/dev/" % SITE,
+            }
+        )
     for i, version in enumerate(releases):
         entry = {
             "name": "v%s" % version,
@@ -83,10 +113,6 @@ def build_entries(releases, has_dev):
             entry["name"] = "v%s (stable)" % version
             entry["preferred"] = True
         entries.append(entry)
-    if has_dev:
-        entries.append(
-            {"name": "dev", "version": "dev", "url": "%s/dev/" % SITE}
-        )
     return entries
 
 
@@ -122,7 +148,7 @@ def main():
     args = parser.parse_args()
 
     releases, has_dev = discover_versions(args.root)
-    entries = build_entries(releases, has_dev)
+    entries = build_entries(releases, planned_version() if has_dev else None)
 
     switcher_path = os.path.join(args.root, "switcher.json")
     with open(switcher_path, "w", encoding="utf-8") as fp:

--- a/doc/src/java/client.rst
+++ b/doc/src/java/client.rst
@@ -21,11 +21,11 @@ The following example program connects to the server, queries it for its version
 .. literalinclude:: /scripts/client/java/Basic.java
 
 To compile this program using javac on the command line, save the source as ``Example.java`` and run
-the following (replace ``<VERSION>`` with the kRPC version you are using):
+the following:
 
-.. code-block:: bash
+.. parsed-literal::
 
-   javac -cp krpc-java-<VERSION>.jar:protobuf-java-4.35.1.jar:javatuples-1.2.jar Example.java
+   javac -cp krpc-java-|jar-version|.jar:protobuf-java-4.35.1.jar:javatuples-1.2.jar Example.java
 
 Note that you may need to change the paths to the JAR files.
 

--- a/server/CHANGELOG.md
+++ b/server/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [0.6.0] - unreleased
+## [v0.6.0] - unreleased
 - Fix server version reported to clients (read from `KRPC.dll` not `KRPC.Core.dll`) (#848)
 - Fix Logger to write to both `KSP.log` and `Player.log` (#780)
 - Improve RPC and stream update performance (#879)
@@ -8,61 +8,61 @@
 - Support switching the game scene by setting `KRPC.GameScene` (#897)
 - Fix repeated toolbar icons appearing in some situations (#939)
 
-## [0.5.4]
+## [v0.5.4]
 - Fix memory leaks when switching game scene (#779)
 
-## [0.5.2]
+## [v0.5.2]
 - Update to protobuf v3.10.1
 - Fix game lagging when first client connects (#712)
 - Change `KRPCDefaultValueAttribute` so that it applies to parameters directly (#677)
 
-## [0.5.0]
+## [v0.5.0]
 - Support for KSP 1.8+
 - Update to protobuf v3.9.1
 - Update to ModuleManager 4.2.2
 - Fix bug with streams where a stream update is not sent initially after a stream is created, if the stream value is null (#515)
 
-## [0.4.8]
+## [v0.4.8]
 - Support for KSP 1.5.1
 - Update to protobuf v3.6.1
 - Add support for specifying more granular game scenes for RPCs (#471)
 
-## [0.4.7]
+## [v0.4.7]
 - Support for KSP 1.4.4
 - Fix launch site clear checks (#483)
 
-## [0.4.6]
+## [v0.4.6]
 - Support for KSP 1.4.3
 - Remove `CompatibilityChecker` as it's deprecated - instead rely on CKAN and KSP-AVC version checks
 - Update icons to be 64x64 to fix blurring when loading as textures (#453)
 - Fix equality checking for streams of collections (#452)
 - Fix RPC errors being reported in `Response.error` instead of individual `ProcedureResult.error` fields (#467)
 
-## [0.4.5]
+## [v0.4.5]
 - Support KSP 1.4.1
 - Update to protobuf v3.5.1
 - Fix server error and client hang when quickly removing and re-adding a stream
 
-## [0.4.4]
+## [v0.4.4]
 - Add support for more complex server side expressions including function definitions and calls, and operations on collections (#435)
 - Fix service ids to not clash (affected cnano client) (#433)
 
-## [0.4.3]
+## [v0.4.3]
 - Add compatibility for KSP 1.2.2 and 1.3.0
 - Add rate control for streams (#116, #141)
 - Add ability to call an RPC using an integer identifier for the service and procedure, rather than its full service and procedure name (reduces code size and communication overhead for cnano client)
 
-## [0.4.2]
+## [v0.4.2]
 - Include missing `KRPC.IO.Ports` DLL
 
-## [0.4.1]
+## [v0.4.1]
 - Add SerialIO server
 - Fix connection timeout when client connects with auto-accept connections disabled (#425)
 - Add option to pause the server when the game is paused
 - New connections time out after 3 seconds if a connection request message is not received (#428)
 - Fix issue with partial receipt of connection request messsages
 
-## [0.4.0]
+## [v0.4.0]
 - New server architecture that allows multiple concurrent servers, using different settings and protocols
 - Add websockets server protocol for communication with browsers
 - Improved communication protocol (#325)
@@ -80,96 +80,96 @@
 - Server no longer freezes if the game is paused (#347)
 - Added `KRPC.Paused` property to get/set whether the game is paused (#422)
 
-## [0.3.11]
+## [v0.3.11]
 - Support for KSP 1.3.1
 
-## [0.3.10]
+## [v0.3.10]
 - Update to protobuf v3.4.0
 
-## [0.3.9]
+## [v0.3.9]
 - Update to protobuf v3.3.0
 - KSP 1.3 support
 - Fix client activity indicators in UI
 
-## [0.3.8]
+## [v0.3.8]
 - Update to protobuf v3.2.0
 
-## [0.3.7]
+## [v0.3.7]
 - Support for KSP 1.2.2
 - Add `KRPCDefaultValue` attribute. Can be used to set default arguments to non-compile time constants.
 - Update to Protocol Buffers v3.1.0
 
-## [0.3.6]
+## [v0.3.6]
 - Add `KRPC.Clients` that clients can use to get a list of connected clients (#304)
 - Make `KRPC.Core.Instance` public so that other mods can subscribe to server events and access other server APIs (#304)
 - Add "Yes (don't show again)" options to dialogs, add option to skip confirmation when force disconnecting a client
 
-## [0.3.5]
+## [v0.3.5]
 - Support for KSP 1.1.3
 - Fix issue with uncaught exceptions when receiving malformed tuples from clients (#276)
 - Fix issue causing empty stream update messages to be sent to clients
 
-## [0.3.4]
+## [v0.3.4]
 - Update protobuf to v3.0.0-beta-3 (#270)
 - Move `settings.cfg` to PluginData directory to avoid trashing module managers cache
 - Fix stack trace output when verbose errors is enabled
 - Performance improvements and reduced memory allocation pressure in main server loop
 - Renamed `Parameter.default_argument` to `default_value` in protobuf definitions
 
-## [0.3.3]
+## [v0.3.3]
 - Fix popup dialogs not displaying (#266)
 
-## [0.3.2]
+## [v0.3.2]
 - Fix `KRPC.CurrentGameScene` (#262)
 
-## [0.2.4]
+## [v0.2.4]
 - Shut down server when switching to main menu (or any other non-game scene)
 
-## [0.2.3]
+## [v0.2.3]
 - Added `KRPC.CurrentGameScene` (#237)
 
-## [0.2.2]
+## [v0.2.2]
 - Stream updates are only sent to clients when the result changes (#170)
 - Removed support for protobuf enumerations and custom protobuf messages as RPC parameter/return values. Note: these features were not used anywhere, and only cause complications for client libraries
 - Fix bug where KSP hangs if the game is quit whilst the server is running
 - Remove support for blizzy's toolbar, in favour of using the stock applauncher
 
-## [0.2.1]
+## [v0.2.1]
 - Add "Any" option to server address drop down
 
-## [0.2.0]
+## [v0.2.0]
 - Update to protobuf 3.0.0-beta-2
 
-## [0.1.12]
+## [v0.1.12]
 - Built for KSP 1.0.5
 
-## [0.1.11]
+## [v0.1.11]
 - Documentation returned by calling `KRPC.GetServices` (#31)
 - Fix bug preventing disconnection of clients from the server window (#161)
 - Fix clearing bytes read/written statistics when the server is restarted
 - Add "Clear Statistics" button to server info window
 - Documentation at http://djungelorm.github.io/krpc/docs/ generated by calling `KRPC.GetServices` (#31)
 
-## [0.1.10]
+## [v0.1.10]
 - KSP 1.0.4 support (#151)
 - Performance improvements (#129,#131,#139)
 - Fix UI disappearing bug (#133)
 
-## [0.1.9]
+## [v0.1.9]
 - None
 
-## [0.1.8]
+## [v0.1.8]
 - KSP 1.0.2 support (#114)
 - Add support for static class methods (#106)
 
-## [0.1.7]
+## [v0.1.7]
 - Fix CKAN install bug on Windows (#105)
 
-## [0.1.6]
+## [v0.1.6]
 - Nicer errors returned to client (#97)
 - Include protobuf source and compiled Python, Java and C++ versions in release (#100)
 
-## [0.1.5]
+## [v0.1.5]
 - Server now persists across game scene changes
 - Services specify during which game scenes they are available
 - Use a combo box for the server address
@@ -178,7 +178,7 @@
 - Add logging severity levels
 - Fix bug where yielded continuations are run more than once per update
 
-## [0.1.4]
+## [v0.1.4]
 - Support for KSP 0.90.0
 - Add support for tuples (#49,#50)
 - Add support for streams (#24,#56)
@@ -187,14 +187,14 @@
 - No longer bundle Toolbar plugin (kRPC will still use Toolbar plugin if available)
 - Performance improvements (#68)
 
-## [0.1.3]
+## [v0.1.3]
 - Add support for collections (lists, dictionaries and sets)
 
-## [0.1.2]
+## [v0.1.2]
 - None
 
-## [0.1.1]
+## [v0.1.1]
 - Minor server code improvements
 
-## [0.1.0]
+## [v0.1.0]
 - Initial pre-release

--- a/service/DockingCamera/CHANGELOG.md
+++ b/service/DockingCamera/CHANGELOG.md
@@ -1,5 +1,5 @@
-## [0.6.0] - unreleased
+## [v0.6.0] - unreleased
 - Fix `DockingCamera.Available` incorrectly reporting false in game scenes other than flight (#937)
 
-## [0.5.0]
+## [v0.5.0]
 - Initial version

--- a/service/Drawing/CHANGELOG.md
+++ b/service/Drawing/CHANGELOG.md
@@ -1,12 +1,12 @@
-## [0.5.0]
+## [v0.5.0]
 - Add `Drawing.AddDirectionFromCoM`
 - Change `Drawing.AddDirection` to start the line at the origin of the reference frame (#518)
 
-## [0.4.8]
+## [v0.4.8]
 - Fix reference frames for `AddDirection` so that the line always starts at the active vessel's CoM (#486)
 
-## [0.4.0]
+## [v0.4.0]
 - Make `Test.AvailableFonts` a static method
 
-## [0.3.4]
+## [v0.3.4]
 - Initial version (#253)

--- a/service/InfernalRobotics/CHANGELOG.md
+++ b/service/InfernalRobotics/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [0.6.0] - unreleased
+## [v0.6.0] - unreleased
 - Add to `Servo`: `UID`, `Mode` (with a new `ServoMode` enum), `TargetPosition`, `TargetSpeed`,
   `CommandedPosition`, `DefaultPosition`, `ForceLimit`, `MaxForce`, `MaxAcceleration`, `MaxSpeed`,
   `ElectricChargeRequired`, `SpringPower`, `DampingPower`, `RotorAcceleration`, `IsLimited`,
@@ -13,26 +13,26 @@
 - Make `InfernalRobotics.Available` report correctly in all game scenes (#941)
 - Fix `InfernalRobotics.Ready` reporting false when queried before IR has finished loading (#941)
 
-## [0.5.0]
+## [v0.5.0]
 - Update to work with Infernal Robotics Next v3.1.9
 - Drop support for original Infernal Robotics mod
 - Remove `Servo.MoveNextPreset` and `Servo.MovePrevPreset` as they no longer exist in the mod
 
-## [0.4.8]
+## [v0.4.8]
 - Add suport for both original Infernal Robotics and Infernal Robotics Next (#476)
 - Add `InfernalRobotics.Ready` which indicates if the IR is on the current vessel and ready to receive commands
 - Change `InfernalRobotics.Available` to return whether the IR mod is installed (not if the IR API is "ready")
 
-## [0.3.7]
+## [v0.3.7]
 - Add `InfernalRobotics.Available`
 
-## [0.3.5]
+## [v0.3.5]
 - Add vessel parameter to `ServoGroups`, `Servos` and `ServoWithName` (#282)
 - Add `Servo.Part`
 - Add `ServoGroup.Parts`
 
-## [0.3.3]
+## [v0.3.3]
 - Rename `ControlGroup` to `ServoGroup`
 
-## [0.1.9]
+## [v0.1.9]
 - Initial version - API for InfernalRobotics (http://forum.kerbalspaceprogram.com/threads/116064)

--- a/service/KerbalAlarmClock/CHANGELOG.md
+++ b/service/KerbalAlarmClock/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [0.6.0] - unreleased
+## [v0.6.0] - unreleased
 - Make available in all game scenes (#944)
 - Add `AlarmType.ScienceLab` (#982)
 - Add `AlarmAction.Custom` and `AlarmAction.Converted` (#982)
@@ -8,17 +8,17 @@
 - Fix alarm equality, so the same alarm obtained twice compares equal (#982)
 - Fix accessing an alarm after it has been removed; it now fails with an "Alarm does not exist" error (#982)
 
-## [0.5.0]
+## [v0.5.0]
 - Update API wrapper to work with KerbalAlarmClock v3.13.0.0
 
-## [0.3.7]
+## [v0.3.7]
 - Add `KerbalAlarmClock.Available`
 
-## [0.1.12]
+## [v0.1.12]
 - Renamed `Alarm.Delete` to `Alarm.Remove` (to not clash with C++ keyword)
 
-## [0.1.10]
+## [v0.1.10]
 - Service now available in all game scenes (#135)
 
-## [0.1.9]
+## [v0.1.9]
 - Initial version - API for Kerbal Alarm Clock (http://forum.kerbalspaceprogram.com/threads/24786)

--- a/service/LiDAR/CHANGELOG.md
+++ b/service/LiDAR/CHANGELOG.md
@@ -1,5 +1,5 @@
-## [0.6.0] - unreleased
+## [v0.6.0] - unreleased
 - Fix `LiDAR.Available` incorrectly reporting false in game scenes other than flight (#937)
 
-## [0.5.0]
+## [v0.5.0]
 - Initial version

--- a/service/RemoteTech/CHANGELOG.md
+++ b/service/RemoteTech/CHANGELOG.md
@@ -1,11 +1,11 @@
-## [0.6.0] - unreleased
+## [v0.6.0] - unreleased
 - Fix `RemoteTech.Available` incorrectly reporting false in game scenes other than flight (#937)
 
-## [0.3.7]
+## [v0.3.7]
 - Add `RemoteTech.Available`
 - Change required RemoteTech version to 1.8.0
 
-## [0.3.3]
+## [v0.3.3]
 - Moved from `SpaceCenter` to separate service
 - Support RemoteTech 1.7
 - Add individual `Antenna` objects

--- a/service/SpaceCenter/CHANGELOG.md
+++ b/service/SpaceCenter/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [0.6.0] - unreleased
+## [v0.6.0] - unreleased
 
 - Space center
   - Add `SpaceCenter.Expansions` to report the installed KSP expansions (#985)
@@ -265,7 +265,7 @@
   - Fix part module field values being formatted using the machine's locale, so that
     `Module.Fields`, `Module.GetField` and `PartField.Value` returned numbers that clients running
     under a locale that writes decimals with a comma could not parse (#993)
-## [0.5.4]
+## [v0.5.4]
 - Fix vessel recovery (#782)
 - Allow vessel switch from any scene (#781)
 - Fix memory leaks on each scene switch (#779)
@@ -276,7 +276,7 @@
 - Make `CelestialBody` parameters doulbe precision (#786)
 - Fix scaled camera distance clamp (#785)
 
-## [0.5.2]
+## [v0.5.2]
 - Fix null reference exception when `SpaceCenter.LaunchVesselFromVAB` is called with no crew (#599)
 - Add `Engine.IndependentThrottle` to check whether it is enabled
 - Allow setting the independent throttle using `Engine.Throttle`
@@ -288,10 +288,10 @@
 - `Module.SetField*` methods now raise an exception if setting the field to the wrong value type
 - Change default names for alarms created by `AlarmManager`
 
-## [0.5.1]
+## [v0.5.1]
 - Fix null reference exception in autopilot for vessels without custom axis controls (#649)
 
-## [0.5.0]
+## [v0.5.0]
 - Update to work with KSP 1.8+
 - Add to `SpaceCenter`:
   - `LaunchSites`
@@ -345,7 +345,7 @@
 - Fix `RCS.GetTorqueVectors` not considering if each direction is enabled (#591)
 - Add `RCS.AvailableForce` and `Vessel.AvailableRCSForce` (#597)
 
-## [0.4.8]
+## [v0.4.8]
 - Allows RPCs to be accessed from game scenes other than just flight (#471)
 - Merge NameTag (http://github.com/krpc/NameTag) into the main kRPC release
 - Fix air-relative velocity calculation for `SimulateAeroDynamicForceAt` with FAR (#500)
@@ -355,10 +355,10 @@
 - Fix `Flight.TerminalVelocity` (#485)
 - Fix null reference exception when deploying fairings after reverting to launch (#501)
 
-## [0.4.7]
+## [v0.4.7]
 - Fix `Flight.Lift` and `Flight.Drag` should return values in Newtons (#475)
 
-## [0.4.6]
+## [v0.4.6]
 - Added `SpaceCenter.GameMode` (#455)
 - Added `SpaceCenter.Science`, `Funds` and `Reputation` (#455)
 - Fix pre-flight checks not happending in `SpaceCenter.LaunchVessel` (#469)
@@ -366,22 +366,22 @@
 - Change `CelestialBody.Biomes` to return an empty list instead of throwing an exception if the body has no biomes (#457)
 - Fixed science transmission not working correctly (#456)
 
-## [0.4.5]
+## [v0.4.5]
 - Fixed roll input when input mode is override (#445)
 - Marked `CelestialBody.Orbit` as nullable, as it returns null for the sun
 
-## [0.4.4]
+## [v0.4.4]
 - Add `ResourceConverter.ThermalEfficiency`, `CoreTemperature` and `OptimumCoreTemperature` (#439)
 
-## [0.4.1]
+## [v0.4.1]
 - Add `SpaceCenter.RaycastDistance` and `RaycastPart` (#423)
 - Add `Vessel.CrewCount`, `CrewCapacity` and `Crew` (#426)
 - Add `CrewMember` class (#426)
 
-## [0.4.0]
+## [v0.4.0]
 - `AutoPilot.Wait` and `Error` methods now throw an exception if the auto-pilot is not engaged (#409)
 
-## [0.3.10]
+## [v0.3.10]
 - Fix maneuver node reference frame to point in the direction of the remaining burn, rather than just the initially planned burn (#404)
 - Add following to `CelestialBody` class: `AltitudeAtPosition`, `LatitudeAtPosition`, `LongitudeAtPosition` and `AtmosphericDensityAtPosition` (#413)
 - Add following to `Orbit` class: `RadiusAt`, `PositionAt`, `MeanAnomalyAtUT`, `TrueAnomalyAtAN`, `TrueAnomalyAtDN`
@@ -390,7 +390,7 @@
 - Add `CelestialBody.TemperatureAt`, `DensityAt` and `PressureAt` (#350, #352)
 - Add `Flight.SimulateAerodynamicForceAt` (#352)
 
-## [0.3.9]
+## [v0.3.9]
 - Add `VesselType.Plane` and `VesselType.Relay` (#385)
 - Fix `Control.WheelThrottle` and `WheelSteering` (#388)
 - Fix off by one error in stage numbers for `Vessel.ResourcesInDecoupleStage` (#380)
@@ -400,7 +400,7 @@
 - Fix `SpaceCenter.SetTarget` not correctly setting target if input locks are enabled (#397)
 - Fix possible null reference exception in `ResourceConverter.State`
 
-## [0.3.8]
+## [v0.3.8]
 - Add support for CommNet
 - Add support for contracts (#361)
 - Add support for RealChutes, add `Parachute.Arm` and `Parachute.Armed` (#382)
@@ -418,7 +418,7 @@
 - Fix bug with `Part.Rotation` (#371)
 - Fix bug with `Part.BoundingBox` (#370)
 
-## [0.3.7]
+## [v0.3.7]
 - Add custom reference frames (`ReferenceFrame.CreateRelative` and `CreateHybrid`) (#252)
 - Add `Vessel.BoundingBox` and `Part.BoundingBox` (#352)
 - Add `LandingGear.IsGrounded` and `LandingLeg.IsGrounded` (#352)
@@ -433,7 +433,7 @@
 - Change maneuver node methods and properties to use double precision values (#357)
 - Add support for Action Groups Extended mod (#364, #365)
 
-## [0.3.6]
+## [v0.3.6]
 - Add `Part.Tag` which can be used to get/set the name tag set via the NameTag mod, or kOS (#297)
 - Add `Parts.WithTag` to get a list of all parts with the given tag value
 - Remove `DockingPort.Name` and `Parts.DockingPortsWithName` - part tagging can now be used instead
@@ -457,7 +457,7 @@
 - Change camera distances to use meters (#339)
 - Fix engine thrust calculation for air breathing engines (#327)
 
-## [0.3.5]
+## [v0.3.5]
 - Improved `AutoPilot` that auto-tunes itself based on the vessels available torque and moment of inertia (#289)
 - Add `Resources.Enabled` to enable/disable all of the resources in a part or stage at once (#283)
 - Add `Vessel.Recoverable` and `Vessel.Recover()` (#277)
@@ -470,21 +470,21 @@
 - Fix `Engine.AvailableThrust` so that it returns 0 if the vessel is not active
 - Make `ReferenceFrame` type, underlying object and its transform accessible via public properties (#290)
 
-## [0.3.4]
+## [v0.3.4]
 - Move drawing functionality into new `Drawing` service (#253)
 - Add `Light.Color`
 - Add RPCs for setting `PartModule` fields: `Module.ResetField`, `SetFieldInt`, `SetFieldFloat` and `SetFieldString`
 
-## [0.3.3]
+## [v0.3.3]
 - Add `AvailableTorque` properties to vessels, reaction wheels, RCS, engines and control surfaces
 - Rename `ReactionWheel.Torque` to `ReactionWheel.MaxTorque`
 - Fix `Vessel.MomentOfInertia` - use custom inertia tensor calculations to avoid issues with KSPs `Vessel.MoI` and `Vessel.findLocalMoI`
 - Move RemoteTech functionality to separate RemoteTech service
 
-## [0.3.2]
+## [v0.3.2]
 - Fix `Control.SpeedMode` (#258)
 
-## [0.3.0]
+## [v0.3.0]
 - Support for KSP 1.1
 - Add camera controls (note: rotation and zooming of the IVA camera is not yet supported)
 - Add saving and loading games using `SpaceCenter.Save`, `Load`, `Quicksave` and `Quickload` (#247)
@@ -508,7 +508,7 @@
 - Fix bug where `Engine.HasFuel` requires the engine to be throttled up
 - Fix bug with vessel center of mass calculations (#218)
 
-## [0.2.3]
+## [v0.2.3]
 - Add support for engine mode switching (#219)
 - `Engine.GimbalLimit` and `GimbalLocked` now return an error if the engine is not gimballed
 - Add cargo bays, fairings and intakes
@@ -519,7 +519,7 @@
 - Fix null pointer exception in autopilot when switching scenes (#220)
 - Fix bug with translation inputs in `Control` class (#223)
 
-## [0.2.2]
+## [v0.2.2]
 - Add `Part.IsFuelLine`
 - Fix bug with `Part.FuelLinesTo` (#193)
 - `Part.FuelLinesTo` and `FuelLinesFrom` now return an error if called on a fuel line part
@@ -527,19 +527,19 @@
 - Fix array index out of range error in `SpaceCenter.WarpTo` (#169)
 - Fix bug with vessel's surface velocity reference frame (#194)
 
-## [0.2.1]
+## [v0.2.1]
 - Fix `Orbit.Speed` always returning 0
 - Add `CelestialBody.SurfaceHeight`, `BedrockHeight`, `MSLPosition`, `SurfacePosition`, `BedrockPosition` (#186)
 
-## [0.2.0]
+## [v0.2.0]
 - Fix `SpaceCenter.HorizontalSpeed` calculation
 - Added support for resource harvesters and converters (#166,#182)
 - Fix bug with `Flight.SideslipAngle` (#189)
 
-## [0.1.12]
+## [v0.1.12]
 - Built for KSP 1.0.5
 
-## [0.1.11]
+## [v0.1.11]
 - Rename `maxRate` parameter in `SpaceCenter.WarpTo` to `maxRailsRate`
 - Add more thermal properties to `Part` class (for new thermal model in KSP 1.0.3) (#155)
 - Add `Comms.HasLocalControl`
@@ -552,7 +552,7 @@
 - Add `SpaceCenter.LaunchVesselFromVAB` and `SpaceCenter.LaunchVesselFromSPH` (#95)
 - Update aero methods to use FAR 0.15 if available
 
-## [0.1.10]
+## [v0.1.10]
 - KSP 1.0.4 support (#151)
 - Add more time warp functionality: `SpaceCenter.WarpMode`, `WarpRate`, `WarpFactor`,
   `RailsWarpFactor`, `PhysicsWarpFactor`, `CanRailsWarpAt` and `MaximumRailsWarpFactor` (#134)
@@ -564,13 +564,13 @@
 - Add `SpaceCenter.DrawLine` to draw arbitrary lines (#150)
 - Rename `SpaceCenter.ClearDirections` to `SpaceCenter.ClearDrawing`
 
-## [0.1.9]
+## [v0.1.9]
 - Fix bug with combined specific impulse calculations (#117)
 - Add `Engine.PropellantRatios` (#118)
 - Combined `VesselResources` and `PartResources` classes into a single `Resources` class
 - Add `Resources.Density`
 
-## [0.1.8]
+## [v0.1.8]
 - Add `Engine.MaxVacuumThrust`
 - Add `Engine.Throttle`
 - Add `Engine.GimbalLimit`
@@ -581,7 +581,7 @@
   `AtmosphereScaleHeight`, `AtmosphereMaxAltitude`, `AtmospherePressureAt`, `AtmosphereDensityAt`
 - Add `CelestialBody.AtmosphereDepth` and `HasAtmosphericOxygen`
 
-## [0.1.7]
+## [v0.1.7]
 - Add `AutoPilot.SAS`, `SASMode` and `SpeedMode` (#94)
 - Update `AutoPilot.Error` to also return SAS error (#94)
 - Change return types of `Vessel.Mass`, `DryMass`, `CrossSectionalArea`, `SpecificImpulse` to float
@@ -590,13 +590,13 @@
 - Fix orientation of docking port reference frames
 - Rename `Engine.Activated` to `Engine.Active` to match other parts
 
-## [0.1.6]
+## [v0.1.6]
 - `Parts`
 - Targeting of vessels, bodies and docking ports
 - Remove `Orbit.ReferenceFrame`
 - Fix `AutoPilot.Error` and add `AutoPilot.RollError` (#98)
 
-## [0.1.5]
+## [v0.1.5]
 - Add `SpaceCenter.DrawDirection` and `ClearDirections` for visual debugging
 - Add `Vessel.Comms` to interact with RemoteTech
 - Add `Control.WheelThrottle` and `WheelSteering`
@@ -617,7 +617,7 @@
 - `AutoPilot` and `Control` inputs reset to 0 when the client that requested them disconnects
 - Change `AutoPilot` to set SAS to false when it's disengaged
 
-## [0.1.4]
+## [v0.1.4]
 - Major refactoring of reference frames (#66)
 - Add `Control.Nodes` (#53)
 - Add `Body.AtmosphereDensity` (#52)
@@ -631,7 +631,7 @@
 - Fix argument type in `Conrol.AddNode` (#59)
 - Fix bug with `Vessel.HorizontalSpeed` (#67)
 
-## [0.1.3]
+## [v0.1.3]
 - Add `SpaceCenter.Vessels`
 - Add `SpaceCenter.Bodies`
 - Remove `SpaceCenter.Body`
@@ -652,15 +652,15 @@
 - Fix bug with `Node.Vector` returning a vector in the wrong vector space
 - Improvements to `Resources` class
 
-## [0.1.2]
+## [v0.1.2]
 - Include reference frame velocity in orbital direction vectors
 - Remove `ReferenceFrame.SurfaceVelocity` and `ReferenceFrame.TargetVelocity`
 - Change default reference frames for `Vessel.Flight()` and `AutoPilot` functions
   to `ReferenceFrame.Orbital`
 - Use Pa instead of kPa for atmospheric pressure
 
-## [0.1.1]
+## [v0.1.1]
 - Add new functionality to `SpaceCenter` service
 
-## [0.1.0]
+## [v0.1.0]
 - Initial pre-release

--- a/service/UI/CHANGELOG.md
+++ b/service/UI/CHANGELOG.md
@@ -1,10 +1,10 @@
-## [0.6.0] - unreleased
+## [v0.6.0] - unreleased
 - Fix locale issues with `UI.Message` (#993)
 
-## [0.3.5]
+## [v0.3.5]
 - Add `Canvas` class (#281)
 - Add `UI.StockCanvas` to get the stock KSP UI canvas and `UI.AddCanvas` to create additional canvases
 - Move `UI.AddPanel` and `UI.RectTransform` to `Canvas` class
 
-## [0.3.4]
+## [v0.3.4]
 - Initial version

--- a/tools/buildenv/CHANGELOG.md
+++ b/tools/buildenv/CHANGELOG.md
@@ -1,8 +1,8 @@
-## [3.9.1] - unreleased
+## [v3.9.1] - unreleased
 - Add `python-is-python3`, providing a `python` executable for the CI
   version-stamping step in the build-setup action
 
-## [3.9.0]
+## [v3.9.0]
 - Replace mono with a system .NET SDK (the `KRPC.sln` consumer build now uses
   `dotnet build`)
 - Remove dotnet SDK/runtime (`rules_dotnet` is hermetic)
@@ -16,60 +16,60 @@
   instead of the huge extracted output base, to stay under the GitHub Actions
   10 GB cache cap
 
-## [3.8.1]
+## [v3.8.1]
 - Add `graphviz` for dot graph generation in documentation
 
-## [3.8.0]
+## [v3.8.0]
 - Add system-installed nanopb for C-nano client testing
 - Remove autotools
 
-## [3.7.1]
+## [v3.7.1]
 - Add `ccache`
 
-## [3.7.0]
+## [v3.7.0]
 - Add system-installed protobuf and ASIO for C++ client testing
 
-## [3.6.0]
+## [v3.6.0]
 - Update bazel to 9.1.1
 
-## [3.5.0]
+## [v3.5.0]
 - Update base image to Ubuntu 24.04
 - Update to Python 3.12
 - Update bazel to 7.2.1
 - Update to dotnet 10
 
-## [3.4.3]
+## [v3.4.3]
 - Run with github actions uid and gid
 - Fix `buildifier` not installed for all users
 
-## [3.4.2]
+## [v3.4.2]
 - Remove `--distinct_host_configuration` from `bazelrc`
 
-## [3.4.1]
+## [v3.4.1]
 - Update `buildifier` to 7.1.2
 
-## [3.4.0]
+## [v3.4.0]
 - Update to Bazel 7.2.1
 
-## [3.3.0]
+## [v3.3.0]
 - Update to Bazel 6.5.0
 
-## [3.2.0]
+## [v3.2.0]
 - Update to Bazel 6.1.1
 - Remove ksp libs (can now be obtained from ksp-lib repository)
 - Remove `gendarme`
 
-## [3.1.1]
+## [v3.1.1]
 - Add `buildifier`
 
-## [3.1.0]
+## [v3.1.0]
 - Update to Bazel 6.1.0
 - Add dotnet
 
-## [3.0.1]
+## [v3.0.1]
 - Add `cmake`
 
-## [3.0.0]
+## [v3.0.0]
 - Clean up to only include necessary dependencies
 - Remove bazel caching (done using github actions caching instead)
 - Remove costly user management
@@ -77,89 +77,89 @@
 - Update bazel config to allow testing in parallel
 - Update bazel config to do less verbose logging
 
-## [2.6.0]
+## [v2.6.0]
 - Update base image to Ubuntu 22.04
 - Update to Bazel 6.0.0
 - Update to KSP 1.12.5
 
-## [2.5.1]
+## [v2.5.1]
 - Update to Bazel 3.7.0
 
-## [2.5.0]
+## [v2.5.0]
 - Update to KSP 1.10.1
 
-## [2.4.0]
+## [v2.4.0]
 - Update to KSP 1.9.0
 
-## [2.3.0]
+## [v2.3.0]
 - Update build tools to use python 3
 - Update to Bazel 0.28.1
 
-## [2.2.0]
+## [v2.2.0]
 - Update to KSP 1.7.3
 
-## [2.1.2]
+## [v2.1.2]
 - Add `latexmk`
 
-## [2.1.1]
+## [v2.1.1]
 - Remove Bazel workarounds
 
-## [2.1.0]
+## [v2.1.0]
 - Update to Bazel 0.28.0
 
-## [2.0.0]
+## [v2.0.0]
 - Move to Ubuntu 18.04
 
-## [1.12.0]
+## [v1.12.0]
 - Update to KSP 1.5.1
 - Update to Bazel 0.18.0
 
-## [1.11.0]
+## [v1.11.0]
 - Update to KSP 1.4.5
 - Update to Bazel 0.16.1
 
-## [1.10.0]
+## [v1.10.0]
 - Update to KSP 1.4.3
 - Update to Bazel 0.15.2
 
-## [1.9.0]
+## [v1.9.0]
 - Update to Bazel 0.13.0
 - Remove protobuf and asio (no longer required by build scripts)
 
-## [1.8.0]
+## [v1.8.0]
 - Update to KSP 1.4.3
 - Update to Bazel 0.12.0
 
-## [1.7.0]
+## [v1.7.0]
 - Update to KSP 1.4.2
 
-## [1.6.0]
+## [v1.6.0]
 - Update to KSP 1.4.1
 
-## [1.5.0]
+## [v1.5.0]
 - Update to KSP 1.4.0
 - Update the Bazel 0.11.1
 - Update to protobuf v3.5.1
 
-## [1.4.0]
+## [v1.4.0]
 - Update to Bazel 0.7.0
 - Add `socat` for SerialIO tests
 
-## [1.3.0]
+## [v1.3.0]
 - Update to KSP 1.3.1
 - Update to Bazel 0.6.1
 - Update to protobuf v3.4.1
 - Update Mono to use Ubuntu 16.04 repository
 - Add dependencies for running lint tests
 
-## [1.2.0]
+## [v1.2.0]
 - Update to Bazel 0.5.4
 - Update to protobuf v3.4.0
 
-## [1.1.0]
+## [v1.1.0]
 - Update to KSP 1.3
 - Update to Bazel 0.5.0
 - Update to protobuf v3.3.0
 
-## [1.0.0]
+## [v1.0.0]
 - Initial version.

--- a/tools/krpctest/CHANGELOG.md
+++ b/tools/krpctest/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [0.6.0] - unreleased
+## [v0.6.0] - unreleased
 - Add the `TestCase.expansions` attribute, to declare KSP expansions a test class
   requires; the class is skipped when a required expansion is not installed
 - Run the integration tests with `pytest`, replacing the custom test runner
@@ -15,11 +15,11 @@
 - Fix a crash when waiting for a vessel and there is no active vessel yet
 - Migrate packaging to `pyproject.toml` (`hatchling`) and require Python 3.10+
 
-## [0.3.9]
+## [v0.3.9]
 - Update test saves for KSP 1.3
 
-## [0.3.8]
+## [v0.3.8]
 - Clean up code to meet PEP 8 guidelines
 
-## [0.3.3]
+## [v0.3.3]
 - Initial version

--- a/tools/krpctools/CHANGELOG.md
+++ b/tools/krpctools/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [0.6.0] - unreleased
+## [v0.6.0] - unreleased
 - **Breaking:** Requires Python 3.10+
 - **Breaking:** `krpc-servicedefs` now runs the `ServiceDefinitions` tool
   on the .NET 8 runtime; Mono is no longer required
@@ -17,37 +17,37 @@
 - Fix generating client stubs and documentation from a KSP install failing when the machine's
   locale is not UTF-8 and a service's documentation contains non-ASCII characters
 
-## [0.5.4]
+## [v0.5.4]
 - Fix incorrect protobuf DLL (#755)
 - Fix required KSP assemblies not being copied (#755)
 - Fix tmp directory not being deleted (#755)
 - Fix `clientgen` generating invalid python code for undocumented enumeration values (#757)
 
-## [0.4.9]
+## [v0.4.9]
 - Fix issue finding `KSP_x64_Data` directory (#523)
 - Add `TestServer` archive to bin directory (#532)
 
-## [0.4.8]
+## [v0.4.8]
 - Fix Python 3 compatibility
 - Fix template loading in `docgen` on Windows
 - Add documentation of game scenes for each RPC
 
-## [0.3.8]
+## [v0.3.8]
 - Clean up code to meet PEP 8 guidelines
 
-## [0.3.7]
+## [v0.3.7]
 - Fix bug parsing nested collection types
 - Fix bug generating key type for dictionaries
 
-## [0.3.6]
+## [v0.3.6]
 - Fix generating Java client stubs using `krpc-clientgen` with Python 3 (#308)
 
-## [0.3.4]
+## [v0.3.4]
 - Update protobuf to v3.0.0-beta-3
 
-## [0.2.2]
+## [v0.2.2]
 - Refactor into '`krpctools`' package containing '`krpc-clientgen`', '`krpc-docgen`' and '`krpc-servicedefs`'.
 - Fixes caused by removal of support for protobuf enumeration and custom protobuf messages from server and clients
 
-## [0.2.1]
+## [v0.2.1]
 - Initial version

--- a/tools/krpctools/krpctools/changelog/__init__.py
+++ b/tools/krpctools/krpctools/changelog/__init__.py
@@ -49,8 +49,11 @@ _ROLES = "\n".join(
 )
 
 # Version header: the bracketed version, then any trailing text (e.g. the
-# ' - unreleased' marker on the in-development version).
-_VERSION_RE = re.compile(r"^##\s+\[(\d[^\]]*)\]\s*(.*)$")
+# ' - unreleased' marker on the in-development version). An optional `v` prefix
+# on the bracketed version is accepted and dropped, so the captured version is
+# bare (older frozen-doc sources predate the prefix); the `v` is re-added when
+# the heading is rendered.
+_VERSION_RE = re.compile(r"^##\s+\[v?(\d[^\]]*)\]\s*(.*)$")
 _RST_SPECIAL_RE = re.compile(r"([\\*`|_])")
 _ISSUE_RE = re.compile(r"#(\d+)")
 _NUM_RE = re.compile(r"^\d+$")
@@ -207,7 +210,9 @@ def render(components, unreleased=()):
     out = [_ROLES, heading("Changelog", "=")]
 
     for version in ordered:
-        title = "%s - unreleased" % version if version in unreleased else version
+        title = (
+            "v%s - unreleased" % version if version in unreleased else "v%s" % version
+        )
         out.append("\n" + heading(title, "-"))
 
         for name, versions in components:

--- a/tools/krpctools/krpctools/clientgen/__init__.py
+++ b/tools/krpctools/krpctools/clientgen/__init__.py
@@ -32,7 +32,7 @@ def main():
         "-v",
         "--version",
         action="version",
-        version="%s version %s" % (prog, __version__),
+        version="%s version v%s" % (prog, __version__),
     )
     parser.add_argument(
         "language", help="Language to generate (%s) or path to generator" % languages

--- a/tools/krpctools/krpctools/docgen/__init__.py
+++ b/tools/krpctools/krpctools/docgen/__init__.py
@@ -31,7 +31,7 @@ def main():
         "-v",
         "--version",
         action="version",
-        version="%s version %s" % (prog, __version__),
+        version="%s version v%s" % (prog, __version__),
     )
     parser.add_argument(
         "language",

--- a/tools/krpctools/krpctools/servicedefs/__init__.py
+++ b/tools/krpctools/krpctools/servicedefs/__init__.py
@@ -18,7 +18,7 @@ def main():
         "-v",
         "--version",
         action="version",
-        version="%s version %s" % (prog, __version__),
+        version="%s version v%s" % (prog, __version__),
     )
     parser.add_argument("ksp", help="Path to Kerbal Space Program directory")
     parser.add_argument("service", help="Name of service")

--- a/tools/release/10-preflight.py
+++ b/tools/release/10-preflight.py
@@ -76,8 +76,8 @@ def check_repository(report):
 def check_changelogs(report):
     lib.banner(f'Changelogs (a component with no user-facing changes has no '
                f'{lib.TAG} section and is omitted from the release notes)')
-    # Matches '## [X.Y.Z]' with or without the ' - unreleased' suffix.
-    header = f'## [{lib.VERSION}]'
+    # Matches '## [vX.Y.Z]' with or without the ' - unreleased' suffix.
+    header = f'## [v{lib.VERSION}]'
     for changelog in lib.changelogs():
         if any(line.startswith(header)
                for line in Path(changelog).read_text().splitlines()):

--- a/tools/release/changes.py
+++ b/tools/release/changes.py
@@ -102,9 +102,10 @@ def get_changes(path):
             line = line.rstrip('\n')
             if line == '':
                 continue
-            # '## [X.Y.Z]' header; any suffix inside the brackets (e.g. a
-            # '.postN') or after them (' - unreleased') is ignored.
-            m = re.match(r'^##\s+\[([0-9]+\.[0-9]+\.[0-9]+)[^\]]*\]', line)
+            # '## [vX.Y.Z]' header; an optional 'v' prefix is dropped so the
+            # captured version is bare, and any suffix inside the brackets (e.g.
+            # a '.postN') or after them (' - unreleased') is ignored.
+            m = re.match(r'^##\s+\[v?([0-9]+\.[0-9]+\.[0-9]+)[^\]]*\]', line)
             if m:
                 version = m.group(1)
                 top = None

--- a/tools/release/lib.py
+++ b/tools/release/lib.py
@@ -139,10 +139,10 @@ def strip_unreleased():
     every component changelog, returning the paths that changed.
 
     While on main the in-development version's header reads
-    ``## [X.Y.Z] - unreleased``; releasing turns it into ``## [X.Y.Z]``.
+    ``## [vX.Y.Z] - unreleased``; releasing turns it into ``## [vX.Y.Z]``.
     """
-    header = f'## [{VERSION}] - unreleased'
-    replacement = f'## [{VERSION}]'
+    header = f'## [v{VERSION}] - unreleased'
+    replacement = f'## [v{VERSION}]'
     changed = []
     for path in changelogs():
         file = Path(path)

--- a/tools/release/publish-docs.py
+++ b/tools/release/publish-docs.py
@@ -6,7 +6,8 @@ The frozen docs are built by grafting the version's documentation *content*
 onto the *current* checkout's toolchain and theme:
 
   * content   -- the handwritten sources and the service API surfaces (doc/src,
-    doc/api, doc/order.txt, the service/*/src trees and core/src/Service/KRPC),
+    doc/api, doc/order.txt, the service/*/src trees and the built-in KRPC
+    service, which releases before 0.5.4 keep under server/ rather than core/),
     taken from the v<version>-docs branch if it exists, otherwise from the
     v<version> tag.
   * toolchain -- everything else (the Bazel setup, krpctools, the sphinx theme
@@ -19,6 +20,11 @@ the sources) are therefore made as commits on a long-lived v<version>-docs
 branch based off the v<version> tag, leaving the version's API surface and prose
 otherwise frozen. This is an explicit, opt-in maintenance action; the docs
 workflow never rebuilds a released version.
+
+The graft reaches back to 0.5.2. Earlier releases fail to build: their KRPC
+service was implemented against core infrastructure since removed (the
+KRPC.Utils.Tuple and the Continuation-based event API), which cannot be supplied
+by an additive shim the way the Paused/CurrentGameScene symbols are.
 
 Usage:
   tools/release/publish-docs.py [options] VERSION
@@ -45,15 +51,14 @@ from pathlib import Path
 
 import lib
 
-# The documentation content inputs, restored from the content ref onto the
-# current toolchain. Pinning core/src/Service/KRPC to the release keeps later
-# changes to the KRPC service API (e.g. the GameScene API, #897) out of the
-# frozen build.
+# The documentation content inputs restored, unchanged in location, from the
+# content ref onto the current toolchain. The KRPC service sources are pinned
+# too, but handled separately by graft_krpc_service since their location moved
+# between releases.
 CONTENT_PATHS = (
     'doc/src',
     'doc/api',
     'doc/order.txt',
-    'core/src/Service/KRPC',
     'service/SpaceCenter/src',
     'service/Drawing/src',
     'service/UI/src',
@@ -63,6 +68,14 @@ CONTENT_PATHS = (
     'service/LiDAR/src',
     'service/DockingCamera/src',
 )
+
+# The built-in KRPC service sources. Pinning them to the content ref keeps later
+# changes to the KRPC service API (e.g. the GameScene API, #897) out of the
+# frozen build. The sources moved from server/ to core/ in 0.5.4; for an earlier
+# content ref they are grafted from their old server/ location into the current
+# core/ location, where the toolchain's core/src/**/*.cs glob compiles them.
+KRPC_SERVICE_DEST = 'core/src/Service/KRPC'
+KRPC_SERVICE_REFS = ('core/src/Service/KRPC', 'server/src/Service/KRPC')
 
 # Grafting an old service API onto newer core/server can drop a type the current
 # toolchain still references. The only such case to date is the namespace-level
@@ -103,6 +116,87 @@ GAMESCENE_SHIM = '''namespace KRPC.Service.KRPC
         ResearchAndDevelopment,
         /// <summary>The administration facility.</summary>
         Administration,
+    }
+}
+'''
+
+# Before 0.5.4 the KRPC service lived in server/ and its Paused and
+# CurrentGameScene properties were implemented against server and KSP symbols --
+# the server Addon and the KSP PauseMenu, EditorDriver and EditorFacility -- that
+# the KSP-free core/ assembly, where the service is now grafted, cannot see.
+# These compile-only shims, placed in the KRPC service's own namespace so the
+# grafted code resolves them unqualified and carrying no [KRPC*] attribute so the
+# scanner ignores them, let those properties build; their bodies never run during
+# doc generation. The service's namespace (not KRPC) keeps the shim Addon from
+# colliding with the server's own KRPC.Addon, which core is imported into. The
+# shim is written only when the grafted service still references these symbols,
+# so 0.5.4 onwards (which moved the properties out of the service) needs it not at
+# all.
+KRPC_COMPAT_SHIM_PATH = 'core/src/Service/KRPC/DocsCompat.cs'
+KRPC_COMPAT_SHIM = '''namespace KRPC.Service.KRPC
+{
+    /// <summary>
+    /// Compatibility shim for the frozen documentation build, written by
+    /// publish-docs.py. Stands in for the server Addon the pre-0.5.4 KRPC
+    /// service's Paused property reads. Doc comments are required because the
+    /// build compiles with warnings-as-errors.
+    /// </summary>
+    public sealed class Addon
+    {
+        /// <summary>The addon instance.</summary>
+        public static Addon Instance { get; private set; }
+
+        /// <summary>Whether the game is paused.</summary>
+        public bool IsPaused { get; set; }
+    }
+
+    /// <summary>
+    /// Compatibility shim for the frozen documentation build, written by
+    /// publish-docs.py. Stands in for the KSP PauseMenu the pre-0.5.4 KRPC
+    /// service's Paused property drives.
+    /// </summary>
+    public static class PauseMenu
+    {
+        /// <summary>Open the pause menu.</summary>
+        public static void Display()
+        {
+        }
+
+        /// <summary>Close the pause menu.</summary>
+        public static void Close()
+        {
+        }
+    }
+
+    /// <summary>
+    /// Compatibility shim for the frozen documentation build, written by
+    /// publish-docs.py. Stands in for the KSP editor facility enum the pre-0.5.4
+    /// KRPC service's CurrentGameScene property compares against.
+    /// </summary>
+    public enum EditorFacility
+    {
+        /// <summary>No editor.</summary>
+        None,
+
+        /// <summary>The Vehicle Assembly Building.</summary>
+        VAB,
+
+        /// <summary>The Space Plane Hangar.</summary>
+        SPH,
+    }
+
+    /// <summary>
+    /// Compatibility shim for the frozen documentation build, written by
+    /// publish-docs.py. Stands in for the KSP EditorDriver the pre-0.5.4 KRPC
+    /// service's CurrentGameScene property reads.
+    /// </summary>
+    public static class EditorDriver
+    {
+        /// <summary>The facility currently being edited.</summary>
+        public static EditorFacility editorFacility
+        {
+            get { return EditorFacility.None; }
+        }
     }
 }
 '''
@@ -157,12 +251,44 @@ def graft(worktree, base, ref):
     """
     lib.run('git', '-C', worktree, 'rm', '-rq', *CONTENT_PATHS)
     lib.run('git', '-C', worktree, 'checkout', ref, '--', *CONTENT_PATHS)
+    graft_krpc_service(worktree, ref)
     lib.run('git', '-C', worktree, 'rm', '-rqf', '--ignore-unmatch',
             'doc/src/_static', 'doc/src/_templates')
     lib.run('git', '-C', worktree, 'checkout', base, '--', 'doc/src/_static')
     if lib.succeeds('git', 'cat-file', '-e', f'{base}:doc/src/_templates'):
         lib.run('git', '-C', worktree, 'checkout', base, '--',
                 'doc/src/_templates')
+
+
+def graft_krpc_service(worktree, ref):
+    """Graft the content ref's KRPC service sources into the current core/
+    location.
+
+    The sources moved from server/src/Service/KRPC to core/src/Service/KRPC in
+    0.5.4. Whichever location the ref used, they are placed at the current core/
+    location, where the toolchain's core/src/**/*.cs glob compiles them as the
+    frozen KRPC service.
+    """
+    source = next((path for path in KRPC_SERVICE_REFS
+                   if lib.succeeds('git', 'cat-file', '-e', f'{ref}:{path}')),
+                  None)
+    if source is None:
+        raise lib.ReleaseError(
+            f'{ref} has no KRPC service sources at '
+            f'{" or ".join(KRPC_SERVICE_REFS)}')
+    lib.run('git', '-C', worktree, 'rm', '-rqf', '--ignore-unmatch',
+            KRPC_SERVICE_DEST)
+    if source == KRPC_SERVICE_DEST:
+        lib.run('git', '-C', worktree, 'checkout', ref, '--', KRPC_SERVICE_DEST)
+        return
+    # Relocate: materialize the ref's tree at its old path, then move it into the
+    # current core/ location. The stale index entry the checkout leaves at the
+    # old path is harmless -- the build reads the worktree, and the move leaves
+    # the sources there only at the core/ location.
+    lib.run('git', '-C', worktree, 'checkout', ref, '--', source)
+    dest = worktree / KRPC_SERVICE_DEST
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    shutil.move(str(worktree / source), str(dest))
 
 
 def maybe_write_gamescene_shim(worktree):
@@ -177,6 +303,21 @@ def maybe_write_gamescene_shim(worktree):
         for path in (worktree / directory).rglob('*.cs'))
     if referenced:
         shim.write_text(GAMESCENE_SHIM, encoding='utf-8')
+
+
+def maybe_write_krpc_compat_shim(worktree):
+    """Write the server/KSP compatibility shim if the grafted KRPC service still
+    implements the pre-0.5.4 Paused and CurrentGameScene properties against
+    symbols the core/ assembly cannot see."""
+    service = worktree / KRPC_SERVICE_DEST
+    markers = ('Addon.Instance', 'PauseMenu.', 'EditorDriver', 'EditorFacility')
+    references = any(
+        any(marker in text for marker in markers)
+        for path in service.rglob('*.cs')
+        for text in (path.read_text(encoding='utf-8'),))
+    if references:
+        (worktree / KRPC_COMPAT_SHIM_PATH).write_text(
+            KRPC_COMPAT_SHIM, encoding='utf-8')
 
 
 def exclude_changelog(worktree):
@@ -279,6 +420,7 @@ def main():
     try:
         graft(worktree, base, ref)
         maybe_write_gamescene_shim(worktree)
+        maybe_write_krpc_compat_shim(worktree)
         exclude_changelog(worktree)
         pin_version(worktree, version)
 


### PR DESCRIPTION
Several related documentation and release-tooling changes.

**Version numbers as `vX.Y.Z`.** Standalone version numbers shown to users now carry a `v` prefix: the documentation version switcher labels, the rendered changelog page headings and the `CHANGELOG.md` source headers, the docs browser-tab title, and the krpctools CLIs' `--version` output. Package filenames, `config.bzl` and other artifact version fields stay bare. The changelog parsers and release tooling accept an optional `v` on the `## [vX.Y.Z]` headers and keep the captured version bare, so version sorting, cross-component merging and rebuilds of older frozen docs are unaffected.

**Version switcher.** The dev build now leads the dropdown, where the newest build belongs, and is labelled with the version it is working towards (`v0.6.0 (dev)`) rather than a bare `dev`. The newest release stays marked preferred, so it remains the default the site root redirects to.

**Java client compile example.** The `javac` command in the Java client docs named the jar with a `<VERSION>` placeholder the reader had to substitute by hand. The full `config.bzl` version is now exposed to reStructuredText as a `|jar-version|` substitution and used from a parsed-literal block, so the example names the exact jar the build produced.

**Frozen documentation builds.** `publish-docs.py` can now rebuild the frozen docs for 0.5.2 through 0.5.4, grafting each release's KRPC service into the current `core/` location and supplying compile-only shims for the pre-0.5.4 `Paused`/`CurrentGameScene` properties. 0.5.1 and earlier remain outside the rebuild path.
