### PR TITLE
Deduplicate Infernal Robotics servos within a group

### DIFF
--- a/service/InfernalRobotics/CHANGELOG.md
+++ b/service/InfernalRobotics/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [v0.7.0] - unreleased
+- Fix servos being reported multiple times in a `ServoGroup` after switching to and from their
+  vessel repeatedly (#1014)
+
 ## [v0.6.0]
 - Add to `Servo`: `UID`, `Mode` (with a new `ServoMode` enum), `TargetPosition`, `TargetSpeed`,
   `CommandedPosition`, `DefaultPosition`, `ForceLimit`, `MaxForce`, `MaxAcceleration`, `MaxSpeed`,

--- a/service/InfernalRobotics/src/IRWrapper.cs
+++ b/service/InfernalRobotics/src/IRWrapper.cs
@@ -361,9 +361,15 @@ namespace KRPC.InfernalRobotics
 					return listToReturn;
 
 				try {
-					//iterate each "value" in the dictionary
-					foreach(var item in (IList)actualServos)
-						listToReturn.Add(new IRServo (item));
+					// Infernal Robotics can add the same servo to a group more than once when
+					// its groupName has picked up duplicate membership tokens; wrap each
+					// underlying servo at most once so the group lists it a single time.
+					var seen = new HashSet<IServo> ();
+					foreach(var item in (IList)actualServos) {
+						var servo = new IRServo (item);
+						if (seen.Add (servo))
+							listToReturn.Add(servo);
+					}
 				} catch (Exception ex) {
 					LogFormatted("Error extracting from actualServos: {0}", ex.Message);
 				}
@@ -835,10 +841,12 @@ namespace KRPC.InfernalRobotics
 		{
 			if (EnsureReady ()) {
 				var fromController = new List<IServo> ();
+				var seen = new HashSet<IServo> ();
 				foreach (var group in IRController.ServoGroups)
 					if (group.Vessel != null && group.Vessel.id == vessel.id)
 						foreach (var servo in group.Servos)
-							fromController.Add (servo);
+							if (seen.Add (servo))
+								fromController.Add (servo);
 				if (fromController.Count > 0)
 					return fromController;
 			}
@@ -892,9 +900,16 @@ namespace KRPC.InfernalRobotics
 				var raw = GroupNameField != null ? GroupNameField.GetValue (servo) as string : null;
 				if (string.IsNullOrEmpty (raw))
 					continue;
+				// Infernal Robotics can write the same group into a servo's groupName more
+				// than once (its flight rebuild re-appends a servo's membership on every
+				// vessel activation without clearing the old one), so keep only the first
+				// membership per group to ensure the servo appears once in each group.
+				var servoGroups = new HashSet<string> ();
 				foreach (var membership in raw.Split ('|')) {
 					var parts = membership.Split (';');
 					var name = parts [0];
+					if (!servoGroups.Add (name))
+						continue;
 					int index;
 					if (parts.Length < 2 || !int.TryParse (parts [1], out index))
 						index = int.MaxValue;

--- a/service/InfernalRobotics/test/test_non_active_vessel.py
+++ b/service/InfernalRobotics/test/test_non_active_vessel.py
@@ -32,18 +32,47 @@ class TestNonActiveVessel(krpctest.TestCase):
         # command pod (one part). Switch to the pod so the servo vehicle becomes non-active.
         vessels = sc.vessels
         cls.vessel = max(vessels, key=lambda v: len(v.parts.all))
-        pod = min(vessels, key=lambda v: len(v.parts.all))
-        sc.active_vessel = pod
-        for _ in range(300):
-            if sc.active_vessel == pod:
-                break
-            cls.wait()
+        cls.pod = min(vessels, key=lambda v: len(v.parts.all))
+        cls._make_active(cls.pod)
         if sc.active_vessel == cls.vessel:
             raise RuntimeError("failed to make the servo vehicle non-active")
+
+    @classmethod
+    def _make_active(cls, vessel):
+        sc = cls.connect().space_center
+        sc.active_vessel = vessel
+        for _ in range(300):
+            if sc.active_vessel == vessel:
+                return
+            cls.wait()
+        raise RuntimeError("failed to switch active vessel")
 
     def test_vessel_is_non_active(self):
         active = self.connect().space_center.active_vessel
         self.assertNotEqual(active, self.vessel)
+
+    def test_servo_count_stable_across_switches(self):
+        # Infernal Robotics appends a duplicate group membership to each servo every time
+        # its vessel is activated, so repeatedly switching to the servo vehicle and away
+        # again would otherwise make the same servo appear many times in its group. The
+        # reported servos must stay unique regardless of how often the vessel is activated.
+        def servo_names():
+            group = self.ir.servo_group_with_name(self.vessel, "Group1")
+            return sorted(x.name for x in group.servos)
+
+        expected = ["Joint Pivotron - Basic", "Rotatron - Basic", "Rotatron - Basic"]
+        self.assertEqual(expected, servo_names())
+        try:
+            for _ in range(3):
+                self._make_active(self.vessel)
+                # Active vessel: served from Infernal Robotics' own controller.
+                self.assertEqual(expected, servo_names())
+                self._make_active(self.pod)
+                self.wait(0.5)
+                # Non-active vessel: synthesized from the servo modules directly.
+                self.assertEqual(expected, servo_names())
+        finally:
+            self._make_active(self.pod)
 
     def test_servo_groups(self):
         groups = self.ir.servo_groups(self.vessel)


### PR DESCRIPTION
Infernal Robotics servos on a non-active vessel appear duplicated many times over, and that on the active vessel the servo count doubles each time we switch away from the vessel and back, even though the Infernal Robotics UI shows the correct servos.

**Root cause.** Infernal Robotics stores each servo's group memberships in the module's `groupName` field, encoded as `<group>;<index>` tokens joined by `|`. Its flight rebuild re-appends a servo's membership every time the vessel is activated without clearing the previous token, so `groupName` grows by one duplicate token per activation. kRPC's active-vessel path reads Infernal Robotics' own `ServoGroups` list (which is built from that field) and its non-active path parses `groupName` directly, so both faithfully report the same servo several times per group. Infernal Robotics' own UI hides this because it deduplicates on display.

**Fix.** Ensure a servo appears at most once per group. Repeated group memberships are skipped when synthesizing groups for a non-active vessel, and each underlying servo is wrapped at most once when extracting a group's servos and a vessel's servo list from the controller.

**Testing.** Reproduced in-game: reading the servos while repeatedly switching to and from the servo vehicle showed the per-group servo count climbing (4, 8, 12, 16, …) before the fix and holding steady after. Added a regression test to `test_non_active_vessel.py` that switches to and from the vehicle repeatedly and asserts the reported servos stay unique on both the active and non-active paths.

Note that the underlying `groupName` accumulation is a bug in Infernal Robotics itself and is out of kRPC's reach to fix; this change stops kRPC from surfacing it. The unbounded growth is also the likely source of the reported intermittent stutter and should be raised with the Infernal Robotics maintainers.