### PR TITLE
Add --skip-mod-install to launch with a locally built mod

### DIFF
--- a/tools/krpctest/CHANGELOG.md
+++ b/tools/krpctest/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [v0.7.0] - unreleased
+- Add `--skip-mod-install` to `krpc-install` and `krpc-run-ksp`, and the
+  `KRPC_SKIP_MOD_INSTALL` environment variable honored when the tests auto-launch KSP,
+  to leave the managed third-party mods in GameData untouched so a locally built mod
+  assembly is preserved across a launch (#1016)
+
 ## [v0.6.0]
 - Add the `TestCase.expansions` attribute, to declare KSP expansions a test class
   requires; the class is skipped when a required expansion is not installed

--- a/tools/krpctest/krpctest/game.py
+++ b/tools/krpctest/krpctest/game.py
@@ -90,6 +90,10 @@ def _gamedata_check_enabled():
     return os.environ.get("KRPC_SKIP_GAMEDATA_CHECK", "0") != "1"
 
 
+def _skip_mod_install_enabled():
+    return os.environ.get("KRPC_SKIP_MOD_INSTALL", "0") == "1"
+
+
 def copy_blank_save(name, ksp_dir=None):
     """Copy the bundled blank save into the KSP install's saves/<name>/persistent.sfs."""
     blank_save = str(files("krpctest").joinpath(name + ".sfs"))
@@ -153,7 +157,11 @@ def _install_mods(required):
         "building and installing kRPC (mods: %s)",
         ", ".join(sorted(required)) or "none",
     )
-    install(mods=sorted(required), validate_gamedata=_gamedata_check_enabled())
+    install(
+        mods=sorted(required),
+        validate_gamedata=_gamedata_check_enabled(),
+        skip_mod_install=_skip_mod_install_enabled(),
+    )
 
 
 def _launch_ksp(required):

--- a/tools/krpctest/krpctest/install.py
+++ b/tools/krpctest/krpctest/install.py
@@ -134,12 +134,16 @@ def _normalize_permissions(path):
             os.chmod(os.path.join(root, name), 0o644)
 
 
-def install(mods=(), ksp_dir=None, validate_gamedata=True):
+def install(mods=(), ksp_dir=None, validate_gamedata=True, skip_mod_install=False):
     """Build the mod and install it (plus exactly the requested managed mods) into the KSP
     GameData directory. mods is an iterable of names from MODS; ksp_dir defaults to the
     KSP install given by KSP_DIR. Set validate_gamedata=False to skip the check that
     GameData holds only the known-valid set, for a dev deliberately running an unmanaged
-    mod alongside the tests."""
+    mod alongside the tests. Set skip_mod_install=True to leave the managed third-party
+    mods in GameData exactly as they are — neither installing the requested ones nor
+    removing the others — so a locally built or hand-placed mod assembly is preserved
+    across a launch; the requested mods are still used to validate GameData, so name
+    whatever is installed."""
     mods = list(mods)
     unknown = [m for m in mods if m not in MODS]
     if unknown:
@@ -183,7 +187,8 @@ def install(mods=(), ksp_dir=None, validate_gamedata=True):
     for module_manager in glob.glob(os.path.join(gamedata_root, "ModuleManager*.dll")):
         os.chmod(module_manager, 0o644)
 
-    _reconcile_mods(mods, root, gamedata_root)
+    if not skip_mod_install:
+        _reconcile_mods(mods, root, gamedata_root)
     if validate_gamedata:
         _validate_gamedata(gamedata_root, _requested_mod_subdirs(mods))
 
@@ -270,6 +275,14 @@ def main():
         help="skip the check that GameData holds only the known-valid set, to allow "
         "an unmanaged mod to remain installed",
     )
+    parser.add_argument(
+        "--skip-mod-install",
+        action="store_true",
+        default=False,
+        help="leave the managed third-party mods in GameData untouched — neither "
+        "installing the requested ones nor removing others — to preserve a locally "
+        "built mod assembly",
+    )
     args = parser.parse_args()
     mods = [m for m in args.mods.split(",") if m]
     try:
@@ -277,6 +290,7 @@ def main():
             mods=mods,
             ksp_dir=args.ksp_dir,
             validate_gamedata=not args.skip_gamedata_check,
+            skip_mod_install=args.skip_mod_install,
         )
     except (ValueError, RuntimeError) as ex:
         sys.stderr.write("Error: %s\n" % ex)

--- a/tools/krpctest/krpctest/run_ksp.py
+++ b/tools/krpctest/krpctest/run_ksp.py
@@ -133,6 +133,14 @@ def main():
         help="skip the check that GameData holds only the known-valid set, to launch "
         "with an unmanaged mod installed",
     )
+    parser.add_argument(
+        "--skip-mod-install",
+        action="store_true",
+        default=False,
+        help="leave the managed third-party mods in GameData untouched — neither "
+        "installing the requested ones nor removing others — to launch with a locally "
+        "built mod assembly",
+    )
 
     autoload = parser.add_argument_group(
         "auto-load options",
@@ -191,7 +199,12 @@ def main():
             ksp_args.append("%s=%s" % (flag, value))
 
     ksp_dir = get_ksp_dir(args.ksp_dir)
-    install(mods=mods, ksp_dir=ksp_dir, validate_gamedata=not args.skip_gamedata_check)
+    install(
+        mods=mods,
+        ksp_dir=ksp_dir,
+        validate_gamedata=not args.skip_gamedata_check,
+        skip_mod_install=args.skip_mod_install,
+    )
     if args.load_game is not None:
         _stage_blank_save(args.load_game, ksp_dir)
 


### PR DESCRIPTION
The test harness reconciles the managed third-party mods in GameData to exactly the requested set on every launch, copying each mod's assembly from its Bazel-fetched archive. That overwrites a locally built or hand-placed mod DLL, so there was no way to launch KSP (or run the in-game tests) against a development build of a wrapped mod such as InfernalRobotics.
This adds a `--skip-mod-install` flag to `krpc-install` and `krpc-run-ksp`, and a matching `KRPC_SKIP_MOD_INSTALL` environment variable honored by the test framework's auto-launch. When set, the managed mods in GameData are left exactly as they are — neither installing the requested ones nor removing others — while kRPC itself is still built and installed as usual. The requested mods still drive the GameData validation, so a preserved mod must be named to remain allowed.