### PR TITLE
Support nullable values and default-value presence

### DIFF
--- a/client/cnano/CHANGELOG.md
+++ b/client/cnano/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [v0.7.0] - unreleased
+- **Breaking:** Support null for any nullable type; a nullable non-class return adds a `bool*
+  returnValueIsNull` out-parameter and a nullable argument is a pointer (#1017)
+
 ## [v0.6.0]
 - Distribute via vcpkg (#874)
 - **Breaking:** Drop autotools build; CMake is now the only supported build system (#870)

--- a/client/cnano/include/krpc_cnano/encoder.h
+++ b/client/cnano/include/krpc_cnano/encoder.h
@@ -32,6 +32,9 @@ krpc_error_t krpc_add_argument(krpc_call_t* call, uint32_t position,
                                               void* const* arg),
                                const void* arg);
 
+/* Add a null argument, signaled by is_null with the value left unset */
+krpc_error_t krpc_add_null_argument(krpc_call_t* call, uint32_t position);
+
 /*[[[cog
 types = [
   ('double', 'double'),

--- a/client/cnano/src/encoder.c
+++ b/client/cnano/src/encoder.c
@@ -51,8 +51,20 @@ krpc_error_t krpc_add_argument(krpc_call_t* call, uint32_t position,
                                const void* arg) {
   krpc_argument_t* argument = call->arguments + position;
   argument->message.position = position;
+  // The arguments array is caller-allocated and may be uninitialized, so is_null is set
+  // explicitly rather than relying on it being zeroed.
+  argument->message.is_null = false;
   argument->message.value.funcs.encode = encode;
   argument->message.value.arg = (void*)arg;
+  return KRPC_OK;
+}
+
+krpc_error_t krpc_add_null_argument(krpc_call_t* call, uint32_t position) {
+  krpc_argument_t* argument = call->arguments + position;
+  argument->message.position = position;
+  // A null argument is signaled by is_null with the value field left unset.
+  argument->message.is_null = true;
+  argument->message.value.funcs.encode = NULL;
   return KRPC_OK;
 }
 

--- a/client/cnano/test/test_client.cpp
+++ b/client/cnano/test/test_client.cpp
@@ -108,6 +108,89 @@ TEST_F(test_client, test_class_none_value) {
   ASSERT_EQ(none, object);
 }
 
+TEST_F(test_client, test_nullable_non_class_values) {
+  // Nullable value-type, string and collection parameters and return values. Each nullable
+  // non-class argument is a pointer where NULL means null, and each such return has an extra
+  // returnValueIsNull out-parameter.
+  int32_t int_result = 0;
+  bool int_null = false;
+  int32_t int_value = 42;
+  ASSERT_EQ(KRPC_OK, krpc_TestService_EchoNullableInt(conn, &int_result, &int_null, &int_value));
+  ASSERT_FALSE(int_null);
+  ASSERT_EQ(42, int_result);
+  ASSERT_EQ(KRPC_OK, krpc_TestService_EchoNullableInt(conn, &int_result, &int_null, NULL));
+  ASSERT_TRUE(int_null);
+
+  char* string_result = nullptr;
+  bool string_null = false;
+  ASSERT_EQ(KRPC_OK,
+            krpc_TestService_EchoNullableString(conn, &string_result, &string_null, "foo"));
+  ASSERT_FALSE(string_null);
+  ASSERT_STREQ("foo", string_result);
+  krpc_free(string_result);
+  ASSERT_EQ(KRPC_OK, krpc_TestService_EchoNullableString(conn, &string_result, &string_null, NULL));
+  ASSERT_TRUE(string_null);
+
+  krpc_list_int32_t list = KRPC_NULL_LIST;
+  list.size = 3;
+  list.items = new int32_t[3];
+  list.items[0] = 1;
+  list.items[1] = 2;
+  list.items[2] = 3;
+  krpc_list_int32_t list_result = KRPC_NULL_LIST;
+  bool list_null = false;
+  ASSERT_EQ(KRPC_OK, krpc_TestService_EchoNullableList(conn, &list_result, &list_null, &list));
+  ASSERT_FALSE(list_null);
+  ASSERT_EQ(3u, list_result.size);
+  delete[] list.items;
+  KRPC_FREE_LIST(list_result);
+  ASSERT_EQ(KRPC_OK, krpc_TestService_EchoNullableList(conn, &list_result, &list_null, NULL));
+  ASSERT_TRUE(list_null);
+}
+
+TEST_F(test_client, test_non_nullable_parameter_rejects_null) {
+  // A null argument to a parameter that is not nullable is rejected by the server
+  krpc_TestService_TestClass_t result;
+  ASSERT_EQ(KRPC_ERROR_RPC_FAILED, krpc_TestService_NotNullableObject(conn, &result, KRPC_NULL));
+}
+
+TEST_F(test_client, test_nullable_class_method) {
+  krpc_TestService_TestClass_t obj;
+  ASSERT_EQ(KRPC_OK, krpc_TestService_CreateTestObject(conn, &obj, "jeb"));
+  krpc_TestService_TestClass_t obj2;
+  ASSERT_EQ(KRPC_OK, krpc_TestService_CreateTestObject(conn, &obj2, "bob"));
+  krpc_TestService_TestClass_t result;
+  ASSERT_EQ(KRPC_OK, krpc_TestService_TestClass_EchoNullableObject(conn, &result, obj, obj2));
+  ASSERT_EQ(obj2, result);
+  ASSERT_EQ(KRPC_OK, krpc_TestService_TestClass_EchoNullableObject(conn, &result, obj, KRPC_NULL));
+  ASSERT_EQ(KRPC_NULL, result);
+}
+
+TEST_F(test_client, test_nullable_class_static_method) {
+  krpc_TestService_TestClass_t obj;
+  ASSERT_EQ(KRPC_OK, krpc_TestService_CreateTestObject(conn, &obj, "jeb"));
+  krpc_TestService_TestClass_t result;
+  ASSERT_EQ(KRPC_OK, krpc_TestService_TestClass_StaticNullableObject(conn, &result, obj));
+  ASSERT_EQ(obj, result);
+  ASSERT_EQ(KRPC_OK, krpc_TestService_TestClass_StaticNullableObject(conn, &result, KRPC_NULL));
+  ASSERT_EQ(KRPC_NULL, result);
+}
+
+TEST_F(test_client, test_nullable_property) {
+  krpc_TestService_TestClass_t obj;
+  ASSERT_EQ(KRPC_OK, krpc_TestService_CreateTestObject(conn, &obj, "jeb"));
+  krpc_TestService_TestClass_t result;
+  // ObjectProperty is nullable and its setter accepts null
+  ASSERT_EQ(KRPC_OK, krpc_TestService_set_ObjectProperty(conn, KRPC_NULL));
+  ASSERT_EQ(KRPC_OK, krpc_TestService_ObjectProperty(conn, &result));
+  ASSERT_EQ(KRPC_NULL, result);
+  // NullableObject is nullable for reads, but its setter guards against null
+  ASSERT_EQ(KRPC_OK, krpc_TestService_set_NullableObject(conn, obj));
+  ASSERT_EQ(KRPC_OK, krpc_TestService_NullableObject(conn, &result));
+  ASSERT_EQ(obj, result);
+  ASSERT_EQ(KRPC_ERROR_RPC_FAILED, krpc_TestService_set_NullableObject(conn, KRPC_NULL));
+}
+
 TEST_F(test_client, test_class_methods) {
   krpc_TestService_TestClass_t object;
   ASSERT_EQ(KRPC_OK, krpc_TestService_CreateTestObject(conn, &object, "bob"));

--- a/client/cpp/CHANGELOG.md
+++ b/client/cpp/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [v0.7.0] - unreleased
+- **Breaking:** Support null for any nullable type; nullable non-class values use
+  `std::optional`, changing generated signatures (#1017)
+
 ## [v0.6.0]
 - Update to protobuf v35.1 (#850)
 - Update to ASIO 1.38.0 (#850)

--- a/client/cpp/include/krpc/client.hpp
+++ b/client/cpp/include/krpc/client.hpp
@@ -10,6 +10,7 @@
 #include <utility>
 #include <vector>
 
+#include "krpc/encoder.hpp"
 #include "krpc/krpc.pb.hpp"
 
 namespace krpc {
@@ -24,16 +25,18 @@ class Client {
   Client(const std::string& name, const std::string& address, unsigned int rpc_port = 50000,
          unsigned int stream_port = 50001);
 
-  std::string invoke(const schema::Request& request);
-  std::string invoke(const schema::ProcedureCall& call);
-  std::string invoke(const std::string& service, const std::string& procedure,
-                     const std::vector<std::string>& args = std::vector<std::string>());
+  schema::ProcedureResult invoke(const schema::Request& request);
+  schema::ProcedureResult invoke(const schema::ProcedureCall& call);
+  schema::ProcedureResult invoke(
+      const std::string& service, const std::string& procedure,
+      const std::vector<encoder::Value>& args = std::vector<encoder::Value>());
 
-  schema::Request build_request(const std::string& service, const std::string& procedure,
-                                const std::vector<std::string>& args = std::vector<std::string>());
+  schema::Request build_request(
+      const std::string& service, const std::string& procedure,
+      const std::vector<encoder::Value>& args = std::vector<encoder::Value>());
   schema::ProcedureCall build_call(
       const std::string& service, const std::string& procedure,
-      const std::vector<std::string>& args = std::vector<std::string>());
+      const std::vector<encoder::Value>& args = std::vector<encoder::Value>());
   void add_exception_thrower(const std::string& service, const std::string& name,
                              const std::function<void(std::string)>& thrower);
 

--- a/client/cpp/include/krpc/decoder.hpp
+++ b/client/cpp/include/krpc/decoder.hpp
@@ -3,6 +3,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <map>
+#include <optional>
 #include <set>
 #include <string>
 #include <tuple>
@@ -49,6 +50,8 @@ template <typename... Ts>
 void decode(std::tuple<Ts...>& tuple, const std::string& data, Client* client = nullptr);
 
 template <typename T>
+void decode(std::optional<T>& value, const std::string& data, Client* client = nullptr);
+template <typename T>
 void decode(std::vector<T>& list, const std::string& data, Client* client = nullptr);
 template <typename T>
 void decode(std::set<T>& set, const std::string& data, Client* client = nullptr);
@@ -71,6 +74,15 @@ inline void decode(std::tuple<Ts...>& tuple, const std::string& data, Client* cl
   if (!tupleMessage.ParseFromString(data)) throw EncodingError("Failed to decode message");
   int index = 0;
   std::apply([&](Ts&... args) { (decode(args, tupleMessage.items(index++), client), ...); }, tuple);
+}
+
+template <typename T>
+inline void decode(std::optional<T>& value, const std::string& data, Client* client) {
+  // Only called for a present value; a null value is signaled by is_null and leaves the
+  // optional empty.
+  T inner;
+  decode(inner, data, client);
+  value = inner;
 }
 
 template <typename T>

--- a/client/cpp/include/krpc/encoder.hpp
+++ b/client/cpp/include/krpc/encoder.hpp
@@ -2,9 +2,11 @@
 
 #include <cstdint>
 #include <map>
+#include <optional>
 #include <set>
 #include <string>
 #include <tuple>
+#include <utility>
 #include <vector>
 
 #include "krpc/krpc.pb.hpp"
@@ -85,6 +87,35 @@ inline std::string encode(const std::tuple<Ts...>& tuple) {
   std::apply([&tupleMessage](const Ts&... args) { (tupleMessage.add_items(encode(args)), ...); },
              tuple);
   return encode(tupleMessage);
+}
+
+// An encoded argument value together with whether the argument is null. A null argument
+// is signaled by is_null on the wire and leaves the value field unset.
+struct Value {
+  std::string value;
+  bool is_null;
+  // Implicit so a plain encoded value (the common, non-null case) becomes a Value.
+  Value(std::string value) : value(std::move(value)), is_null(false) {}  // NOLINT(runtime/explicit)
+  static Value null() {
+    Value value("");
+    value.is_null = true;
+    return value;
+  }
+};
+
+// Encode a nullable non-class argument: an empty optional is null, otherwise the
+// contained value is encoded as its underlying type.
+template <typename T>
+inline Value encode_nullable(const std::optional<T>& value) {
+  if (value) return Value(encode(*value));
+  return Value::null();
+}
+
+// Encode a nullable class argument: an object with id 0 is the null representation.
+template <typename T>
+inline Value encode_nullable(const Object<T>& object) {
+  if (object._id == 0) return Value::null();
+  return Value(encode(object));
 }
 
 }  // namespace encoder

--- a/client/cpp/include/krpc/stream.hpp
+++ b/client/cpp/include/krpc/stream.hpp
@@ -101,8 +101,10 @@ inline T Stream<T>::operator()() {
   check_exists();
   if (!impl->has_started()) start();
   std::string data = impl->get_data();
-  T value;
-  decoder::decode(value, data, impl->get_client());
+  // A null value is signaled out-of-band by is_null; leave value default-constructed
+  // (an empty optional, or an object with id 0).
+  T value{};
+  if (!impl->is_null()) decoder::decode(value, data, impl->get_client());
   return value;
 }
 
@@ -148,8 +150,8 @@ template <typename T>
 inline int Stream<T>::add_callback(const Callback& callback) {
   check_exists();
   auto callback_wrapper = [this, callback](const std::string& data) {
-    T value;
-    decoder::decode(value, data, this->impl->get_client());
+    T value{};
+    if (!this->impl->is_null()) decoder::decode(value, data, this->impl->get_client());
     callback(value);
   };
   return impl->add_callback(callback_wrapper);

--- a/client/cpp/include/krpc/stream_impl.hpp
+++ b/client/cpp/include/krpc/stream_impl.hpp
@@ -22,7 +22,8 @@ class StreamImpl {
   float rate() const;
   void set_rate(float value);
   const std::string& get_data();
-  void update(const std::string& data, const std::exception_ptr& exception);
+  bool is_null() const;
+  void update(const std::string& data, bool is_null, const std::exception_ptr& exception);
   bool has_updated() const;
   std::condition_variable& get_condition();
   std::unique_lock<std::mutex>& get_condition_lock();
@@ -40,6 +41,7 @@ class StreamImpl {
   bool started;
   bool updated;
   std::string data;
+  bool _is_null;
   std::exception_ptr exception;
   std::condition_variable condition;
   std::mutex condition_mutex;

--- a/client/cpp/src/client.cpp
+++ b/client/cpp/src/client.cpp
@@ -49,7 +49,7 @@ Client::Client(const std::string& name, const std::string& address, unsigned int
   }
 }
 
-std::string Client::invoke(const schema::Request& request) {
+schema::ProcedureResult Client::invoke(const schema::Request& request) {
   std::string data;
   {
     std::lock_guard<std::mutex> lock_guard(*lock);
@@ -64,10 +64,10 @@ std::string Client::invoke(const schema::Request& request) {
 
   if (response.results(0).has_error()) throw_exception(response.results(0).error());
 
-  return response.results(0).value();
+  return response.results(0);
 }
 
-std::string Client::invoke(const schema::ProcedureCall& call) {
+schema::ProcedureResult Client::invoke(const schema::ProcedureCall& call) {
   schema::Request request;
   // Copied because the call is received by const reference and a Request owns its calls, so it
   // cannot be moved in. CopyFrom also stays correct if ProcedureCall gains fields.
@@ -75,13 +75,13 @@ std::string Client::invoke(const schema::ProcedureCall& call) {
   return this->invoke(request);
 }
 
-std::string Client::invoke(const std::string& service, const std::string& procedure,
-                           const std::vector<std::string>& args) {
+schema::ProcedureResult Client::invoke(const std::string& service, const std::string& procedure,
+                                       const std::vector<encoder::Value>& args) {
   return this->invoke(this->build_request(service, procedure, args));
 }
 
 schema::Request Client::build_request(const std::string& service, const std::string& procedure,
-                                      const std::vector<std::string>& args) {
+                                      const std::vector<encoder::Value>& args) {
   schema::Request request;
   schema::ProcedureCall* call = request.add_calls();
   call->set_service(service);
@@ -89,20 +89,28 @@ schema::Request Client::build_request(const std::string& service, const std::str
   for (unsigned int i = 0; i < args.size(); i++) {
     schema::Argument* arg = call->add_arguments();
     arg->set_position(i);
-    arg->set_value(args[i]);
+    // A null argument is signaled by is_null with the value left unset.
+    if (args[i].is_null)
+      arg->set_is_null(true);
+    else
+      arg->set_value(args[i].value);
   }
   return request;
 }
 
 schema::ProcedureCall Client::build_call(const std::string& service, const std::string& procedure,
-                                         const std::vector<std::string>& args) {
+                                         const std::vector<encoder::Value>& args) {
   schema::ProcedureCall call;
   call.set_service(service);
   call.set_procedure(procedure);
   for (unsigned int i = 0; i < args.size(); i++) {
     schema::Argument* arg = call.add_arguments();
     arg->set_position(i);
-    arg->set_value(args[i]);
+    // A null argument is signaled by is_null with the value left unset.
+    if (args[i].is_null)
+      arg->set_is_null(true);
+    else
+      arg->set_value(args[i].value);
   }
   return call;
 }

--- a/client/cpp/src/event.cpp
+++ b/client/cpp/src/event.cpp
@@ -29,7 +29,7 @@ void Event::release() { _stream.release(); }
 
 void Event::wait(double timeout) {
   start();
-  _stream.impl->update(std::string("\x00", 1), nullptr);
+  _stream.impl->update(std::string("\x00", 1), false, nullptr);
   while (!_stream()) {
     bool origValue = _stream();
     _stream.wait(timeout);

--- a/client/cpp/src/stream_impl.cpp
+++ b/client/cpp/src/stream_impl.cpp
@@ -14,6 +14,7 @@ StreamImpl::StreamImpl(Client* client, uint64_t id, std::recursive_mutex* update
       update_lock(update_lock),
       started(false),
       updated(false),
+      _is_null(false),
       condition_lock(condition_mutex, std::defer_lock),
       next_callback_tag(0),
       _rate(0) {}
@@ -44,10 +45,14 @@ const std::string& StreamImpl::get_data() {
   return data;
 }
 
-void StreamImpl::update(const std::string& data, const std::exception_ptr& exception) {
+bool StreamImpl::is_null() const { return _is_null; }
+
+void StreamImpl::update(const std::string& data, bool is_null,
+                        const std::exception_ptr& exception) {
   std::lock_guard<std::recursive_mutex> guard(*update_lock);
   updated = true;
   this->data = data;
+  this->_is_null = is_null;
   this->exception = exception;
 }
 

--- a/client/cpp/src/stream_manager.cpp
+++ b/client/cpp/src/stream_manager.cpp
@@ -72,12 +72,12 @@ void StreamManager::update(uint64_t id, const schema::ProcedureResult& result) {
   auto stream = it->second.lock();
   if (!stream) return;
   if (!result.has_error()) {
-    stream->update(result.value(), nullptr);
+    stream->update(result.value(), result.is_null(), nullptr);
   } else {
     try {
       client->throw_exception(result.error());
     } catch (...) {
-      stream->update("", std::current_exception());
+      stream->update("", false, std::current_exception());
     }
   }
   stream->get_condition().notify_all();

--- a/client/cpp/test/test_client.cpp
+++ b/client/cpp/test/test_client.cpp
@@ -8,6 +8,7 @@
 #include <iosfwd>
 #include <map>
 #include <memory>
+#include <optional>
 #include <set>
 #include <stdexcept>
 #include <string>
@@ -131,6 +132,59 @@ TEST_F(test_client, test_class_none_value) {
   ASSERT_EQ("bobnull", object.object_to_string(none));
   test_service.set_object_property(none);
   ASSERT_EQ(none, test_service.object_property());
+}
+
+TEST_F(test_client, test_nullable_non_class_values) {
+  // Nullable value-type, string and collection parameters and return values
+  ASSERT_EQ(42, test_service.echo_nullable_int(42).value());
+  ASSERT_FALSE(test_service.echo_nullable_int(std::nullopt).has_value());
+  ASSERT_EQ("foo", test_service.echo_nullable_string("foo").value());
+  ASSERT_FALSE(test_service.echo_nullable_string(std::nullopt).has_value());
+  std::vector<int32_t> list = {1, 2, 3};
+  ASSERT_EQ(list, test_service.echo_nullable_list(list).value());
+  ASSERT_FALSE(test_service.echo_nullable_list(std::nullopt).has_value());
+}
+
+TEST_F(test_client, test_non_nullable_parameter_rejects_null) {
+  // A null argument to a parameter that is not nullable is rejected by the server
+  krpc::services::TestService::TestClass none;
+  ASSERT_THROW(test_service.not_nullable_object(none), krpc::RPCError);
+}
+
+TEST_F(test_client, test_nullable_class_method) {
+  krpc::services::TestService::TestClass none;
+  krpc::services::TestService::TestClass obj = test_service.create_test_object("jeb");
+  krpc::services::TestService::TestClass obj2 = test_service.create_test_object("bob");
+  ASSERT_EQ(obj2, obj.echo_nullable_object(obj2));
+  ASSERT_EQ(none, obj.echo_nullable_object(none));
+}
+
+TEST_F(test_client, test_nullable_class_static_method) {
+  krpc::services::TestService::TestClass none;
+  krpc::services::TestService::TestClass obj = test_service.create_test_object("jeb");
+  ASSERT_EQ(obj, krpc::services::TestService::TestClass::static_nullable_object(conn, obj));
+  ASSERT_EQ(none, krpc::services::TestService::TestClass::static_nullable_object(conn, none));
+}
+
+TEST_F(test_client, test_nullable_property) {
+  krpc::services::TestService::TestClass none;
+  krpc::services::TestService::TestClass obj = test_service.create_test_object("jeb");
+  // ObjectProperty is nullable and its setter accepts null
+  test_service.set_object_property(none);
+  ASSERT_EQ(none, test_service.object_property());
+  // NullableObject is nullable for reads, but its setter guards against null, so writing
+  // null raises the server's ArgumentNullException
+  test_service.set_nullable_object(obj);
+  ASSERT_EQ(obj, test_service.nullable_object());
+  ASSERT_THROW(test_service.set_nullable_object(none), krpc::services::KRPC::ArgumentNullException);
+}
+
+TEST_F(test_client, test_empty_collection_default) {
+  // An empty-collection default is distinguishable from no default: the argument can be
+  // omitted and the empty list is used.
+  ASSERT_EQ(std::vector<std::string>(), test_service.empty_list_default());
+  std::vector<std::string> list = {"foo", "bar"};
+  ASSERT_EQ(list, test_service.empty_list_default(list));
 }
 
 TEST_F(test_client, test_class_methods) {

--- a/client/cpp/test/test_stream.cpp
+++ b/client/cpp/test/test_stream.cpp
@@ -4,6 +4,7 @@
 #include <atomic>
 #include <chrono>  // NOLINT(build/c++11)
 #include <cstddef>
+#include <optional>
 #include <string>
 #include <thread>  // NOLINT(build/c++11)
 #include <vector>
@@ -37,6 +38,16 @@ TEST_F(test_stream, test_property) {
   krpc::Stream<std::string> x = test_service.string_property_stream();
   for (int i = 0; i < 5; i++) {
     ASSERT_EQ("foo", x());
+    wait();
+  }
+}
+
+TEST_F(test_stream, test_nullable) {
+  auto x = test_service.echo_nullable_int_stream(std::nullopt);
+  auto y = test_service.echo_nullable_string_stream(std::nullopt);
+  for (int i = 0; i < 5; i++) {
+    ASSERT_FALSE(x().has_value());
+    ASSERT_FALSE(y().has_value());
     wait();
   }
 }

--- a/client/csharp/CHANGELOG.md
+++ b/client/csharp/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [v0.7.0] - unreleased
+- **Breaking:** Support `null` for any nullable type; nullable value types use the nullable
+  form (`int?`) (#1017)
+
 ## [v0.6.0]
 - **Breaking:** Requires .NET Framework 4.7.2 or later (#948)
 - Update to protobuf v3.35.1 (#850)

--- a/client/csharp/src/Connection.cs
+++ b/client/csharp/src/Connection.cs
@@ -144,13 +144,13 @@ namespace KRPC.Client
         /// Invoke a remote procedure.
         /// Should not be called directly. This interface is used by service client stubs.
         /// </summary>
-        public ByteString Invoke (string service, string procedure, IList<ByteString> arguments = null)
+        public ProcedureResult Invoke (string service, string procedure, IList<ByteString> arguments = null)
         {
             CheckDisposed ();
             return Invoke (GetCall (service, procedure, arguments));
         }
 
-        internal ByteString Invoke (ProcedureCall call)
+        internal ProcedureResult Invoke (ProcedureCall call)
         {
             var request = new Request ();
             request.Calls.Add (call);
@@ -170,7 +170,7 @@ namespace KRPC.Client
                 throw GetException(response.Error);
             if (response.Results[0].Error != null)
                 throw GetException (response.Results [0].Error);
-            return response.Results[0].Value;
+            return response.Results[0];
         }
 
         internal static ProcedureCall GetCall (string service, string procedure, IList<ByteString> arguments = null)
@@ -183,7 +183,12 @@ namespace KRPC.Client
                 foreach (var value in arguments) {
                     var argument = new Argument ();
                     argument.Position = position;
-                    argument.Value = value;
+                    // A null encoding signals a null value, carried out-of-band by is_null
+                    // with the value field left unset.
+                    if (value == null)
+                        argument.IsNull = true;
+                    else
+                        argument.Value = value;
                     call.Arguments.Add (argument);
                     position++;
                 }

--- a/client/csharp/src/Encoder.cs
+++ b/client/csharp/src/Encoder.cs
@@ -28,6 +28,11 @@ namespace KRPC.Client
         /// </summary>
         public static ByteString Encode (object value, Type type)
         {
+            // A Nullable<T> value is boxed to a plain T (or null), so encode it as its
+            // underlying type; the null itself is signaled out-of-band by is_null.
+            type = Nullable.GetUnderlyingType (type) ?? type;
+            if (value == null)
+                return null;
             using (var buffer = new MemoryStream ()) {
                 var stream = new CodedOutputStream (buffer, true);
                 return EncodeObject (value, type, buffer, stream);
@@ -37,13 +42,11 @@ namespace KRPC.Client
         static ByteString EncodeObject (object value, Type type, MemoryStream buffer, CodedOutputStream stream)
         {
             buffer.SetLength (0);
-            if (value != null && !type.IsInstanceOfType (value))
-                throw new ArgumentException ("Value of type " + value.GetType () + " cannot be encoded to type " + type);
-            if (value == null && !type.IsSubclassOf (typeof(RemoteObject)) && !IsACollectionType (type))
-                throw new ArgumentException ("null cannot be encoded to type " + type);
             if (value == null)
-                stream.WriteUInt64 (0);
-            else if (value is Enum)
+                throw new ArgumentException ("null cannot be encoded to type " + type);
+            if (!type.IsInstanceOfType (value))
+                throw new ArgumentException ("Value of type " + value.GetType () + " cannot be encoded to type " + type);
+            if (value is Enum)
                 stream.WriteSInt32 ((int)value);
             else {
                 switch (Type.GetTypeCode (type)) {
@@ -163,6 +166,9 @@ namespace KRPC.Client
         {
             if (ReferenceEquals (type, null))
                 throw new ArgumentNullException (nameof (type));
+            // A Nullable<T> value decodes as its underlying type T; a null value is
+            // signaled out-of-band by is_null and never reaches this method.
+            type = Nullable.GetUnderlyingType (type) ?? type;
             var stream = value.CreateCodedInput ();
             if (type.IsEnum)
                 return stream.ReadSInt32 ();
@@ -190,7 +196,7 @@ namespace KRPC.Client
                     if (client == null)
                         throw new ArgumentException ("Client not passed when decoding remote object");
                     var id = stream.ReadUInt64 ();
-                    return id == 0 ? null : (RemoteObject)Activator.CreateInstance (type, client, id);
+                    return (RemoteObject)Activator.CreateInstance (type, client, id);
                 }
                 if (IsATupleType (type))
                     return DecodeTuple (stream, type, client);

--- a/client/csharp/src/IConnection.cs
+++ b/client/csharp/src/IConnection.cs
@@ -12,7 +12,7 @@ namespace KRPC.Client
         /// <summary>
         /// Invoke a remote procedure call
         /// </summary>
-        ByteString Invoke (string service, string procedure, IList<ByteString> arguments = null);
+        global::KRPC.Schema.KRPC.ProcedureResult Invoke (string service, string procedure, IList<ByteString> arguments = null);
 
         /// <summary>
         /// Add an exception type

--- a/client/csharp/src/StreamManager.cs
+++ b/client/csharp/src/StreamManager.cs
@@ -102,10 +102,12 @@ namespace KRPC.Client
                 if (!streams.ContainsKey (id))
                     return;
                 stream = streams [id];
-                if (result.Error == null)
-                    value = Encoder.Decode (result.Value, stream.ReturnType, connection);
-                else
+                if (result.Error != null)
                     value = connection.GetException (result.Error);
+                else if (result.IsNull)
+                    value = null;
+                else
+                    value = Encoder.Decode (result.Value, stream.ReturnType, connection);
                 callbacks = new List<Action<object>> (stream.Callbacks.Values);
             }
             var condition = stream.Condition;

--- a/client/csharp/test/ConnectionTest.cs
+++ b/client/csharp/test/ConnectionTest.cs
@@ -150,6 +150,96 @@ namespace KRPC.Client.Test
             Assert.AreEqual ("jebbobbillkermin", Connection.TestService ().OptionalArguments ("jeb", "bob", "bill", obj));
         }
 
+        [Test]
+        public void NullableNonClassValues ()
+        {
+            // Nullable value-type, string and collection parameters and return values
+            Assert.AreEqual (42, Connection.TestService ().EchoNullableInt (42));
+            Assert.IsNull (Connection.TestService ().EchoNullableInt (null));
+            Assert.AreEqual ("foo", Connection.TestService ().EchoNullableString ("foo"));
+            Assert.IsNull (Connection.TestService ().EchoNullableString (null));
+            CollectionAssert.AreEqual (
+                new List<int> { 1, 2, 3 },
+                Connection.TestService ().EchoNullableList (new List<int> { 1, 2, 3 }));
+            Assert.IsNull (Connection.TestService ().EchoNullableList (null));
+        }
+
+        [Test]
+        public void NullableClassValues ()
+        {
+            var obj = Connection.TestService ().CreateTestObject ("jeb");
+            Assert.AreEqual (obj, Connection.TestService ().EchoTestObject (obj));
+            Assert.IsNull (Connection.TestService ().EchoTestObject (null));
+        }
+
+        [Test]
+        public void NonNullableParameterRejectsNull ()
+        {
+            // A null argument to a parameter that is not nullable is rejected by the server
+            Assert.Throws<RPCException> (() => Connection.TestService ().NotNullableObject (null));
+            Assert.Throws<RPCException> (() => Connection.TestService ().IncrementList (null));
+        }
+
+        [Test]
+        public void NullableClassMethod ()
+        {
+            var obj = Connection.TestService ().CreateTestObject ("jeb");
+            var obj2 = Connection.TestService ().CreateTestObject ("bob");
+            Assert.AreEqual (obj2, obj.EchoNullableObject (obj2));
+            Assert.IsNull (obj.EchoNullableObject (null));
+        }
+
+        [Test]
+        public void NullableClassStaticMethod ()
+        {
+            var obj = Connection.TestService ().CreateTestObject ("jeb");
+            Assert.AreEqual (obj, TestClass.StaticNullableObject (Connection, obj));
+            Assert.IsNull (TestClass.StaticNullableObject (Connection, null));
+        }
+
+        [Test]
+        public void NullableProperty ()
+        {
+            var obj = Connection.TestService ().CreateTestObject ("jeb");
+            // ObjectProperty is nullable and its setter accepts null
+            Connection.TestService ().ObjectProperty = null;
+            Assert.IsNull (Connection.TestService ().ObjectProperty);
+            // NullableObject is nullable for reads, but its setter guards against null,
+            // so writing null raises the server's ArgumentNullException
+            Connection.TestService ().NullableObject = obj;
+            Assert.AreEqual (obj, Connection.TestService ().NullableObject);
+            Assert.Throws<System.ArgumentNullException> (
+                () => Connection.TestService ().NullableObject = null);
+        }
+
+        [Test]
+        public void NonNullablePropertyRejectsNull ()
+        {
+            Assert.Throws<RPCException> (() => Connection.TestService ().StringProperty = null);
+        }
+
+        [Test]
+        public void NullableClassProperty ()
+        {
+            var obj = Connection.TestService ().CreateTestObject ("jeb");
+            var obj2 = Connection.TestService ().CreateTestObject ("bob");
+            obj.ObjectProperty = obj2;
+            Assert.AreEqual (obj2, obj.ObjectProperty);
+            obj.ObjectProperty = null;
+            Assert.IsNull (obj.ObjectProperty);
+        }
+
+        [Test]
+        public void EmptyCollectionDefault ()
+        {
+            // An empty-collection default is distinguishable from no default: the argument
+            // can be omitted and the empty list is used.
+            CollectionAssert.AreEqual (new List<string> (), Connection.TestService ().EmptyListDefault ());
+            CollectionAssert.AreEqual (
+                new List<string> { "foo", "bar" },
+                Connection.TestService ().EmptyListDefault (new List<string> { "foo", "bar" }));
+        }
+
         [TestCase (0, 0)]
         [TestCase (1, 1)]
         [TestCase (2, 3)]

--- a/client/csharp/test/EncoderTest.cs
+++ b/client/csharp/test/EncoderTest.cs
@@ -45,10 +45,25 @@ namespace KRPC.Client.Test
         }
 
         [Test]
-        public void EncodeNullRemoteObject ()
+        public void EncodeNull ()
         {
-            var data = Encoder.Encode (null, typeof(Services.SpaceCenter.Vessel));
-            Assert.AreEqual ("00", data.ToHexString ());
+            // A null value is signaled out-of-band by is_null; the encoder returns null to
+            // indicate this, regardless of the type.
+            Assert.IsNull (Encoder.Encode (null, typeof(Services.SpaceCenter.Vessel)));
+            Assert.IsNull (Encoder.Encode (null, typeof(string)));
+            Assert.IsNull (Encoder.Encode (null, typeof(int?)));
+            Assert.IsNull (Encoder.Encode (null, typeof(IList<int>)));
+        }
+
+        [Test]
+        public void NullableValue ()
+        {
+            // A Nullable<T> value encodes and decodes as its underlying type.
+            int? value = 300;
+            var data = Encoder.Encode (value, typeof(int?));
+            Assert.AreEqual ("d804", data.ToHexString ());
+            var result = (int?)Encoder.Decode (data, typeof(int?), null);
+            Assert.AreEqual (300, result);
         }
 
         [Test]
@@ -81,14 +96,6 @@ namespace KRPC.Client.Test
             var value = (Services.SpaceCenter.Vessel)Encoder.Decode ("ac02".ToByteString (), typeof(Services.SpaceCenter.Vessel), mockClient.Object);
             Assert.AreEqual (300, value.id);
             Assert.AreSame (mockClient.Object, value.connection);
-        }
-
-        [Test]
-        public void DecodeNullRemoteObject ()
-        {
-            var mockClient = new Mock<IConnection> ();
-            var value = (string)Encoder.Decode ("00".ToByteString (), typeof(Services.SpaceCenter.Vessel), mockClient.Object);
-            Assert.IsNull (value);
         }
 
         [TestCase (3.14159265359f, "db0f4940")]

--- a/client/csharp/test/StreamTest.cs
+++ b/client/csharp/test/StreamTest.cs
@@ -70,6 +70,18 @@ namespace KRPC.Client.Test
         }
 
         [Test]
+        public void NullableValue ()
+        {
+            var x = Connection.AddStream (() => Connection.TestService ().EchoNullableInt (null));
+            var y = Connection.AddStream (() => Connection.TestService ().EchoNullableString (null));
+            for (int i = 0; i < 5; i++) {
+                Assert.IsNull (x.Get ());
+                Assert.IsNull (y.Get ());
+                Wait ();
+            }
+        }
+
+        [Test]
         public void Counter ()
         {
             var count = 0;

--- a/client/java/CHANGELOG.md
+++ b/client/java/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [v0.7.0] - unreleased
+- **Breaking:** Support `null` for any nullable type; nullable value types use the boxed type
+  (`Integer`, `Double`, …) (#1017)
+
 ## [v0.6.0]
 - Update to protobuf v4.35.1, guava 33.4.8-jre, antlr4-runtime 4.13.2 (#850)
 - Mark deprecated members with the `@Deprecated` annotation and an `@deprecated` javadoc tag (#904)

--- a/client/java/src/krpc/client/Connection.java
+++ b/client/java/src/krpc/client/Connection.java
@@ -204,18 +204,18 @@ public class Connection implements AutoCloseable {
    * Invoke a remote procedure call. Should not be called directly. This
    * interface is for generated service code.
    */
-  public ByteString invoke(String service, String procedure, ByteString... arguments)
+  public KRPC.ProcedureResult invoke(String service, String procedure, ByteString... arguments)
       throws RPCException {
     return invoke(buildCall(service, procedure, arguments));
   }
 
-  private ByteString invoke(KRPC.ProcedureCall call) throws RPCException {
+  private KRPC.ProcedureResult invoke(KRPC.ProcedureCall call) throws RPCException {
     KRPC.Response response = invokeInternal(call);
     KRPC.Error error = getErrorFromResponse(response);
     if (error != null) {
       throwException(error);
     }
-    return getReturnValueFromResponse(response);
+    return getResultFromResponse(response);
   }
 
   KRPC.Response invokeInternal(KRPC.ProcedureCall call) throws RPCException {
@@ -244,22 +244,26 @@ public class Connection implements AutoCloseable {
     return null;
   }
 
-  ByteString getReturnValueFromResponse(KRPC.Response response) {
-    return response.getResultsList().get(0).getValue();
+  KRPC.ProcedureResult getResultFromResponse(KRPC.Response response) {
+    return response.getResultsList().get(0);
   }
 
   KRPC.ProcedureCall buildCall(String service, String procedure, ByteString... arguments) {
     KRPC.ProcedureCall.Builder callBuilder = KRPC.ProcedureCall.newBuilder();
     callBuilder.setService(service);
     callBuilder.setProcedure(procedure);
-    if (arguments.length > 0) {
-      KRPC.Argument.Builder argumentBuilder = KRPC.Argument.newBuilder();
-      int position = 0;
-      for (ByteString value : arguments) {
-        KRPC.Argument argument = argumentBuilder.setPosition(position).setValue(value).build();
-        callBuilder.addArguments(argument);
-        position++;
+    int position = 0;
+    for (ByteString value : arguments) {
+      KRPC.Argument.Builder argumentBuilder = KRPC.Argument.newBuilder().setPosition(position);
+      // A null encoded value signals a null argument, carried out-of-band by is_null
+      // with the value field left unset.
+      if (value == null) {
+        argumentBuilder.setIsNull(true);
+      } else {
+        argumentBuilder.setValue(value);
       }
+      callBuilder.addArguments(argumentBuilder.build());
+      position++;
     }
     return callBuilder.build();
   }

--- a/client/java/src/krpc/client/Encoder.java
+++ b/client/java/src/krpc/client/Encoder.java
@@ -57,6 +57,10 @@ public class Encoder {
 
   /** Encode an object. */
   public static ByteString encode(Object value, KRPC.Type type) {
+    // A null value is signaled out-of-band by is_null; return null to indicate this.
+    if (value == null) {
+      return null;
+    }
     try {
       switch (type.getCode()) {
         case DOUBLE:
@@ -78,11 +82,7 @@ public class Encoder {
         case BYTES:
           return encodeBytes((byte[]) value);
         case CLASS:
-          if (value == null) {
-            return encodeUint64(0);
-          } else {
-            return encodeObject((RemoteObject) value);
-          }
+          return encodeObject((RemoteObject) value);
         case ENUMERATION:
           return encodeEnum((RemoteEnum) value);
         case TUPLE:
@@ -343,7 +343,7 @@ public class Encoder {
       Class<?> classType = Class.forName(
           "krpc.client.services." + type.getService() + "$" + type.getName());
       Constructor<?> ctor = classType.getConstructor(Connection.class, long.class);
-      return id == 0 ? null : (T) ctor.newInstance(connection, id);
+      return (T) ctor.newInstance(connection, id);
     } catch (ClassNotFoundException exn) {
       throw new EncodingException("Failed to decode object", exn);
     } catch (NoSuchMethodException exn) {

--- a/client/java/src/krpc/client/StreamManager.java
+++ b/client/java/src/krpc/client/StreamManager.java
@@ -81,10 +81,12 @@ class StreamManager {
         return;
       }
       stream = streams.get(id);
-      if (!result.hasError()) {
-        value = Encoder.decode(result.getValue(), stream.getReturnType(), connection);
-      } else {
+      if (result.hasError()) {
         value = result.getError();
+      } else if (result.getIsNull()) {
+        value = null;
+      } else {
+        value = Encoder.decode(result.getValue(), stream.getReturnType(), connection);
       }
       callbacks = new ArrayList<Consumer<Object>>(stream.getCallbacks().values());
     }

--- a/client/java/test/krpc/client/ConnectionTest.java
+++ b/client/java/test/krpc/client/ConnectionTest.java
@@ -117,6 +117,51 @@ public class ConnectionTest {
   }
 
   @Test
+  public void testNullableNonClassValues() throws RPCException {
+    // Nullable value-type, string and collection parameters and return values
+    assertEquals(Integer.valueOf(42), testService.echoNullableInt(42));
+    assertNull(testService.echoNullableInt(null));
+    assertEquals("foo", testService.echoNullableString("foo"));
+    assertNull(testService.echoNullableString(null));
+    assertEquals(Arrays.asList(1, 2, 3), testService.echoNullableList(Arrays.asList(1, 2, 3)));
+    assertNull(testService.echoNullableList(null));
+  }
+
+  @Test
+  public void testNonNullableParameterRejectsNull() {
+    // A null argument to a parameter that is not nullable is rejected by the server
+    assertThrows(RPCException.class, () -> testService.notNullableObject(null));
+  }
+
+  @Test
+  public void testNullableClassMethod() throws RPCException {
+    TestService.TestClass obj = testService.createTestObject("jeb");
+    TestService.TestClass obj2 = testService.createTestObject("bob");
+    assertEquals(obj2, obj.echoNullableObject(obj2));
+    assertNull(obj.echoNullableObject(null));
+  }
+
+  @Test
+  public void testNullableClassStaticMethod() throws RPCException {
+    TestService.TestClass obj = testService.createTestObject("jeb");
+    assertEquals(obj, TestService.TestClass.staticNullableObject(connection, obj));
+    assertNull(TestService.TestClass.staticNullableObject(connection, null));
+  }
+
+  @Test
+  public void testNullableProperty() throws RPCException {
+    TestService.TestClass obj = testService.createTestObject("jeb");
+    // ObjectProperty is nullable and its setter accepts null
+    testService.setObjectProperty(null);
+    assertNull(testService.getObjectProperty());
+    // NullableObject is nullable for reads, but its setter guards against null, so writing
+    // null raises the server's ArgumentNullException
+    testService.setNullableObject(obj);
+    assertEquals(obj, testService.getNullableObject());
+    assertThrows(IllegalArgumentException.class, () -> testService.setNullableObject(null));
+  }
+
+  @Test
   public void testClassMethods() throws RPCException {
     TestService.TestClass obj = testService.createTestObject("bob");
     assertEquals("value=bob", obj.getValue());

--- a/client/java/test/krpc/client/EncoderTest.java
+++ b/client/java/test/krpc/client/EncoderTest.java
@@ -54,10 +54,13 @@ public class EncoderTest {
   }
 
   @Test
-  public void testEncodeClassNull() {
-    Type type = Types.createClass("TestService", "TestClass");
-    ByteString data = Encoder.encode(null, type);
-    assertEquals("00", hexlify(data));
+  public void testEncodeNull() {
+    // A null value is signaled out-of-band by is_null; the encoder returns null to indicate
+    // this, regardless of the type.
+    assertNull(Encoder.encode(null, Types.createClass("TestService", "TestClass")));
+    assertNull(Encoder.encode(null, Types.createValue(TypeCode.STRING)));
+    assertNull(Encoder.encode(null, Types.createValue(TypeCode.SINT32)));
+    assertNull(Encoder.encode(null, Types.createList(Types.createValue(TypeCode.SINT32))));
   }
 
   @Test
@@ -92,13 +95,6 @@ public class EncoderTest {
     assertEquals(new TestService.TestClass(null, 300), value);
   }
 
-  @Test
-  public void testDecodeClassNull() {
-    Type type = Types.createClass("TestService", "TestClass");
-    TestService.TestClass value =
-        (TestService.TestClass) Encoder.decode(unhexlify("00"), type, null);
-    assertNull(value);
-  }
 
   @Test
   public void testGuid() {

--- a/client/java/test/krpc/client/StreamTest.java
+++ b/client/java/test/krpc/client/StreamTest.java
@@ -2,6 +2,7 @@ package krpc.client;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -50,6 +51,17 @@ public class StreamTest {
     Stream<String> stream = connection.addStream(TestService.class, "getStringProperty");
     for (int i = 0; i < 5; i++) {
       assertEquals("foo", stream.get());
+      pause();
+    }
+  }
+
+  @Test
+  public void testNullable()
+      throws RPCException, StreamException, NoSuchMethodException {
+    Stream<Integer> stream =
+        connection.addStream(TestService.class, "echoNullableInt", (Object) null);
+    for (int i = 0; i < 5; i++) {
+      assertNull(stream.get());
       pause();
     }
   }

--- a/client/lua/CHANGELOG.md
+++ b/client/lua/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [v0.7.0] - unreleased
+- **Breaking:** Support `Types.none` for any nullable type (#1017)
+
 ## [v0.6.0]
 - Fix `attributes` module to always return boolean for `is_a_class_member` and `is_a_class_property_accessor` (#850)
 - Fix service, method and property names being converted to snake case using the machine's locale (#993)

--- a/client/lua/krpc/client.lua
+++ b/client/lua/krpc/client.lua
@@ -54,6 +54,10 @@ function Client:_invoke(service, procedure, args, param_names, param_types, retu
 
   -- Decode the response and return the (optional) result
   if return_type then
+    -- A null result is signaled out-of-band by is_null; the value field is unset
+    if result.is_null then
+      return Types.none
+    end
     return decoder.decode(result.value, return_type)
   end
   return nil
@@ -68,24 +72,29 @@ function Client:_build_request(service, procedure, args, param_names, param_type
 
   for i,value in ipairs(args) do
     local typ = param_types[i]
-    local valid = false
-    if type(typ.lua_type) == 'string' then
-      valid = typ.lua_type == type(value)
-    elseif type(typ.lua_type) == 'table' then
-      valid = typ.lua_type:class_of(value)
-    end
-    if not valid then
-      -- Only ok is declared here; value is the loop variable and must stay so, as the
-      -- coerced value is read below, outside this block
-      local ok
-      ok,value = pcall(self._types.coerce_to, self._types, value, typ)
-      if not ok then
-        error(string.format('%s.%s() argument %d must be a %s, got a %s', service, procedure, i, typ.lua_type, type(value)))
-      end
-    end
     local arg = call.arguments:add()
     arg.position = i-1
-    arg.value = encoder.encode(value, typ)
+    if value == Types.none then
+      -- A null argument is signaled out-of-band by is_null; the value field is left unset
+      arg.is_null = true
+    else
+      local valid = false
+      if type(typ.lua_type) == 'string' then
+        valid = typ.lua_type == type(value)
+      elseif type(typ.lua_type) == 'table' then
+        valid = typ.lua_type:class_of(value)
+      end
+      if not valid then
+        -- Only ok is declared here; value is the loop variable and must stay so, as the
+        -- coerced value is read below, outside this block
+        local ok
+        ok,value = pcall(self._types.coerce_to, self._types, value, typ)
+        if not ok then
+          error(string.format('%s.%s() argument %d must be a %s, got a %s', service, procedure, i, typ.lua_type, type(value)))
+        end
+      end
+      arg.value = encoder.encode(value, typ)
+    end
   end
 
   return request

--- a/client/lua/krpc/decoder.lua
+++ b/client/lua/krpc/decoder.lua
@@ -81,15 +81,8 @@ function decoder.decode(data, typ)
   elseif typ:is_a(Types.ClassType) then
     local object_id_typ = _types:uint64_type()
     local object_id = _decode_value(data, object_id_typ)
-    if object_id == 0 then
-      return Types.none
-    else
-      return typ.lua_type(object_id)
-    end
+    return typ.lua_type(object_id)
   elseif typ:is_a(Types.ListType) then
-    if data == '\00' then
-      return nil
-    end
     local msg = decoder.decode_message(data, schema.List)
     local result = List{}
     for _,item in ipairs(msg.items) do
@@ -97,9 +90,6 @@ function decoder.decode(data, typ)
     end
     return result
   elseif typ:is_a(Types.DictionaryType) then
-    if data == '\00' then
-      return nil
-    end
     local msg = decoder.decode_message(data, schema.Dictionary)
     local result = Map{}
     for _,item in ipairs(msg.entries) do
@@ -109,9 +99,6 @@ function decoder.decode(data, typ)
     end
     return result
   elseif typ:is_a(Types.SetType) then
-    if data == '\00' then
-      return nil
-    end
     local msg = decoder.decode_message(data, schema.Set)
     local result = Set{}
     for _,item in ipairs(msg.items) do
@@ -119,9 +106,6 @@ function decoder.decode(data, typ)
     end
     return result
   elseif typ:is_a(Types.TupleType) then
-    if data == '\00' then
-      return nil
-    end
     local msg = decoder.decode_message(data, schema.Tuple)
     local result = List{}
     for _,item in ipairs(tablex.zip(msg.items, typ.value_types)) do

--- a/client/lua/krpc/encoder.lua
+++ b/client/lua/krpc/encoder.lua
@@ -76,11 +76,7 @@ function encoder.encode(x, typ)
   elseif typ:is_a(Types.EnumerationType) then
     return _encode_value(x.value, _types:sint32_type())
   elseif typ:is_a(Types.ClassType) then
-    local object_id = 0
-    if x then
-      object_id = x._object_id
-    end
-    return _encode_value(object_id, _types:uint64_type())
+    return _encode_value(x._object_id, _types:uint64_type())
   elseif typ:is_a(Types.ListType) then
     local msg = schema.List()
     for item in x:iter() do

--- a/client/lua/krpc/service.lua
+++ b/client/lua/krpc/service.lua
@@ -84,11 +84,15 @@ function ServiceBase:_parse_procedure(procedure)
 
   local param_names = seq.copy(seq.map(function (x) return service.to_snake_case(x.name) end, procedure.parameters))
   local param_types = seq.copy(seq.map(function (x) return self._client._types:as_type(x.type) end, procedure.parameters))
-  local param_required = seq.copy(seq.map(function (x) return not x:HasField('default_value') end, procedure.parameters))
+  local param_required = seq.copy(seq.map(function (x) return not x.has_default_value end, procedure.parameters))
   local param_default = List{}
   for param,typ in seq.zip(procedure.parameters, param_types) do
-    if param:HasField('default_value') then
-      param_default:append(decoder.decode(param.default_value, typ))
+    if param.has_default_value then
+      if param.default_value_is_null then
+        param_default:append(Types.none)
+      else
+        param_default:append(decoder.decode(param.default_value, typ))
+      end
     else
       param_default:append(nil)
     end

--- a/client/lua/krpc/test/test_client.lua
+++ b/client/lua/krpc/test/test_client.lua
@@ -91,6 +91,52 @@ function TestClient:test_class_none_value()
   luaunit.assertEquals(self.conn.test_service.object_property, Types.none)
 end
 
+function TestClient:test_nullable_non_class_values()
+  -- Nullable value-type, string and collection parameters and return values
+  luaunit.assertEquals(42, self.conn.test_service.echo_nullable_int(42))
+  luaunit.assertEquals(Types.none, self.conn.test_service.echo_nullable_int(Types.none))
+  luaunit.assertEquals('foo', self.conn.test_service.echo_nullable_string('foo'))
+  luaunit.assertEquals(Types.none, self.conn.test_service.echo_nullable_string(Types.none))
+  luaunit.assertEquals(List{1,2,3}, self.conn.test_service.echo_nullable_list(List{1,2,3}))
+  luaunit.assertEquals(Types.none, self.conn.test_service.echo_nullable_list(Types.none))
+end
+
+function TestClient:test_non_nullable_parameter_rejects_null()
+  -- A null argument to a parameter that is not nullable is rejected by the server
+  luaunit.assertError(self.conn.test_service.not_nullable_object, Types.none)
+end
+
+function TestClient:test_nullable_class_method()
+  local obj = self.conn.test_service.create_test_object('jeb')
+  local obj2 = self.conn.test_service.create_test_object('bob')
+  luaunit.assertEquals(obj2, obj:echo_nullable_object(obj2))
+  luaunit.assertEquals(Types.none, obj:echo_nullable_object(Types.none))
+end
+
+function TestClient:test_nullable_class_static_method()
+  local obj = self.conn.test_service.create_test_object('jeb')
+  luaunit.assertEquals(obj, self.conn.test_service.TestClass.static_nullable_object(obj))
+  luaunit.assertEquals(Types.none, self.conn.test_service.TestClass.static_nullable_object(Types.none))
+end
+
+function TestClient:test_nullable_property()
+  local obj = self.conn.test_service.create_test_object('jeb')
+  -- object_property is nullable and its setter accepts null
+  self.conn.test_service.object_property = Types.none
+  luaunit.assertEquals(Types.none, self.conn.test_service.object_property)
+  -- nullable_object is nullable for reads, but its setter guards against null
+  self.conn.test_service.nullable_object = obj
+  luaunit.assertEquals(obj, self.conn.test_service.nullable_object)
+  luaunit.assertError(function() self.conn.test_service.nullable_object = Types.none end)
+end
+
+function TestClient:test_empty_collection_default()
+  -- An empty-collection default is distinguishable from no default: the argument can be
+  -- omitted and the empty list is used.
+  luaunit.assertEquals(List{}, self.conn.test_service.empty_list_default())
+  luaunit.assertEquals(List{'foo', 'bar'}, self.conn.test_service.empty_list_default(List{'foo', 'bar'}))
+end
+
 function TestClient:test_class_methods()
   local obj = self.conn.test_service.create_test_object('bob')
   luaunit.assertEquals('value=bob', obj:get_value())
@@ -324,12 +370,17 @@ function TestClient:test_test_service_service_members()
      'deprecated_procedure_no_message',
      'dictionary_default',
      'double_to_string',
+     'echo_nullable_int',
+     'echo_nullable_list',
+     'echo_nullable_string',
      'echo_test_object',
+     'empty_list_default',
      'enum_default_arg',
      'enum_echo',
      'enum_return',
      'float_to_string',
      'get_deprecated_property',
+     'get_nullable_object',
      'get_object_property',
      'get_string_property',
      'get_string_property_private_set',
@@ -341,6 +392,7 @@ function TestClient:test_test_service_service_members()
      'int32_to_string',
      'int64_to_string',
      'list_default',
+     'not_nullable_object',
      'on_timer',
      'on_timer_using_lambda',
      'optional_arguments',
@@ -349,6 +401,7 @@ function TestClient:test_test_service_service_members()
      'return_null_when_not_allowed',
      'set_default',
      'set_deprecated_property',
+     'set_nullable_object',
      'set_object_property',
      'set_string_property',
      'set_string_property_private_get',
@@ -368,7 +421,8 @@ function TestClient:test_test_service_test_class_members()
   table.sort(members)
   luaunit.assertEquals(
     members,
-    {'float_to_string',
+    {'echo_nullable_object',
+     'float_to_string',
      'get_int_property',
      'get_object_property',
      'get_string_property_private_set',
@@ -378,7 +432,8 @@ function TestClient:test_test_service_test_class_members()
      'set_int_property',
      'set_object_property',
      'set_string_property_private_get',
-     'static_method'})
+     'static_method',
+     'static_nullable_object'})
 end
 
 function TestClient:test_test_service_enum_members()

--- a/client/lua/krpc/test/test_decoder.lua
+++ b/client/lua/krpc/test/test_decoder.lua
@@ -40,12 +40,6 @@ function TestDecoder:test_decode_class()
   luaunit.assertEquals(300, value._object_id)
 end
 
-function TestDecoder:test_decode_class_none()
-  local typ = types:class_type('ServiceName', 'ClassName')
-  local value = decoder.decode(platform.unhexlify('00'), typ)
-  luaunit.assertEquals(Types.none, value)
-end
-
 function TestDecoder:test_guid()
   luaunit.assertEquals(
     '6f271b39-00dd-4de4-9732-f0d3a68838df',

--- a/client/lua/krpc/test/test_encoder.lua
+++ b/client/lua/krpc/test/test_encoder.lua
@@ -46,11 +46,4 @@ function TestEncoder:test_encode_class()
   luaunit.assertEquals('ac02', platform.hexlify(data))
 end
 
-function TestEncoder:test_encode_class_none()
-  local typ = types:class_type('ServiceName', 'ClassName')
-  local value = nil
-  local data = encoder.encode(value, typ)
-  luaunit.assertEquals('00', platform.hexlify(data))
-end
-
 return TestEncoder

--- a/client/python/CHANGELOG.md
+++ b/client/python/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [v0.7.0] - unreleased
+- **Breaking:** Support `None` for any nullable type (#1017)
+
 ## [v0.6.0]
 - **Breaking:** Requires Python 3.10+ (#837)
 - Update to protobuf v7.35.1 (#850)

--- a/client/python/krpc/client.py
+++ b/client/python/krpc/client.py
@@ -226,7 +226,7 @@ class Client(krpc.services.Client):
 
         # Decode the response and return the (optional) result
         result = None
-        if return_type is not None:
+        if return_type is not None and not response.results[0].is_null:
             result = Decoder.decode(self, response.results[0].value, return_type)
             if isinstance(result, KRPC.Event):
                 result = Event(self, result)
@@ -249,6 +249,10 @@ class Client(krpc.services.Client):
 
         for i, (value, typ) in enumerate(zip(args, param_types)):
             if isinstance(value, DefaultArgument):
+                continue
+            if value is None:
+                # A null argument is signaled out-of-band; the value field is left unset
+                call.arguments.add(position=i, is_null=True)
                 continue
             if not isinstance(value, typ.python_type):
                 try:

--- a/client/python/krpc/decoder.py
+++ b/client/python/krpc/decoder.py
@@ -63,16 +63,12 @@ class Decoder:
         if isinstance(typ, ClassType):
             object_id_typ = cls._types.uint64_type
             object_id = cls._decode_value(data, object_id_typ)
-            return typ.python_type(client, object_id) if object_id != 0 else None
+            return typ.python_type(client, object_id)
         msg: object
         if isinstance(typ, ListType):
-            if data == b"\x00":
-                return None
             msg = cast(KRPC.List, cls.decode_message(data, KRPC.List))
             return [cls.decode(client, item, typ.value_type) for item in msg.items]
         if isinstance(typ, DictionaryType):
-            if data == b"\x00":
-                return None
             msg = cast(KRPC.Dictionary, cls.decode_message(data, KRPC.Dictionary))
             return dict(
                 (
@@ -82,13 +78,9 @@ class Decoder:
                 for entry in msg.entries
             )
         if isinstance(typ, SetType):
-            if data == b"\x00":
-                return None
             msg = cast(KRPC.Set, cls.decode_message(data, KRPC.Set))
             return set(cls.decode(client, item, typ.value_type) for item in msg.items)
         if isinstance(typ, TupleType):
-            if data == b"\x00":
-                return None
             msg = cast(KRPC.Tuple, cls.decode_message(data, KRPC.Tuple))
             return tuple(
                 cls.decode(client, item, value_type)

--- a/client/python/krpc/encoder.py
+++ b/client/python/krpc/encoder.py
@@ -48,7 +48,7 @@ class Encoder:
         if isinstance(typ, EnumerationType):
             return cls._encode_value(cast(Enum, x).value, cls._types.sint32_type)
         if isinstance(typ, ClassType):
-            object_id = x._object_id if x is not None else 0  # type: ignore[attr-defined]
+            object_id = x._object_id  # type: ignore[attr-defined]
             return cls._encode_value(object_id, cls._types.uint64_type)
         if isinstance(typ, ListType):
             list_msg = KRPC.List()

--- a/client/python/krpc/service.py
+++ b/client/python/krpc/service.py
@@ -40,6 +40,8 @@ def _signature(param_types: Iterable[TypeBase], return_type: TypeBase) -> str:
 
 
 def _as_literal(value: object, typ: TypeBase) -> str:
+    if value is None:
+        return "None"
     if typ.python_type == str:
         return "'" + cast(str, value) + "'"
     return str(value)
@@ -389,10 +391,10 @@ class ServiceBase(DynamicType):
         param_types = [
             cls._client._types.as_type(param.type) for param in procedure.parameters
         ]
-        param_required = [not param.default_value for param in procedure.parameters]
+        param_required = [not param.has_default_value for param in procedure.parameters]
         param_default: List[Optional[object]] = []
         for param, typ in zip(procedure.parameters, param_types):
-            if param.default_value:
+            if param.has_default_value and not param.default_value_is_null:
                 param_default.append(
                     Decoder.decode(cls._client, param.default_value, typ)
                 )

--- a/client/python/krpc/streammanager.py
+++ b/client/python/krpc/streammanager.py
@@ -207,6 +207,8 @@ class StreamManager:
                 stream = self._streams[result.id]
                 if result.result.HasField("error"):
                     value = self._client._build_error(result.result.error)
+                elif result.result.is_null:
+                    value = None
                 else:
                     # Decode the return value
                     value = Decoder.decode(

--- a/client/python/krpc/test/test_client.py
+++ b/client/python/krpc/test/test_client.py
@@ -166,6 +166,75 @@ class TestClient(ServerTestCase, unittest.TestCase):
             )
         )
 
+    def test_nullable_procedure_non_class(self) -> None:
+        # Nullable value-type, string and collection parameters and return values
+        self.assertEqual(42, self.conn.test_service.echo_nullable_int(42))
+        self.assertIsNone(self.conn.test_service.echo_nullable_int(None))
+        self.assertEqual("foo", self.conn.test_service.echo_nullable_string("foo"))
+        self.assertIsNone(self.conn.test_service.echo_nullable_string(None))
+        self.assertEqual(
+            [1, 2, 3], self.conn.test_service.echo_nullable_list([1, 2, 3])
+        )
+        self.assertIsNone(self.conn.test_service.echo_nullable_list(None))
+
+    def test_nullable_procedure_class(self) -> None:
+        obj = self.conn.test_service.create_test_object("jeb")
+        self.assertEqual(obj, self.conn.test_service.echo_test_object(obj))
+        self.assertIsNone(self.conn.test_service.echo_test_object(None))
+
+    def test_non_nullable_parameter_rejects_null(self) -> None:
+        with self.assertRaises(krpc.error.RPCError):
+            self.conn.test_service.not_nullable_object(None)
+
+    def test_nullable_class_method(self) -> None:
+        obj = self.conn.test_service.create_test_object("jeb")
+        obj2 = self.conn.test_service.create_test_object("bob")
+        self.assertEqual(obj2, obj.echo_nullable_object(obj2))
+        self.assertIsNone(obj.echo_nullable_object(None))
+
+    def test_nullable_class_static_method(self) -> None:
+        obj = self.conn.test_service.create_test_object("jeb")
+        self.assertEqual(
+            obj, self.conn.test_service.TestClass.static_nullable_object(obj)
+        )
+        self.assertIsNone(self.conn.test_service.TestClass.static_nullable_object(None))
+
+    def test_nullable_property(self) -> None:
+        obj = self.conn.test_service.create_test_object("jeb")
+        # ObjectProperty is nullable and its setter accepts null
+        self.conn.test_service.object_property = None
+        self.assertIsNone(self.conn.test_service.object_property)
+        # NullableObject is nullable for reads, but its setter guards against null, so writing
+        # null raises the server's ArgumentNullException (mapped to ValueError on the client)
+        self.conn.test_service.nullable_object = obj
+        self.assertEqual(obj, self.conn.test_service.nullable_object)
+        with self.assertRaises(ValueError):
+            self.conn.test_service.nullable_object = None
+
+    def test_non_nullable_property_rejects_null(self) -> None:
+        with self.assertRaises(krpc.error.RPCError):
+            self.conn.test_service.string_property = None
+
+    def test_nullable_class_property(self) -> None:
+        obj = self.conn.test_service.create_test_object("jeb")
+        obj2 = self.conn.test_service.create_test_object("bob")
+        obj.object_property = obj2
+        self.assertEqual(obj2, obj.object_property)
+        obj.object_property = None
+        self.assertIsNone(obj.object_property)
+
+    def test_empty_collection_default(self) -> None:
+        # An empty-collection default is distinguishable from no default: the argument
+        # can be omitted and the empty list is used.
+        self.assertEqual([], self.conn.test_service.empty_list_default())
+        self.assertEqual(
+            ["foo", "bar"], self.conn.test_service.empty_list_default(["foo", "bar"])
+        )
+
+    def test_nullable_stream(self) -> None:
+        with self.conn.stream(self.conn.test_service.echo_nullable_int, None) as stream:
+            self.assertIsNone(stream())
+
     def test_class_methods(self) -> None:
         obj = self.conn.test_service.create_test_object("bob")
         self.assertEqual("value=bob", obj.get_value())
@@ -316,9 +385,10 @@ class TestClient(ServerTestCase, unittest.TestCase):
             set([1, 2, 3]), self.conn.test_service.increment_set(set([0, 1, 2]))
         )
         self.assertEqual((2, 3), self.conn.test_service.increment_tuple((1, 2)))
-        self.assertRaises(TypeError, self.conn.test_service.increment_list, None)
-        self.assertRaises(TypeError, self.conn.test_service.increment_set, None)
-        self.assertRaises(TypeError, self.conn.test_service.increment_dictionary, None)
+        # These collection parameters are not nullable, so null is rejected by the server
+        self.assertRaises(RPCError, self.conn.test_service.increment_list, None)
+        self.assertRaises(RPCError, self.conn.test_service.increment_set, None)
+        self.assertRaises(RPCError, self.conn.test_service.increment_dictionary, None)
 
     def test_nested_collections(self) -> None:
         self.assertEqual({}, self.conn.test_service.increment_nested_collection({}))
@@ -468,6 +538,12 @@ class TestClient(ServerTestCase, unittest.TestCase):
                     "echo_test_object",
                     "object_property",
                     "return_null_when_not_allowed",
+                    "not_nullable_object",
+                    "echo_nullable_string",
+                    "echo_nullable_list",
+                    "echo_nullable_int",
+                    "nullable_object",
+                    "empty_list_default",
                     "TestClass",
                     "optional_arguments",
                     "TestEnum",
@@ -516,12 +592,14 @@ class TestClient(ServerTestCase, unittest.TestCase):
                     "get_value",
                     "float_to_string",
                     "object_to_string",
+                    "echo_nullable_object",
                     "int_property",
                     "object_property",
                     "string_property_private_get",
                     "string_property_private_set",
                     "optional_arguments",
                     "static_method",
+                    "static_nullable_object",
                 ]
             ),
             set(

--- a/client/python/krpc/test/test_decoder.py
+++ b/client/python/krpc/test/test_decoder.py
@@ -38,11 +38,6 @@ class TestDecoder(unittest.TestCase):
         self.assertTrue(isinstance(value, typ.python_type))
         self.assertEqual(300, value._object_id)  # type: ignore[attr-defined]
 
-    def test_decode_class_none(self) -> None:
-        typ = self.types.class_type("ServiceName", "ClassName")
-        value = Decoder.decode(None, unhexlify("00"), typ)
-        self.assertIsNone(value)
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/client/python/krpc/test/test_encoder.py
+++ b/client/python/krpc/test/test_encoder.py
@@ -44,12 +44,6 @@ class TestEncoder(unittest.TestCase):
         data = Encoder.encode(value, typ)
         self.assertEqual("ac02", hexlify(data))
 
-    def test_encode_class_none(self) -> None:
-        typ = self.types.class_type("ServiceName", "ClassName")
-        value = None
-        data = Encoder.encode(value, typ)
-        self.assertEqual("00", hexlify(data))
-
     def test_encode_tuple_wrong_arity(self) -> None:
         typ = self.types.tuple_type(
             self.types.uint32_type, self.types.uint32_type, self.types.uint32_type

--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [v0.7.0] - unreleased
+- Support for nullable values across all types (#1017)
+- **Breaking:** Null values are now signaled by an `is_null` field rather than by an object id
+  of 0, and nullability is enforced uniformly for every type. Class-typed arguments are no longer implicitly nullable (#1017)
+
 ## [v0.6.0]
 - Add `Version` property to `Core`, set by the server plugin on startup (#848)
 - Enable `TCP_NODELAY` on client TCP connections, reducing RPC round-trip latency (#879)

--- a/core/src/Server/ProtocolBuffers/Encoder.cs
+++ b/core/src/Server/ProtocolBuffers/Encoder.cs
@@ -24,10 +24,11 @@ namespace KRPC.Server.ProtocolBuffers
 
         static ByteString EncodeObject (object value, MemoryStream buffer, CodedOutputStream stream)
         {
-            buffer.SetLength (0);
             if (value == null) {
-                stream.WriteUInt64 (0);
-            } else if (value is Enum) {
+                throw new ArgumentNullException (nameof (value));
+            }
+            buffer.SetLength (0);
+            if (value is Enum) {
                 stream.WriteSInt32 ((int)value);
             } else {
                 var type = value.GetType ();

--- a/core/src/Server/ProtocolBuffers/MessageExtensions.cs
+++ b/core/src/Server/ProtocolBuffers/MessageExtensions.cs
@@ -34,8 +34,12 @@ namespace KRPC.Server.ProtocolBuffers
         public static Schema.KRPC.ProcedureResult ToProtobufMessage (this ProcedureResult procedureResult)
         {
             var result = new Schema.KRPC.ProcedureResult ();
-            if (procedureResult.HasValue)
-                result.Value = Encoder.Encode (procedureResult.Value);
+            if (procedureResult.HasValue) {
+                if (procedureResult.Value == null)
+                    result.IsNull = true;
+                else
+                    result.Value = Encoder.Encode (procedureResult.Value);
+            }
             if (procedureResult.HasError)
                 result.Error = procedureResult.Error.ToProtobufMessage ();
             return result;
@@ -129,9 +133,14 @@ namespace KRPC.Server.ProtocolBuffers
             var result = new Schema.KRPC.Parameter ();
             result.Name = parameter.Name;
             result.Type = parameter.Type.ToProtobufMessage ();
-            if (parameter.HasDefaultValue)
-                result.DefaultValue = Encoder.Encode (parameter.DefaultValue);
             result.Nullable = parameter.Nullable;
+            result.HasDefaultValue = parameter.HasDefaultValue;
+            if (parameter.HasDefaultValue) {
+                if (parameter.DefaultValue == null)
+                    result.DefaultValueIsNull = true;
+                else
+                    result.DefaultValue = Encoder.Encode (parameter.DefaultValue);
+            }
             return result;
         }
 
@@ -319,7 +328,8 @@ namespace KRPC.Server.ProtocolBuffers
 
         public static Argument ToMessage (this Schema.KRPC.Argument argument, Type type)
         {
-            return new Argument (argument.Position, Encoder.Decode (argument.Value, type));
+            var value = argument.IsNull ? null : Encoder.Decode (argument.Value, type);
+            return new Argument (argument.Position, value);
         }
     }
 }

--- a/core/src/Server/ProtocolBuffers/StreamStream.cs
+++ b/core/src/Server/ProtocolBuffers/StreamStream.cs
@@ -67,10 +67,14 @@ namespace KRPC.Server.ProtocolBuffers
                 }
                 var pr = protoResult.Result;
                 pr.Value = ByteString.Empty;
+                pr.IsNull = false;
                 pr.Error = null;
-                if (r.Result.HasValue)
-                    pr.Value = Encoder.Encode (r.Result.Value);
-                else if (r.Result.HasError)
+                if (r.Result.HasValue) {
+                    if (r.Result.Value == null)
+                        pr.IsNull = true;
+                    else
+                        pr.Value = Encoder.Encode (r.Result.Value);
+                } else if (r.Result.HasError)
                     pr.Error = r.Result.Error.ToProtobufMessage ();
                 streamUpdateMessage.Add (protoResult);
             }

--- a/core/src/Service/ClassMethodHandler.cs
+++ b/core/src/Service/ClassMethodHandler.cs
@@ -45,6 +45,15 @@ namespace KRPC.Service
 
         public bool ReturnIsNullable { get; private set; }
 
+        /// <summary>
+        /// Mark the property value parameter (the last parameter) as nullable. Used for the setter
+        /// of a nullable property, whose synthesized value parameter cannot carry [KRPCNullable].
+        /// </summary>
+        public void SetValueParameterNullable ()
+        {
+            parameters [parameters.Length - 1].Nullable = true;
+        }
+
         static Func<object, object[], object> BuildInvoker (Type classType, MethodInfo method)
         {
             var instanceParam = Expression.Parameter (typeof(object), "instance");

--- a/core/src/Service/KRPC/Expression.cs
+++ b/core/src/Service/KRPC/Expression.cs
@@ -132,8 +132,13 @@ namespace KRPC.Service.KRPC
             var result = LinqExpression.Call(
                 servicesExpr, executeCallMethod,
                 new[] { procedureExpr, instanceExpr, argumentsExpr });
+            var returnType = procedure.ReturnType;
+            // A nullable value-type return may be null, so evaluate it as Nullable<T> so the
+            // null is representable rather than faulting the conversion.
+            if (procedure.ReturnIsNullable && returnType.IsValueType)
+                returnType = typeof(System.Nullable<>).MakeGenericType(returnType);
             var value = LinqExpression.Convert(
-                LinqExpression.Property(result, "Value"), procedure.ReturnType);
+                LinqExpression.Property(result, "Value"), returnType);
             return new Expression(value);
         }
 

--- a/core/src/Service/ProcedureHandler.cs
+++ b/core/src/Service/ProcedureHandler.cs
@@ -37,6 +37,15 @@ namespace KRPC.Service
 
         public bool ReturnIsNullable { get; private set; }
 
+        /// <summary>
+        /// Mark the property value parameter (the last parameter) as nullable. Used for the setter
+        /// of a nullable property, whose synthesized value parameter cannot carry [KRPCNullable].
+        /// </summary>
+        public void SetValueParameterNullable ()
+        {
+            parameters [parameters.Length - 1].Nullable = true;
+        }
+
         static Func<object, object[], object> BuildInvoker (MethodInfo method)
         {
             var instanceParam = Expression.Parameter (typeof(object), "instance");

--- a/core/src/Service/ProcedureParameter.cs
+++ b/core/src/Service/ProcedureParameter.cs
@@ -36,7 +36,7 @@ namespace KRPC.Service
         /// <summary>
         /// Whether the parameters value could be null.
         /// </summary>
-        public bool Nullable { get; private set; }
+        public bool Nullable { get; internal set; }
 
         /// <summary>
         /// Create parameter information from a reflected parameter.
@@ -45,11 +45,21 @@ namespace KRPC.Service
         {
             Type = parameter.ParameterType;
             Name = parameter.Name;
+            // A Nullable<T> value-type parameter is represented by its underlying type T, and is
+            // implicitly nullable.
+            var underlyingType = System.Nullable.GetUnderlyingType (Type);
+            bool nullableValueType = underlyingType != null;
+            if (nullableValueType)
+                Type = underlyingType;
             bool hasDefaultValue = parameter.IsOptional && (parameter.Attributes & ParameterAttributes.HasDefault) == ParameterAttributes.HasDefault;
             DefaultValue = hasDefaultValue ? parameter.DefaultValue : DBNull.Value;
             if (Reflection.HasAttribute<KRPCDefaultValueAttribute> (parameter))
                 DefaultValue = Reflection.GetAttribute<KRPCDefaultValueAttribute> (parameter).Value;
-            Nullable = Reflection.HasAttribute<KRPCNullableAttribute> (parameter);
+            // A parameter is nullable if its type is Nullable<T>, or it has a null default value
+            // (itself a declaration that null is valid), or it is marked [KRPCNullable].
+            Nullable = nullableValueType
+                || Reflection.HasAttribute<KRPCNullableAttribute> (parameter)
+                || (HasDefaultValue && DefaultValue == null);
         }
 
         /// <summary>

--- a/core/src/Service/Scanner/ParameterSignature.cs
+++ b/core/src/Service/Scanner/ParameterSignature.cs
@@ -59,8 +59,12 @@ namespace KRPC.Service.Scanner
         {
             info.AddValue ("name", Name);
             info.AddValue ("type", TypeUtils.SerializeType (Type));
-            if (HasDefaultValue)
-                info.AddValue ("default_value", Server.ProtocolBuffers.Encoder.Encode (DefaultValue).ToByteArray ());
+            if (HasDefaultValue) {
+                if (DefaultValue == null)
+                    info.AddValue ("default_value", (object)null);
+                else
+                    info.AddValue ("default_value", Server.ProtocolBuffers.Encoder.Encode (DefaultValue).ToByteArray ());
+            }
             if (Nullable) {
                 info.AddValue ("nullable", Nullable);
             }

--- a/core/src/Service/Scanner/ProcedureSignature.cs
+++ b/core/src/Service/Scanner/ProcedureSignature.cs
@@ -118,11 +118,18 @@ namespace KRPC.Service.Scanner
             var returnType = handler.ReturnType;
             HasReturnType = (returnType != typeof(void));
             if (HasReturnType) {
+                ReturnIsNullable = handler.ReturnIsNullable;
+                // A Nullable<T> value-type return is represented by its underlying type T, and is
+                // implicitly nullable.
+                var underlyingType = System.Nullable.GetUnderlyingType (returnType);
+                if (underlyingType != null) {
+                    returnType = underlyingType;
+                    ReturnIsNullable = true;
+                }
                 ReturnType = returnType;
                 // Check it's a valid return type
                 if (!TypeUtils.IsAValidType (returnType))
                     throw new ServiceException (returnType + " is not a valid Procedure return type, " + "in " + FullyQualifiedName);
-                ReturnIsNullable = handler.ReturnIsNullable;
             }
 
             var parts = procedureName.Split (new char[]{'_'});

--- a/core/src/Service/Scanner/ServiceSignature.cs
+++ b/core/src/Service/Scanner/ServiceSignature.cs
@@ -138,15 +138,21 @@ namespace KRPC.Service.Scanner
             TypeUtils.ValidateKRPCProperty (property);
             var getter = property.GetGetMethod ();
             var setter = property.GetSetMethod ();
+            var nullable = TypeUtils.GetNullable (property);
             if (getter != null)
-                AddPropertyProcedure (property, getter);
+                AddPropertyProcedure (property, getter, nullable, false);
             if (setter != null)
-                AddPropertyProcedure (property, setter);
+                AddPropertyProcedure (property, setter, nullable, true);
         }
 
-        void AddPropertyProcedure (PropertyInfo property, MethodInfo method)
+        void AddPropertyProcedure (PropertyInfo property, MethodInfo method, bool nullable, bool isSetter)
         {
-            var handler = new ProcedureHandler (method, TypeUtils.GetNullable (property));
+            // For a getter the nullable flag makes the return value nullable; for a setter it makes
+            // the synthesized value parameter nullable, since that parameter cannot itself carry
+            // the [KRPCNullable] attribute.
+            var handler = new ProcedureHandler (method, isSetter ? false : nullable);
+            if (isSetter && nullable)
+                handler.SetValueParameterNullable ();
             string deprecatedReason;
             var deprecated = TypeUtils.GetPropertyDeprecated (property, method, out deprecatedReason);
             AddProcedure (new ProcedureSignature (
@@ -249,15 +255,21 @@ namespace KRPC.Service.Scanner
                 throw new ArgumentException ("Class " + cls + " does not exist");
             var getter = property.GetGetMethod ();
             var setter = property.GetSetMethod ();
+            var nullable = TypeUtils.GetNullable (property);
             if (getter != null)
-                AddClassPropertyMethod (cls, classType, property, getter, TypeUtils.GetNullable (property));
+                AddClassPropertyMethod (cls, classType, property, getter, nullable, false);
             if (setter != null)
-                AddClassPropertyMethod (cls, classType, property, setter, false);
+                AddClassPropertyMethod (cls, classType, property, setter, nullable, true);
         }
 
-        void AddClassPropertyMethod (string cls, Type classType, PropertyInfo property, MethodInfo method, bool nullable)
+        void AddClassPropertyMethod (string cls, Type classType, PropertyInfo property, MethodInfo method, bool nullable, bool isSetter)
         {
-            var handler = new ClassMethodHandler (classType, method, nullable);
+            // For a getter the nullable flag makes the return value nullable; for a setter it makes
+            // the synthesized value parameter nullable, since that parameter cannot itself carry
+            // the [KRPCNullable] attribute.
+            var handler = new ClassMethodHandler (classType, method, isSetter ? false : nullable);
+            if (isSetter && nullable)
+                handler.SetValueParameterNullable ();
             var classGameScene = TypeUtils.GetClassGameScene(classType, gameScene);
             string deprecatedReason;
             var deprecated = TypeUtils.GetPropertyDeprecated (property, method, out deprecatedReason);

--- a/core/src/Service/Services.cs
+++ b/core/src/Service/Services.cs
@@ -271,7 +271,7 @@ namespace KRPC.Service
                     throw new RPCException (
                         "Incorrect argument type for parameter " + parameter.Name + " in " + procedure.FullyQualifiedName + ". " +
                         "Expected an argument of type " + type + ", got " + value.GetType ());
-                if (value == null && !TypeUtils.IsAClassType (type))
+                if (value == null && !parameter.Nullable)
                     throw new RPCException (
                         "Incorrect argument type for parameter " + parameter.Name + " in " + procedure.FullyQualifiedName + ". " +
                         "Expected an argument of type " + type + ", got null");
@@ -326,8 +326,8 @@ namespace KRPC.Service
                     throw new RPCException (
                         "Incorrect argument type for parameter " + parameter.Name + " in " + procedure.FullyQualifiedName + ". " +
                         "Expected an argument of type " + type + ", got " + value.GetType ());
-                } else if (value == null && !TypeUtils.IsAClassType (type)) {
-                    // Check the type of the null argument value
+                } else if (value == null && !parameter.Nullable) {
+                    // Reject a null argument for a parameter that is not nullable
                     throw new RPCException (
                         "Incorrect argument type for parameter " + parameter.Name + " in " + procedure.FullyQualifiedName + ". " +
                         "Expected an argument of type " + type + ", got null");
@@ -347,11 +347,6 @@ namespace KRPC.Service
                 throw new RPCException (
                     "Incorrect value returned by " + procedure.FullyQualifiedName + ". " +
                     "Expected a value of type " + procedure.ReturnType + ", got " + returnValue.GetType ());
-            }
-            if (returnValue == null && !TypeUtils.IsAClassType (procedure.ReturnType)) {
-                throw new RPCException (
-                    "Incorrect value returned by " + procedure.FullyQualifiedName + ". " +
-                    "Expected a value of type " + procedure.ReturnType + ", got null");
             }
             // Check if the return value is null, but the procedure is not marked as nullable
             if (returnValue == null && !procedure.ReturnIsNullable)

--- a/core/test/Server/ProtocolBuffers/EncoderTest.cs
+++ b/core/test/Server/ProtocolBuffers/EncoderTest.cs
@@ -51,10 +51,9 @@ namespace KRPC.Test.Server.ProtocolBuffers
         }
 
         [Test]
-        public void EncodeClassNone ()
+        public void EncodeNull ()
         {
-            var data = Encoder.Encode (null);
-            Assert.AreEqual ("00", data.ToHexString ());
+            Assert.Throws<ArgumentNullException> (() => Encoder.Encode (null));
         }
 
         [Test]

--- a/core/test/Server/ProtocolBuffers/MessageExtensionsTest.cs
+++ b/core/test/Server/ProtocolBuffers/MessageExtensionsTest.cs
@@ -37,5 +37,76 @@ namespace KRPC.Test.Server.ProtocolBuffers
         {
             CollectionAssert.IsEmpty (Encode (GameScene.All).GameScenes);
         }
+
+        [Test]
+        public void EncodeProcedureResultWithValue ()
+        {
+            var result = new ProcedureResult ();
+            result.Value = 42;
+            var wire = result.ToProtobufMessage ();
+            Assert.IsFalse (wire.IsNull);
+            Assert.Greater (wire.Value.Length, 0);
+        }
+
+        [Test]
+        public void EncodeProcedureResultWithNullValue ()
+        {
+            var result = new ProcedureResult ();
+            result.Value = null;
+            var wire = result.ToProtobufMessage ();
+            Assert.IsTrue (wire.IsNull);
+            Assert.AreEqual (0, wire.Value.Length);
+        }
+
+        [Test]
+        public void EncodeParameterWithNoDefault ()
+        {
+            var wire = new Parameter ("x", typeof(int), false).ToProtobufMessage ();
+            Assert.IsFalse (wire.HasDefaultValue);
+            Assert.IsFalse (wire.DefaultValueIsNull);
+            Assert.AreEqual (0, wire.DefaultValue.Length);
+        }
+
+        [Test]
+        public void EncodeParameterWithValueDefault ()
+        {
+            var parameter = new Parameter ("x", typeof(int), false);
+            parameter.DefaultValue = 42;
+            var wire = parameter.ToProtobufMessage ();
+            Assert.IsTrue (wire.HasDefaultValue);
+            Assert.IsFalse (wire.DefaultValueIsNull);
+            Assert.Greater (wire.DefaultValue.Length, 0);
+        }
+
+        [Test]
+        public void EncodeParameterWithNullDefault ()
+        {
+            var parameter = new Parameter ("x", typeof(string), true);
+            parameter.DefaultValue = null;
+            var wire = parameter.ToProtobufMessage ();
+            Assert.IsTrue (wire.HasDefaultValue);
+            Assert.IsTrue (wire.DefaultValueIsNull);
+            Assert.AreEqual (0, wire.DefaultValue.Length);
+        }
+
+        [Test]
+        public void DecodeArgumentWithValue ()
+        {
+            var argument = new Schema.KRPC.Argument ();
+            argument.Position = 0;
+            argument.Value = Encoder.Encode ("foo");
+            var message = argument.ToMessage (typeof(string));
+            Assert.AreEqual ("foo", message.Value);
+        }
+
+        [Test]
+        public void DecodeArgumentWithNull ()
+        {
+            var argument = new Schema.KRPC.Argument ();
+            argument.Position = 0;
+            argument.IsNull = true;
+            var message = argument.ToMessage (typeof(string));
+            Assert.IsNull (message.Value);
+        }
     }
 }

--- a/core/test/Service/ITestService.cs
+++ b/core/test/Service/ITestService.cs
@@ -23,6 +23,8 @@ namespace KRPC.Test.Service
 
         string PropertyWithSet { set; }
 
+        string NullableProperty { get; set; }
+
         TestService.TestClass CreateTestObject (string value);
 
         void DeleteTestObject (TestService.TestClass obj);
@@ -30,6 +32,14 @@ namespace KRPC.Test.Service
         TestService.TestClass EchoTestObject (TestService.TestClass obj);
 
         TestService.TestClass ReturnNullWhenNotAllowed ();
+
+        string EchoNullableString (string x);
+
+        int? EchoNullableInt (int? x);
+
+        TestService.TestEnum? EchoNullableEnum (TestService.TestEnum? x);
+
+        IList<string> EchoNullableList (IList<string> l);
 
         void ProcedureSingleOptionalArgNoReturn (string x);
 

--- a/core/test/Service/MessageAssert.cs
+++ b/core/test/Service/MessageAssert.cs
@@ -25,6 +25,29 @@ namespace KRPC.Test.Service
             Assert.AreEqual (name, parameter.Name);
             Assert.IsFalse (parameter.HasDefaultValue);
             Assert.IsNull (parameter.DefaultValue);
+            Assert.IsFalse (parameter.Nullable);
+        }
+
+        public static void HasNullableParameter (Procedure procedure, int position, Type type, string name)
+        {
+            Assert.Less (position, procedure.Parameters.Count);
+            var parameter = procedure.Parameters [position];
+            Assert.AreEqual (type, parameter.Type);
+            Assert.AreEqual (name, parameter.Name);
+            Assert.IsFalse (parameter.HasDefaultValue);
+            Assert.IsNull (parameter.DefaultValue);
+            Assert.IsTrue (parameter.Nullable);
+        }
+
+        public static void HasNullableParameterWithDefaultValue (Procedure procedure, int position, Type type, string name, object defaultValue)
+        {
+            Assert.Less (position, procedure.Parameters.Count);
+            var parameter = procedure.Parameters [position];
+            Assert.AreEqual (type, parameter.Type);
+            Assert.AreEqual (name, parameter.Name);
+            Assert.IsTrue (parameter.HasDefaultValue);
+            Assert.AreEqual (defaultValue, parameter.DefaultValue);
+            Assert.IsTrue (parameter.Nullable);
         }
 
         public static void HasParameterWithDefaultValue (Procedure procedure, int position, Type type, string name, object defaultValue)

--- a/core/test/Service/ScannerTest.cs
+++ b/core/test/Service/ScannerTest.cs
@@ -31,7 +31,7 @@ namespace KRPC.Test.Service
         public void TestService ()
         {
             var service = services.ServicesList.First (x => x.Name == "TestService");
-            Assert.AreEqual (53, service.Procedures.Count);
+            Assert.AreEqual (61, service.Procedures.Count);
             Assert.AreEqual (3, service.Classes.Count);
             Assert.AreEqual (2, service.Enumerations.Count);
             Assert.AreEqual ("<doc>\n<summary>\nTest service documentation.\n</summary>\n</doc>", service.Documentation);
@@ -146,6 +146,17 @@ namespace KRPC.Test.Service
                     MessageAssert.HasNoReturnType (proc);
                     MessageAssert.HasGameScene (proc, global::KRPC.Service.GameScene.Flight);
                     MessageAssert.HasNoDocumentation (proc);
+                } else if (proc.Name == "get_NullableProperty") {
+                    MessageAssert.HasNoParameters (proc);
+                    MessageAssert.HasReturnType (proc, typeof(string), true);
+                    MessageAssert.HasGameScene (proc, global::KRPC.Service.GameScene.Flight);
+                    MessageAssert.HasNoDocumentation (proc);
+                } else if (proc.Name == "set_NullableProperty") {
+                    MessageAssert.HasParameters (proc, 1);
+                    MessageAssert.HasNullableParameter (proc, 0, typeof(string), "value");
+                    MessageAssert.HasNoReturnType (proc);
+                    MessageAssert.HasGameScene (proc, global::KRPC.Service.GameScene.Flight);
+                    MessageAssert.HasNoDocumentation (proc);
                 } else if (proc.Name == "CreateTestObject") {
                     MessageAssert.HasParameters (proc, 1);
                     MessageAssert.HasParameter (proc, 0, typeof(string), "value");
@@ -160,8 +171,32 @@ namespace KRPC.Test.Service
                     MessageAssert.HasNoDocumentation (proc);
                 } else if (proc.Name == "EchoTestObject") {
                     MessageAssert.HasParameters (proc, 1);
-                    MessageAssert.HasParameter (proc, 0, typeof(TestService.TestClass), "obj");
+                    MessageAssert.HasNullableParameter (proc, 0, typeof(TestService.TestClass), "obj");
                     MessageAssert.HasReturnType (proc, typeof(TestService.TestClass), true);
+                    MessageAssert.HasGameScene (proc, global::KRPC.Service.GameScene.Flight);
+                    MessageAssert.HasNoDocumentation (proc);
+                } else if (proc.Name == "EchoNullableString") {
+                    MessageAssert.HasParameters (proc, 1);
+                    MessageAssert.HasNullableParameter (proc, 0, typeof(string), "x");
+                    MessageAssert.HasReturnType (proc, typeof(string), true);
+                    MessageAssert.HasGameScene (proc, global::KRPC.Service.GameScene.Flight);
+                    MessageAssert.HasNoDocumentation (proc);
+                } else if (proc.Name == "EchoNullableInt") {
+                    MessageAssert.HasParameters (proc, 1);
+                    MessageAssert.HasNullableParameter (proc, 0, typeof(int), "x");
+                    MessageAssert.HasReturnType (proc, typeof(int), true);
+                    MessageAssert.HasGameScene (proc, global::KRPC.Service.GameScene.Flight);
+                    MessageAssert.HasNoDocumentation (proc);
+                } else if (proc.Name == "EchoNullableEnum") {
+                    MessageAssert.HasParameters (proc, 1);
+                    MessageAssert.HasNullableParameter (proc, 0, typeof(TestService.TestEnum), "x");
+                    MessageAssert.HasReturnType (proc, typeof(TestService.TestEnum), true);
+                    MessageAssert.HasGameScene (proc, global::KRPC.Service.GameScene.Flight);
+                    MessageAssert.HasNoDocumentation (proc);
+                } else if (proc.Name == "EchoNullableList") {
+                    MessageAssert.HasParameters (proc, 1);
+                    MessageAssert.HasNullableParameter (proc, 0, typeof(IList<string>), "l");
+                    MessageAssert.HasReturnType (proc, typeof(IList<string>), true);
                     MessageAssert.HasGameScene (proc, global::KRPC.Service.GameScene.Flight);
                     MessageAssert.HasNoDocumentation (proc);
                 } else if (proc.Name == "ReturnNullWhenNotAllowed") {
@@ -181,6 +216,13 @@ namespace KRPC.Test.Service
                     MessageAssert.HasParameter (proc, 0, typeof(TestService.TestClass), "this");
                     MessageAssert.HasParameter (proc, 1, typeof(TestService.TestClass), "other");
                     MessageAssert.HasReturnType (proc, typeof(string));
+                    MessageAssert.HasGameScene (proc, global::KRPC.Service.GameScene.Flight | global::KRPC.Service.GameScene.SpaceCenter);
+                    MessageAssert.HasNoDocumentation (proc);
+                } else if (proc.Name == "TestClass_EchoNullableObject") {
+                    MessageAssert.HasParameters (proc, 2);
+                    MessageAssert.HasParameter (proc, 0, typeof(TestService.TestClass), "this");
+                    MessageAssert.HasNullableParameter (proc, 1, typeof(TestService.TestClass), "other");
+                    MessageAssert.HasReturnType (proc, typeof(TestService.TestClass), true);
                     MessageAssert.HasGameScene (proc, global::KRPC.Service.GameScene.Flight | global::KRPC.Service.GameScene.SpaceCenter);
                     MessageAssert.HasNoDocumentation (proc);
                 } else if (proc.Name == "TestClass_IntToString") {
@@ -212,7 +254,7 @@ namespace KRPC.Test.Service
                 } else if (proc.Name == "TestClass_set_ObjectProperty") {
                     MessageAssert.HasParameters (proc, 2);
                     MessageAssert.HasParameter (proc, 0, typeof(TestService.TestClass), "this");
-                    MessageAssert.HasParameter (proc, 1, typeof(TestService.TestClass), "value");
+                    MessageAssert.HasNullableParameter (proc, 1, typeof(TestService.TestClass), "value");
                     MessageAssert.HasNoReturnType (proc);
                     MessageAssert.HasGameScene (proc, global::KRPC.Service.GameScene.Flight | global::KRPC.Service.GameScene.SpaceCenter);
                     MessageAssert.HasNoDocumentation (proc);
@@ -220,6 +262,12 @@ namespace KRPC.Test.Service
                     MessageAssert.HasParameters (proc, 1);
                     MessageAssert.HasParameterWithDefaultValue (proc, 0, typeof(string), "a", string.Empty);
                     MessageAssert.HasReturnType (proc, typeof(string));
+                    MessageAssert.HasGameScene (proc, global::KRPC.Service.GameScene.Flight | global::KRPC.Service.GameScene.SpaceCenter);
+                    MessageAssert.HasNoDocumentation (proc);
+                } else if (proc.Name == "TestClass_static_StaticNullableMethod") {
+                    MessageAssert.HasParameters (proc, 1);
+                    MessageAssert.HasNullableParameter (proc, 0, typeof(string), "x");
+                    MessageAssert.HasReturnType (proc, typeof(string), true);
                     MessageAssert.HasGameScene (proc, global::KRPC.Service.GameScene.Flight | global::KRPC.Service.GameScene.SpaceCenter);
                     MessageAssert.HasNoDocumentation (proc);
                 } else if (proc.Name == "TestClass_MethodAvailableInInheritedGameScene") {
@@ -282,7 +330,7 @@ namespace KRPC.Test.Service
                     MessageAssert.HasNoDocumentation (proc);
                 } else if (proc.Name == "ProcedureOptionalNullArg") {
                     MessageAssert.HasParameters (proc, 1);
-                    MessageAssert.HasParameterWithDefaultValue (proc, 0, typeof(TestService.TestClass), "x", null);
+                    MessageAssert.HasNullableParameterWithDefaultValue (proc, 0, typeof(TestService.TestClass), "x", null);
                     MessageAssert.HasNoReturnType (proc);
                     MessageAssert.HasGameScene (proc, global::KRPC.Service.GameScene.Flight);
                     MessageAssert.HasNoDocumentation (proc);
@@ -396,8 +444,8 @@ namespace KRPC.Test.Service
                 }
                 foundProcedures++;
             }
-            Assert.AreEqual (53, foundProcedures);
-            Assert.AreEqual (53, service.Procedures.Count);
+            Assert.AreEqual (61, foundProcedures);
+            Assert.AreEqual (61, service.Procedures.Count);
         }
 
         [Test]

--- a/core/test/Service/ServicesTest.cs
+++ b/core/test/Service/ServicesTest.cs
@@ -134,7 +134,8 @@ namespace KRPC.Test.Service
             mock.Setup (x => x.ProcedureNoArgsReturns ()).Returns ((string)null);
             TestService.Service = mock.Object;
             CheckError (String.Empty, "Incorrect value returned by TestService.ProcedureNoArgsReturns. " +
-                        "Expected a value of type System.String, got null",
+                        "Expected a non-null value of type System.String, got null, " +
+                        "but the procedure is not marked as nullable.",
                         Run (Call ("TestService", "ProcedureNoArgsReturns")));
             mock.Verify (x => x.ProcedureNoArgsReturns (), Times.Once ());
         }
@@ -290,6 +291,111 @@ namespace KRPC.Test.Service
         }
 
         [Test]
+        public void ExecuteCallWithNullArgumentToNonNullableParameter ()
+        {
+            var mock = new Mock<ITestService> (MockBehavior.Strict);
+            mock.Setup (x => x.DeleteTestObject (It.IsAny<TestService.TestClass> ()));
+            TestService.Service = mock.Object;
+            CheckError (String.Empty, "Incorrect argument type for parameter obj in " +
+                        "TestService.DeleteTestObject. Expected an argument of type " +
+                        "KRPC.Test.Service.TestService+TestClass, got null",
+                        Run (Call ("TestService", "DeleteTestObject", Arg (0, null))));
+            mock.Verify (x => x.DeleteTestObject (It.IsAny<TestService.TestClass> ()), Times.Never ());
+        }
+
+        [Test]
+        public void ExecuteCallWithNullableStringArgumentAndReturn ()
+        {
+            var mock = new Mock<ITestService> (MockBehavior.Strict);
+            mock.Setup (x => x.EchoNullableString (It.IsAny<string> ()))
+                .Callback ((string x) => Assert.IsNull (x))
+                .Returns ((string x) => x);
+            TestService.Service = mock.Object;
+            var result = Run (Call ("TestService", "EchoNullableString", Arg (0, null)));
+            CheckResultNotEmpty (result);
+            Assert.IsNull (result.Value);
+        }
+
+        [Test]
+        public void ExecuteCallWithNullableIntArgumentAndReturnNull ()
+        {
+            var mock = new Mock<ITestService> (MockBehavior.Strict);
+            mock.Setup (x => x.EchoNullableInt (It.IsAny<int?> ()))
+                .Callback ((int? x) => Assert.IsFalse (x.HasValue))
+                .Returns ((int? x) => x);
+            TestService.Service = mock.Object;
+            var result = Run (Call ("TestService", "EchoNullableInt", Arg (0, null)));
+            CheckResultNotEmpty (result);
+            Assert.IsNull (result.Value);
+        }
+
+        [Test]
+        public void ExecuteCallWithNullableIntArgumentAndReturnValue ()
+        {
+            var mock = new Mock<ITestService> (MockBehavior.Strict);
+            mock.Setup (x => x.EchoNullableInt (It.IsAny<int?> ()))
+                .Callback ((int? x) => Assert.AreEqual (42, x))
+                .Returns ((int? x) => x);
+            TestService.Service = mock.Object;
+            var result = Run (Call ("TestService", "EchoNullableInt", Arg (0, 42)));
+            CheckResultNotEmpty (result);
+            Assert.AreEqual (42, (int)result.Value);
+        }
+
+        [Test]
+        public void ExecuteCallWithNullableEnumArgumentAndReturnNull ()
+        {
+            var mock = new Mock<ITestService> (MockBehavior.Strict);
+            mock.Setup (x => x.EchoNullableEnum (It.IsAny<TestService.TestEnum?> ()))
+                .Callback ((TestService.TestEnum? x) => Assert.IsFalse (x.HasValue))
+                .Returns ((TestService.TestEnum? x) => x);
+            TestService.Service = mock.Object;
+            var result = Run (Call ("TestService", "EchoNullableEnum", Arg (0, null)));
+            CheckResultNotEmpty (result);
+            Assert.IsNull (result.Value);
+        }
+
+        [Test]
+        public void ExecuteCallWithNullableEnumArgumentAndReturnValue ()
+        {
+            var mock = new Mock<ITestService> (MockBehavior.Strict);
+            mock.Setup (x => x.EchoNullableEnum (It.IsAny<TestService.TestEnum?> ()))
+                .Callback ((TestService.TestEnum? x) => Assert.AreEqual (TestService.TestEnum.Y, x))
+                .Returns ((TestService.TestEnum? x) => x);
+            TestService.Service = mock.Object;
+            var result = Run (Call ("TestService", "EchoNullableEnum", Arg (0, TestService.TestEnum.Y)));
+            CheckResultNotEmpty (result);
+            Assert.AreEqual (TestService.TestEnum.Y, (TestService.TestEnum)result.Value);
+        }
+
+        [Test]
+        public void ExecuteCallWithNullableListArgumentAndReturnNull ()
+        {
+            var mock = new Mock<ITestService> (MockBehavior.Strict);
+            mock.Setup (x => x.EchoNullableList (It.IsAny<IList<string>> ()))
+                .Callback ((IList<string> l) => Assert.IsNull (l))
+                .Returns ((IList<string> l) => l);
+            TestService.Service = mock.Object;
+            var result = Run (Call ("TestService", "EchoNullableList", Arg (0, null)));
+            CheckResultNotEmpty (result);
+            Assert.IsNull (result.Value);
+        }
+
+        [Test]
+        public void ExecuteCallWithNullableListArgumentAndReturnValue ()
+        {
+            var list = new List<string> { "foo", "bar" };
+            var mock = new Mock<ITestService> (MockBehavior.Strict);
+            mock.Setup (x => x.EchoNullableList (It.IsAny<IList<string>> ()))
+                .Callback ((IList<string> l) => CollectionAssert.AreEqual (list, l))
+                .Returns ((IList<string> l) => l);
+            TestService.Service = mock.Object;
+            var result = Run (Call ("TestService", "EchoNullableList", Arg (0, list)));
+            CheckResultNotEmpty (result);
+            CollectionAssert.AreEqual (list, (IList<string>)result.Value);
+        }
+
+        [Test]
         public void ExecuteCallForObjectMethod ()
         {
             var instance = new TestService.TestClass ("jeb");
@@ -335,6 +441,99 @@ namespace KRPC.Test.Service
             var result = Run (Call ("TestService", "TestClass_static_StaticMethod", Arg (0, "bob")));
             CheckResultNotEmpty (result);
             Assert.AreEqual ("jebbob", (string)result.Value);
+        }
+
+        [Test]
+        public void ExecuteCallForNullableObjectMethodWithNull ()
+        {
+            var instance = new TestService.TestClass ("jeb");
+            var result = Run (Call ("TestService", "TestClass_EchoNullableObject",
+                             Arg (0, instance), Arg (1, null)));
+            CheckResultNotEmpty (result);
+            Assert.IsNull (result.Value);
+        }
+
+        [Test]
+        public void ExecuteCallOptionalNullArgExplicitNull ()
+        {
+            // A null default makes the parameter nullable, so passing null explicitly is accepted
+            // as well as omitting the argument (see ExecuteCallOptionalNullArg).
+            var mock = new Mock<ITestService> (MockBehavior.Strict);
+            mock.Setup (x => x.ProcedureOptionalNullArg (It.IsAny<TestService.TestClass> ()))
+                .Callback ((TestService.TestClass x) => Assert.IsNull (x));
+            TestService.Service = mock.Object;
+            var result = Run (Call ("TestService", "ProcedureOptionalNullArg", Arg (0, null)));
+            mock.Verify (x => x.ProcedureOptionalNullArg (It.IsAny<TestService.TestClass> ()), Times.Once ());
+            CheckResultEmpty (result);
+        }
+
+        [Test]
+        public void ExecuteCallForClassStaticNullableMethod ()
+        {
+            var result = Run (Call ("TestService", "TestClass_static_StaticNullableMethod", Arg (0, null)));
+            CheckResultNotEmpty (result);
+            Assert.IsNull (result.Value);
+        }
+
+        [Test]
+        public void ExecuteCallSetNullablePropertyToNull ()
+        {
+            var mock = new Mock<ITestService> (MockBehavior.Strict);
+            mock.SetupSet (x => x.NullableProperty = null);
+            TestService.Service = mock.Object;
+            var result = Run (Call ("TestService", "set_NullableProperty", Arg (0, null)));
+            mock.VerifySet (x => x.NullableProperty = null, Times.Once ());
+            CheckResultEmpty (result);
+        }
+
+        [Test]
+        public void ExecuteCallGetNullablePropertyReturningNull ()
+        {
+            var mock = new Mock<ITestService> (MockBehavior.Strict);
+            mock.Setup (x => x.NullableProperty).Returns ((string)null);
+            TestService.Service = mock.Object;
+            var result = Run (Call ("TestService", "get_NullableProperty"));
+            CheckResultNotEmpty (result);
+            Assert.IsNull (result.Value);
+        }
+
+        [Test]
+        public void ExecuteCallGetNonNullablePropertyReturningNull ()
+        {
+            // A property getter is a return: a null read from a property not marked nullable is
+            // rejected, exactly like a null return from a non-nullable procedure.
+            var mock = new Mock<ITestService> (MockBehavior.Strict);
+            mock.Setup (x => x.PropertyWithGet).Returns ((string)null);
+            TestService.Service = mock.Object;
+            CheckError (String.Empty, "Incorrect value returned by TestService.get_PropertyWithGet. " +
+                        "Expected a non-null value of type System.String, got null, " +
+                        "but the procedure is not marked as nullable.",
+                        Run (Call ("TestService", "get_PropertyWithGet")));
+            mock.Verify (x => x.PropertyWithGet, Times.Once ());
+        }
+
+        [Test]
+        public void ExecuteCallSetNonNullablePropertyToNull ()
+        {
+            var mock = new Mock<ITestService> (MockBehavior.Strict);
+            mock.SetupSet (x => x.PropertyWithSet = It.IsAny<string> ());
+            TestService.Service = mock.Object;
+            CheckError (String.Empty, "Incorrect argument type for parameter value in " +
+                        "TestService.set_PropertyWithSet. Expected an argument of type " +
+                        "System.String, got null",
+                        Run (Call ("TestService", "set_PropertyWithSet", Arg (0, null))));
+            mock.VerifySet (x => x.PropertyWithSet = It.IsAny<string> (), Times.Never ());
+        }
+
+        [Test]
+        public void ExecuteCallSetNullableClassPropertyToNull ()
+        {
+            var instance = new TestService.TestClass ("jeb");
+            instance.ObjectProperty = new TestService.TestClass ("initial");
+            var result = Run (Call ("TestService", "TestClass_set_ObjectProperty",
+                             Arg (0, instance), Arg (1, null)));
+            CheckResultEmpty (result);
+            Assert.IsNull (instance.ObjectProperty);
         }
 
         [Test]

--- a/core/test/Service/TestService.cs
+++ b/core/test/Service/TestService.cs
@@ -74,6 +74,12 @@ namespace KRPC.Test.Service
             set { Service.PropertyWithSet = value; }
         }
 
+        [KRPCProperty (Nullable = true)]
+        public static string NullableProperty {
+            get { return Service.NullableProperty; }
+            set { Service.NullableProperty = value; }
+        }
+
         [KRPCProcedure]
         public static TestClass CreateTestObject (string value)
         {
@@ -87,7 +93,7 @@ namespace KRPC.Test.Service
         }
 
         [KRPCProcedure (Nullable = true)]
-        public static TestClass EchoTestObject (TestClass obj)
+        public static TestClass EchoTestObject ([KRPCNullable] TestClass obj)
         {
             return Service.EchoTestObject (obj);
         }
@@ -96,6 +102,30 @@ namespace KRPC.Test.Service
         public static TestClass ReturnNullWhenNotAllowed ()
         {
             return Service.ReturnNullWhenNotAllowed ();
+        }
+
+        [KRPCProcedure (Nullable = true)]
+        public static string EchoNullableString ([KRPCNullable] string x)
+        {
+            return Service.EchoNullableString (x);
+        }
+
+        [KRPCProcedure]
+        public static int? EchoNullableInt (int? x)
+        {
+            return Service.EchoNullableInt (x);
+        }
+
+        [KRPCProcedure]
+        public static TestEnum? EchoNullableEnum (TestEnum? x)
+        {
+            return Service.EchoNullableEnum (x);
+        }
+
+        [KRPCProcedure (Nullable = true)]
+        public static IList<string> EchoNullableList ([KRPCNullable] IList<string> l)
+        {
+            return Service.EchoNullableList (l);
         }
 
         [KRPCClass (GameScene = GameScene.Flight | GameScene.SpaceCenter)]
@@ -120,6 +150,12 @@ namespace KRPC.Test.Service
                 return Value + other.Value;
             }
 
+            [KRPCMethod (Nullable = true)]
+            public TestClass EchoNullableObject ([KRPCNullable] TestClass other)
+            {
+                return other;
+            }
+
             [KRPCMethod]
             public string IntToString (int x = 42)
             {
@@ -136,6 +172,12 @@ namespace KRPC.Test.Service
             public static string StaticMethod (string a = "")
             {
                 return "jeb" + a;
+            }
+
+            [KRPCMethod (Nullable = true)]
+            public static string StaticNullableMethod ([KRPCNullable] string x)
+            {
+                return x;
             }
 
             [KRPCMethod]

--- a/core/test/Utils/ReflectionTest.cs
+++ b/core/test/Utils/ReflectionTest.cs
@@ -30,8 +30,8 @@ namespace KRPC.Test.Utils
         [Test]
         public void GetMethodsWithAttribute ()
         {
-            Assert.AreEqual (30, Reflection.GetMethodsWith<KRPCProcedureAttribute> (typeof(TestService)).Count ());
-            Assert.AreEqual (6, Reflection.GetMethodsWith<KRPCMethodAttribute> (typeof(TestService.TestClass)).Count ());
+            Assert.AreEqual (34, Reflection.GetMethodsWith<KRPCProcedureAttribute> (typeof(TestService)).Count ());
+            Assert.AreEqual (8, Reflection.GetMethodsWith<KRPCMethodAttribute> (typeof(TestService.TestClass)).Count ());
             Assert.AreEqual (0, Reflection.GetMethodsWith<KRPCProcedureAttribute> (typeof(TestService.TestClass)).Count ());
             Assert.AreEqual (0, Reflection.GetMethodsWith<KRPCProcedureAttribute> (typeof(string)).Count ());
         }
@@ -39,7 +39,7 @@ namespace KRPC.Test.Utils
         [Test]
         public void GetPropertiesWithAttribute ()
         {
-            Assert.AreEqual (6, Reflection.GetPropertiesWith<KRPCPropertyAttribute> (typeof(TestService)).Count ());
+            Assert.AreEqual (7, Reflection.GetPropertiesWith<KRPCPropertyAttribute> (typeof(TestService)).Count ());
             Assert.AreEqual (4, Reflection.GetPropertiesWith<KRPCPropertyAttribute> (typeof(TestService.TestClass)).Count ());
             Assert.AreEqual (0, Reflection.GetPropertiesWith<KRPCPropertyAttribute> (typeof(string)).Count ());
         }

--- a/doc/src/communication-protocols/messages.rst
+++ b/doc/src/communication-protocols/messages.rst
@@ -54,6 +54,7 @@ format:
    message Argument {
      uint32 position = 1;
      bytes value = 2;
+     bool is_null = 3;
    }
 
 A request message contains one or more procedure calls. This allows efficient batching of multiple
@@ -75,7 +76,11 @@ The fields of a procedure call are:
   * ``position`` - The zero-indexed position of the of the argument in the procedure's
     signature.
 
-  * ``value`` - The value of the argument, encoded in Protocol Buffer format.
+  * ``value`` - The value of the argument, encoded in Protocol Buffer format. Ignored when
+    ``is_null`` is set.
+
+  * ``is_null`` - Whether the argument's value is null. When set, the argument is null and
+    ``value`` is unset. Only permitted for parameters that accept null.
 
 The service containing the procedure to call is specified by setting either ``service`` or
 ``service_id``. The procedure to call is specified by setting either ``procedure`` or
@@ -106,6 +111,7 @@ format:
    message ProcedureResult {
      Error error = 1;
      bytes value = 2;
+     bool is_null = 3;
    }
 
    message Error {
@@ -121,6 +127,9 @@ associated request message.
 The ``value`` field of a procedure result message contains the value of the return value of the
 remote procedure, if any, encoded in protocol buffer format. See
 :ref:`communication-protocol-protobuf-encoding` for details on how to decode the return value.
+
+The ``is_null`` field indicates that the return value is null. When it is set, the ``value`` field
+is unset and must be ignored. This is only permitted for procedures whose return value is nullable.
 
 If an error occurs processing a request message, the ``error`` field in the response message will
 contain a description of the error. If an individual procedure call encounters an error, the
@@ -166,6 +175,13 @@ Protocol Buffer version 3 serialization format:
 
 * Protocol Buffer libraries in many languages are available here:
   https://github.com/google/protobuf/releases
+
+A null value is not encoded in the ``value`` field. Instead it is signaled out-of-band by the
+``is_null`` field on the ``Argument`` or ``ProcedureResult`` message. When ``is_null`` is set, the
+``value`` field is unset and carries no encoded value. Null is signaled out-of-band because the
+encoding of every type already assigns a meaning to all byte sequences, leaving no spare value to
+reserve for null. This applies to values of any type. Note that a zero-length ``value`` is a valid
+encoding -- for example an empty collection -- and is distinct from a null value.
 
 .. _communication-protocol-streams:
 
@@ -400,8 +416,10 @@ Details about a procedure are given by a ``Procedure`` message, with the format:
    message Parameter {
      string name = 1;
      Type type = 2;
-     bytes default_value = 3;
      bool nullable = 4;
+     bool has_default_value = 5;
+     bytes default_value = 3;
+     bool default_value_is_null = 6;
    }
 
 The fields are:
@@ -416,15 +434,45 @@ The fields are:
 
   * ``type`` - The :ref:`type <communication-protocol-type>` of the parameter.
 
-  * ``default_value`` - The value of the default value of the parameter, if any, :ref:`encoded
-    using Protocol Buffer format <communication-protocol-protobuf-encoding>`.
+  * ``nullable`` - Whether null can be passed as the argument for this parameter.
 
-  * ``nullable`` - If the parameter has a class type, indicates whether null can be passed.
+  * ``has_default_value`` - Whether the parameter has a default value. When it is not set, the
+    parameter is required and ``default_value`` and ``default_value_is_null`` are unset.
+
+  * ``default_value`` - The default value of the parameter, :ref:`encoded using Protocol Buffer
+    format <communication-protocol-protobuf-encoding>`. Set only when ``has_default_value`` is set
+    and ``default_value_is_null`` is not. A zero-length value is a valid default, for example an
+    empty collection.
+
+  * ``default_value_is_null`` - Whether the default value is null. Set only when ``has_default_value``
+    is set, in which case ``default_value`` is unset.
+
+  The presence and nullability of the default value are given by these three fields as follows:
+
+  .. list-table::
+     :header-rows: 1
+
+     * - Default value
+       - ``has_default_value``
+       - ``default_value_is_null``
+       - ``default_value``
+     * - none (required parameter)
+       - unset
+       - unset
+       - unset
+     * - a value (including an empty collection)
+       - set
+       - unset
+       - encoded bytes (may be zero-length)
+     * - null
+       - set
+       - set
+       - unset
 
 * ``return_type`` - The :ref:`return type <communication-protocol-type>` of the procedure. If the
   procedure does not return anything its type is set to ``NONE``.
 
-* ``return_is_nullable`` - If the return type is a class type, indicates whether null could returned.
+* ``return_is_nullable`` - Whether the procedure can return null.
 
 * ``game_scenes`` - The :ref:`game scenes <communication-protocol-game-scene>` that the procedure is
   available in. If this repeated field is empty, the procedure is available in all game scenes.
@@ -663,5 +711,9 @@ properties make remote procedure calls to the server. Object identifiers have ty
 
 When a procedure returns a proxy object or takes one as a parameter, the type code will be set to
 ``CLASS``.
+
+A null object reference is signaled by the ``is_null`` field of the ``ProcedureResult`` or
+``Argument`` message, in the same way as a null value of any other type. The object identifier is
+not used to represent null on the wire.
 
 .. _C# XML documentation: https://msdn.microsoft.com/en-us/library/aa288481%28v=vs.71%29.aspx

--- a/doc/src/dictionary.txt
+++ b/doc/src/dictionary.txt
@@ -117,6 +117,7 @@ normangle
 nozzel
 nozzels
 ns
+nullability
 nullable
 omni
 online

--- a/doc/src/extending.rst
+++ b/doc/src/extending.rst
@@ -150,7 +150,8 @@ to add functionality to the kRPC server.
    * Parameters can have default arguments.
 
    If the procedure might return a null value, the ``Nullable`` parameter of the attribute must be
-   set to true.
+   set to true. A parameter that may be ``null`` must likewise be made nullable. See
+   :ref:`service-api-null-values`.
 
    **Example**
 
@@ -263,7 +264,8 @@ to add functionality to the kRPC server.
    * Parameters can have default arguments.
 
    If the method might return a null value, the ``Nullable`` parameter of the attribute must be set
-   to true.
+   to true. A parameter that may be ``null`` must likewise be made nullable. See
+   :ref:`service-api-null-values`.
 
    **Example**
 
@@ -284,7 +286,8 @@ to add functionality to the kRPC server.
 
    :parameters:
 
-    * **Nullable** -- Whether the return value of the procedure can be null. Defaults to false.
+    * **Nullable** -- Whether the property can be null. This makes both the getter's return value
+      and the setter's argument nullable. Defaults to false.
 
     * **GameScene** -- The game scenes in which the property is available. Defaults to inherit this
       setting from the class the property is defined in.
@@ -311,8 +314,9 @@ to add functionality to the kRPC server.
 
       * Must be declared inside a :csharp:attr:`KRPCClass`.
 
-   If the property getter might return a null value, the ``Nullable`` parameter of the attribute
-   must be set to true.
+   If the property getter might return a null value, or the setter should accept ``null``, the
+   ``Nullable`` parameter of the attribute must be set to true. A ``null`` write to a property that
+   is not nullable fails with an error. See :ref:`service-api-null-values`.
 
    **Examples**
 
@@ -475,14 +479,14 @@ to add functionality to the kRPC server.
 
 .. csharp:attribute:: KRPCNullable
 
-   This `attribute <https://msdn.microsoft.com/en-us/library/aa287992.aspx>`_ can be applied to a
-   kRPC procedure/class method parameter that has a class type. It indicates that the parameter
-   is permitted to be ``null``. Without this attribute, a client can assume that the parameter
-   should never be null.
+   This `attribute <https://msdn.microsoft.com/en-us/library/aa287992.aspx>`_ is applied to a
+   kRPC procedure or class method parameter to indicate that the parameter is permitted to be
+   ``null``. It can be applied to a parameter of any serializable type, not only class types.
 
-   Note: the server does not check if a value passed to an RPC is ``null``. This needs to be
-   explicitly checked in the RPC's code (if desired) and an appropriate exception thrown.
-   This attribute is only used as a hint to the client that the parameter is nullable.
+   The server enforces nullability: a call that passes ``null`` for a parameter that is not
+   nullable fails with an error. A parameter is nullable if it is marked with ``KRPCNullable``,
+   is assigned a default value of ``null``, or has a ``Nullable<T>`` type. See
+   :ref:`service-api-null-values`.
 
    **Example**
 
@@ -493,7 +497,7 @@ to add functionality to the kRPC server.
           [KRPCProcedure]
           public static void DestroyVessel ([KRPCNullable] Vessel vessel)
           {
-              // don't do anything if vessel is null
+              // vessel may be null
               ...
           }
       }
@@ -535,6 +539,55 @@ following types are serializable:
 * Return types can be ``void``
 
 * Protocol buffer message types from namespace ``KRPC.Service.Messages``
+
+.. _service-api-null-values:
+
+Null Values
+^^^^^^^^^^^
+
+A parameter or return value may be ``null`` only when it is declared *nullable*. This applies
+uniformly to every serializable type -- class types, ``string``, collections and value types
+alike. The server enforces it:
+
+* Passing ``null`` as an argument for a parameter that is not nullable fails the call with an
+  error.
+
+* Returning ``null`` from a procedure, method or property getter that is not nullable fails the
+  call with an error.
+
+A **parameter** is nullable if any of the following hold:
+
+* It is annotated with :csharp:attr:`KRPCNullable`.
+
+* It has a default value of ``null`` (for example ``Vessel target = null``). A null default is
+  itself a declaration that ``null`` is a valid value, so no further annotation is needed.
+
+* Its type is a nullable value type, ``Nullable<T>`` (for example ``int?``); see below.
+
+A **return value** is nullable if the ``Nullable`` parameter of its :csharp:attr:`KRPCProcedure`,
+:csharp:attr:`KRPCMethod` or :csharp:attr:`KRPCProperty` attribute is set to true, or if its type
+is ``Nullable<T>``. For a property, ``Nullable = true`` makes the getter's return value *and* the
+setter's argument nullable.
+
+Whether a procedure returns ``null`` cannot necessarily be statically determined from its code, so
+return nullability must always be declared -- kRPC never infers it from the method body.
+
+.. _service-api-nullable-value-types:
+
+Nullable Value Types
+""""""""""""""""""""
+
+A parameter or return value of type ``Nullable<T>`` -- ``int?``, ``float?``, ``bool?``, an
+``enum?`` and so on -- is automatically nullable; it needs neither :csharp:attr:`KRPCNullable` nor
+``Nullable = true``. To clients it appears as an ordinary value of type ``T`` that may be null.
+
+Only value types can be ``Nullable<T>``. Reference types -- ``string``, :csharp:attr:`KRPCClass`
+types and collections such as ``IList<T>`` -- cannot be, so a `nullable reference type
+<https://learn.microsoft.com/en-us/dotnet/csharp/nullable-references>`_ annotation like ``string?``
+or ``IList<int>?`` is **not** recognized: it is a compile-time annotation only and does not change
+the runtime type, so the ``?`` is erased before kRPC sees the type and the parameter or return value
+is treated as non-nullable. Use :csharp:attr:`KRPCNullable` or ``Nullable = true`` to make a
+reference-typed parameter or return value nullable.
 
 Events
 ^^^^^^

--- a/protobuf/krpc.proto
+++ b/protobuf/krpc.proto
@@ -48,6 +48,7 @@ message ProcedureCall {
 message Argument {
   uint32 position = 1;
   bytes value = 2;
+  bool is_null = 3;
 }
 
 message Response {
@@ -58,6 +59,7 @@ message Response {
 message ProcedureResult {
   Error error = 1;
   bytes value = 2;
+  bool is_null = 3;
 }
 
 message Error {
@@ -122,8 +124,10 @@ message Procedure {
 message Parameter {
   string name = 1;
   Type type = 2;
-  bytes default_value = 3;
   bool nullable = 4;
+  bool has_default_value = 5;
+  bytes default_value = 3;
+  bool default_value_is_null = 6;
 }
 
 message Class {

--- a/service/SpaceCenter/CHANGELOG.md
+++ b/service/SpaceCenter/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [v0.7.0] - unreleased
+
+- Space center
+  - `SpaceCenter.LaunchVessel` now accepts an optional `crew` parameter (#1017)
+
 ## [v0.6.0]
 
 - Space center

--- a/service/SpaceCenter/src/Services/Alarm.cs
+++ b/service/SpaceCenter/src/Services/Alarm.cs
@@ -198,8 +198,6 @@ namespace KRPC.SpaceCenter.Services
                 if (maneuverAlarm == null)
                     throw new InvalidOperationException(
                         "Alarm is not a Maneuver alarm, it has no associated maneuver node.");
-                if (ReferenceEquals(value, null))
-                    throw new ArgumentNullException(nameof(value));
                 maneuverAlarm.Maneuver = value.InternalNode;
                 UpdateAlarm();
             }
@@ -236,8 +234,6 @@ namespace KRPC.SpaceCenter.Services
                 if (transferAlarm == null)
                     throw new InvalidOperationException(
                         "Alarm is not a TransferWindow alarm, it has no associated origin body.");
-                if (ReferenceEquals(value, null))
-                    throw new ArgumentNullException(nameof(value));
                 transferAlarm.source = value.InternalBody;
                 UpdateAlarm();
             }
@@ -274,8 +270,6 @@ namespace KRPC.SpaceCenter.Services
                 if (transferAlarm == null)
                     throw new InvalidOperationException(
                         "Alarm is not a TransferWindow alarm, it has no associated destination body.");
-                if (ReferenceEquals(value, null))
-                    throw new ArgumentNullException(nameof(value));
                 transferAlarm.dest = value.InternalBody;
                 UpdateAlarm();
             }

--- a/service/SpaceCenter/src/Services/AlarmManager.cs
+++ b/service/SpaceCenter/src/Services/AlarmManager.cs
@@ -113,8 +113,6 @@ namespace KRPC.SpaceCenter.Services
         [KRPCMethod]
         public static Alarm AddVesselAlarm(double time, Vessel vessel, string title="Vessel Alarm", string description="")
         {
-            if (ReferenceEquals (vessel, null))
-                throw new ArgumentNullException (nameof (vessel));
             var alarm = AddRawAlarm(time, title, description);
             alarm.vesselId = vessel.InternalVessel.persistentId;
             AlarmClockScenario.AddAlarm(alarm);
@@ -132,8 +130,6 @@ namespace KRPC.SpaceCenter.Services
         [KRPCMethod]
         public static Alarm AddApoapsisAlarm(Vessel vessel, double offset = 60, string title="Apoapsis Alarm", string description="")
         {
-            if (ReferenceEquals (vessel, null))
-                throw new ArgumentNullException (nameof (vessel));
             AlarmTypeApoapsis alarm = new AlarmTypeApoapsis
             {
                 title = title,
@@ -160,8 +156,6 @@ namespace KRPC.SpaceCenter.Services
         [KRPCMethod]
         public static Alarm AddPeriapsisAlarm(Vessel vessel, double offset = 60, string title="Periapsis Alarm", string description = "")
         {
-            if (ReferenceEquals (vessel, null))
-                throw new ArgumentNullException (nameof (vessel));
             AlarmTypePeriapsis alarm = new AlarmTypePeriapsis
             {
                 title = title,
@@ -190,10 +184,6 @@ namespace KRPC.SpaceCenter.Services
         [KRPCMethod]
         public static Alarm AddManeuverNodeAlarm(Vessel vessel, Node node, double offset = 60, bool addBurnTime = true, string title="Maneuver Node Alarm", string description="" )
         {
-            if (ReferenceEquals (vessel, null))
-                throw new ArgumentNullException (nameof (vessel));
-            if (ReferenceEquals (node, null))
-                throw new ArgumentNullException (nameof (node));
             AlarmTypeManeuver alarm = new AlarmTypeManeuver
             {
                 title = title,
@@ -223,8 +213,6 @@ namespace KRPC.SpaceCenter.Services
         [KRPCMethod]
         public static Alarm AddSOIAlarm(Vessel vessel, double offset = 60, string title="SOI Change Alarm", string description="" )
         {
-            if (ReferenceEquals (vessel, null))
-                throw new ArgumentNullException (nameof (vessel));
             AlarmTypeSOI alarm = new AlarmTypeSOI
             {
                 title = title,
@@ -258,10 +246,6 @@ namespace KRPC.SpaceCenter.Services
         [KRPCMethod]
         public static Alarm AddTransferWindowAlarm(Vessel vessel, CelestialBody target, string title="Transfer Window Alarm", string description="")
         {
-            if (ReferenceEquals(vessel, null))
-                throw new ArgumentNullException(nameof(vessel));
-            if (ReferenceEquals(target, null))
-                throw new ArgumentNullException(nameof(target));
             AlarmTypeTransferWindow alarm = new AlarmTypeTransferWindow
             {
                 title = title,

--- a/service/SpaceCenter/src/Services/AutoPilot.cs
+++ b/service/SpaceCenter/src/Services/AutoPilot.cs
@@ -230,8 +230,6 @@ namespace KRPC.SpaceCenter.Services
         public ReferenceFrame ReferenceFrame {
             get { return Controller.ReferenceFrame; }
             set {
-                if (ReferenceEquals (value, null))
-                    throw new ArgumentNullException ("ReferenceFrame");
                 var rotatesWithVessel = false;
                 switch (value.Type) {
                 case ReferenceFrameType.Vessel:

--- a/service/SpaceCenter/src/Services/CelestialBody.cs
+++ b/service/SpaceCenter/src/Services/CelestialBody.cs
@@ -251,8 +251,6 @@ namespace KRPC.SpaceCenter.Services
 
         Tuple3 PositionAt (double latitude, double longitude, double altitude, ReferenceFrame referenceFrame)
         {
-            if (ReferenceEquals (referenceFrame, null))
-                throw new ArgumentNullException (nameof (referenceFrame));
             var position = InternalBody.GetWorldSurfacePosition (latitude, longitude, altitude);
             return referenceFrame.PositionFromWorldSpace (position).ToTuple ();
         }
@@ -265,8 +263,6 @@ namespace KRPC.SpaceCenter.Services
         [KRPCMethod]
         public double LatitudeAtPosition (Tuple3 position, ReferenceFrame referenceFrame)
         {
-            if (ReferenceEquals(referenceFrame, null))
-                throw new ArgumentNullException(nameof(referenceFrame));
             return InternalBody.GetLatitude(referenceFrame.PositionToWorldSpace(position.ToVector()));
         }
 
@@ -278,8 +274,6 @@ namespace KRPC.SpaceCenter.Services
         [KRPCMethod]
         public double LongitudeAtPosition (Tuple3 position, ReferenceFrame referenceFrame)
         {
-            if (ReferenceEquals(referenceFrame, null))
-                throw new ArgumentNullException(nameof(referenceFrame));
             return InternalBody.GetLongitude(referenceFrame.PositionToWorldSpace(position.ToVector()));
         }
 
@@ -291,8 +285,6 @@ namespace KRPC.SpaceCenter.Services
         [KRPCMethod]
         public double AltitudeAtPosition (Tuple3 position, ReferenceFrame referenceFrame)
         {
-            if (ReferenceEquals(referenceFrame, null))
-                throw new ArgumentNullException(nameof(referenceFrame));
             return InternalBody.GetAltitude(referenceFrame.PositionToWorldSpace(position.ToVector()));
         }
 
@@ -349,8 +341,6 @@ namespace KRPC.SpaceCenter.Services
         [KRPCMethod]
         public double AtmosphericDensityAtPosition(Tuple3 position, ReferenceFrame referenceFrame)
         {
-            if (ReferenceEquals(referenceFrame, null))
-                throw new ArgumentNullException(nameof(referenceFrame));
             return StockAerodynamics.GetAtmosphericState(
                 referenceFrame.PositionToWorldSpace(position.ToVector()),
                 InternalBody, Planetarium.GetUniversalTime()).Density;
@@ -374,8 +364,6 @@ namespace KRPC.SpaceCenter.Services
         [KRPCMethod]
         public double TemperatureAt (Tuple3 position, ReferenceFrame referenceFrame)
         {
-            if (ReferenceEquals (referenceFrame, null))
-                throw new ArgumentNullException (nameof (referenceFrame));
             return StockAerodynamics.GetTemperature(referenceFrame.PositionToWorldSpace(position.ToVector()), InternalBody);
         }
 
@@ -523,8 +511,6 @@ namespace KRPC.SpaceCenter.Services
         [KRPCMethod]
         public Tuple3 Position (ReferenceFrame referenceFrame)
         {
-            if (ReferenceEquals (referenceFrame, null))
-                throw new ArgumentNullException (nameof (referenceFrame));
             return referenceFrame.PositionFromWorldSpace (InternalBody.position).ToTuple ();
         }
 
@@ -538,8 +524,6 @@ namespace KRPC.SpaceCenter.Services
         [KRPCMethod]
         public Tuple3 Velocity (ReferenceFrame referenceFrame)
         {
-            if (ReferenceEquals (referenceFrame, null))
-                throw new ArgumentNullException (nameof (referenceFrame));
             return referenceFrame.VelocityFromWorldSpace (InternalBody.position, InternalBody.GetWorldVelocity ()).ToTuple ();
         }
 
@@ -552,8 +536,6 @@ namespace KRPC.SpaceCenter.Services
         [KRPCMethod]
         public Tuple4 Rotation (ReferenceFrame referenceFrame)
         {
-            if (ReferenceEquals (referenceFrame, null))
-                throw new ArgumentNullException (nameof (referenceFrame));
             return referenceFrame.RotationFromWorldSpace (ReferenceFrame.Object (InternalBody).Rotation).ToTuple ();
         }
 
@@ -567,8 +549,6 @@ namespace KRPC.SpaceCenter.Services
         [KRPCMethod]
         public Tuple3 Direction (ReferenceFrame referenceFrame)
         {
-            if (ReferenceEquals (referenceFrame, null))
-                throw new ArgumentNullException (nameof (referenceFrame));
             return referenceFrame.DirectionFromWorldSpace (InternalBody.transform.up).ToTuple ();
         }
 
@@ -584,8 +564,6 @@ namespace KRPC.SpaceCenter.Services
         [KRPCMethod]
         public Tuple3 AngularVelocity (ReferenceFrame referenceFrame)
         {
-            if (ReferenceEquals (referenceFrame, null))
-                throw new ArgumentNullException (nameof (referenceFrame));
             return referenceFrame.AngularVelocityFromWorldSpace (InternalBody.angularVelocity).ToTuple ();
         }
     }

--- a/service/SpaceCenter/src/Services/ClosestApproach.cs
+++ b/service/SpaceCenter/src/Services/ClosestApproach.cs
@@ -149,7 +149,7 @@ namespace KRPC.SpaceCenter.Services
         /// vector is in. Defaults to the orbital reference frame of the object the orbit
         /// belongs to.</param>
         [KRPCMethod]
-        public Tuple3 Position ([KRPCNullable] ReferenceFrame referenceFrame = null)
+        public Tuple3 Position (ReferenceFrame referenceFrame = null)
         {
             referenceFrame = DefaultedFrame (referenceFrame);
             return referenceFrame.PositionFromWorldSpace (WorldPosition (orbit)).ToTuple ();
@@ -163,7 +163,7 @@ namespace KRPC.SpaceCenter.Services
         /// vector is in. Defaults to the orbital reference frame of the object the orbit
         /// belongs to.</param>
         [KRPCMethod]
-        public Tuple3 TargetPosition ([KRPCNullable] ReferenceFrame referenceFrame = null)
+        public Tuple3 TargetPosition (ReferenceFrame referenceFrame = null)
         {
             referenceFrame = DefaultedFrame (referenceFrame);
             return referenceFrame.PositionFromWorldSpace (WorldPosition (target)).ToTuple ();
@@ -177,7 +177,7 @@ namespace KRPC.SpaceCenter.Services
         /// vector is in. Defaults to the orbital reference frame of the object the orbit
         /// belongs to.</param>
         [KRPCMethod]
-        public Tuple3 Velocity ([KRPCNullable] ReferenceFrame referenceFrame = null)
+        public Tuple3 Velocity (ReferenceFrame referenceFrame = null)
         {
             referenceFrame = DefaultedFrame (referenceFrame);
             return referenceFrame.VelocityFromWorldSpace (WorldPosition (orbit), WorldVelocity (orbit)).ToTuple ();
@@ -191,7 +191,7 @@ namespace KRPC.SpaceCenter.Services
         /// vector is in. Defaults to the orbital reference frame of the object the orbit
         /// belongs to.</param>
         [KRPCMethod]
-        public Tuple3 TargetVelocity ([KRPCNullable] ReferenceFrame referenceFrame = null)
+        public Tuple3 TargetVelocity (ReferenceFrame referenceFrame = null)
         {
             referenceFrame = DefaultedFrame (referenceFrame);
             return referenceFrame.VelocityFromWorldSpace (WorldPosition (target), WorldVelocity (target)).ToTuple ();
@@ -206,7 +206,7 @@ namespace KRPC.SpaceCenter.Services
         /// vector is expressed in. Defaults to the orbital reference frame of the object
         /// the orbit belongs to.</param>
         [KRPCMethod]
-        public Tuple3 RelativePosition ([KRPCNullable] ReferenceFrame referenceFrame = null)
+        public Tuple3 RelativePosition (ReferenceFrame referenceFrame = null)
         {
             referenceFrame = DefaultedFrame (referenceFrame);
             return referenceFrame.DirectionFromWorldSpace (WorldPosition (target) - WorldPosition (orbit)).ToTuple ();
@@ -221,7 +221,7 @@ namespace KRPC.SpaceCenter.Services
         /// vector is expressed in. Defaults to the orbital reference frame of the object
         /// the orbit belongs to.</param>
         [KRPCMethod]
-        public Tuple3 RelativeVelocity ([KRPCNullable] ReferenceFrame referenceFrame = null)
+        public Tuple3 RelativeVelocity (ReferenceFrame referenceFrame = null)
         {
             referenceFrame = DefaultedFrame (referenceFrame);
             return referenceFrame.DirectionFromWorldSpace (WorldVelocity (target) - WorldVelocity (orbit)).ToTuple ();

--- a/service/SpaceCenter/src/Services/Flight.cs
+++ b/service/SpaceCenter/src/Services/Flight.cs
@@ -682,8 +682,6 @@ namespace KRPC.SpaceCenter.Services
         [KRPCMethod]
         public Tuple3 SimulateAerodynamicForceAt(CelestialBody body, Tuple3 position, Tuple3 velocity, Tuple4 rotation)
         {
-            if (ReferenceEquals (body, null))
-                throw new ArgumentNullException (nameof (body));
             var vessel = InternalVessel;
             var worldVelocity = referenceFrame.VelocityToWorldSpace(position.ToVector(), velocity.ToVector());
             var worldPosition = referenceFrame.PositionToWorldSpace(position.ToVector());
@@ -748,8 +746,6 @@ namespace KRPC.SpaceCenter.Services
         [KRPCMethod]
         public TupleT3 SimulateAerodynamicWrenchAt(CelestialBody body, Tuple3 position, Tuple3 velocity, Tuple4 rotation, Tuple3 angularVelocity, double ut)
         {
-            if (ReferenceEquals (body, null))
-                throw new ArgumentNullException (nameof (body));
             var vessel = InternalVessel;
             var worldVelocity = referenceFrame.VelocityToWorldSpace(position.ToVector(), velocity.ToVector());
             var worldPosition = referenceFrame.PositionToWorldSpace(position.ToVector());

--- a/service/SpaceCenter/src/Services/Node.cs
+++ b/service/SpaceCenter/src/Services/Node.cs
@@ -181,7 +181,7 @@ namespace KRPC.SpaceCenter.Services
         /// Does not change when executing the maneuver node. See <see cref="RemainingBurnVector"/>.
         /// </remarks>
         [KRPCMethod]
-        public Tuple3 BurnVector ([KRPCNullable] ReferenceFrame referenceFrame = null)
+        public Tuple3 BurnVector (ReferenceFrame referenceFrame = null)
         {
             if (ReferenceEquals (referenceFrame, null))
                 referenceFrame = ReferenceFrame.Orbital (InternalVessel);
@@ -200,7 +200,7 @@ namespace KRPC.SpaceCenter.Services
         /// Changes as the maneuver node is executed. See <see cref="BurnVector"/>.
         /// </remarks>
         [KRPCMethod]
-        public Tuple3 RemainingBurnVector ([KRPCNullable] ReferenceFrame referenceFrame = null)
+        public Tuple3 RemainingBurnVector (ReferenceFrame referenceFrame = null)
         {
             if (ReferenceEquals (referenceFrame, null))
                 referenceFrame = ReferenceFrame.Orbital (InternalVessel);
@@ -295,8 +295,6 @@ namespace KRPC.SpaceCenter.Services
         [KRPCMethod]
         public Tuple3 Position (ReferenceFrame referenceFrame)
         {
-            if (ReferenceEquals (referenceFrame, null))
-                throw new ArgumentNullException (nameof (referenceFrame));
             return referenceFrame.PositionFromWorldSpace (SafeNode.patch.getPositionAtUT (SafeNode.UT)).ToTuple ();
         }
 
@@ -309,8 +307,6 @@ namespace KRPC.SpaceCenter.Services
         [KRPCMethod]
         public Tuple4 Rotation (ReferenceFrame referenceFrame)
         {
-            if (ReferenceEquals (referenceFrame, null))
-                throw new ArgumentNullException (nameof (referenceFrame));
             return referenceFrame.RotationFromWorldSpace (this.ReferenceFrame.Rotation).ToTuple ();
         }
 
@@ -323,8 +319,6 @@ namespace KRPC.SpaceCenter.Services
         [KRPCMethod]
         public Tuple3 Direction (ReferenceFrame referenceFrame)
         {
-            if (ReferenceEquals (referenceFrame, null))
-                throw new ArgumentNullException (nameof (referenceFrame));
             return referenceFrame.DirectionFromWorldSpace (WorldBurnVector.normalized).ToTuple ();
         }
     }

--- a/service/SpaceCenter/src/Services/Orbit.cs
+++ b/service/SpaceCenter/src/Services/Orbit.cs
@@ -329,8 +329,6 @@ namespace KRPC.SpaceCenter.Services
         [KRPCMethod]
         public static Tuple3 ReferencePlaneNormal (ReferenceFrame referenceFrame)
         {
-            if (ReferenceEquals (referenceFrame, null))
-                throw new ArgumentNullException (nameof (referenceFrame));
             return referenceFrame.DirectionFromWorldSpace (Planetarium.up).normalized.ToTuple ();
         }
 
@@ -344,8 +342,6 @@ namespace KRPC.SpaceCenter.Services
         [KRPCMethod]
         public static Tuple3 ReferencePlaneDirection (ReferenceFrame referenceFrame)
         {
-            if (ReferenceEquals (referenceFrame, null))
-                throw new ArgumentNullException (nameof (referenceFrame));
             return referenceFrame.DirectionFromWorldSpace (Planetarium.right).normalized.ToTuple ();
         }
 
@@ -480,8 +476,6 @@ namespace KRPC.SpaceCenter.Services
         [KRPCMethod]
         public Tuple3 PositionAt (double ut, ReferenceFrame referenceFrame)
         {
-            if (ReferenceEquals (referenceFrame, null))
-                throw new ArgumentNullException (nameof (referenceFrame));
             return referenceFrame.PositionFromWorldSpace(InternalOrbit.getPositionAtUT(ut)).ToTuple();
         }
 
@@ -492,8 +486,6 @@ namespace KRPC.SpaceCenter.Services
         [KRPCMethod]
         public ClosestApproach NextClosestApproach (Orbit target)
         {
-            if (ReferenceEquals (target, null))
-                throw new ArgumentNullException (nameof (target));
             return new ClosestApproach (this, target, Planetarium.GetUniversalTime ());
         }
 
@@ -506,8 +498,6 @@ namespace KRPC.SpaceCenter.Services
         [KRPCMethod]
         public IList<ClosestApproach> ClosestApproaches (Orbit target, int orbits)
         {
-            if (ReferenceEquals (target, null))
-                throw new ArgumentNullException (nameof (target));
             var approaches = new List<ClosestApproach> ();
             double orbitstart = Planetarium.GetUniversalTime ();
             double period = InternalOrbit.period;
@@ -527,8 +517,6 @@ namespace KRPC.SpaceCenter.Services
         [KRPCMethod]
         public double TimeOfClosestApproach (Orbit target)
         {
-            if (ReferenceEquals (target, null))
-                throw new ArgumentNullException (nameof (target));
             double distance;
             return CalcClosestAproach(this, target, Planetarium.GetUniversalTime(), out distance);
         }
@@ -541,8 +529,6 @@ namespace KRPC.SpaceCenter.Services
         [KRPCMethod]
         public double DistanceAtClosestApproach (Orbit target)
         {
-            if (ReferenceEquals (target, null))
-                throw new ArgumentNullException (nameof (target));
             double distance;
             CalcClosestAproach(this, target, Planetarium.GetUniversalTime(), out distance);
             return distance;
@@ -562,8 +548,6 @@ namespace KRPC.SpaceCenter.Services
         [KRPCMethod]
         public IList<IList<double>> ListClosestApproaches(Orbit target, int orbits)
         {
-            if (ReferenceEquals (target, null))
-                throw new ArgumentNullException (nameof (target));
             var times = new List<double>();
             var distances = new List<double>();
             double distance;
@@ -647,8 +631,6 @@ namespace KRPC.SpaceCenter.Services
         [KRPCMethod]
         public double TrueAnomalyAtAN(Orbit target)
         {
-            if (ReferenceEquals (target, null))
-                throw new ArgumentNullException (nameof (target));
             var degrees = FinePrint.Utilities.OrbitUtilities.AngleOfAscendingNode(InternalOrbit, target.InternalOrbit);
             return GeometryExtensions.ToRadians (GeometryExtensions.ClampAngle180 (degrees));
         }
@@ -660,8 +642,6 @@ namespace KRPC.SpaceCenter.Services
         [KRPCMethod]
         public double TrueAnomalyAtDN(Orbit target)
         {
-            if (ReferenceEquals (target, null))
-                throw new ArgumentNullException (nameof (target));
             var degrees = FinePrint.Utilities.OrbitUtilities.AngleOfDescendingNode(InternalOrbit, target.InternalOrbit);
             return GeometryExtensions.ToRadians (GeometryExtensions.ClampAngle180 (degrees));
         }
@@ -673,8 +653,6 @@ namespace KRPC.SpaceCenter.Services
         [KRPCMethod]
         public double RelativeInclination(Orbit target)
         {
-            if (ReferenceEquals (target, null))
-                throw new ArgumentNullException (nameof (target));
             var degrees = FinePrint.Utilities.OrbitUtilities.GetRelativeInclination(InternalOrbit, target.InternalOrbit);
             return GeometryExtensions.ToRadians(degrees);
         }

--- a/service/SpaceCenter/src/Services/Parts/DockingPort.cs
+++ b/service/SpaceCenter/src/Services/Parts/DockingPort.cs
@@ -242,8 +242,6 @@ namespace KRPC.SpaceCenter.Services.Parts
         [KRPCMethod]
         public Tuple3 Position (ReferenceFrame referenceFrame)
         {
-            if (ReferenceEquals (referenceFrame, null))
-                throw new ArgumentNullException (nameof (referenceFrame));
             return referenceFrame.PositionFromWorldSpace (port.nodeTransform.position).ToTuple ();
         }
 
@@ -256,8 +254,6 @@ namespace KRPC.SpaceCenter.Services.Parts
         [KRPCMethod]
         public Tuple3 Direction (ReferenceFrame referenceFrame)
         {
-            if (ReferenceEquals (referenceFrame, null))
-                throw new ArgumentNullException (nameof (referenceFrame));
             return referenceFrame.DirectionFromWorldSpace (port.nodeTransform.forward).ToTuple ();
         }
 
@@ -270,8 +266,6 @@ namespace KRPC.SpaceCenter.Services.Parts
         [KRPCMethod]
         public Tuple4 Rotation (ReferenceFrame referenceFrame)
         {
-            if (ReferenceEquals (referenceFrame, null))
-                throw new ArgumentNullException (nameof (referenceFrame));
             return referenceFrame.RotationFromWorldSpace (port.nodeTransform.rotation * Quaternion.Euler (90, 0, 0)).ToTuple ();
         }
 

--- a/service/SpaceCenter/src/Services/Parts/Part.cs
+++ b/service/SpaceCenter/src/Services/Parts/Part.cs
@@ -772,8 +772,6 @@ namespace KRPC.SpaceCenter.Services.Parts
         [KRPCMethod]
         public Tuple3 Position (ReferenceFrame referenceFrame)
         {
-            if (ReferenceEquals (referenceFrame, null))
-                throw new ArgumentNullException (nameof (referenceFrame));
             return referenceFrame.PositionFromWorldSpace (InternalPart.transform.position).ToTuple ();
         }
 
@@ -787,8 +785,6 @@ namespace KRPC.SpaceCenter.Services.Parts
         [KRPCMethod]
         public Tuple3 CenterOfMass (ReferenceFrame referenceFrame)
         {
-            if (ReferenceEquals (referenceFrame, null))
-                throw new ArgumentNullException (nameof (referenceFrame));
             return referenceFrame.PositionFromWorldSpace (InternalPart.CenterOfMass ()).ToTuple ();
         }
 
@@ -807,8 +803,6 @@ namespace KRPC.SpaceCenter.Services.Parts
         [KRPCMethod]
         public TupleT3 BoundingBox (ReferenceFrame referenceFrame)
         {
-            if (ReferenceEquals (referenceFrame, null))
-                throw new ArgumentNullException (nameof (referenceFrame));
             return InternalPart.GetBounds (referenceFrame).ToTuples ();
         }
 
@@ -821,8 +815,6 @@ namespace KRPC.SpaceCenter.Services.Parts
         [KRPCMethod]
         public Tuple3 Direction (ReferenceFrame referenceFrame)
         {
-            if (ReferenceEquals (referenceFrame, null))
-                throw new ArgumentNullException (nameof (referenceFrame));
             return referenceFrame.DirectionFromWorldSpace (InternalPart.transform.up).ToTuple ();
         }
 
@@ -836,8 +828,6 @@ namespace KRPC.SpaceCenter.Services.Parts
         [KRPCMethod]
         public Tuple3 Velocity (ReferenceFrame referenceFrame)
         {
-            if (ReferenceEquals (referenceFrame, null))
-                throw new ArgumentNullException (nameof (referenceFrame));
             var part = InternalPart;
             return referenceFrame.VelocityFromWorldSpace (part.transform.position, part.orbit.GetVel ()).ToTuple ();
         }
@@ -851,8 +841,6 @@ namespace KRPC.SpaceCenter.Services.Parts
         [KRPCMethod]
         public Tuple4 Rotation (ReferenceFrame referenceFrame)
         {
-            if (ReferenceEquals (referenceFrame, null))
-                throw new ArgumentNullException (nameof (referenceFrame));
             return referenceFrame.RotationFromWorldSpace (InternalPart.transform.rotation).ToTuple ();
         }
 
@@ -870,8 +858,6 @@ namespace KRPC.SpaceCenter.Services.Parts
         [KRPCMethod]
         public Tuple3 Lift (ReferenceFrame referenceFrame)
         {
-            if (ReferenceEquals (referenceFrame, null))
-                throw new ArgumentNullException (nameof (referenceFrame));
             CheckNoFAR ();
             return referenceFrame.DirectionFromWorldSpace (WorldLift).ToTuple ();
         }
@@ -890,8 +876,6 @@ namespace KRPC.SpaceCenter.Services.Parts
         [KRPCMethod]
         public Tuple3 Drag (ReferenceFrame referenceFrame)
         {
-            if (ReferenceEquals (referenceFrame, null))
-                throw new ArgumentNullException (nameof (referenceFrame));
             CheckNoFAR ();
             return referenceFrame.DirectionFromWorldSpace (WorldDrag).ToTuple ();
         }

--- a/service/SpaceCenter/src/Services/Parts/Parts.cs
+++ b/service/SpaceCenter/src/Services/Parts/Parts.cs
@@ -70,8 +70,6 @@ namespace KRPC.SpaceCenter.Services.Parts
                 return new Part (vessel.GetReferenceTransformPart () ?? vessel.rootPart);
             }
             set {
-                if (ReferenceEquals (value, null))
-                    throw new ArgumentNullException ("Controlling");
                 var part = value.InternalPart;
                 if (part.HasModule <ModuleCommand> ()) {
                     part.Module<ModuleCommand> ().MakeReference ();

--- a/service/SpaceCenter/src/Services/Parts/ResourceDrain.cs
+++ b/service/SpaceCenter/src/Services/Parts/ResourceDrain.cs
@@ -70,8 +70,6 @@ namespace KRPC.SpaceCenter.Services.Parts
         [KRPCMethod]
         public void SetResource(Resource resource, bool enabled)
         {
-            if (ReferenceEquals (resource, null))
-                throw new ArgumentNullException (nameof (resource));
             drain.TogglePartResource(resource.InternalResource, enabled);
         }
 
@@ -81,8 +79,6 @@ namespace KRPC.SpaceCenter.Services.Parts
         [KRPCMethod]
         public bool CheckResource(Resource resource)
         {
-            if (ReferenceEquals (resource, null))
-                throw new ArgumentNullException (nameof (resource));
             return drain.IsResourceDraining(resource.InternalResource);
         }
 

--- a/service/SpaceCenter/src/Services/Parts/RoboticController.cs
+++ b/service/SpaceCenter/src/Services/Parts/RoboticController.cs
@@ -122,8 +122,6 @@ namespace KRPC.SpaceCenter.Services.Parts
         [KRPCMethod]
         public bool HasPart(Part part)
         {
-            if (ReferenceEquals (part, null))
-                throw new ArgumentNullException (nameof (part));
             return controller.HasPart(part.InternalPart);
         }
 
@@ -151,8 +149,6 @@ namespace KRPC.SpaceCenter.Services.Parts
         [KRPCMethod]
         public bool AddAxis(Module module, string fieldName)
         {
-            if (module == null)
-                throw new ArgumentNullException (nameof (module));
             var internalPart = module.Part.InternalPart;
             var internalModule = internalPart.Modules[module.Name];
             var axisField = internalModule.Fields[fieldName] as BaseAxisField;
@@ -174,8 +170,6 @@ namespace KRPC.SpaceCenter.Services.Parts
         [KRPCMethod]
         public bool AddKeyFrame(Module module, string fieldName, float time, float value)
         {
-            if (module == null)
-                throw new ArgumentNullException (nameof (module));
             var internalPart = module.Part.InternalPart;
             var internalModule = internalPart.Modules[module.Name];
 
@@ -206,8 +200,6 @@ namespace KRPC.SpaceCenter.Services.Parts
         [KRPCMethod]
         public bool ClearAxis(Module module, string fieldName)
         {
-            if (module == null)
-                throw new ArgumentNullException (nameof (module));
             var internalPart = module.Part.InternalPart;
             var internalModule = internalPart.Modules[module.Name];
 

--- a/service/SpaceCenter/src/Services/Parts/Thruster.cs
+++ b/service/SpaceCenter/src/Services/Parts/Thruster.cs
@@ -74,8 +74,6 @@ namespace KRPC.SpaceCenter.Services.Parts
         [KRPCMethod]
         public Tuple3 ThrustPosition (ReferenceFrame referenceFrame)
         {
-            if (ReferenceEquals (referenceFrame, null))
-                throw new ArgumentNullException (nameof (referenceFrame));
             return referenceFrame.PositionFromWorldSpace (WorldTransform.position).ToTuple ();
         }
 
@@ -90,8 +88,6 @@ namespace KRPC.SpaceCenter.Services.Parts
         [KRPCMethod]
         public Tuple3 ThrustDirection (ReferenceFrame referenceFrame)
         {
-            if (ReferenceEquals (referenceFrame, null))
-                throw new ArgumentNullException (nameof (referenceFrame));
             return referenceFrame.DirectionFromWorldSpace (WorldThrustDirection).ToTuple ();
         }
 
@@ -109,8 +105,6 @@ namespace KRPC.SpaceCenter.Services.Parts
         [KRPCMethod]
         public Tuple3 InitialThrustPosition (ReferenceFrame referenceFrame)
         {
-            if (ReferenceEquals (referenceFrame, null))
-                throw new ArgumentNullException (nameof (referenceFrame));
             StashGimbalRotation ();
             var position = WorldTransform.position;
             RestoreGimbalRotation ();
@@ -128,8 +122,6 @@ namespace KRPC.SpaceCenter.Services.Parts
         [KRPCMethod]
         public Tuple3 InitialThrustDirection (ReferenceFrame referenceFrame)
         {
-            if (ReferenceEquals (referenceFrame, null))
-                throw new ArgumentNullException (nameof (referenceFrame));
             StashGimbalRotation ();
             var direction = WorldThrustDirection;
             RestoreGimbalRotation ();
@@ -181,8 +173,6 @@ namespace KRPC.SpaceCenter.Services.Parts
         [KRPCMethod]
         public Tuple3 GimbalPosition (ReferenceFrame referenceFrame)
         {
-            if (ReferenceEquals (referenceFrame, null))
-                throw new ArgumentNullException (nameof (referenceFrame));
             CheckGimballed ();
             return referenceFrame.PositionFromWorldSpace (gimbal.gimbalTransforms [transformIndex].position).ToTuple ();
         }

--- a/service/SpaceCenter/src/Services/ResourceTransfer.cs
+++ b/service/SpaceCenter/src/Services/ResourceTransfer.cs
@@ -48,10 +48,6 @@ namespace KRPC.SpaceCenter.Services
         [KRPCMethod]
         public static ResourceTransfer Start (Parts.Part fromPart, Parts.Part toPart, string resource, float maxAmount)
         {
-            if (ReferenceEquals (fromPart, null))
-                throw new ArgumentNullException (nameof (fromPart));
-            if (ReferenceEquals (toPart, null))
-                throw new ArgumentNullException (nameof (toPart));
             // Get the internal part objects
             var internalFromPart = fromPart.InternalPart;
             var internalToPart = toPart.InternalPart;

--- a/service/SpaceCenter/src/Services/SpaceCenter.cs
+++ b/service/SpaceCenter/src/Services/SpaceCenter.cs
@@ -386,17 +386,17 @@ namespace KRPC.SpaceCenter.Services
         /// in the save directory, without the ".craft" file extension.</param>
         /// <param name="launchSite">Name of the launch site. For example <c>"LaunchPad"</c> or
         /// <c>"Runway"</c>.</param>
-        /// <param name="crew">A list of names of Kerbals to place in the craft. Pass an empty list to use default crew assignments.</param>
         /// <param name="recover">If true and there is a vessel on the launch site,
         /// recover it before launching.</param>
+        /// <param name="crew">If not <c>null</c>, a list of names of Kerbals to place in the craft. Otherwise the crew will use default assignments.</param>
         /// <param name="flagUrl">If not <c>null</c>, the asset URL of the mission flag to use for the launch.</param>
         /// <remarks>
         /// Throws an exception if any of the games pre-flight checks fail.
         /// </remarks>
         [KRPCProcedure]
         public static void LaunchVessel (
-            string craftDirectory, string name, string launchSite, IList<string> crew,
-            bool recover = true, string flagUrl = "")
+            string craftDirectory, string name, string launchSite, bool recover = true,
+            IList<string> crew = null, string flagUrl = "")
         {
             CloseDialogs();
             var config = new LaunchConfig(craftDirectory, name, launchSite, recover, crew, flagUrl);
@@ -486,7 +486,7 @@ namespace KRPC.SpaceCenter.Services
         [KRPCProcedure]
         public static void LaunchVesselFromVAB (string name, bool recover = true)
         {
-            LaunchVessel ("VAB", name, "LaunchPad", new List<string>(), recover);
+            LaunchVessel ("VAB", name, "LaunchPad", recover);
         }
 
         /// <summary>
@@ -503,7 +503,7 @@ namespace KRPC.SpaceCenter.Services
         [KRPCProcedure]
         public static void LaunchVesselFromSPH (string name, bool recover = true)
         {
-            LaunchVessel ("SPH", name, "Runway", new List<string>(), recover);
+            LaunchVessel ("SPH", name, "Runway", recover);
         }
 
         /// <summary>

--- a/service/SpaceCenter/src/Services/SpaceCenter.cs
+++ b/service/SpaceCenter/src/Services/SpaceCenter.cs
@@ -599,10 +599,6 @@ namespace KRPC.SpaceCenter.Services
         [KRPCProcedure(GameScene = GameScene.Flight)]
         public static void TransferCrew(CrewMember crewMember, Parts.Part targetPart)
         {
-            if (crewMember == null)
-                throw new ArgumentNullException (nameof (crewMember));
-            if (targetPart == null)
-                throw new ArgumentNullException (nameof (targetPart));
             var internalCrewMember = crewMember.InternalCrewMember;
             var transfer = CrewTransfer.Create(internalCrewMember.seat.part, internalCrewMember, delegate {});
             transfer.crew = internalCrewMember;
@@ -1018,8 +1014,6 @@ namespace KRPC.SpaceCenter.Services
         [KRPCProcedure]
         public static double RaycastDistance (Tuple3 position, Tuple3 direction, ReferenceFrame referenceFrame)
         {
-            if (ReferenceEquals (referenceFrame, null))
-                throw new ArgumentNullException (nameof (referenceFrame));
             var worldPosition = referenceFrame.PositionToWorldSpace (position.ToVector ());
             var worldDirection = referenceFrame.DirectionToWorldSpace (direction.ToVector ());
             RaycastHit hitInfo;
@@ -1038,8 +1032,6 @@ namespace KRPC.SpaceCenter.Services
         [KRPCProcedure (Nullable = true, GameScene = GameScene.Flight)]
         public static Parts.Part RaycastPart (Tuple3 position, Tuple3 direction, ReferenceFrame referenceFrame)
         {
-            if (ReferenceEquals (referenceFrame, null))
-                throw new ArgumentNullException (nameof (referenceFrame));
             var worldPosition = referenceFrame.PositionToWorldSpace (position.ToVector ());
             var worldDirection = referenceFrame.DirectionToWorldSpace (direction.ToVector ());
             RaycastHit hitInfo;

--- a/service/SpaceCenter/src/Services/Vessel.cs
+++ b/service/SpaceCenter/src/Services/Vessel.cs
@@ -209,7 +209,7 @@ namespace KRPC.SpaceCenter.Services
         /// (<see cref="SurfaceReferenceFrame"/>).
         /// </param>
         [KRPCMethod (GameScene = GameScene.Flight)]
-        public Flight Flight ([KRPCNullable] ReferenceFrame referenceFrame = null)
+        public Flight Flight (ReferenceFrame referenceFrame = null)
         {
             var vessel = InternalVessel;
             if (ReferenceEquals (referenceFrame, null))
@@ -1038,8 +1038,6 @@ namespace KRPC.SpaceCenter.Services
         [KRPCMethod (GameScene = GameScene.Flight)]
         public Tuple3 Position (ReferenceFrame referenceFrame)
         {
-            if (ReferenceEquals (referenceFrame, null))
-                throw new ArgumentNullException (nameof (referenceFrame));
             return referenceFrame.PositionFromWorldSpace (InternalVessel.CoM).ToTuple ();
         }
 
@@ -1053,8 +1051,6 @@ namespace KRPC.SpaceCenter.Services
         [KRPCMethod (GameScene = GameScene.Flight)]
         public TupleT3 BoundingBox (ReferenceFrame referenceFrame)
         {
-            if (ReferenceEquals (referenceFrame, null))
-                throw new ArgumentNullException (nameof (referenceFrame));
             var parts = InternalVessel.parts;
             var bounds = parts [0].GetBounds (referenceFrame);
             for (int i = 1; i < parts.Count; i++)
@@ -1072,8 +1068,6 @@ namespace KRPC.SpaceCenter.Services
         [KRPCMethod (GameScene = GameScene.Flight)]
         public Tuple3 Velocity (ReferenceFrame referenceFrame)
         {
-            if (ReferenceEquals (referenceFrame, null))
-                throw new ArgumentNullException (nameof (referenceFrame));
             var vessel = InternalVessel;
             var worldCoM = vessel.CoM;
             var worldVelocity = vessel.GetOrbit ().GetVel ();
@@ -1089,8 +1083,6 @@ namespace KRPC.SpaceCenter.Services
         [KRPCMethod (GameScene = GameScene.Flight)]
         public Tuple4 Rotation (ReferenceFrame referenceFrame)
         {
-            if (ReferenceEquals (referenceFrame, null))
-                throw new ArgumentNullException (nameof (referenceFrame));
             return referenceFrame.RotationFromWorldSpace (InternalVessel.ReferenceTransform.rotation).ToTuple ();
         }
 
@@ -1103,8 +1095,6 @@ namespace KRPC.SpaceCenter.Services
         [KRPCMethod (GameScene = GameScene.Flight)]
         public Tuple3 Direction (ReferenceFrame referenceFrame)
         {
-            if (ReferenceEquals (referenceFrame, null))
-                throw new ArgumentNullException (nameof (referenceFrame));
             return referenceFrame.DirectionFromWorldSpace (InternalVessel.ReferenceTransform.up).ToTuple ();
         }
 
@@ -1119,8 +1109,6 @@ namespace KRPC.SpaceCenter.Services
         [KRPCMethod (GameScene = GameScene.Flight)]
         public Tuple3 AngularVelocity (ReferenceFrame referenceFrame)
         {
-            if (ReferenceEquals (referenceFrame, null))
-                throw new ArgumentNullException (nameof (referenceFrame));
             return referenceFrame.AngularVelocityFromWorldSpace (InternalVessel.WorldAngularVelocity ()).ToTuple ();
         }
     }

--- a/service/SpaceCenter/src/Services/Waypoint.cs
+++ b/service/SpaceCenter/src/Services/Waypoint.cs
@@ -65,8 +65,6 @@ namespace KRPC.SpaceCenter.Services
         public CelestialBody Body {
             get { return new CelestialBody (InternalWaypoint.celestialBody); }
             set {
-                if (ReferenceEquals (value, null))
-                    throw new ArgumentNullException ("Body");
                 if (HasContract)
                     throw new InvalidOperationException ("Cannot set body for waypoint attached to a contract.");
                 InternalWaypoint.celestialName = value.Name;

--- a/service/SpaceCenter/src/Services/WaypointManager.cs
+++ b/service/SpaceCenter/src/Services/WaypointManager.cs
@@ -62,8 +62,6 @@ namespace KRPC.SpaceCenter.Services
         [KRPCMethod]
         public Waypoint AddWaypoint (double latitude, double longitude, CelestialBody body, string name)
         {
-            if (body == null)
-                throw new ArgumentNullException (nameof (body));
             return new Waypoint (latitude, longitude, body.SurfaceHeight (latitude, longitude), body, name);
         }
 
@@ -80,8 +78,6 @@ namespace KRPC.SpaceCenter.Services
         [KRPCMethod]
         public Waypoint AddWaypointAtAltitude (double latitude, double longitude, double altitude, CelestialBody body, string name)
         {
-            if (body == null)
-                throw new ArgumentNullException (nameof (body));
             return new Waypoint (latitude, longitude, altitude, body, name);
         }
 

--- a/service/SpaceCenter/test/test_camera.py
+++ b/service/SpaceCenter/test/test_camera.py
@@ -43,6 +43,11 @@ class TestCamera(krpctest.TestCase):
         self.wait(1)
         self.assertEqual(self.mode.automatic, self.camera.mode)
 
+    def test_focussed_rejects_null(self):
+        # The focussed body and vessel are nullable for reads, but their setters reject null
+        self.assertRaises(ValueError, setattr, self.camera, "focussed_body", None)
+        self.assertRaises(ValueError, setattr, self.camera, "focussed_vessel", None)
+
 
 class CameraTestBase:
     def reset_distance(self):

--- a/tools/TestServer/src/TestService.cs
+++ b/tools/TestServer/src/TestService.cs
@@ -103,6 +103,44 @@ namespace TestServer
             return null;
         }
 
+        [KRPCProcedure]
+        public static TestClass NotNullableObject (TestClass value)
+        {
+            return value;
+        }
+
+        [KRPCProcedure (Nullable = true)]
+        public static string EchoNullableString ([KRPCNullable] string value)
+        {
+            return value;
+        }
+
+        [KRPCProcedure (Nullable = true)]
+        public static IList<int> EchoNullableList ([KRPCNullable] IList<int> l)
+        {
+            return l;
+        }
+
+        [KRPCProcedure]
+        public static int? EchoNullableInt (int? value)
+        {
+            return value;
+        }
+
+        static TestClass nullableObject;
+
+        // Nullable for reads, but the setter rejects null: the value may be null yet cannot be
+        // cleared by writing null.
+        [KRPCProperty (Nullable = true)]
+        public static TestClass NullableObject {
+            get { return nullableObject; }
+            set {
+                if (ReferenceEquals (value, null))
+                    throw new ArgumentNullException (nameof (value));
+                nullableObject = value;
+            }
+        }
+
         /// <summary>
         /// Class documentation string.
         /// </summary>
@@ -147,6 +185,12 @@ namespace TestServer
                 return instanceValue + (ReferenceEquals (other, null) ? "null" : other.instanceValue);
             }
 
+            [KRPCMethod (Nullable = true)]
+            public TestClass EchoNullableObject ([KRPCNullable] TestClass value)
+            {
+                return value;
+            }
+
             /// <summary>
             /// Property documentation string.
             /// </summary>
@@ -176,6 +220,12 @@ namespace TestServer
             public static string StaticMethod (string a = "", string b = "")
             {
                 return "jeb" + a + b;
+            }
+
+            [KRPCMethod (Nullable = true)]
+            public static TestClass StaticNullableObject ([KRPCNullable] TestClass value)
+            {
+                return value;
             }
         }
 
@@ -340,6 +390,21 @@ namespace TestServer
         [KRPCProcedure]
         public static IDictionary<int,bool> DictionaryDefault (
             [KRPCDefaultValue (typeof(CreateDictionaryDefault))] IDictionary<int,bool> x)
+        {
+            return x;
+        }
+
+        public static class CreateEmptyListDefault
+        {
+            public static object Create ()
+            {
+                return new List<string> ();
+            }
+        }
+
+        [KRPCProcedure]
+        public static IList<string> EmptyListDefault (
+            [KRPCDefaultValue (typeof(CreateEmptyListDefault))] IList<string> x)
         {
             return x;
         }

--- a/tools/krpctools/CHANGELOG.md
+++ b/tools/krpctools/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [v0.7.0] - unreleased
+- Support for nullable values across all types (#1017)
+
 ## [v0.6.0]
 - **Breaking:** Requires Python 3.10+
 - **Breaking:** `krpc-servicedefs` now runs the `ServiceDefinitions` tool

--- a/tools/krpctools/krpctools/clientgen/cnano.py
+++ b/tools/krpctools/krpctools/clientgen/cnano.py
@@ -1,4 +1,7 @@
 import collections
+
+# pylint: disable=no-name-in-module
+from krpc.schema.KRPC_pb2 import Type
 from krpc.types import (
     ValueType,
     ClassType,
@@ -13,6 +16,7 @@ from krpc.utils import snake_case
 from .generator import Generator
 from .docparser import DocParser
 from ..lang.cnano import CnanoLanguage
+from ..utils import as_type
 
 
 class CnanoGenerator(Generator):
@@ -154,6 +158,37 @@ class CnanoGenerator(Generator):
     def parse_parameter_type(self, typ):
         return self.parse_type(typ)
 
+    @staticmethod
+    def _needs_pointer(typ):
+        # By-value non-class scalars and enums have no null sentinel, so a nullable one
+        # is passed as a pointer (NULL means null). Strings and collections are already
+        # pointers, and classes use KRPC_NULL, so they are unchanged.
+        if isinstance(typ, EnumerationType):
+            return True
+        if isinstance(typ, ValueType):
+            return typ.protobuf_type.code != Type.STRING
+        return False
+
+    def generate_context_parameters(self, procedure):
+        parameters = super().generate_context_parameters(procedure)
+        for i, parameter in enumerate(parameters):
+            if not parameter["nullable"]:
+                continue
+            typ = as_type(self.types, procedure["parameters"][i]["type"])
+            if isinstance(typ, ClassType):
+                parameter["null_check"] = "%s == KRPC_NULL" % parameter["name"]
+            else:
+                parameter["null_check"] = "%s == NULL" % parameter["name"]
+                if self._needs_pointer(typ):
+                    ctype = parameter["type"]["ctype"]
+                    parameter["type"]["ccvtype"] = "const %s *" % ctype
+                    parameter["type"]["getptr"] = ""
+        return parameters
+
+    def _annotate_return(self, return_type, procedure):
+        return_type["nullable"] = procedure.get("return_is_nullable", False)
+        return_type["is_class"] = isinstance(self.get_return_type(procedure), ClassType)
+
     def parse_default_value(self, value, typ):  # pylint: disable=unused-argument
         # No default arguments in C
         return None
@@ -172,13 +207,23 @@ class CnanoGenerator(Generator):
             typ["ccvtype"] = typ["cvtype"]
             return typ
 
+        for info in context["procedures"].values():
+            self._annotate_return(info["return_type"], info["procedure"])
+        for class_info in context["classes"].values():
+            for info in class_info["methods"].values():
+                self._annotate_return(info["return_type"], info["procedure"])
+            for info in class_info["static_methods"].values():
+                self._annotate_return(info["return_type"], info["procedure"])
+
         properties = collections.OrderedDict()
         for name, info in context["properties"].items():
             if info["getter"]:
+                getter_return = return_type(info["type"])
+                self._annotate_return(getter_return, info["getter"]["procedure"])
                 properties[name] = {
                     "remote_id": info["getter"]["remote_id"],
                     "parameters": [],
-                    "return_type": return_type(info["type"]),
+                    "return_type": getter_return,
                     "documentation": info["documentation"],
                     "deprecated": info["deprecated"],
                     "deprecated_reason": info["deprecated_reason"],
@@ -199,10 +244,12 @@ class CnanoGenerator(Generator):
             class_properties = collections.OrderedDict()
             for name, info in class_info["properties"].items():
                 if info["getter"]:
+                    getter_return = return_type(info["type"])
+                    self._annotate_return(getter_return, info["getter"]["procedure"])
                     class_properties[name] = {
                         "remote_id": info["getter"]["remote_id"],
                         "parameters": [],
-                        "return_type": return_type(info["type"]),
+                        "return_type": getter_return,
                         "documentation": info["documentation"],
                         "deprecated": info["deprecated"],
                         "deprecated_reason": info["deprecated_reason"],

--- a/tools/krpctools/krpctools/clientgen/cnano.tmpl
+++ b/tools/krpctools/krpctools/clientgen/cnano.tmpl
@@ -17,7 +17,15 @@ KRPC_CHECK(krpc_call(&_call, {{ service_id }}, {{ procedure_id }}, {{ parameters
 KRPC_CHECK(krpc_call(&_call, {{ service_id }}, {{ procedure_id }}, 0, NULL));
 {% endif %}
 {% for x in parameters %}
+{% if x.nullable is defined and x.nullable %}
+if ({{ x.null_check }}) {
+  KRPC_CHECK(krpc_add_null_argument(&_call, {{ loop.index0 }}));
+} else {
+  KRPC_CHECK(krpc_add_argument(&_call, {{ loop.index0 }}, &krpc_encode_callback_{{ x.type.name }}, {{ x.type.getptr }}{{ x.name }}));
+}
+{% else %}
 KRPC_CHECK(krpc_add_argument(&_call, {{ loop.index0 }}, &krpc_encode_callback_{{ x.type.name }}, {{ x.type.getptr }}{{ x.name }}));
+{% endif %}
 {% endfor %}
 {% endmacro %}
 {% macro return(return_type) %}
@@ -26,9 +34,30 @@ KRPC_CHECK(krpc_init_result(&_result));
 KRPC_CHECK(krpc_invoke(connection, &_result.message, &_call.message));
 {% if return_type.ctype != 'void' %}
 if (returnValue) {
+{% if return_type.nullable and return_type.is_class %}
+  if (_result.message.is_null) {
+    *returnValue = KRPC_NULL;
+  } else {
+    pb_istream_t _stream;
+    KRPC_CHECK(krpc_get_return_value(&_result, &_stream));
+    KRPC_CHECK(krpc_decode_{{ return_type.name }}(&_stream, returnValue));
+  }
+{% elif return_type.nullable %}
+  if (_result.message.is_null) {
+    if (returnValueIsNull)
+      *returnValueIsNull = true;
+  } else {
+    if (returnValueIsNull)
+      *returnValueIsNull = false;
+    pb_istream_t _stream;
+    KRPC_CHECK(krpc_get_return_value(&_result, &_stream));
+    KRPC_CHECK(krpc_decode_{{ return_type.name }}(&_stream, {% if return_type.name == 'enum' %}(int*){% endif %}returnValue));
+  }
+{% else %}
   pb_istream_t _stream;
   KRPC_CHECK(krpc_get_return_value(&_result, &_stream));
   KRPC_CHECK(krpc_decode_{{ return_type.name }}(&_stream, {% if return_type.name == 'enum' %}(int*){% endif %}returnValue));
+{% endif %}
 }
 {% else %}
 {% endif %}
@@ -39,7 +68,7 @@ return KRPC_OK;
 {% for x in [{'type': {'ccvtype': 'krpc_connection_t'}, 'name': 'connection'}] + parameters %}{{x.type.ccvtype}} {{x.name}}{% if not loop.last %}, {% endif %}{% endfor %}
 {% endmacro %}
 {% macro parameters(return_type, parameters) %}
-{% if return_type.ctype != 'void' %}{{ _parameters([{'type': return_type, 'name': 'returnValue'}] + parameters) }}{% else %}{{ _parameters(parameters) }}{% endif %}
+{% if return_type.ctype != 'void' %}{% if return_type.nullable and not return_type.is_class %}{{ _parameters([{'type': return_type, 'name': 'returnValue'}, {'type': {'ccvtype': 'bool *'}, 'name': 'returnValueIsNull'}] + parameters) }}{% else %}{{ _parameters([{'type': return_type, 'name': 'returnValue'}] + parameters) }}{% endif %}{% else %}{{ _parameters(parameters) }}{% endif %}
 {% endmacro %}
 {% macro procedure_parameters(procedure) %}
 {{ parameters(procedure.return_type, procedure.parameters) }}{% endmacro %}

--- a/tools/krpctools/krpctools/clientgen/cpp.py
+++ b/tools/krpctools/krpctools/clientgen/cpp.py
@@ -4,6 +4,7 @@ from krpc.utils import snake_case
 from .generator import Generator
 from .docparser import DocParser
 from ..lang.cpp import CppLanguage
+from ..utils import as_type
 
 
 def _cpp_template_fix(typ):
@@ -25,6 +26,38 @@ class CppGenerator(Generator):
         return _cpp_template_fix(self.language.parse_type(typ))
 
     @staticmethod
+    def _wrap_optional(type_str):
+        return _cpp_template_fix("std::optional<%s>" % type_str)
+
+    def generate_context_parameters(self, procedure):
+        parameters = super().generate_context_parameters(procedure)
+        for i, parameter in enumerate(parameters):
+            # A nullable class parameter keeps its class type (null is the id-0 object);
+            # every other nullable parameter is wrapped in std::optional.
+            typ = as_type(self.types, procedure["parameters"][i]["type"])
+            if parameter["nullable"] and not isinstance(typ, ClassType):
+                parameter["type"] = self._wrap_optional(parameter["type"])
+        return parameters
+
+    def _wrap_nullable_return(self, info):
+        procedure = info["procedure"]
+        if procedure.get("return_is_nullable", False):
+            typ = self.get_return_type(procedure)
+            if not isinstance(typ, ClassType):
+                info["return_type"] = self._wrap_optional(info["return_type"])
+
+    def _property_return_type(self, info):
+        # info["type"] is the property's C++ type; wrap it in std::optional when the getter
+        # is a nullable non-class return (a nullable class stays the id-0 object type).
+        return_type = info["type"]
+        getter = info["getter"]
+        if getter and getter["procedure"].get("return_is_nullable", False):
+            typ = self.get_return_type(getter["procedure"])
+            if not isinstance(typ, ClassType):
+                return_type = self._wrap_optional(return_type)
+        return return_type
+
+    @staticmethod
     def parse_documentation(documentation):
         documentation = CppDocParser().parse(documentation)
         if documentation == "":
@@ -35,6 +68,7 @@ class CppGenerator(Generator):
     def parse_context(self, context):
         for info in context["procedures"].values():
             info["return_set_client"] = self.parse_set_client(info["procedure"])
+            self._wrap_nullable_return(info)
 
         properties = collections.OrderedDict()
         for name, info in context["properties"].items():
@@ -42,7 +76,7 @@ class CppGenerator(Generator):
                 properties[name] = {
                     "remote_name": info["getter"]["remote_name"],
                     "parameters": [],
-                    "return_type": info["type"],
+                    "return_type": self._property_return_type(info),
                     "return_set_client": self.parse_set_client(
                         info["getter"]["procedure"]
                     ),
@@ -66,9 +100,11 @@ class CppGenerator(Generator):
         for class_info in context["classes"].values():
             for info in class_info["methods"].values():
                 info["return_set_client"] = self.parse_set_client(info["procedure"])
+                self._wrap_nullable_return(info)
 
             for info in class_info["static_methods"].values():
                 info["return_set_client"] = self.parse_set_client(info["procedure"])
+                self._wrap_nullable_return(info)
 
             class_properties = collections.OrderedDict()
             for name, info in class_info["properties"].items():
@@ -76,7 +112,7 @@ class CppGenerator(Generator):
                     class_properties[name] = {
                         "remote_name": info["getter"]["remote_name"],
                         "parameters": [],
-                        "return_type": info["type"],
+                        "return_type": self._property_return_type(info),
                         "return_set_client_fn": self.parse_set_client(
                             info["getter"]["procedure"]
                         ),

--- a/tools/krpctools/krpctools/clientgen/cpp.tmpl
+++ b/tools/krpctools/krpctools/clientgen/cpp.tmpl
@@ -1,16 +1,17 @@
 #pragma once
 {% macro args(parameters) %}
-std::vector<std::string> _args;
+std::vector<krpc::encoder::Value> _args;
 {% for x in parameters %}
-_args.push_back(encoder::encode({{x.name}}));
+_args.push_back({% if x.nullable is defined and x.nullable %}encoder::encode_nullable({{x.name}}){% else %}encoder::encode({{x.name}}){% endif %});
 {% endfor %}
 {% endmacro %}
 {% macro call(service, procedure, has_return, has_args, is_static=False) %}
-{% if has_return %}std::string _data = {% endif %}{% if is_static %}_client.{% else %}this->_client->{% endif %}invoke("{{service}}", "{{procedure}}"{% if has_args %}, _args{% endif %});
+{% if has_return %}auto _data = {% endif %}{% if is_static %}_client.{% else %}this->_client->{% endif %}invoke("{{service}}", "{{procedure}}"{% if has_args %}, _args{% endif %});
 {% endmacro %}
 {% macro return(type, set_client, is_static=False) %}
-{{type}} _result;
-decoder::decode(_result, _data, {% if is_static %}&_client{% else %}this->_client{% endif %});
+{{type}} _result{};
+if (!_data.is_null())
+  decoder::decode(_result, _data.value(), {% if is_static %}&_client{% else %}this->_client{% endif %});
 return _result;
 {% endmacro %}
 {% macro stream(service, procedure, type, has_args, is_static=False) %}

--- a/tools/krpctools/krpctools/clientgen/csharp.py
+++ b/tools/krpctools/krpctools/clientgen/csharp.py
@@ -1,10 +1,24 @@
+# pylint: disable=no-name-in-module
+from krpc.schema.KRPC_pb2 import Type
+from krpc.types import ValueType, EnumerationType
 from .generator import Generator
 from ..lang.csharp import CsharpLanguage
+from ..utils import as_type
 
 
 class CsharpGenerator(Generator):
 
     language = CsharpLanguage()
+
+    @staticmethod
+    def _is_nullable_value_type(typ):
+        # C# reference types (string, byte[], classes and collections) carry null
+        # naturally; only genuine value types need the nullable form T?.
+        if isinstance(typ, EnumerationType):
+            return True
+        if isinstance(typ, ValueType):
+            return typ.protobuf_type.code not in (Type.STRING, Type.BYTES)
+        return False
 
     @staticmethod
     def parse_documentation(documentation):
@@ -20,17 +34,22 @@ class CsharpGenerator(Generator):
 
     def generate_context_parameters(self, procedure):
         parameters = super().generate_context_parameters(procedure)
-        for parameter in parameters:
+        for i, parameter in enumerate(parameters):
+            typ = as_type(self.types, procedure["parameters"][i]["type"])
+            if parameter["nullable"] and self._is_nullable_value_type(typ):
+                parameter["type"] += "?"
             if "default_value" not in parameter:
                 parameter["name_value"] = parameter["name"]
                 continue
-            typ = parameter["type"]
+            ctype = parameter["type"]
             default_value = parameter["default_value"]
             if (
-                typ.startswith("systemAlias::Tuple")
-                or typ.startswith("global::System.Collections.Generic.IList")
-                or typ.startswith("genericCollectionsAlias::ISet")
-                or typ.startswith("global::System.Collections" + ".Generic.IDictionary")
+                ctype.startswith("systemAlias::Tuple")
+                or ctype.startswith("global::System.Collections.Generic.IList")
+                or ctype.startswith("genericCollectionsAlias::ISet")
+                or ctype.startswith(
+                    "global::System.Collections" + ".Generic.IDictionary"
+                )
             ):
                 parameter["name_value"] = "%s ?? %s" % (
                     parameter["name"],
@@ -41,6 +60,41 @@ class CsharpGenerator(Generator):
                 parameter["name_value"] = parameter["name"]
         return parameters
 
-    @staticmethod
-    def parse_context(context):
+    def _apply_return_nullable(self, info):
+        procedure = info["procedure"]
+        nullable = procedure.get("return_is_nullable", False)
+        info["return_is_nullable"] = nullable
+        if nullable and self._is_nullable_value_type(self.get_return_type(procedure)):
+            info["return_type"] += "?"
+
+    def _apply_property_nullable(self, info):
+        # A property's nullability spans its getter and setter; the value type is the
+        # same on both, so read the flag from whichever accessor exists.
+        nullable = False
+        typ = None
+        if info["getter"]:
+            procedure = info["getter"]["procedure"]
+            nullable = procedure.get("return_is_nullable", False)
+            typ = self.get_return_type(procedure)
+        elif info["setter"]:
+            procedure = info["setter"]["procedure"]
+            param = procedure["parameters"][-1]
+            nullable = param.get("nullable", False)
+            typ = as_type(self.types, param["type"])
+        info["return_is_nullable"] = nullable
+        if nullable and typ is not None and self._is_nullable_value_type(typ):
+            info["type"] += "?"
+
+    def parse_context(self, context):
+        for info in context["procedures"].values():
+            self._apply_return_nullable(info)
+        for info in context["properties"].values():
+            self._apply_property_nullable(info)
+        for cls in context["classes"].values():
+            for info in cls["methods"].values():
+                self._apply_return_nullable(info)
+            for info in cls["static_methods"].values():
+                self._apply_return_nullable(info)
+            for info in cls["properties"].values():
+                self._apply_property_nullable(info)
         return context

--- a/tools/krpctools/krpctools/clientgen/csharp.tmpl
+++ b/tools/krpctools/krpctools/clientgen/csharp.tmpl
@@ -11,10 +11,14 @@ var _args = new ByteString[] {
 };
 {% endmacro %}
 {% macro call(service, procedure, has_return, has_args, is_static=False) %}
-{% if has_return %}ByteString _data = {% endif %}connection.Invoke ("{{service}}", "{{procedure}}"{% if has_args %}, _args{% endif %});
+{% if has_return %}var _result = {% endif %}connection.Invoke ("{{service}}", "{{procedure}}"{% if has_args %}, _args{% endif %});
 {% endmacro %}
-{% macro return(type, is_static=False) %}
-return ({{type}})global::KRPC.Client.Encoder.Decode (_data, typeof({{type}}), connection);
+{% macro return(type, is_nullable=False) %}
+{% if is_nullable %}
+if (_result.IsNull)
+    return null;
+{% endif %}
+return ({{type}})global::KRPC.Client.Encoder.Decode (_result.Value, typeof({{type}}), connection);
 {% endmacro %}
 {% macro sig_parameters(parameters) %}
 {% for x in parameters %}{{x.type}} {{x.name}}{% if 'default_value' in x %} = {{x.default_value}}{%- endif %}{% if not loop.last %}, {% endif %}{% endfor %}
@@ -92,7 +96,7 @@ namespace KRPC.Client.Services.{{ service_name }}
 {% if procedure.parameters | length > 0 %}{{ args(procedure.parameters) | indent(width=12) }}
 {% endif %}
 {{ call(service_name, procedure.remote_name, procedure.return_type != 'void', procedure.parameters | length > 0) | indent(width=12) }}
-{% if procedure.return_type != 'void' %}{{ return(procedure.return_type) | indent(width=12) }}
+{% if procedure.return_type != 'void' %}{{ return(procedure.return_type, procedure.return_is_nullable) | indent(width=12) }}
 {% endif %}
         }
         {% endfor %}
@@ -109,7 +113,7 @@ namespace KRPC.Client.Services.{{ service_name }}
         {% if property.getter %}
             get {
 {{ call(service_name, property.getter.remote_name, true, false) | indent(width=16) }}
-{{ return(property.type, false) | indent(width=16) }}
+{{ return(property.type, property.return_is_nullable) | indent(width=16) }}
             }
         {% endif %}
         {% if property.setter %}
@@ -205,7 +209,7 @@ namespace KRPC.Client.Services.{{ service_name }}
         {
 {{ args([{'name': 'this', 'name_value': 'this', 'type': service_name+'.'+class_name}] + method.parameters) | indent(width=12) }}
 {{ call(service_name, method.remote_name, method.return_type != 'void', true) | indent(width=12) }}
-{% if method.return_type != 'void' %}{{ return(method.return_type) | indent(width=12) }}
+{% if method.return_type != 'void' %}{{ return(method.return_type, method.return_is_nullable) | indent(width=12) }}
 {% endif %}
         }
         {% endfor %}
@@ -224,7 +228,7 @@ namespace KRPC.Client.Services.{{ service_name }}
 {% if method.parameters | length > 0 %}{{ args(method.parameters) | indent(width=12) }}
 {% endif %}
 {{ call(service_name, method.remote_name, method.return_type != 'void', method.parameters | length > 0, true) | indent(width=12) }}
-{% if method.return_type != 'void' %}{{ return(method.return_type, true) | indent(width=12) }}
+{% if method.return_type != 'void' %}{{ return(method.return_type, method.return_is_nullable) | indent(width=12) }}
 {% endif %}
         }
         {% endfor %}
@@ -242,7 +246,7 @@ namespace KRPC.Client.Services.{{ service_name }}
             get {
 {{ args([{'name': 'this', 'name_value': 'this', 'type': service_name+'.'+class_name }]) | indent(width=16) }}
 {{ call(service_name, property.getter.remote_name, true, true) | indent(width=16) }}
-{{ return(property.type, false) | indent(width=16) }}
+{{ return(property.type, property.return_is_nullable) | indent(width=16) }}
             }
         {% endif %}
         {% if property.setter %}

--- a/tools/krpctools/krpctools/clientgen/java.py
+++ b/tools/krpctools/krpctools/clientgen/java.py
@@ -78,6 +78,39 @@ class JavaGenerator(Generator):
         lines = ["/**"] + [" * " + line for line in documentation.split("\n")] + [" */"]
         return "\n".join(line.rstrip() for line in lines)
 
+    @staticmethod
+    def _needs_boxing(typ):
+        # Java reference types (String, byte[], classes, enums, collections) carry null
+        # naturally; only the primitive value types need the boxed form to hold null.
+        return isinstance(typ, ValueType) and typ.protobuf_type.code not in (
+            Type.STRING,
+            Type.BYTES,
+        )
+
+    def generate_context_parameters(self, procedure):
+        parameters = super().generate_context_parameters(procedure)
+        for i, parameter in enumerate(parameters):
+            typ = as_type(self.types, procedure["parameters"][i]["type"])
+            if parameter["nullable"] and self._needs_boxing(typ):
+                parameter["type"] = self.language.type_map_classes[
+                    typ.protobuf_type.code
+                ]
+        return parameters
+
+    def _make_return_type(self, info):
+        procedure = info["procedure"]
+        name = info["return_type"]
+        nullable = procedure.get("return_is_nullable", False)
+        if nullable:
+            return_type = self.get_return_type(procedure)
+            if self._needs_boxing(return_type):
+                name = self.language.type_map_classes[return_type.protobuf_type.code]
+        return {
+            "name": name,
+            "spec": self.parse_type_specification(self.get_return_type(procedure)),
+            "nullable": nullable,
+        }
+
     def parse_context(self, context):
         # Expand service properties into get and set methods
         properties = collections.OrderedDict()
@@ -150,12 +183,7 @@ class JavaGenerator(Generator):
             )
         )
         for info in procedures:
-            info["return_type"] = {
-                "name": info["return_type"],
-                "spec": self.parse_type_specification(
-                    self.get_return_type(info["procedure"])
-                ),
-            }
+            info["return_type"] = self._make_return_type(info)
             pos = 0
             for i, pinfo in enumerate(info["parameters"]):
                 param_type = as_type(
@@ -172,12 +200,7 @@ class JavaGenerator(Generator):
                 class_info["properties"].values()
             )
             for info in items:
-                info["return_type"] = {
-                    "name": info["return_type"],
-                    "spec": self.parse_type_specification(
-                        self.get_return_type(info["procedure"])
-                    ),
-                }
+                info["return_type"] = self._make_return_type(info)
                 pos = 0
                 for i, pinfo in enumerate(info["parameters"]):
                     param_type = as_type(

--- a/tools/krpctools/krpctools/clientgen/java.tmpl
+++ b/tools/krpctools/krpctools/clientgen/java.tmpl
@@ -8,10 +8,15 @@ ByteString[] _args = new ByteString[] {
 };
 {% endmacro %}
 {% macro call(service, procedure, has_return, has_args, is_static=False) %}
-{% if has_return %}ByteString _data = {% endif %}{% if is_static %}connection{% else %}this.connection{% endif %}.invoke("{{service}}", "{{procedure}}"{% if has_args %}, _args{% endif %});
+{% if has_return %}krpc.schema.KRPC.ProcedureResult _data = {% endif %}{% if is_static %}connection{% else %}this.connection{% endif %}.invoke("{{service}}", "{{procedure}}"{% if has_args %}, _args{% endif %});
 {% endmacro %}
 {% macro return(type, is_static=False) %}
-return ({{type.name}}) Encoder.decode(_data, {{type.spec}}, {% if is_static %}connection{% else %}this.connection{% endif %});
+{% if type.nullable %}
+if (_data.getIsNull()) {
+  return null;
+}
+{% endif %}
+return ({{type.name}}) Encoder.decode(_data.getValue(), {{type.spec}}, {% if is_static %}connection{% else %}this.connection{% endif %});
 {% endmacro %}
 {% macro sig_parameters(parameters) %}
 {% for x in parameters %}{{x.type.name}} {{x.name}}{% if not loop.last %}, {% endif %}{% endfor %}

--- a/tools/krpctools/krpctools/lang/python.py
+++ b/tools/krpctools/krpctools/lang/python.py
@@ -54,10 +54,10 @@ class PythonLanguage(Language):
         raise RuntimeError("Unknown type '%s'" % str(typ))
 
     def parse_default_value(self, value, typ):
-        if isinstance(typ, ValueType) and typ.protobuf_type.code == Type.STRING:
-            return "'%s'" % value
         if value is None:
             return "None"
+        if isinstance(typ, ValueType) and typ.protobuf_type.code == Type.STRING:
+            return "'%s'" % value
         if isinstance(typ, EnumerationType):
             return self.parse_type(typ) + "(%d)" % value
         return str(value)

--- a/tools/krpctools/krpctools/test/clientgen-TestService-cnano.txt
+++ b/tools/krpctools/krpctools/test/clientgen-TestService-cnano.txt
@@ -140,6 +140,26 @@ static inline krpc_error_t krpc_decode_list_object(
 
 #endif  // KRPC_TYPE_LIST_OBJECT
 
+#ifndef KRPC_TYPE_LIST_STRING
+#define KRPC_TYPE_LIST_STRING
+
+typedef struct krpc_list_string_s krpc_list_string_t;
+struct krpc_list_string_s {
+  size_t size;
+  char * * items;
+};
+
+static inline krpc_error_t krpc_encode_list_string(
+  pb_ostream_t * stream, const krpc_list_string_t * value);
+static inline krpc_error_t krpc_encode_size_list_string(
+  size_t * size, const krpc_list_string_t * value);
+static inline bool krpc_encode_callback_list_string(
+  pb_ostream_t * stream, const pb_field_t * field, void * const * arg);
+static inline krpc_error_t krpc_decode_list_string(
+  pb_istream_t * stream, krpc_list_string_t * value);
+
+#endif  // KRPC_TYPE_LIST_STRING
+
 #ifndef KRPC_TYPE_SET_INT32
 #define KRPC_TYPE_SET_INT32
 
@@ -262,7 +282,15 @@ static inline krpc_error_t krpc_TestService_DictionaryDefault(krpc_connection_t 
 
 static inline krpc_error_t krpc_TestService_DoubleToString(krpc_connection_t connection, char * * returnValue, double value);
 
+static inline krpc_error_t krpc_TestService_EchoNullableInt(krpc_connection_t connection, int32_t * returnValue, int32_t value);
+
+static inline krpc_error_t krpc_TestService_EchoNullableList(krpc_connection_t connection, krpc_list_int32_t * returnValue, const krpc_list_int32_t * l);
+
+static inline krpc_error_t krpc_TestService_EchoNullableString(krpc_connection_t connection, char * * returnValue, const char * value);
+
 static inline krpc_error_t krpc_TestService_EchoTestObject(krpc_connection_t connection, krpc_TestService_TestClass_t * returnValue, krpc_TestService_TestClass_t value);
+
+static inline krpc_error_t krpc_TestService_EmptyListDefault(krpc_connection_t connection, krpc_list_string_t * returnValue, const krpc_list_string_t * x);
 
 static inline krpc_error_t krpc_TestService_EnumDefaultArg(krpc_connection_t connection, krpc_TestService_TestEnum_t * returnValue, krpc_TestService_TestEnum_t x);
 
@@ -290,6 +318,8 @@ static inline krpc_error_t krpc_TestService_Int32ToString(krpc_connection_t conn
 static inline krpc_error_t krpc_TestService_Int64ToString(krpc_connection_t connection, char * * returnValue, int64_t value);
 
 static inline krpc_error_t krpc_TestService_ListDefault(krpc_connection_t connection, krpc_list_int32_t * returnValue, const krpc_list_int32_t * x);
+
+static inline krpc_error_t krpc_TestService_NotNullableObject(krpc_connection_t connection, krpc_TestService_TestClass_t * returnValue, krpc_TestService_TestClass_t value);
 
 static inline krpc_error_t krpc_TestService_OnTimer(krpc_connection_t connection, krpc_schema_Event * returnValue, uint32_t milliseconds, uint32_t repeats);
 
@@ -335,6 +365,10 @@ static inline krpc_error_t krpc_TestService_DeprecatedProperty(krpc_connection_t
 KRPC_DEPRECATED("Use StringProperty instead.")
 static inline krpc_error_t krpc_TestService_set_DeprecatedProperty(krpc_connection_t connection, const char * value);
 
+static inline krpc_error_t krpc_TestService_NullableObject(krpc_connection_t connection, krpc_TestService_TestClass_t * returnValue);
+
+static inline krpc_error_t krpc_TestService_set_NullableObject(krpc_connection_t connection, krpc_TestService_TestClass_t value);
+
 static inline krpc_error_t krpc_TestService_ObjectProperty(krpc_connection_t connection, krpc_TestService_TestClass_t * returnValue);
 
 static inline krpc_error_t krpc_TestService_set_ObjectProperty(krpc_connection_t connection, krpc_TestService_TestClass_t value);
@@ -359,6 +393,8 @@ static inline krpc_error_t krpc_TestService_StringPropertyPrivateSet(krpc_connec
 KRPC_DEPRECATED("Use TestClass.GetValue instead.")
 static inline krpc_error_t krpc_TestService_DeprecatedClass_DeprecatedMethod(krpc_connection_t connection, char * * returnValue, krpc_TestService_DeprecatedClass_t instance);
 
+static inline krpc_error_t krpc_TestService_TestClass_EchoNullableObject(krpc_connection_t connection, krpc_TestService_TestClass_t * returnValue, krpc_TestService_TestClass_t instance, krpc_TestService_TestClass_t value);
+
 static inline krpc_error_t krpc_TestService_TestClass_FloatToString(krpc_connection_t connection, char * * returnValue, krpc_TestService_TestClass_t instance, float x);
 
 /**
@@ -371,6 +407,8 @@ static inline krpc_error_t krpc_TestService_TestClass_ObjectToString(krpc_connec
 static inline krpc_error_t krpc_TestService_TestClass_OptionalArguments(krpc_connection_t connection, char * * returnValue, krpc_TestService_TestClass_t instance, const char * x, const char * y, const char * z, krpc_TestService_TestClass_t obj);
 
 static inline krpc_error_t krpc_TestService_TestClass_StaticMethod(krpc_connection_t connection, char * * returnValue, const char * a, const char * b);
+
+static inline krpc_error_t krpc_TestService_TestClass_StaticNullableObject(krpc_connection_t connection, krpc_TestService_TestClass_t * returnValue, krpc_TestService_TestClass_t value);
 
 /**
  * Property documentation string.
@@ -950,6 +988,87 @@ static inline krpc_error_t krpc_decode_list_object(
 
 #endif  // KRPC_IMPL_TYPE_LIST_OBJECT
 
+#ifndef KRPC_IMPL_TYPE_LIST_STRING
+#define KRPC_IMPL_TYPE_LIST_STRING
+
+static inline bool krpc_encode_callback_items_list_string(
+  pb_ostream_t * stream, const pb_field_t * field, void * const * arg) {
+  const krpc_list_string_t * value = (const krpc_list_string_t*)(*arg);
+  size_t i = 0;
+  for (; i < value->size; i++) {
+    if (!pb_encode_tag_for_field(stream, field))
+      KRPC_CALLBACK_RETURN_ERROR("encoding tag for list item");
+    size_t size;
+    KRPC_CALLBACK_RETURN_ON_ERROR(krpc_encode_size_string(&size, value->items[i]));
+    if (!pb_encode_varint(stream, size))
+      KRPC_CALLBACK_RETURN_ERROR("encoding size for list item");
+    KRPC_CALLBACK_RETURN_ON_ERROR(krpc_encode_string(stream, value->items[i]));
+  }
+  return true;
+}
+
+static inline krpc_error_t krpc_encode_list_string(
+  pb_ostream_t * stream, const krpc_list_string_t * value) {
+  krpc_schema_List message = krpc_schema_List_init_default;
+  message.items.funcs.encode = &krpc_encode_callback_items_list_string;
+  message.items.arg = (krpc_list_string_t*)value;
+  KRPC_RETURN_ON_ERROR(krpc_encode_message_List(stream, &message));
+  return KRPC_OK;
+}
+
+static inline krpc_error_t krpc_encode_size_list_string(
+  size_t * size, const krpc_list_string_t * value) {
+  pb_ostream_t stream = PB_OSTREAM_SIZING;
+  KRPC_RETURN_ON_ERROR(krpc_encode_list_string(&stream, value));
+  *size = stream.bytes_written;
+  return KRPC_OK;
+}
+
+static inline bool krpc_encode_callback_list_string(
+  pb_ostream_t * stream, const pb_field_t * field, void * const * arg) {
+  if (!pb_encode_tag_for_field(stream, field))
+    KRPC_CALLBACK_RETURN_ERROR("encoding tag for list_string");
+  krpc_list_string_t * value = (krpc_list_string_t*)(*arg);
+  size_t size;
+  KRPC_CALLBACK_RETURN_ON_ERROR(krpc_encode_size_list_string(&size, value));
+  if (!pb_encode_varint(stream, size))
+    KRPC_CALLBACK_RETURN_ERROR("encoding size for list_string");
+  KRPC_CALLBACK_RETURN_ON_ERROR(krpc_encode_list_string(stream, value));
+  return true;
+}
+
+static inline bool krpc_decode_callback_item_list_string(
+  pb_istream_t * stream, const pb_field_t * field, void ** arg) {
+  typedef struct State { size_t capacity; krpc_list_string_t * value; } State;
+  State * state = (State*)(*arg);
+  size_t i = state->value->size;
+  state->value->size++;
+  if (state->capacity > 0 && state->value->size > state->capacity) {
+    state->value->items = (char **)krpc_recalloc(state->value->items, state->capacity, KRPC_ALLOC_BLOCK_SIZE, sizeof(char *));
+    state->capacity += KRPC_ALLOC_BLOCK_SIZE;
+  }
+  KRPC_CALLBACK_RETURN_ON_ERROR(krpc_decode_string(stream, &state->value->items[i]));
+  return true;
+}
+
+static inline krpc_error_t krpc_decode_list_string(
+  pb_istream_t * stream, krpc_list_string_t * value) {
+  typedef struct State { size_t capacity; krpc_list_string_t * value; } State;
+  State state = { 0, value };
+  value->size = 0;
+  if (value->items == NULL) {
+    value->items = (char **)krpc_calloc(KRPC_ALLOC_BLOCK_SIZE, sizeof(char *));
+    state.capacity = KRPC_ALLOC_BLOCK_SIZE;
+  }
+  krpc_schema_List message = krpc_schema_List_init_default;
+  message.items.funcs.decode = &krpc_decode_callback_item_list_string;
+  message.items.arg = &state;
+  KRPC_RETURN_ON_ERROR(krpc_decode_message_List(stream, &message));
+  return KRPC_OK;
+}
+
+#endif  // KRPC_IMPL_TYPE_LIST_STRING
+
 #ifndef KRPC_IMPL_TYPE_SET_INT32
 #define KRPC_IMPL_TYPE_SET_INT32
 
@@ -1231,7 +1350,7 @@ static inline krpc_error_t krpc_TestService_AddMultipleValues(krpc_connection_t 
 static inline krpc_error_t krpc_TestService_AddToObjectList(krpc_connection_t connection, krpc_list_object_t * returnValue, const krpc_list_object_t * l, const char * value) {
   krpc_call_t _call;
   krpc_argument_t _arguments[2];
-  KRPC_CHECK(krpc_call(&_call, 9999, 26, 2, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 31, 2, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_list_object, l));
   KRPC_CHECK(krpc_add_argument(&_call, 1, &krpc_encode_callback_string, &value));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
@@ -1249,7 +1368,7 @@ static inline krpc_error_t krpc_TestService_AddToObjectList(krpc_connection_t co
 static inline krpc_error_t krpc_TestService_BlockingProcedure(krpc_connection_t connection, int32_t * returnValue, int32_t n, int32_t sum) {
   krpc_call_t _call;
   krpc_argument_t _arguments[2];
-  KRPC_CHECK(krpc_call(&_call, 9999, 16, 2, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 20, 2, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_int32, &n));
   KRPC_CHECK(krpc_add_argument(&_call, 1, &krpc_encode_callback_int32, &sum));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
@@ -1301,7 +1420,7 @@ static inline krpc_error_t krpc_TestService_BytesToHexString(krpc_connection_t c
 static inline krpc_error_t krpc_TestService_Counter(krpc_connection_t connection, int32_t * returnValue, const char * id, int32_t divisor) {
   krpc_call_t _call;
   krpc_argument_t _arguments[2];
-  KRPC_CHECK(krpc_call(&_call, 9999, 27, 2, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 32, 2, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_string, &id));
   KRPC_CHECK(krpc_add_argument(&_call, 1, &krpc_encode_callback_int32, &divisor));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
@@ -1336,7 +1455,7 @@ static inline krpc_error_t krpc_TestService_CreateTestObject(krpc_connection_t c
 static inline krpc_error_t krpc_TestService_DeprecatedProcedure(krpc_connection_t connection, char * * returnValue, float value) {
   krpc_call_t _call;
   krpc_argument_t _arguments[1];
-  KRPC_CHECK(krpc_call(&_call, 9999, 39, 1, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 44, 1, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_float, &value));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
@@ -1353,7 +1472,7 @@ static inline krpc_error_t krpc_TestService_DeprecatedProcedure(krpc_connection_
 static inline krpc_error_t krpc_TestService_DeprecatedProcedureNoMessage(krpc_connection_t connection, char * * returnValue, float value) {
   krpc_call_t _call;
   krpc_argument_t _arguments[1];
-  KRPC_CHECK(krpc_call(&_call, 9999, 40, 1, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 45, 1, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_float, &value));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
@@ -1370,7 +1489,7 @@ static inline krpc_error_t krpc_TestService_DeprecatedProcedureNoMessage(krpc_co
 static inline krpc_error_t krpc_TestService_DictionaryDefault(krpc_connection_t connection, krpc_dictionary_int32_bool_t * returnValue, const krpc_dictionary_int32_bool_t * x) {
   krpc_call_t _call;
   krpc_argument_t _arguments[1];
-  KRPC_CHECK(krpc_call(&_call, 9999, 25, 1, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 29, 1, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_dictionary_int32_bool, x));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
@@ -1401,6 +1520,57 @@ static inline krpc_error_t krpc_TestService_DoubleToString(krpc_connection_t con
   return KRPC_OK;
 }
 
+static inline krpc_error_t krpc_TestService_EchoNullableInt(krpc_connection_t connection, int32_t * returnValue, int32_t value) {
+  krpc_call_t _call;
+  krpc_argument_t _arguments[1];
+  KRPC_CHECK(krpc_call(&_call, 9999, 15, 1, _arguments));
+  KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_int32, &value));
+  krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
+  KRPC_CHECK(krpc_init_result(&_result));
+  KRPC_CHECK(krpc_invoke(connection, &_result.message, &_call.message));
+  if (returnValue) {
+    pb_istream_t _stream;
+    KRPC_CHECK(krpc_get_return_value(&_result, &_stream));
+    KRPC_CHECK(krpc_decode_int32(&_stream, returnValue));
+  }
+  KRPC_CHECK(krpc_free_result(&_result));
+  return KRPC_OK;
+}
+
+static inline krpc_error_t krpc_TestService_EchoNullableList(krpc_connection_t connection, krpc_list_int32_t * returnValue, const krpc_list_int32_t * l) {
+  krpc_call_t _call;
+  krpc_argument_t _arguments[1];
+  KRPC_CHECK(krpc_call(&_call, 9999, 14, 1, _arguments));
+  KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_list_int32, l));
+  krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
+  KRPC_CHECK(krpc_init_result(&_result));
+  KRPC_CHECK(krpc_invoke(connection, &_result.message, &_call.message));
+  if (returnValue) {
+    pb_istream_t _stream;
+    KRPC_CHECK(krpc_get_return_value(&_result, &_stream));
+    KRPC_CHECK(krpc_decode_list_int32(&_stream, returnValue));
+  }
+  KRPC_CHECK(krpc_free_result(&_result));
+  return KRPC_OK;
+}
+
+static inline krpc_error_t krpc_TestService_EchoNullableString(krpc_connection_t connection, char * * returnValue, const char * value) {
+  krpc_call_t _call;
+  krpc_argument_t _arguments[1];
+  KRPC_CHECK(krpc_call(&_call, 9999, 13, 1, _arguments));
+  KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_string, &value));
+  krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
+  KRPC_CHECK(krpc_init_result(&_result));
+  KRPC_CHECK(krpc_invoke(connection, &_result.message, &_call.message));
+  if (returnValue) {
+    pb_istream_t _stream;
+    KRPC_CHECK(krpc_get_return_value(&_result, &_stream));
+    KRPC_CHECK(krpc_decode_string(&_stream, returnValue));
+  }
+  KRPC_CHECK(krpc_free_result(&_result));
+  return KRPC_OK;
+}
+
 static inline krpc_error_t krpc_TestService_EchoTestObject(krpc_connection_t connection, krpc_TestService_TestClass_t * returnValue, krpc_TestService_TestClass_t value) {
   krpc_call_t _call;
   krpc_argument_t _arguments[1];
@@ -1418,10 +1588,27 @@ static inline krpc_error_t krpc_TestService_EchoTestObject(krpc_connection_t con
   return KRPC_OK;
 }
 
+static inline krpc_error_t krpc_TestService_EmptyListDefault(krpc_connection_t connection, krpc_list_string_t * returnValue, const krpc_list_string_t * x) {
+  krpc_call_t _call;
+  krpc_argument_t _arguments[1];
+  KRPC_CHECK(krpc_call(&_call, 9999, 30, 1, _arguments));
+  KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_list_string, x));
+  krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
+  KRPC_CHECK(krpc_init_result(&_result));
+  KRPC_CHECK(krpc_invoke(connection, &_result.message, &_call.message));
+  if (returnValue) {
+    pb_istream_t _stream;
+    KRPC_CHECK(krpc_get_return_value(&_result, &_stream));
+    KRPC_CHECK(krpc_decode_list_string(&_stream, returnValue));
+  }
+  KRPC_CHECK(krpc_free_result(&_result));
+  return KRPC_OK;
+}
+
 static inline krpc_error_t krpc_TestService_EnumDefaultArg(krpc_connection_t connection, krpc_TestService_TestEnum_t * returnValue, krpc_TestService_TestEnum_t x) {
   krpc_call_t _call;
   krpc_argument_t _arguments[1];
-  KRPC_CHECK(krpc_call(&_call, 9999, 15, 1, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 19, 1, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_enum, &x));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
@@ -1438,7 +1625,7 @@ static inline krpc_error_t krpc_TestService_EnumDefaultArg(krpc_connection_t con
 static inline krpc_error_t krpc_TestService_EnumEcho(krpc_connection_t connection, krpc_TestService_TestEnum_t * returnValue, krpc_TestService_TestEnum_t x) {
   krpc_call_t _call;
   krpc_argument_t _arguments[1];
-  KRPC_CHECK(krpc_call(&_call, 9999, 14, 1, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 18, 1, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_enum, &x));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
@@ -1454,7 +1641,7 @@ static inline krpc_error_t krpc_TestService_EnumEcho(krpc_connection_t connectio
 
 static inline krpc_error_t krpc_TestService_EnumReturn(krpc_connection_t connection, krpc_TestService_TestEnum_t * returnValue) {
   krpc_call_t _call;
-  KRPC_CHECK(krpc_call(&_call, 9999, 13, 0, NULL));
+  KRPC_CHECK(krpc_call(&_call, 9999, 17, 0, NULL));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
   KRPC_CHECK(krpc_invoke(connection, &_result.message, &_call.message));
@@ -1487,7 +1674,7 @@ static inline krpc_error_t krpc_TestService_FloatToString(krpc_connection_t conn
 static inline krpc_error_t krpc_TestService_IncrementDictionary(krpc_connection_t connection, krpc_dictionary_string_int32_t * returnValue, const krpc_dictionary_string_int32_t * d) {
   krpc_call_t _call;
   krpc_argument_t _arguments[1];
-  KRPC_CHECK(krpc_call(&_call, 9999, 18, 1, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 22, 1, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_dictionary_string_int32, d));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
@@ -1504,7 +1691,7 @@ static inline krpc_error_t krpc_TestService_IncrementDictionary(krpc_connection_
 static inline krpc_error_t krpc_TestService_IncrementList(krpc_connection_t connection, krpc_list_int32_t * returnValue, const krpc_list_int32_t * l) {
   krpc_call_t _call;
   krpc_argument_t _arguments[1];
-  KRPC_CHECK(krpc_call(&_call, 9999, 17, 1, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 21, 1, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_list_int32, l));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
@@ -1521,7 +1708,7 @@ static inline krpc_error_t krpc_TestService_IncrementList(krpc_connection_t conn
 static inline krpc_error_t krpc_TestService_IncrementNestedCollection(krpc_connection_t connection, krpc_dictionary_string_list_int32_t * returnValue, const krpc_dictionary_string_list_int32_t * d) {
   krpc_call_t _call;
   krpc_argument_t _arguments[1];
-  KRPC_CHECK(krpc_call(&_call, 9999, 21, 1, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 25, 1, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_dictionary_string_list_int32, d));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
@@ -1538,7 +1725,7 @@ static inline krpc_error_t krpc_TestService_IncrementNestedCollection(krpc_conne
 static inline krpc_error_t krpc_TestService_IncrementSet(krpc_connection_t connection, krpc_set_int32_t * returnValue, const krpc_set_int32_t * h) {
   krpc_call_t _call;
   krpc_argument_t _arguments[1];
-  KRPC_CHECK(krpc_call(&_call, 9999, 19, 1, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 23, 1, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_set_int32, h));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
@@ -1555,7 +1742,7 @@ static inline krpc_error_t krpc_TestService_IncrementSet(krpc_connection_t conne
 static inline krpc_error_t krpc_TestService_IncrementTuple(krpc_connection_t connection, krpc_tuple_int32_int64_t * returnValue, const krpc_tuple_int32_int64_t * t) {
   krpc_call_t _call;
   krpc_argument_t _arguments[1];
-  KRPC_CHECK(krpc_call(&_call, 9999, 20, 1, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 24, 1, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_tuple_int32_int64, t));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
@@ -1606,7 +1793,7 @@ static inline krpc_error_t krpc_TestService_Int64ToString(krpc_connection_t conn
 static inline krpc_error_t krpc_TestService_ListDefault(krpc_connection_t connection, krpc_list_int32_t * returnValue, const krpc_list_int32_t * x) {
   krpc_call_t _call;
   krpc_argument_t _arguments[1];
-  KRPC_CHECK(krpc_call(&_call, 9999, 23, 1, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 27, 1, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_list_int32, x));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
@@ -1620,10 +1807,27 @@ static inline krpc_error_t krpc_TestService_ListDefault(krpc_connection_t connec
   return KRPC_OK;
 }
 
+static inline krpc_error_t krpc_TestService_NotNullableObject(krpc_connection_t connection, krpc_TestService_TestClass_t * returnValue, krpc_TestService_TestClass_t value) {
+  krpc_call_t _call;
+  krpc_argument_t _arguments[1];
+  KRPC_CHECK(krpc_call(&_call, 9999, 12, 1, _arguments));
+  KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_object, &value));
+  krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
+  KRPC_CHECK(krpc_init_result(&_result));
+  KRPC_CHECK(krpc_invoke(connection, &_result.message, &_call.message));
+  if (returnValue) {
+    pb_istream_t _stream;
+    KRPC_CHECK(krpc_get_return_value(&_result, &_stream));
+    KRPC_CHECK(krpc_decode_object(&_stream, returnValue));
+  }
+  KRPC_CHECK(krpc_free_result(&_result));
+  return KRPC_OK;
+}
+
 static inline krpc_error_t krpc_TestService_OnTimer(krpc_connection_t connection, krpc_schema_Event * returnValue, uint32_t milliseconds, uint32_t repeats) {
   krpc_call_t _call;
   krpc_argument_t _arguments[2];
-  KRPC_CHECK(krpc_call(&_call, 9999, 37, 2, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 42, 2, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_uint32, &milliseconds));
   KRPC_CHECK(krpc_add_argument(&_call, 1, &krpc_encode_callback_uint32, &repeats));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
@@ -1641,7 +1845,7 @@ static inline krpc_error_t krpc_TestService_OnTimer(krpc_connection_t connection
 static inline krpc_error_t krpc_TestService_OnTimerUsingLambda(krpc_connection_t connection, krpc_schema_Event * returnValue, uint32_t milliseconds) {
   krpc_call_t _call;
   krpc_argument_t _arguments[1];
-  KRPC_CHECK(krpc_call(&_call, 9999, 38, 1, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 43, 1, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_uint32, &milliseconds));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
@@ -1658,7 +1862,7 @@ static inline krpc_error_t krpc_TestService_OnTimerUsingLambda(krpc_connection_t
 static inline krpc_error_t krpc_TestService_OptionalArguments(krpc_connection_t connection, char * * returnValue, const char * x, const char * y, const char * z, krpc_TestService_TestClass_t obj) {
   krpc_call_t _call;
   krpc_argument_t _arguments[4];
-  KRPC_CHECK(krpc_call(&_call, 9999, 12, 4, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 16, 4, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_string, &x));
   KRPC_CHECK(krpc_add_argument(&_call, 1, &krpc_encode_callback_string, &y));
   KRPC_CHECK(krpc_add_argument(&_call, 2, &krpc_encode_callback_string, &z));
@@ -1677,7 +1881,7 @@ static inline krpc_error_t krpc_TestService_OptionalArguments(krpc_connection_t 
 
 static inline krpc_error_t krpc_TestService_ResetCustomExceptionLater(krpc_connection_t connection) {
   krpc_call_t _call;
-  KRPC_CHECK(krpc_call(&_call, 9999, 35, 0, NULL));
+  KRPC_CHECK(krpc_call(&_call, 9999, 40, 0, NULL));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
   KRPC_CHECK(krpc_invoke(connection, &_result.message, &_call.message));
@@ -1687,7 +1891,7 @@ static inline krpc_error_t krpc_TestService_ResetCustomExceptionLater(krpc_conne
 
 static inline krpc_error_t krpc_TestService_ResetInvalidOperationExceptionLater(krpc_connection_t connection) {
   krpc_call_t _call;
-  KRPC_CHECK(krpc_call(&_call, 9999, 29, 0, NULL));
+  KRPC_CHECK(krpc_call(&_call, 9999, 34, 0, NULL));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
   KRPC_CHECK(krpc_invoke(connection, &_result.message, &_call.message));
@@ -1713,7 +1917,7 @@ static inline krpc_error_t krpc_TestService_ReturnNullWhenNotAllowed(krpc_connec
 static inline krpc_error_t krpc_TestService_SetDefault(krpc_connection_t connection, krpc_set_int32_t * returnValue, const krpc_set_int32_t * x) {
   krpc_call_t _call;
   krpc_argument_t _arguments[1];
-  KRPC_CHECK(krpc_call(&_call, 9999, 24, 1, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 28, 1, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_set_int32, x));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
@@ -1746,7 +1950,7 @@ static inline krpc_error_t krpc_TestService_StringToInt32(krpc_connection_t conn
 
 static inline krpc_error_t krpc_TestService_ThrowArgumentException(krpc_connection_t connection, int32_t * returnValue) {
   krpc_call_t _call;
-  KRPC_CHECK(krpc_call(&_call, 9999, 31, 0, NULL));
+  KRPC_CHECK(krpc_call(&_call, 9999, 36, 0, NULL));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
   KRPC_CHECK(krpc_invoke(connection, &_result.message, &_call.message));
@@ -1762,7 +1966,7 @@ static inline krpc_error_t krpc_TestService_ThrowArgumentException(krpc_connecti
 static inline krpc_error_t krpc_TestService_ThrowArgumentNullException(krpc_connection_t connection, int32_t * returnValue, const char * foo) {
   krpc_call_t _call;
   krpc_argument_t _arguments[1];
-  KRPC_CHECK(krpc_call(&_call, 9999, 32, 1, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 37, 1, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_string, &foo));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
@@ -1779,7 +1983,7 @@ static inline krpc_error_t krpc_TestService_ThrowArgumentNullException(krpc_conn
 static inline krpc_error_t krpc_TestService_ThrowArgumentOutOfRangeException(krpc_connection_t connection, int32_t * returnValue, int32_t foo) {
   krpc_call_t _call;
   krpc_argument_t _arguments[1];
-  KRPC_CHECK(krpc_call(&_call, 9999, 33, 1, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 38, 1, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_int32, &foo));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
@@ -1795,7 +1999,7 @@ static inline krpc_error_t krpc_TestService_ThrowArgumentOutOfRangeException(krp
 
 static inline krpc_error_t krpc_TestService_ThrowCustomException(krpc_connection_t connection, int32_t * returnValue) {
   krpc_call_t _call;
-  KRPC_CHECK(krpc_call(&_call, 9999, 34, 0, NULL));
+  KRPC_CHECK(krpc_call(&_call, 9999, 39, 0, NULL));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
   KRPC_CHECK(krpc_invoke(connection, &_result.message, &_call.message));
@@ -1810,7 +2014,7 @@ static inline krpc_error_t krpc_TestService_ThrowCustomException(krpc_connection
 
 static inline krpc_error_t krpc_TestService_ThrowCustomExceptionLater(krpc_connection_t connection, int32_t * returnValue) {
   krpc_call_t _call;
-  KRPC_CHECK(krpc_call(&_call, 9999, 36, 0, NULL));
+  KRPC_CHECK(krpc_call(&_call, 9999, 41, 0, NULL));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
   KRPC_CHECK(krpc_invoke(connection, &_result.message, &_call.message));
@@ -1825,7 +2029,7 @@ static inline krpc_error_t krpc_TestService_ThrowCustomExceptionLater(krpc_conne
 
 static inline krpc_error_t krpc_TestService_ThrowInvalidOperationException(krpc_connection_t connection, int32_t * returnValue) {
   krpc_call_t _call;
-  KRPC_CHECK(krpc_call(&_call, 9999, 28, 0, NULL));
+  KRPC_CHECK(krpc_call(&_call, 9999, 33, 0, NULL));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
   KRPC_CHECK(krpc_invoke(connection, &_result.message, &_call.message));
@@ -1840,7 +2044,7 @@ static inline krpc_error_t krpc_TestService_ThrowInvalidOperationException(krpc_
 
 static inline krpc_error_t krpc_TestService_ThrowInvalidOperationExceptionLater(krpc_connection_t connection, int32_t * returnValue) {
   krpc_call_t _call;
-  KRPC_CHECK(krpc_call(&_call, 9999, 30, 0, NULL));
+  KRPC_CHECK(krpc_call(&_call, 9999, 35, 0, NULL));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
   KRPC_CHECK(krpc_invoke(connection, &_result.message, &_call.message));
@@ -1856,7 +2060,7 @@ static inline krpc_error_t krpc_TestService_ThrowInvalidOperationExceptionLater(
 static inline krpc_error_t krpc_TestService_TupleDefault(krpc_connection_t connection, krpc_tuple_int32_bool_t * returnValue, const krpc_tuple_int32_bool_t * x) {
   krpc_call_t _call;
   krpc_argument_t _arguments[1];
-  KRPC_CHECK(krpc_call(&_call, 9999, 22, 1, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 26, 1, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_tuple_int32_bool, x));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
@@ -1872,7 +2076,7 @@ static inline krpc_error_t krpc_TestService_TupleDefault(krpc_connection_t conne
 
 static inline krpc_error_t krpc_TestService_DeprecatedProperty(krpc_connection_t connection, char * * returnValue) {
   krpc_call_t _call;
-  KRPC_CHECK(krpc_call(&_call, 9999, 47, 0, NULL));
+  KRPC_CHECK(krpc_call(&_call, 9999, 54, 0, NULL));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
   KRPC_CHECK(krpc_invoke(connection, &_result.message, &_call.message));
@@ -1888,8 +2092,35 @@ static inline krpc_error_t krpc_TestService_DeprecatedProperty(krpc_connection_t
 static inline krpc_error_t krpc_TestService_set_DeprecatedProperty(krpc_connection_t connection, const char * value) {
   krpc_call_t _call;
   krpc_argument_t _arguments[1];
-  KRPC_CHECK(krpc_call(&_call, 9999, 48, 1, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 55, 1, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_string, &value));
+  krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
+  KRPC_CHECK(krpc_init_result(&_result));
+  KRPC_CHECK(krpc_invoke(connection, &_result.message, &_call.message));
+  KRPC_CHECK(krpc_free_result(&_result));
+  return KRPC_OK;
+}
+
+static inline krpc_error_t krpc_TestService_NullableObject(krpc_connection_t connection, krpc_TestService_TestClass_t * returnValue) {
+  krpc_call_t _call;
+  KRPC_CHECK(krpc_call(&_call, 9999, 52, 0, NULL));
+  krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
+  KRPC_CHECK(krpc_init_result(&_result));
+  KRPC_CHECK(krpc_invoke(connection, &_result.message, &_call.message));
+  if (returnValue) {
+    pb_istream_t _stream;
+    KRPC_CHECK(krpc_get_return_value(&_result, &_stream));
+    KRPC_CHECK(krpc_decode_object(&_stream, returnValue));
+  }
+  KRPC_CHECK(krpc_free_result(&_result));
+  return KRPC_OK;
+}
+
+static inline krpc_error_t krpc_TestService_set_NullableObject(krpc_connection_t connection, krpc_TestService_TestClass_t value) {
+  krpc_call_t _call;
+  krpc_argument_t _arguments[1];
+  KRPC_CHECK(krpc_call(&_call, 9999, 53, 1, _arguments));
+  KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_object, &value));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
   KRPC_CHECK(krpc_invoke(connection, &_result.message, &_call.message));
@@ -1899,7 +2130,7 @@ static inline krpc_error_t krpc_TestService_set_DeprecatedProperty(krpc_connecti
 
 static inline krpc_error_t krpc_TestService_ObjectProperty(krpc_connection_t connection, krpc_TestService_TestClass_t * returnValue) {
   krpc_call_t _call;
-  KRPC_CHECK(krpc_call(&_call, 9999, 45, 0, NULL));
+  KRPC_CHECK(krpc_call(&_call, 9999, 50, 0, NULL));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
   KRPC_CHECK(krpc_invoke(connection, &_result.message, &_call.message));
@@ -1915,7 +2146,7 @@ static inline krpc_error_t krpc_TestService_ObjectProperty(krpc_connection_t con
 static inline krpc_error_t krpc_TestService_set_ObjectProperty(krpc_connection_t connection, krpc_TestService_TestClass_t value) {
   krpc_call_t _call;
   krpc_argument_t _arguments[1];
-  KRPC_CHECK(krpc_call(&_call, 9999, 46, 1, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 51, 1, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_object, &value));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
@@ -1926,7 +2157,7 @@ static inline krpc_error_t krpc_TestService_set_ObjectProperty(krpc_connection_t
 
 static inline krpc_error_t krpc_TestService_StringProperty(krpc_connection_t connection, char * * returnValue) {
   krpc_call_t _call;
-  KRPC_CHECK(krpc_call(&_call, 9999, 41, 0, NULL));
+  KRPC_CHECK(krpc_call(&_call, 9999, 46, 0, NULL));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
   KRPC_CHECK(krpc_invoke(connection, &_result.message, &_call.message));
@@ -1942,7 +2173,7 @@ static inline krpc_error_t krpc_TestService_StringProperty(krpc_connection_t con
 static inline krpc_error_t krpc_TestService_set_StringProperty(krpc_connection_t connection, const char * value) {
   krpc_call_t _call;
   krpc_argument_t _arguments[1];
-  KRPC_CHECK(krpc_call(&_call, 9999, 42, 1, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 47, 1, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_string, &value));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
@@ -1954,7 +2185,7 @@ static inline krpc_error_t krpc_TestService_set_StringProperty(krpc_connection_t
 static inline krpc_error_t krpc_TestService_set_StringPropertyPrivateGet(krpc_connection_t connection, const char * value) {
   krpc_call_t _call;
   krpc_argument_t _arguments[1];
-  KRPC_CHECK(krpc_call(&_call, 9999, 43, 1, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 48, 1, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_string, &value));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
@@ -1965,7 +2196,7 @@ static inline krpc_error_t krpc_TestService_set_StringPropertyPrivateGet(krpc_co
 
 static inline krpc_error_t krpc_TestService_StringPropertyPrivateSet(krpc_connection_t connection, char * * returnValue) {
   krpc_call_t _call;
-  KRPC_CHECK(krpc_call(&_call, 9999, 44, 0, NULL));
+  KRPC_CHECK(krpc_call(&_call, 9999, 49, 0, NULL));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
   KRPC_CHECK(krpc_invoke(connection, &_result.message, &_call.message));
@@ -1981,7 +2212,7 @@ static inline krpc_error_t krpc_TestService_StringPropertyPrivateSet(krpc_connec
 static inline krpc_error_t krpc_TestService_DeprecatedClass_DeprecatedMethod(krpc_connection_t connection, char * * returnValue, krpc_TestService_DeprecatedClass_t instance) {
   krpc_call_t _call;
   krpc_argument_t _arguments[1];
-  KRPC_CHECK(krpc_call(&_call, 9999, 60, 1, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 69, 1, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_uint64, &instance));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
@@ -1995,10 +2226,28 @@ static inline krpc_error_t krpc_TestService_DeprecatedClass_DeprecatedMethod(krp
   return KRPC_OK;
 }
 
+static inline krpc_error_t krpc_TestService_TestClass_EchoNullableObject(krpc_connection_t connection, krpc_TestService_TestClass_t * returnValue, krpc_TestService_TestClass_t instance, krpc_TestService_TestClass_t value) {
+  krpc_call_t _call;
+  krpc_argument_t _arguments[2];
+  KRPC_CHECK(krpc_call(&_call, 9999, 59, 2, _arguments));
+  KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_uint64, &instance));
+  KRPC_CHECK(krpc_add_argument(&_call, 1, &krpc_encode_callback_object, &value));
+  krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
+  KRPC_CHECK(krpc_init_result(&_result));
+  KRPC_CHECK(krpc_invoke(connection, &_result.message, &_call.message));
+  if (returnValue) {
+    pb_istream_t _stream;
+    KRPC_CHECK(krpc_get_return_value(&_result, &_stream));
+    KRPC_CHECK(krpc_decode_object(&_stream, returnValue));
+  }
+  KRPC_CHECK(krpc_free_result(&_result));
+  return KRPC_OK;
+}
+
 static inline krpc_error_t krpc_TestService_TestClass_FloatToString(krpc_connection_t connection, char * * returnValue, krpc_TestService_TestClass_t instance, float x) {
   krpc_call_t _call;
   krpc_argument_t _arguments[2];
-  KRPC_CHECK(krpc_call(&_call, 9999, 50, 2, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 57, 2, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_uint64, &instance));
   KRPC_CHECK(krpc_add_argument(&_call, 1, &krpc_encode_callback_float, &x));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
@@ -2016,7 +2265,7 @@ static inline krpc_error_t krpc_TestService_TestClass_FloatToString(krpc_connect
 static inline krpc_error_t krpc_TestService_TestClass_GetValue(krpc_connection_t connection, char * * returnValue, krpc_TestService_TestClass_t instance) {
   krpc_call_t _call;
   krpc_argument_t _arguments[1];
-  KRPC_CHECK(krpc_call(&_call, 9999, 49, 1, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 56, 1, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_uint64, &instance));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
@@ -2033,7 +2282,7 @@ static inline krpc_error_t krpc_TestService_TestClass_GetValue(krpc_connection_t
 static inline krpc_error_t krpc_TestService_TestClass_ObjectToString(krpc_connection_t connection, char * * returnValue, krpc_TestService_TestClass_t instance, krpc_TestService_TestClass_t other) {
   krpc_call_t _call;
   krpc_argument_t _arguments[2];
-  KRPC_CHECK(krpc_call(&_call, 9999, 51, 2, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 58, 2, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_uint64, &instance));
   KRPC_CHECK(krpc_add_argument(&_call, 1, &krpc_encode_callback_object, &other));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
@@ -2051,7 +2300,7 @@ static inline krpc_error_t krpc_TestService_TestClass_ObjectToString(krpc_connec
 static inline krpc_error_t krpc_TestService_TestClass_OptionalArguments(krpc_connection_t connection, char * * returnValue, krpc_TestService_TestClass_t instance, const char * x, const char * y, const char * z, krpc_TestService_TestClass_t obj) {
   krpc_call_t _call;
   krpc_argument_t _arguments[5];
-  KRPC_CHECK(krpc_call(&_call, 9999, 52, 5, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 60, 5, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_uint64, &instance));
   KRPC_CHECK(krpc_add_argument(&_call, 1, &krpc_encode_callback_string, &x));
   KRPC_CHECK(krpc_add_argument(&_call, 2, &krpc_encode_callback_string, &y));
@@ -2072,7 +2321,7 @@ static inline krpc_error_t krpc_TestService_TestClass_OptionalArguments(krpc_con
 static inline krpc_error_t krpc_TestService_TestClass_IntProperty(krpc_connection_t connection, int32_t * returnValue, krpc_TestService_TestClass_t instance) {
   krpc_call_t _call;
   krpc_argument_t _arguments[1];
-  KRPC_CHECK(krpc_call(&_call, 9999, 54, 1, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 63, 1, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_uint64, &instance));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
@@ -2089,7 +2338,7 @@ static inline krpc_error_t krpc_TestService_TestClass_IntProperty(krpc_connectio
 static inline krpc_error_t krpc_TestService_TestClass_set_IntProperty(krpc_connection_t connection, krpc_TestService_TestClass_t instance, int32_t value) {
   krpc_call_t _call;
   krpc_argument_t _arguments[2];
-  KRPC_CHECK(krpc_call(&_call, 9999, 55, 2, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 64, 2, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_uint64, &instance));
   KRPC_CHECK(krpc_add_argument(&_call, 1, &krpc_encode_callback_int32, &value));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
@@ -2102,7 +2351,7 @@ static inline krpc_error_t krpc_TestService_TestClass_set_IntProperty(krpc_conne
 static inline krpc_error_t krpc_TestService_TestClass_ObjectProperty(krpc_connection_t connection, krpc_TestService_TestClass_t * returnValue, krpc_TestService_TestClass_t instance) {
   krpc_call_t _call;
   krpc_argument_t _arguments[1];
-  KRPC_CHECK(krpc_call(&_call, 9999, 56, 1, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 65, 1, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_uint64, &instance));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
@@ -2119,7 +2368,7 @@ static inline krpc_error_t krpc_TestService_TestClass_ObjectProperty(krpc_connec
 static inline krpc_error_t krpc_TestService_TestClass_set_ObjectProperty(krpc_connection_t connection, krpc_TestService_TestClass_t instance, krpc_TestService_TestClass_t value) {
   krpc_call_t _call;
   krpc_argument_t _arguments[2];
-  KRPC_CHECK(krpc_call(&_call, 9999, 57, 2, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 66, 2, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_uint64, &instance));
   KRPC_CHECK(krpc_add_argument(&_call, 1, &krpc_encode_callback_object, &value));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
@@ -2132,7 +2381,7 @@ static inline krpc_error_t krpc_TestService_TestClass_set_ObjectProperty(krpc_co
 static inline krpc_error_t krpc_TestService_TestClass_set_StringPropertyPrivateGet(krpc_connection_t connection, krpc_TestService_TestClass_t instance, const char * value) {
   krpc_call_t _call;
   krpc_argument_t _arguments[2];
-  KRPC_CHECK(krpc_call(&_call, 9999, 58, 2, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 67, 2, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_uint64, &instance));
   KRPC_CHECK(krpc_add_argument(&_call, 1, &krpc_encode_callback_string, &value));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
@@ -2145,7 +2394,7 @@ static inline krpc_error_t krpc_TestService_TestClass_set_StringPropertyPrivateG
 static inline krpc_error_t krpc_TestService_TestClass_StringPropertyPrivateSet(krpc_connection_t connection, char * * returnValue, krpc_TestService_TestClass_t instance) {
   krpc_call_t _call;
   krpc_argument_t _arguments[1];
-  KRPC_CHECK(krpc_call(&_call, 9999, 59, 1, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 68, 1, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_uint64, &instance));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
@@ -2162,7 +2411,7 @@ static inline krpc_error_t krpc_TestService_TestClass_StringPropertyPrivateSet(k
 static inline krpc_error_t krpc_TestService_TestClass_StaticMethod(krpc_connection_t connection, char * * returnValue, const char * a, const char * b) {
   krpc_call_t _call;
   krpc_argument_t _arguments[2];
-  KRPC_CHECK(krpc_call(&_call, 9999, 53, 2, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 61, 2, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_string, &a));
   KRPC_CHECK(krpc_add_argument(&_call, 1, &krpc_encode_callback_string, &b));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
@@ -2172,6 +2421,23 @@ static inline krpc_error_t krpc_TestService_TestClass_StaticMethod(krpc_connecti
     pb_istream_t _stream;
     KRPC_CHECK(krpc_get_return_value(&_result, &_stream));
     KRPC_CHECK(krpc_decode_string(&_stream, returnValue));
+  }
+  KRPC_CHECK(krpc_free_result(&_result));
+  return KRPC_OK;
+}
+
+static inline krpc_error_t krpc_TestService_TestClass_StaticNullableObject(krpc_connection_t connection, krpc_TestService_TestClass_t * returnValue, krpc_TestService_TestClass_t value) {
+  krpc_call_t _call;
+  krpc_argument_t _arguments[1];
+  KRPC_CHECK(krpc_call(&_call, 9999, 62, 1, _arguments));
+  KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_object, &value));
+  krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
+  KRPC_CHECK(krpc_init_result(&_result));
+  KRPC_CHECK(krpc_invoke(connection, &_result.message, &_call.message));
+  if (returnValue) {
+    pb_istream_t _stream;
+    KRPC_CHECK(krpc_get_return_value(&_result, &_stream));
+    KRPC_CHECK(krpc_decode_object(&_stream, returnValue));
   }
   KRPC_CHECK(krpc_free_result(&_result));
   return KRPC_OK;

--- a/tools/krpctools/krpctools/test/clientgen-TestService-cnano.txt
+++ b/tools/krpctools/krpctools/test/clientgen-TestService-cnano.txt
@@ -282,11 +282,11 @@ static inline krpc_error_t krpc_TestService_DictionaryDefault(krpc_connection_t 
 
 static inline krpc_error_t krpc_TestService_DoubleToString(krpc_connection_t connection, char * * returnValue, double value);
 
-static inline krpc_error_t krpc_TestService_EchoNullableInt(krpc_connection_t connection, int32_t * returnValue, int32_t value);
+static inline krpc_error_t krpc_TestService_EchoNullableInt(krpc_connection_t connection, int32_t * returnValue, bool * returnValueIsNull, const int32_t * value);
 
-static inline krpc_error_t krpc_TestService_EchoNullableList(krpc_connection_t connection, krpc_list_int32_t * returnValue, const krpc_list_int32_t * l);
+static inline krpc_error_t krpc_TestService_EchoNullableList(krpc_connection_t connection, krpc_list_int32_t * returnValue, bool * returnValueIsNull, const krpc_list_int32_t * l);
 
-static inline krpc_error_t krpc_TestService_EchoNullableString(krpc_connection_t connection, char * * returnValue, const char * value);
+static inline krpc_error_t krpc_TestService_EchoNullableString(krpc_connection_t connection, char * * returnValue, bool * returnValueIsNull, const char * value);
 
 static inline krpc_error_t krpc_TestService_EchoTestObject(krpc_connection_t connection, krpc_TestService_TestClass_t * returnValue, krpc_TestService_TestClass_t value);
 
@@ -1520,52 +1520,85 @@ static inline krpc_error_t krpc_TestService_DoubleToString(krpc_connection_t con
   return KRPC_OK;
 }
 
-static inline krpc_error_t krpc_TestService_EchoNullableInt(krpc_connection_t connection, int32_t * returnValue, int32_t value) {
+static inline krpc_error_t krpc_TestService_EchoNullableInt(krpc_connection_t connection, int32_t * returnValue, bool * returnValueIsNull, const int32_t * value) {
   krpc_call_t _call;
   krpc_argument_t _arguments[1];
   KRPC_CHECK(krpc_call(&_call, 9999, 15, 1, _arguments));
-  KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_int32, &value));
+  if (value == NULL) {
+    KRPC_CHECK(krpc_add_null_argument(&_call, 0));
+  } else {
+    KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_int32, value));
+  }
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
   KRPC_CHECK(krpc_invoke(connection, &_result.message, &_call.message));
   if (returnValue) {
-    pb_istream_t _stream;
-    KRPC_CHECK(krpc_get_return_value(&_result, &_stream));
-    KRPC_CHECK(krpc_decode_int32(&_stream, returnValue));
+    if (_result.message.is_null) {
+      if (returnValueIsNull)
+        *returnValueIsNull = true;
+    } else {
+      if (returnValueIsNull)
+        *returnValueIsNull = false;
+      pb_istream_t _stream;
+      KRPC_CHECK(krpc_get_return_value(&_result, &_stream));
+      KRPC_CHECK(krpc_decode_int32(&_stream, returnValue));
+    }
   }
   KRPC_CHECK(krpc_free_result(&_result));
   return KRPC_OK;
 }
 
-static inline krpc_error_t krpc_TestService_EchoNullableList(krpc_connection_t connection, krpc_list_int32_t * returnValue, const krpc_list_int32_t * l) {
+static inline krpc_error_t krpc_TestService_EchoNullableList(krpc_connection_t connection, krpc_list_int32_t * returnValue, bool * returnValueIsNull, const krpc_list_int32_t * l) {
   krpc_call_t _call;
   krpc_argument_t _arguments[1];
   KRPC_CHECK(krpc_call(&_call, 9999, 14, 1, _arguments));
-  KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_list_int32, l));
+  if (l == NULL) {
+    KRPC_CHECK(krpc_add_null_argument(&_call, 0));
+  } else {
+    KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_list_int32, l));
+  }
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
   KRPC_CHECK(krpc_invoke(connection, &_result.message, &_call.message));
   if (returnValue) {
-    pb_istream_t _stream;
-    KRPC_CHECK(krpc_get_return_value(&_result, &_stream));
-    KRPC_CHECK(krpc_decode_list_int32(&_stream, returnValue));
+    if (_result.message.is_null) {
+      if (returnValueIsNull)
+        *returnValueIsNull = true;
+    } else {
+      if (returnValueIsNull)
+        *returnValueIsNull = false;
+      pb_istream_t _stream;
+      KRPC_CHECK(krpc_get_return_value(&_result, &_stream));
+      KRPC_CHECK(krpc_decode_list_int32(&_stream, returnValue));
+    }
   }
   KRPC_CHECK(krpc_free_result(&_result));
   return KRPC_OK;
 }
 
-static inline krpc_error_t krpc_TestService_EchoNullableString(krpc_connection_t connection, char * * returnValue, const char * value) {
+static inline krpc_error_t krpc_TestService_EchoNullableString(krpc_connection_t connection, char * * returnValue, bool * returnValueIsNull, const char * value) {
   krpc_call_t _call;
   krpc_argument_t _arguments[1];
   KRPC_CHECK(krpc_call(&_call, 9999, 13, 1, _arguments));
-  KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_string, &value));
+  if (value == NULL) {
+    KRPC_CHECK(krpc_add_null_argument(&_call, 0));
+  } else {
+    KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_string, &value));
+  }
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
   KRPC_CHECK(krpc_invoke(connection, &_result.message, &_call.message));
   if (returnValue) {
-    pb_istream_t _stream;
-    KRPC_CHECK(krpc_get_return_value(&_result, &_stream));
-    KRPC_CHECK(krpc_decode_string(&_stream, returnValue));
+    if (_result.message.is_null) {
+      if (returnValueIsNull)
+        *returnValueIsNull = true;
+    } else {
+      if (returnValueIsNull)
+        *returnValueIsNull = false;
+      pb_istream_t _stream;
+      KRPC_CHECK(krpc_get_return_value(&_result, &_stream));
+      KRPC_CHECK(krpc_decode_string(&_stream, returnValue));
+    }
   }
   KRPC_CHECK(krpc_free_result(&_result));
   return KRPC_OK;
@@ -1575,14 +1608,22 @@ static inline krpc_error_t krpc_TestService_EchoTestObject(krpc_connection_t con
   krpc_call_t _call;
   krpc_argument_t _arguments[1];
   KRPC_CHECK(krpc_call(&_call, 9999, 10, 1, _arguments));
-  KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_object, &value));
+  if (value == KRPC_NULL) {
+    KRPC_CHECK(krpc_add_null_argument(&_call, 0));
+  } else {
+    KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_object, &value));
+  }
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
   KRPC_CHECK(krpc_invoke(connection, &_result.message, &_call.message));
   if (returnValue) {
-    pb_istream_t _stream;
-    KRPC_CHECK(krpc_get_return_value(&_result, &_stream));
-    KRPC_CHECK(krpc_decode_object(&_stream, returnValue));
+    if (_result.message.is_null) {
+      *returnValue = KRPC_NULL;
+    } else {
+      pb_istream_t _stream;
+      KRPC_CHECK(krpc_get_return_value(&_result, &_stream));
+      KRPC_CHECK(krpc_decode_object(&_stream, returnValue));
+    }
   }
   KRPC_CHECK(krpc_free_result(&_result));
   return KRPC_OK;
@@ -1866,7 +1907,11 @@ static inline krpc_error_t krpc_TestService_OptionalArguments(krpc_connection_t 
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_string, &x));
   KRPC_CHECK(krpc_add_argument(&_call, 1, &krpc_encode_callback_string, &y));
   KRPC_CHECK(krpc_add_argument(&_call, 2, &krpc_encode_callback_string, &z));
-  KRPC_CHECK(krpc_add_argument(&_call, 3, &krpc_encode_callback_object, &obj));
+  if (obj == KRPC_NULL) {
+    KRPC_CHECK(krpc_add_null_argument(&_call, 3));
+  } else {
+    KRPC_CHECK(krpc_add_argument(&_call, 3, &krpc_encode_callback_object, &obj));
+  }
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
   KRPC_CHECK(krpc_invoke(connection, &_result.message, &_call.message));
@@ -2108,9 +2153,13 @@ static inline krpc_error_t krpc_TestService_NullableObject(krpc_connection_t con
   KRPC_CHECK(krpc_init_result(&_result));
   KRPC_CHECK(krpc_invoke(connection, &_result.message, &_call.message));
   if (returnValue) {
-    pb_istream_t _stream;
-    KRPC_CHECK(krpc_get_return_value(&_result, &_stream));
-    KRPC_CHECK(krpc_decode_object(&_stream, returnValue));
+    if (_result.message.is_null) {
+      *returnValue = KRPC_NULL;
+    } else {
+      pb_istream_t _stream;
+      KRPC_CHECK(krpc_get_return_value(&_result, &_stream));
+      KRPC_CHECK(krpc_decode_object(&_stream, returnValue));
+    }
   }
   KRPC_CHECK(krpc_free_result(&_result));
   return KRPC_OK;
@@ -2120,7 +2169,11 @@ static inline krpc_error_t krpc_TestService_set_NullableObject(krpc_connection_t
   krpc_call_t _call;
   krpc_argument_t _arguments[1];
   KRPC_CHECK(krpc_call(&_call, 9999, 53, 1, _arguments));
-  KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_object, &value));
+  if (value == KRPC_NULL) {
+    KRPC_CHECK(krpc_add_null_argument(&_call, 0));
+  } else {
+    KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_object, &value));
+  }
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
   KRPC_CHECK(krpc_invoke(connection, &_result.message, &_call.message));
@@ -2135,9 +2188,13 @@ static inline krpc_error_t krpc_TestService_ObjectProperty(krpc_connection_t con
   KRPC_CHECK(krpc_init_result(&_result));
   KRPC_CHECK(krpc_invoke(connection, &_result.message, &_call.message));
   if (returnValue) {
-    pb_istream_t _stream;
-    KRPC_CHECK(krpc_get_return_value(&_result, &_stream));
-    KRPC_CHECK(krpc_decode_object(&_stream, returnValue));
+    if (_result.message.is_null) {
+      *returnValue = KRPC_NULL;
+    } else {
+      pb_istream_t _stream;
+      KRPC_CHECK(krpc_get_return_value(&_result, &_stream));
+      KRPC_CHECK(krpc_decode_object(&_stream, returnValue));
+    }
   }
   KRPC_CHECK(krpc_free_result(&_result));
   return KRPC_OK;
@@ -2147,7 +2204,11 @@ static inline krpc_error_t krpc_TestService_set_ObjectProperty(krpc_connection_t
   krpc_call_t _call;
   krpc_argument_t _arguments[1];
   KRPC_CHECK(krpc_call(&_call, 9999, 51, 1, _arguments));
-  KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_object, &value));
+  if (value == KRPC_NULL) {
+    KRPC_CHECK(krpc_add_null_argument(&_call, 0));
+  } else {
+    KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_object, &value));
+  }
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
   KRPC_CHECK(krpc_invoke(connection, &_result.message, &_call.message));
@@ -2231,14 +2292,22 @@ static inline krpc_error_t krpc_TestService_TestClass_EchoNullableObject(krpc_co
   krpc_argument_t _arguments[2];
   KRPC_CHECK(krpc_call(&_call, 9999, 59, 2, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_uint64, &instance));
-  KRPC_CHECK(krpc_add_argument(&_call, 1, &krpc_encode_callback_object, &value));
+  if (value == KRPC_NULL) {
+    KRPC_CHECK(krpc_add_null_argument(&_call, 1));
+  } else {
+    KRPC_CHECK(krpc_add_argument(&_call, 1, &krpc_encode_callback_object, &value));
+  }
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
   KRPC_CHECK(krpc_invoke(connection, &_result.message, &_call.message));
   if (returnValue) {
-    pb_istream_t _stream;
-    KRPC_CHECK(krpc_get_return_value(&_result, &_stream));
-    KRPC_CHECK(krpc_decode_object(&_stream, returnValue));
+    if (_result.message.is_null) {
+      *returnValue = KRPC_NULL;
+    } else {
+      pb_istream_t _stream;
+      KRPC_CHECK(krpc_get_return_value(&_result, &_stream));
+      KRPC_CHECK(krpc_decode_object(&_stream, returnValue));
+    }
   }
   KRPC_CHECK(krpc_free_result(&_result));
   return KRPC_OK;
@@ -2284,7 +2353,11 @@ static inline krpc_error_t krpc_TestService_TestClass_ObjectToString(krpc_connec
   krpc_argument_t _arguments[2];
   KRPC_CHECK(krpc_call(&_call, 9999, 58, 2, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_uint64, &instance));
-  KRPC_CHECK(krpc_add_argument(&_call, 1, &krpc_encode_callback_object, &other));
+  if (other == KRPC_NULL) {
+    KRPC_CHECK(krpc_add_null_argument(&_call, 1));
+  } else {
+    KRPC_CHECK(krpc_add_argument(&_call, 1, &krpc_encode_callback_object, &other));
+  }
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
   KRPC_CHECK(krpc_invoke(connection, &_result.message, &_call.message));
@@ -2305,7 +2378,11 @@ static inline krpc_error_t krpc_TestService_TestClass_OptionalArguments(krpc_con
   KRPC_CHECK(krpc_add_argument(&_call, 1, &krpc_encode_callback_string, &x));
   KRPC_CHECK(krpc_add_argument(&_call, 2, &krpc_encode_callback_string, &y));
   KRPC_CHECK(krpc_add_argument(&_call, 3, &krpc_encode_callback_string, &z));
-  KRPC_CHECK(krpc_add_argument(&_call, 4, &krpc_encode_callback_object, &obj));
+  if (obj == KRPC_NULL) {
+    KRPC_CHECK(krpc_add_null_argument(&_call, 4));
+  } else {
+    KRPC_CHECK(krpc_add_argument(&_call, 4, &krpc_encode_callback_object, &obj));
+  }
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
   KRPC_CHECK(krpc_invoke(connection, &_result.message, &_call.message));
@@ -2357,9 +2434,13 @@ static inline krpc_error_t krpc_TestService_TestClass_ObjectProperty(krpc_connec
   KRPC_CHECK(krpc_init_result(&_result));
   KRPC_CHECK(krpc_invoke(connection, &_result.message, &_call.message));
   if (returnValue) {
-    pb_istream_t _stream;
-    KRPC_CHECK(krpc_get_return_value(&_result, &_stream));
-    KRPC_CHECK(krpc_decode_object(&_stream, returnValue));
+    if (_result.message.is_null) {
+      *returnValue = KRPC_NULL;
+    } else {
+      pb_istream_t _stream;
+      KRPC_CHECK(krpc_get_return_value(&_result, &_stream));
+      KRPC_CHECK(krpc_decode_object(&_stream, returnValue));
+    }
   }
   KRPC_CHECK(krpc_free_result(&_result));
   return KRPC_OK;
@@ -2370,7 +2451,11 @@ static inline krpc_error_t krpc_TestService_TestClass_set_ObjectProperty(krpc_co
   krpc_argument_t _arguments[2];
   KRPC_CHECK(krpc_call(&_call, 9999, 66, 2, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_uint64, &instance));
-  KRPC_CHECK(krpc_add_argument(&_call, 1, &krpc_encode_callback_object, &value));
+  if (value == KRPC_NULL) {
+    KRPC_CHECK(krpc_add_null_argument(&_call, 1));
+  } else {
+    KRPC_CHECK(krpc_add_argument(&_call, 1, &krpc_encode_callback_object, &value));
+  }
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
   KRPC_CHECK(krpc_invoke(connection, &_result.message, &_call.message));
@@ -2430,14 +2515,22 @@ static inline krpc_error_t krpc_TestService_TestClass_StaticNullableObject(krpc_
   krpc_call_t _call;
   krpc_argument_t _arguments[1];
   KRPC_CHECK(krpc_call(&_call, 9999, 62, 1, _arguments));
-  KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_object, &value));
+  if (value == KRPC_NULL) {
+    KRPC_CHECK(krpc_add_null_argument(&_call, 0));
+  } else {
+    KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_object, &value));
+  }
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
   KRPC_CHECK(krpc_invoke(connection, &_result.message, &_call.message));
   if (returnValue) {
-    pb_istream_t _stream;
-    KRPC_CHECK(krpc_get_return_value(&_result, &_stream));
-    KRPC_CHECK(krpc_decode_object(&_stream, returnValue));
+    if (_result.message.is_null) {
+      *returnValue = KRPC_NULL;
+    } else {
+      pb_istream_t _stream;
+      KRPC_CHECK(krpc_get_return_value(&_result, &_stream));
+      KRPC_CHECK(krpc_decode_object(&_stream, returnValue));
+    }
   }
   KRPC_CHECK(krpc_free_result(&_result));
   return KRPC_OK;

--- a/tools/krpctools/krpctools/test/clientgen-TestService-cpp.txt
+++ b/tools/krpctools/krpctools/test/clientgen-TestService-cpp.txt
@@ -108,7 +108,15 @@ class TestService : public Service {
 
   std::string double_to_string(double value);
 
+  int32_t echo_nullable_int(int32_t value);
+
+  std::vector<int32_t> echo_nullable_list(std::vector<int32_t> l);
+
+  std::string echo_nullable_string(std::string value);
+
   TestService::TestClass echo_test_object(TestService::TestClass value);
+
+  std::vector<std::string> empty_list_default(std::vector<std::string> x);
 
   TestService::TestEnum enum_default_arg(TestService::TestEnum x);
 
@@ -136,6 +144,8 @@ class TestService : public Service {
   std::string int64_to_string(int64_t value);
 
   std::vector<int32_t> list_default(std::vector<int32_t> x);
+
+  TestService::TestClass not_nullable_object(TestService::TestClass value);
 
   ::krpc::Event on_timer(uint32_t milliseconds, uint32_t repeats);
 
@@ -185,6 +195,10 @@ class TestService : public Service {
   [[deprecated("Use string_property instead.")]]
   void set_deprecated_property(std::string value);
 
+  TestService::TestClass nullable_object();
+
+  void set_nullable_object(TestService::TestClass value);
+
   TestService::TestClass object_property();
 
   void set_object_property(TestService::TestClass value);
@@ -225,7 +239,15 @@ class TestService : public Service {
 
   ::krpc::Stream<std::string> double_to_string_stream(double value);
 
+  ::krpc::Stream<int32_t> echo_nullable_int_stream(int32_t value);
+
+  ::krpc::Stream<std::vector<int32_t>> echo_nullable_list_stream(std::vector<int32_t> l);
+
+  ::krpc::Stream<std::string> echo_nullable_string_stream(std::string value);
+
   ::krpc::Stream<TestService::TestClass> echo_test_object_stream(TestService::TestClass value);
+
+  ::krpc::Stream<std::vector<std::string>> empty_list_default_stream(std::vector<std::string> x);
 
   ::krpc::Stream<TestService::TestEnum> enum_default_arg_stream(TestService::TestEnum x);
 
@@ -250,6 +272,8 @@ class TestService : public Service {
   ::krpc::Stream<std::string> int64_to_string_stream(int64_t value);
 
   ::krpc::Stream<std::vector<int32_t>> list_default_stream(std::vector<int32_t> x);
+
+  ::krpc::Stream<TestService::TestClass> not_nullable_object_stream(TestService::TestClass value);
 
   ::krpc::Stream<::krpc::Event> on_timer_stream(uint32_t milliseconds, uint32_t repeats);
 
@@ -281,6 +305,8 @@ class TestService : public Service {
 
   ::krpc::Stream<std::string> deprecated_property_stream();
 
+  ::krpc::Stream<TestService::TestClass> nullable_object_stream();
+
   ::krpc::Stream<TestService::TestClass> object_property_stream();
 
   ::krpc::Stream<std::string> string_property_stream();
@@ -309,7 +335,15 @@ class TestService : public Service {
 
   ::krpc::schema::ProcedureCall double_to_string_call(double value);
 
+  ::krpc::schema::ProcedureCall echo_nullable_int_call(int32_t value);
+
+  ::krpc::schema::ProcedureCall echo_nullable_list_call(std::vector<int32_t> l);
+
+  ::krpc::schema::ProcedureCall echo_nullable_string_call(std::string value);
+
   ::krpc::schema::ProcedureCall echo_test_object_call(TestService::TestClass value);
+
+  ::krpc::schema::ProcedureCall empty_list_default_call(std::vector<std::string> x);
 
   ::krpc::schema::ProcedureCall enum_default_arg_call(TestService::TestEnum x);
 
@@ -334,6 +368,8 @@ class TestService : public Service {
   ::krpc::schema::ProcedureCall int64_to_string_call(int64_t value);
 
   ::krpc::schema::ProcedureCall list_default_call(std::vector<int32_t> x);
+
+  ::krpc::schema::ProcedureCall not_nullable_object_call(TestService::TestClass value);
 
   ::krpc::schema::ProcedureCall on_timer_call(uint32_t milliseconds, uint32_t repeats);
 
@@ -370,6 +406,10 @@ class TestService : public Service {
   ::krpc::schema::ProcedureCall deprecated_property_call();
 
   ::krpc::schema::ProcedureCall set_deprecated_property_call(std::string value);
+
+  ::krpc::schema::ProcedureCall nullable_object_call();
+
+  ::krpc::schema::ProcedureCall set_nullable_object_call(TestService::TestClass value);
 
   ::krpc::schema::ProcedureCall object_property_call();
 
@@ -412,6 +452,8 @@ class TestService : public Service {
    public:
     explicit TestClass(Client* client = nullptr, uint64_t id = 0);
 
+    TestService::TestClass echo_nullable_object(TestService::TestClass value);
+
     std::string float_to_string(float x);
 
     /**
@@ -424,6 +466,8 @@ class TestService : public Service {
     std::string optional_arguments(std::string x, std::string y, std::string z, TestService::TestClass obj);
 
     static std::string static_method(Client& client, std::string a, std::string b);
+
+    static TestService::TestClass static_nullable_object(Client& client, TestService::TestClass value);
 
     /**
      * Property documentation string.
@@ -443,6 +487,8 @@ class TestService : public Service {
 
     std::string string_property_private_set();
 
+    ::krpc::Stream<TestService::TestClass> echo_nullable_object_stream(TestService::TestClass value);
+
     ::krpc::Stream<std::string> float_to_string_stream(float x);
 
     ::krpc::Stream<std::string> get_value_stream();
@@ -453,11 +499,15 @@ class TestService : public Service {
 
     static ::krpc::Stream<std::string> static_method_stream(Client& client, std::string a, std::string b);
 
+    static ::krpc::Stream<TestService::TestClass> static_nullable_object_stream(Client& client, TestService::TestClass value);
+
     ::krpc::Stream<int32_t> int_property_stream();
 
     ::krpc::Stream<TestService::TestClass> object_property_stream();
 
     ::krpc::Stream<std::string> string_property_private_set_stream();
+
+    ::krpc::schema::ProcedureCall echo_nullable_object_call(TestService::TestClass value);
 
     ::krpc::schema::ProcedureCall float_to_string_call(float x);
 
@@ -468,6 +518,8 @@ class TestService : public Service {
     ::krpc::schema::ProcedureCall optional_arguments_call(std::string x, std::string y, std::string z, TestService::TestClass obj);
 
     static ::krpc::schema::ProcedureCall static_method_call(Client& client, std::string a, std::string b);
+
+    static ::krpc::schema::ProcedureCall static_nullable_object_call(Client& client, TestService::TestClass value);
 
     ::krpc::schema::ProcedureCall int_property_call();
 
@@ -650,11 +702,47 @@ inline std::string TestService::double_to_string(double value) {
   return _result;
 }
 
+inline int32_t TestService::echo_nullable_int(int32_t value) {
+  std::vector<std::string> _args;
+  _args.push_back(encoder::encode(value));
+  std::string _data = this->_client->invoke("TestService", "EchoNullableInt", _args);
+  int32_t _result;
+  decoder::decode(_result, _data, this->_client);
+  return _result;
+}
+
+inline std::vector<int32_t> TestService::echo_nullable_list(std::vector<int32_t> l) {
+  std::vector<std::string> _args;
+  _args.push_back(encoder::encode(l));
+  std::string _data = this->_client->invoke("TestService", "EchoNullableList", _args);
+  std::vector<int32_t> _result;
+  decoder::decode(_result, _data, this->_client);
+  return _result;
+}
+
+inline std::string TestService::echo_nullable_string(std::string value) {
+  std::vector<std::string> _args;
+  _args.push_back(encoder::encode(value));
+  std::string _data = this->_client->invoke("TestService", "EchoNullableString", _args);
+  std::string _result;
+  decoder::decode(_result, _data, this->_client);
+  return _result;
+}
+
 inline TestService::TestClass TestService::echo_test_object(TestService::TestClass value) {
   std::vector<std::string> _args;
   _args.push_back(encoder::encode(value));
   std::string _data = this->_client->invoke("TestService", "EchoTestObject", _args);
   TestService::TestClass _result;
+  decoder::decode(_result, _data, this->_client);
+  return _result;
+}
+
+inline std::vector<std::string> TestService::empty_list_default(std::vector<std::string> x = std::vector<std::string>{}) {
+  std::vector<std::string> _args;
+  _args.push_back(encoder::encode(x));
+  std::string _data = this->_client->invoke("TestService", "EmptyListDefault", _args);
+  std::vector<std::string> _result;
   decoder::decode(_result, _data, this->_client);
   return _result;
 }
@@ -761,6 +849,15 @@ inline std::vector<int32_t> TestService::list_default(std::vector<int32_t> x = s
   _args.push_back(encoder::encode(x));
   std::string _data = this->_client->invoke("TestService", "ListDefault", _args);
   std::vector<int32_t> _result;
+  decoder::decode(_result, _data, this->_client);
+  return _result;
+}
+
+inline TestService::TestClass TestService::not_nullable_object(TestService::TestClass value) {
+  std::vector<std::string> _args;
+  _args.push_back(encoder::encode(value));
+  std::string _data = this->_client->invoke("TestService", "NotNullableObject", _args);
+  TestService::TestClass _result;
   decoder::decode(_result, _data, this->_client);
   return _result;
 }
@@ -904,6 +1001,19 @@ inline void TestService::set_deprecated_property(std::string value) {
   this->_client->invoke("TestService", "set_DeprecatedProperty", _args);
 }
 
+inline TestService::TestClass TestService::nullable_object() {
+  std::string _data = this->_client->invoke("TestService", "get_NullableObject");
+  TestService::TestClass _result;
+  decoder::decode(_result, _data, this->_client);
+  return _result;
+}
+
+inline void TestService::set_nullable_object(TestService::TestClass value) {
+  std::vector<std::string> _args;
+  _args.push_back(encoder::encode(value));
+  this->_client->invoke("TestService", "set_NullableObject", _args);
+}
+
 inline TestService::TestClass TestService::object_property() {
   std::string _data = this->_client->invoke("TestService", "get_ObjectProperty");
   TestService::TestClass _result;
@@ -1014,10 +1124,34 @@ inline ::krpc::Stream<std::string> TestService::double_to_string_stream(double v
   return ::krpc::Stream<std::string>(this->_client, this->_client->build_call("TestService", "DoubleToString", _args));
 }
 
+inline ::krpc::Stream<int32_t> TestService::echo_nullable_int_stream(int32_t value) {
+  std::vector<std::string> _args;
+  _args.push_back(encoder::encode(value));
+  return ::krpc::Stream<int32_t>(this->_client, this->_client->build_call("TestService", "EchoNullableInt", _args));
+}
+
+inline ::krpc::Stream<std::vector<int32_t>> TestService::echo_nullable_list_stream(std::vector<int32_t> l) {
+  std::vector<std::string> _args;
+  _args.push_back(encoder::encode(l));
+  return ::krpc::Stream<std::vector<int32_t>>(this->_client, this->_client->build_call("TestService", "EchoNullableList", _args));
+}
+
+inline ::krpc::Stream<std::string> TestService::echo_nullable_string_stream(std::string value) {
+  std::vector<std::string> _args;
+  _args.push_back(encoder::encode(value));
+  return ::krpc::Stream<std::string>(this->_client, this->_client->build_call("TestService", "EchoNullableString", _args));
+}
+
 inline ::krpc::Stream<TestService::TestClass> TestService::echo_test_object_stream(TestService::TestClass value) {
   std::vector<std::string> _args;
   _args.push_back(encoder::encode(value));
   return ::krpc::Stream<TestService::TestClass>(this->_client, this->_client->build_call("TestService", "EchoTestObject", _args));
+}
+
+inline ::krpc::Stream<std::vector<std::string>> TestService::empty_list_default_stream(std::vector<std::string> x = std::vector<std::string>{}) {
+  std::vector<std::string> _args;
+  _args.push_back(encoder::encode(x));
+  return ::krpc::Stream<std::vector<std::string>>(this->_client, this->_client->build_call("TestService", "EmptyListDefault", _args));
 }
 
 inline ::krpc::Stream<TestService::TestEnum> TestService::enum_default_arg_stream(TestService::TestEnum x = static_cast<TestService::TestEnum>(2)) {
@@ -1088,6 +1222,12 @@ inline ::krpc::Stream<std::vector<int32_t>> TestService::list_default_stream(std
   std::vector<std::string> _args;
   _args.push_back(encoder::encode(x));
   return ::krpc::Stream<std::vector<int32_t>>(this->_client, this->_client->build_call("TestService", "ListDefault", _args));
+}
+
+inline ::krpc::Stream<TestService::TestClass> TestService::not_nullable_object_stream(TestService::TestClass value) {
+  std::vector<std::string> _args;
+  _args.push_back(encoder::encode(value));
+  return ::krpc::Stream<TestService::TestClass>(this->_client, this->_client->build_call("TestService", "NotNullableObject", _args));
 }
 
 inline ::krpc::Stream<::krpc::Event> TestService::on_timer_stream(uint32_t milliseconds, uint32_t repeats = 1) {
@@ -1168,6 +1308,10 @@ inline ::krpc::Stream<std::tuple<int32_t, bool>> TestService::tuple_default_stre
 
 inline ::krpc::Stream<std::string> TestService::deprecated_property_stream() {
   return ::krpc::Stream<std::string>(this->_client, this->_client->build_call("TestService", "get_DeprecatedProperty"));
+}
+
+inline ::krpc::Stream<TestService::TestClass> TestService::nullable_object_stream() {
+  return ::krpc::Stream<TestService::TestClass>(this->_client, this->_client->build_call("TestService", "get_NullableObject"));
 }
 
 inline ::krpc::Stream<TestService::TestClass> TestService::object_property_stream() {
@@ -1253,10 +1397,34 @@ inline ::krpc::schema::ProcedureCall TestService::double_to_string_call(double v
   return this->_client->build_call("TestService", "DoubleToString", _args);
 }
 
+inline ::krpc::schema::ProcedureCall TestService::echo_nullable_int_call(int32_t value) {
+  std::vector<std::string> _args;
+  _args.push_back(encoder::encode(value));
+  return this->_client->build_call("TestService", "EchoNullableInt", _args);
+}
+
+inline ::krpc::schema::ProcedureCall TestService::echo_nullable_list_call(std::vector<int32_t> l) {
+  std::vector<std::string> _args;
+  _args.push_back(encoder::encode(l));
+  return this->_client->build_call("TestService", "EchoNullableList", _args);
+}
+
+inline ::krpc::schema::ProcedureCall TestService::echo_nullable_string_call(std::string value) {
+  std::vector<std::string> _args;
+  _args.push_back(encoder::encode(value));
+  return this->_client->build_call("TestService", "EchoNullableString", _args);
+}
+
 inline ::krpc::schema::ProcedureCall TestService::echo_test_object_call(TestService::TestClass value) {
   std::vector<std::string> _args;
   _args.push_back(encoder::encode(value));
   return this->_client->build_call("TestService", "EchoTestObject", _args);
+}
+
+inline ::krpc::schema::ProcedureCall TestService::empty_list_default_call(std::vector<std::string> x = std::vector<std::string>{}) {
+  std::vector<std::string> _args;
+  _args.push_back(encoder::encode(x));
+  return this->_client->build_call("TestService", "EmptyListDefault", _args);
 }
 
 inline ::krpc::schema::ProcedureCall TestService::enum_default_arg_call(TestService::TestEnum x = static_cast<TestService::TestEnum>(2)) {
@@ -1327,6 +1495,12 @@ inline ::krpc::schema::ProcedureCall TestService::list_default_call(std::vector<
   std::vector<std::string> _args;
   _args.push_back(encoder::encode(x));
   return this->_client->build_call("TestService", "ListDefault", _args);
+}
+
+inline ::krpc::schema::ProcedureCall TestService::not_nullable_object_call(TestService::TestClass value) {
+  std::vector<std::string> _args;
+  _args.push_back(encoder::encode(value));
+  return this->_client->build_call("TestService", "NotNullableObject", _args);
 }
 
 inline ::krpc::schema::ProcedureCall TestService::on_timer_call(uint32_t milliseconds, uint32_t repeats = 1) {
@@ -1423,6 +1597,16 @@ inline ::krpc::schema::ProcedureCall TestService::set_deprecated_property_call(s
   return this->_client->build_call("TestService", "set_DeprecatedProperty", _args);
 }
 
+inline ::krpc::schema::ProcedureCall TestService::nullable_object_call() {
+  return this->_client->build_call("TestService", "get_NullableObject");
+}
+
+inline ::krpc::schema::ProcedureCall TestService::set_nullable_object_call(TestService::TestClass value) {
+  std::vector<std::string> _args;
+  _args.push_back(encoder::encode(value));
+  return this->_client->build_call("TestService", "set_NullableObject", _args);
+}
+
 inline ::krpc::schema::ProcedureCall TestService::object_property_call() {
   return this->_client->build_call("TestService", "get_ObjectProperty");
 }
@@ -1479,6 +1663,16 @@ inline ::krpc::schema::ProcedureCall TestService::DeprecatedClass::deprecated_me
 
 inline TestService::TestClass::TestClass(Client* client, uint64_t id):
   Object(client, "TestService::TestClass", id) {}
+
+inline TestService::TestClass TestService::TestClass::echo_nullable_object(TestService::TestClass value) {
+  std::vector<std::string> _args;
+  _args.push_back(encoder::encode(*this));
+  _args.push_back(encoder::encode(value));
+  std::string _data = this->_client->invoke("TestService", "TestClass_EchoNullableObject", _args);
+  TestService::TestClass _result;
+  decoder::decode(_result, _data, this->_client);
+  return _result;
+}
 
 inline std::string TestService::TestClass::float_to_string(float x) {
   std::vector<std::string> _args;
@@ -1580,6 +1774,22 @@ inline std::string TestService::TestClass::static_method(Client& _client, std::s
   return _result;
 }
 
+inline TestService::TestClass TestService::TestClass::static_nullable_object(Client& _client, TestService::TestClass value) {
+    std::vector<std::string> _args;
+  _args.push_back(encoder::encode(value));
+  std::string _data = _client.invoke("TestService", "TestClass_static_StaticNullableObject", _args);
+    TestService::TestClass _result;
+  decoder::decode(_result, _data, &_client);
+  return _result;
+}
+
+inline ::krpc::Stream<TestService::TestClass> TestService::TestClass::echo_nullable_object_stream(TestService::TestClass value) {
+  std::vector<std::string> _args;
+  _args.push_back(encoder::encode(*this));
+  _args.push_back(encoder::encode(value));
+  return ::krpc::Stream<TestService::TestClass>(this->_client, this->_client->build_call("TestService", "TestClass_EchoNullableObject", _args));
+}
+
 inline ::krpc::Stream<std::string> TestService::TestClass::float_to_string_stream(float x) {
   std::vector<std::string> _args;
   _args.push_back(encoder::encode(*this));
@@ -1633,6 +1843,19 @@ inline ::krpc::Stream<std::string> TestService::TestClass::static_method_stream(
   _args.push_back(encoder::encode(a));
   _args.push_back(encoder::encode(b));
   return ::krpc::Stream<std::string>(&_client, _client.build_call("TestService", "TestClass_static_StaticMethod", _args));
+}
+
+inline ::krpc::Stream<TestService::TestClass> TestService::TestClass::static_nullable_object_stream(Client& _client, TestService::TestClass value) {
+  std::vector<std::string> _args;
+  _args.push_back(encoder::encode(value));
+  return ::krpc::Stream<TestService::TestClass>(&_client, _client.build_call("TestService", "TestClass_static_StaticNullableObject", _args));
+}
+
+inline ::krpc::schema::ProcedureCall TestService::TestClass::echo_nullable_object_call(TestService::TestClass value) {
+  std::vector<std::string> _args;
+  _args.push_back(encoder::encode(*this));
+  _args.push_back(encoder::encode(value));
+  return this->_client->build_call("TestService", "TestClass_EchoNullableObject", _args);
 }
 
 inline ::krpc::schema::ProcedureCall TestService::TestClass::float_to_string_call(float x) {
@@ -1709,6 +1932,12 @@ inline ::krpc::schema::ProcedureCall TestService::TestClass::static_method_call(
   _args.push_back(encoder::encode(a));
   _args.push_back(encoder::encode(b));
   return _client.build_call("TestService", "TestClass_static_StaticMethod", _args);
+}
+
+inline ::krpc::schema::ProcedureCall TestService::TestClass::static_nullable_object_call(Client& _client, TestService::TestClass value) {
+  std::vector<std::string> _args;
+  _args.push_back(encoder::encode(value));
+  return _client.build_call("TestService", "TestClass_static_StaticNullableObject", _args);
 }
 }  // namespace services
 

--- a/tools/krpctools/krpctools/test/clientgen-TestService-cpp.txt
+++ b/tools/krpctools/krpctools/test/clientgen-TestService-cpp.txt
@@ -108,11 +108,11 @@ class TestService : public Service {
 
   std::string double_to_string(double value);
 
-  int32_t echo_nullable_int(int32_t value);
+  std::optional<int32_t> echo_nullable_int(std::optional<int32_t> value);
 
-  std::vector<int32_t> echo_nullable_list(std::vector<int32_t> l);
+  std::optional<std::vector<int32_t> > echo_nullable_list(std::optional<std::vector<int32_t> > l);
 
-  std::string echo_nullable_string(std::string value);
+  std::optional<std::string> echo_nullable_string(std::optional<std::string> value);
 
   TestService::TestClass echo_test_object(TestService::TestClass value);
 
@@ -239,11 +239,11 @@ class TestService : public Service {
 
   ::krpc::Stream<std::string> double_to_string_stream(double value);
 
-  ::krpc::Stream<int32_t> echo_nullable_int_stream(int32_t value);
+  ::krpc::Stream<std::optional<int32_t>> echo_nullable_int_stream(std::optional<int32_t> value);
 
-  ::krpc::Stream<std::vector<int32_t>> echo_nullable_list_stream(std::vector<int32_t> l);
+  ::krpc::Stream<std::optional<std::vector<int32_t> >> echo_nullable_list_stream(std::optional<std::vector<int32_t> > l);
 
-  ::krpc::Stream<std::string> echo_nullable_string_stream(std::string value);
+  ::krpc::Stream<std::optional<std::string>> echo_nullable_string_stream(std::optional<std::string> value);
 
   ::krpc::Stream<TestService::TestClass> echo_test_object_stream(TestService::TestClass value);
 
@@ -335,11 +335,11 @@ class TestService : public Service {
 
   ::krpc::schema::ProcedureCall double_to_string_call(double value);
 
-  ::krpc::schema::ProcedureCall echo_nullable_int_call(int32_t value);
+  ::krpc::schema::ProcedureCall echo_nullable_int_call(std::optional<int32_t> value);
 
-  ::krpc::schema::ProcedureCall echo_nullable_list_call(std::vector<int32_t> l);
+  ::krpc::schema::ProcedureCall echo_nullable_list_call(std::optional<std::vector<int32_t> > l);
 
-  ::krpc::schema::ProcedureCall echo_nullable_string_call(std::string value);
+  ::krpc::schema::ProcedureCall echo_nullable_string_call(std::optional<std::string> value);
 
   ::krpc::schema::ProcedureCall echo_test_object_call(TestService::TestClass value);
 
@@ -599,297 +599,329 @@ inline TestService::TestService(Client* client):
 }
 
 inline std::string TestService::add_multiple_values(float x, int32_t y, int64_t z) {
-  std::vector<std::string> _args;
+  std::vector<krpc::encoder::Value> _args;
   _args.push_back(encoder::encode(x));
   _args.push_back(encoder::encode(y));
   _args.push_back(encoder::encode(z));
-  std::string _data = this->_client->invoke("TestService", "AddMultipleValues", _args);
-  std::string _result;
-  decoder::decode(_result, _data, this->_client);
+  auto _data = this->_client->invoke("TestService", "AddMultipleValues", _args);
+  std::string _result{};
+  if (!_data.is_null())
+    decoder::decode(_result, _data.value(), this->_client);
   return _result;
 }
 
 inline std::vector<TestService::TestClass> TestService::add_to_object_list(std::vector<TestService::TestClass> l, std::string value) {
-  std::vector<std::string> _args;
+  std::vector<krpc::encoder::Value> _args;
   _args.push_back(encoder::encode(l));
   _args.push_back(encoder::encode(value));
-  std::string _data = this->_client->invoke("TestService", "AddToObjectList", _args);
-  std::vector<TestService::TestClass> _result;
-  decoder::decode(_result, _data, this->_client);
+  auto _data = this->_client->invoke("TestService", "AddToObjectList", _args);
+  std::vector<TestService::TestClass> _result{};
+  if (!_data.is_null())
+    decoder::decode(_result, _data.value(), this->_client);
   return _result;
 }
 
 inline int32_t TestService::blocking_procedure(int32_t n, int32_t sum = 0) {
-  std::vector<std::string> _args;
+  std::vector<krpc::encoder::Value> _args;
   _args.push_back(encoder::encode(n));
   _args.push_back(encoder::encode(sum));
-  std::string _data = this->_client->invoke("TestService", "BlockingProcedure", _args);
-  int32_t _result;
-  decoder::decode(_result, _data, this->_client);
+  auto _data = this->_client->invoke("TestService", "BlockingProcedure", _args);
+  int32_t _result{};
+  if (!_data.is_null())
+    decoder::decode(_result, _data.value(), this->_client);
   return _result;
 }
 
 inline std::string TestService::bool_to_string(bool value) {
-  std::vector<std::string> _args;
+  std::vector<krpc::encoder::Value> _args;
   _args.push_back(encoder::encode(value));
-  std::string _data = this->_client->invoke("TestService", "BoolToString", _args);
-  std::string _result;
-  decoder::decode(_result, _data, this->_client);
+  auto _data = this->_client->invoke("TestService", "BoolToString", _args);
+  std::string _result{};
+  if (!_data.is_null())
+    decoder::decode(_result, _data.value(), this->_client);
   return _result;
 }
 
 inline std::string TestService::bytes_to_hex_string(std::string value) {
-  std::vector<std::string> _args;
+  std::vector<krpc::encoder::Value> _args;
   _args.push_back(encoder::encode(value));
-  std::string _data = this->_client->invoke("TestService", "BytesToHexString", _args);
-  std::string _result;
-  decoder::decode(_result, _data, this->_client);
+  auto _data = this->_client->invoke("TestService", "BytesToHexString", _args);
+  std::string _result{};
+  if (!_data.is_null())
+    decoder::decode(_result, _data.value(), this->_client);
   return _result;
 }
 
 inline int32_t TestService::counter(std::string id = "", int32_t divisor = 1) {
-  std::vector<std::string> _args;
+  std::vector<krpc::encoder::Value> _args;
   _args.push_back(encoder::encode(id));
   _args.push_back(encoder::encode(divisor));
-  std::string _data = this->_client->invoke("TestService", "Counter", _args);
-  int32_t _result;
-  decoder::decode(_result, _data, this->_client);
+  auto _data = this->_client->invoke("TestService", "Counter", _args);
+  int32_t _result{};
+  if (!_data.is_null())
+    decoder::decode(_result, _data.value(), this->_client);
   return _result;
 }
 
 inline TestService::TestClass TestService::create_test_object(std::string value) {
-  std::vector<std::string> _args;
+  std::vector<krpc::encoder::Value> _args;
   _args.push_back(encoder::encode(value));
-  std::string _data = this->_client->invoke("TestService", "CreateTestObject", _args);
-  TestService::TestClass _result;
-  decoder::decode(_result, _data, this->_client);
+  auto _data = this->_client->invoke("TestService", "CreateTestObject", _args);
+  TestService::TestClass _result{};
+  if (!_data.is_null())
+    decoder::decode(_result, _data.value(), this->_client);
   return _result;
 }
 
 inline std::string TestService::deprecated_procedure(float value) {
-  std::vector<std::string> _args;
+  std::vector<krpc::encoder::Value> _args;
   _args.push_back(encoder::encode(value));
-  std::string _data = this->_client->invoke("TestService", "DeprecatedProcedure", _args);
-  std::string _result;
-  decoder::decode(_result, _data, this->_client);
+  auto _data = this->_client->invoke("TestService", "DeprecatedProcedure", _args);
+  std::string _result{};
+  if (!_data.is_null())
+    decoder::decode(_result, _data.value(), this->_client);
   return _result;
 }
 
 inline std::string TestService::deprecated_procedure_no_message(float value) {
-  std::vector<std::string> _args;
+  std::vector<krpc::encoder::Value> _args;
   _args.push_back(encoder::encode(value));
-  std::string _data = this->_client->invoke("TestService", "DeprecatedProcedureNoMessage", _args);
-  std::string _result;
-  decoder::decode(_result, _data, this->_client);
+  auto _data = this->_client->invoke("TestService", "DeprecatedProcedureNoMessage", _args);
+  std::string _result{};
+  if (!_data.is_null())
+    decoder::decode(_result, _data.value(), this->_client);
   return _result;
 }
 
 inline std::map<int32_t, bool> TestService::dictionary_default(std::map<int32_t, bool> x = std::map<int32_t, bool>{{1, false}, {2, true}}) {
-  std::vector<std::string> _args;
+  std::vector<krpc::encoder::Value> _args;
   _args.push_back(encoder::encode(x));
-  std::string _data = this->_client->invoke("TestService", "DictionaryDefault", _args);
-  std::map<int32_t, bool> _result;
-  decoder::decode(_result, _data, this->_client);
+  auto _data = this->_client->invoke("TestService", "DictionaryDefault", _args);
+  std::map<int32_t, bool> _result{};
+  if (!_data.is_null())
+    decoder::decode(_result, _data.value(), this->_client);
   return _result;
 }
 
 inline std::string TestService::double_to_string(double value) {
-  std::vector<std::string> _args;
+  std::vector<krpc::encoder::Value> _args;
   _args.push_back(encoder::encode(value));
-  std::string _data = this->_client->invoke("TestService", "DoubleToString", _args);
-  std::string _result;
-  decoder::decode(_result, _data, this->_client);
+  auto _data = this->_client->invoke("TestService", "DoubleToString", _args);
+  std::string _result{};
+  if (!_data.is_null())
+    decoder::decode(_result, _data.value(), this->_client);
   return _result;
 }
 
-inline int32_t TestService::echo_nullable_int(int32_t value) {
-  std::vector<std::string> _args;
-  _args.push_back(encoder::encode(value));
-  std::string _data = this->_client->invoke("TestService", "EchoNullableInt", _args);
-  int32_t _result;
-  decoder::decode(_result, _data, this->_client);
+inline std::optional<int32_t> TestService::echo_nullable_int(std::optional<int32_t> value) {
+  std::vector<krpc::encoder::Value> _args;
+  _args.push_back(encoder::encode_nullable(value));
+  auto _data = this->_client->invoke("TestService", "EchoNullableInt", _args);
+  std::optional<int32_t> _result{};
+  if (!_data.is_null())
+    decoder::decode(_result, _data.value(), this->_client);
   return _result;
 }
 
-inline std::vector<int32_t> TestService::echo_nullable_list(std::vector<int32_t> l) {
-  std::vector<std::string> _args;
-  _args.push_back(encoder::encode(l));
-  std::string _data = this->_client->invoke("TestService", "EchoNullableList", _args);
-  std::vector<int32_t> _result;
-  decoder::decode(_result, _data, this->_client);
+inline std::optional<std::vector<int32_t> > TestService::echo_nullable_list(std::optional<std::vector<int32_t> > l) {
+  std::vector<krpc::encoder::Value> _args;
+  _args.push_back(encoder::encode_nullable(l));
+  auto _data = this->_client->invoke("TestService", "EchoNullableList", _args);
+  std::optional<std::vector<int32_t> > _result{};
+  if (!_data.is_null())
+    decoder::decode(_result, _data.value(), this->_client);
   return _result;
 }
 
-inline std::string TestService::echo_nullable_string(std::string value) {
-  std::vector<std::string> _args;
-  _args.push_back(encoder::encode(value));
-  std::string _data = this->_client->invoke("TestService", "EchoNullableString", _args);
-  std::string _result;
-  decoder::decode(_result, _data, this->_client);
+inline std::optional<std::string> TestService::echo_nullable_string(std::optional<std::string> value) {
+  std::vector<krpc::encoder::Value> _args;
+  _args.push_back(encoder::encode_nullable(value));
+  auto _data = this->_client->invoke("TestService", "EchoNullableString", _args);
+  std::optional<std::string> _result{};
+  if (!_data.is_null())
+    decoder::decode(_result, _data.value(), this->_client);
   return _result;
 }
 
 inline TestService::TestClass TestService::echo_test_object(TestService::TestClass value) {
-  std::vector<std::string> _args;
-  _args.push_back(encoder::encode(value));
-  std::string _data = this->_client->invoke("TestService", "EchoTestObject", _args);
-  TestService::TestClass _result;
-  decoder::decode(_result, _data, this->_client);
+  std::vector<krpc::encoder::Value> _args;
+  _args.push_back(encoder::encode_nullable(value));
+  auto _data = this->_client->invoke("TestService", "EchoTestObject", _args);
+  TestService::TestClass _result{};
+  if (!_data.is_null())
+    decoder::decode(_result, _data.value(), this->_client);
   return _result;
 }
 
 inline std::vector<std::string> TestService::empty_list_default(std::vector<std::string> x = std::vector<std::string>{}) {
-  std::vector<std::string> _args;
+  std::vector<krpc::encoder::Value> _args;
   _args.push_back(encoder::encode(x));
-  std::string _data = this->_client->invoke("TestService", "EmptyListDefault", _args);
-  std::vector<std::string> _result;
-  decoder::decode(_result, _data, this->_client);
+  auto _data = this->_client->invoke("TestService", "EmptyListDefault", _args);
+  std::vector<std::string> _result{};
+  if (!_data.is_null())
+    decoder::decode(_result, _data.value(), this->_client);
   return _result;
 }
 
 inline TestService::TestEnum TestService::enum_default_arg(TestService::TestEnum x = static_cast<TestService::TestEnum>(2)) {
-  std::vector<std::string> _args;
+  std::vector<krpc::encoder::Value> _args;
   _args.push_back(encoder::encode(x));
-  std::string _data = this->_client->invoke("TestService", "EnumDefaultArg", _args);
-  TestService::TestEnum _result;
-  decoder::decode(_result, _data, this->_client);
+  auto _data = this->_client->invoke("TestService", "EnumDefaultArg", _args);
+  TestService::TestEnum _result{};
+  if (!_data.is_null())
+    decoder::decode(_result, _data.value(), this->_client);
   return _result;
 }
 
 inline TestService::TestEnum TestService::enum_echo(TestService::TestEnum x) {
-  std::vector<std::string> _args;
+  std::vector<krpc::encoder::Value> _args;
   _args.push_back(encoder::encode(x));
-  std::string _data = this->_client->invoke("TestService", "EnumEcho", _args);
-  TestService::TestEnum _result;
-  decoder::decode(_result, _data, this->_client);
+  auto _data = this->_client->invoke("TestService", "EnumEcho", _args);
+  TestService::TestEnum _result{};
+  if (!_data.is_null())
+    decoder::decode(_result, _data.value(), this->_client);
   return _result;
 }
 
 inline TestService::TestEnum TestService::enum_return() {
-  std::string _data = this->_client->invoke("TestService", "EnumReturn");
-  TestService::TestEnum _result;
-  decoder::decode(_result, _data, this->_client);
+  auto _data = this->_client->invoke("TestService", "EnumReturn");
+  TestService::TestEnum _result{};
+  if (!_data.is_null())
+    decoder::decode(_result, _data.value(), this->_client);
   return _result;
 }
 
 inline std::string TestService::float_to_string(float value) {
-  std::vector<std::string> _args;
+  std::vector<krpc::encoder::Value> _args;
   _args.push_back(encoder::encode(value));
-  std::string _data = this->_client->invoke("TestService", "FloatToString", _args);
-  std::string _result;
-  decoder::decode(_result, _data, this->_client);
+  auto _data = this->_client->invoke("TestService", "FloatToString", _args);
+  std::string _result{};
+  if (!_data.is_null())
+    decoder::decode(_result, _data.value(), this->_client);
   return _result;
 }
 
 inline std::map<std::string, int32_t> TestService::increment_dictionary(std::map<std::string, int32_t> d) {
-  std::vector<std::string> _args;
+  std::vector<krpc::encoder::Value> _args;
   _args.push_back(encoder::encode(d));
-  std::string _data = this->_client->invoke("TestService", "IncrementDictionary", _args);
-  std::map<std::string, int32_t> _result;
-  decoder::decode(_result, _data, this->_client);
+  auto _data = this->_client->invoke("TestService", "IncrementDictionary", _args);
+  std::map<std::string, int32_t> _result{};
+  if (!_data.is_null())
+    decoder::decode(_result, _data.value(), this->_client);
   return _result;
 }
 
 inline std::vector<int32_t> TestService::increment_list(std::vector<int32_t> l) {
-  std::vector<std::string> _args;
+  std::vector<krpc::encoder::Value> _args;
   _args.push_back(encoder::encode(l));
-  std::string _data = this->_client->invoke("TestService", "IncrementList", _args);
-  std::vector<int32_t> _result;
-  decoder::decode(_result, _data, this->_client);
+  auto _data = this->_client->invoke("TestService", "IncrementList", _args);
+  std::vector<int32_t> _result{};
+  if (!_data.is_null())
+    decoder::decode(_result, _data.value(), this->_client);
   return _result;
 }
 
 inline std::map<std::string, std::vector<int32_t> > TestService::increment_nested_collection(std::map<std::string, std::vector<int32_t> > d) {
-  std::vector<std::string> _args;
+  std::vector<krpc::encoder::Value> _args;
   _args.push_back(encoder::encode(d));
-  std::string _data = this->_client->invoke("TestService", "IncrementNestedCollection", _args);
-  std::map<std::string, std::vector<int32_t> > _result;
-  decoder::decode(_result, _data, this->_client);
+  auto _data = this->_client->invoke("TestService", "IncrementNestedCollection", _args);
+  std::map<std::string, std::vector<int32_t> > _result{};
+  if (!_data.is_null())
+    decoder::decode(_result, _data.value(), this->_client);
   return _result;
 }
 
 inline std::set<int32_t> TestService::increment_set(std::set<int32_t> h) {
-  std::vector<std::string> _args;
+  std::vector<krpc::encoder::Value> _args;
   _args.push_back(encoder::encode(h));
-  std::string _data = this->_client->invoke("TestService", "IncrementSet", _args);
-  std::set<int32_t> _result;
-  decoder::decode(_result, _data, this->_client);
+  auto _data = this->_client->invoke("TestService", "IncrementSet", _args);
+  std::set<int32_t> _result{};
+  if (!_data.is_null())
+    decoder::decode(_result, _data.value(), this->_client);
   return _result;
 }
 
 inline std::tuple<int32_t, int64_t> TestService::increment_tuple(std::tuple<int32_t, int64_t> t) {
-  std::vector<std::string> _args;
+  std::vector<krpc::encoder::Value> _args;
   _args.push_back(encoder::encode(t));
-  std::string _data = this->_client->invoke("TestService", "IncrementTuple", _args);
-  std::tuple<int32_t, int64_t> _result;
-  decoder::decode(_result, _data, this->_client);
+  auto _data = this->_client->invoke("TestService", "IncrementTuple", _args);
+  std::tuple<int32_t, int64_t> _result{};
+  if (!_data.is_null())
+    decoder::decode(_result, _data.value(), this->_client);
   return _result;
 }
 
 inline std::string TestService::int32_to_string(int32_t value) {
-  std::vector<std::string> _args;
+  std::vector<krpc::encoder::Value> _args;
   _args.push_back(encoder::encode(value));
-  std::string _data = this->_client->invoke("TestService", "Int32ToString", _args);
-  std::string _result;
-  decoder::decode(_result, _data, this->_client);
+  auto _data = this->_client->invoke("TestService", "Int32ToString", _args);
+  std::string _result{};
+  if (!_data.is_null())
+    decoder::decode(_result, _data.value(), this->_client);
   return _result;
 }
 
 inline std::string TestService::int64_to_string(int64_t value) {
-  std::vector<std::string> _args;
+  std::vector<krpc::encoder::Value> _args;
   _args.push_back(encoder::encode(value));
-  std::string _data = this->_client->invoke("TestService", "Int64ToString", _args);
-  std::string _result;
-  decoder::decode(_result, _data, this->_client);
+  auto _data = this->_client->invoke("TestService", "Int64ToString", _args);
+  std::string _result{};
+  if (!_data.is_null())
+    decoder::decode(_result, _data.value(), this->_client);
   return _result;
 }
 
 inline std::vector<int32_t> TestService::list_default(std::vector<int32_t> x = std::vector<int32_t>{1, 2, 3}) {
-  std::vector<std::string> _args;
+  std::vector<krpc::encoder::Value> _args;
   _args.push_back(encoder::encode(x));
-  std::string _data = this->_client->invoke("TestService", "ListDefault", _args);
-  std::vector<int32_t> _result;
-  decoder::decode(_result, _data, this->_client);
+  auto _data = this->_client->invoke("TestService", "ListDefault", _args);
+  std::vector<int32_t> _result{};
+  if (!_data.is_null())
+    decoder::decode(_result, _data.value(), this->_client);
   return _result;
 }
 
 inline TestService::TestClass TestService::not_nullable_object(TestService::TestClass value) {
-  std::vector<std::string> _args;
+  std::vector<krpc::encoder::Value> _args;
   _args.push_back(encoder::encode(value));
-  std::string _data = this->_client->invoke("TestService", "NotNullableObject", _args);
-  TestService::TestClass _result;
-  decoder::decode(_result, _data, this->_client);
+  auto _data = this->_client->invoke("TestService", "NotNullableObject", _args);
+  TestService::TestClass _result{};
+  if (!_data.is_null())
+    decoder::decode(_result, _data.value(), this->_client);
   return _result;
 }
 
 inline ::krpc::Event TestService::on_timer(uint32_t milliseconds, uint32_t repeats = 1) {
-  std::vector<std::string> _args;
+  std::vector<krpc::encoder::Value> _args;
   _args.push_back(encoder::encode(milliseconds));
   _args.push_back(encoder::encode(repeats));
-  std::string _data = this->_client->invoke("TestService", "OnTimer", _args);
-  ::krpc::Event _result;
-  decoder::decode(_result, _data, this->_client);
+  auto _data = this->_client->invoke("TestService", "OnTimer", _args);
+  ::krpc::Event _result{};
+  if (!_data.is_null())
+    decoder::decode(_result, _data.value(), this->_client);
   return _result;
 }
 
 inline ::krpc::Event TestService::on_timer_using_lambda(uint32_t milliseconds) {
-  std::vector<std::string> _args;
+  std::vector<krpc::encoder::Value> _args;
   _args.push_back(encoder::encode(milliseconds));
-  std::string _data = this->_client->invoke("TestService", "OnTimerUsingLambda", _args);
-  ::krpc::Event _result;
-  decoder::decode(_result, _data, this->_client);
+  auto _data = this->_client->invoke("TestService", "OnTimerUsingLambda", _args);
+  ::krpc::Event _result{};
+  if (!_data.is_null())
+    decoder::decode(_result, _data.value(), this->_client);
   return _result;
 }
 
 inline std::string TestService::optional_arguments(std::string x, std::string y = "foo", std::string z = "bar", TestService::TestClass obj = TestService::TestClass()) {
-  std::vector<std::string> _args;
+  std::vector<krpc::encoder::Value> _args;
   _args.push_back(encoder::encode(x));
   _args.push_back(encoder::encode(y));
   _args.push_back(encoder::encode(z));
-  _args.push_back(encoder::encode(obj));
-  std::string _data = this->_client->invoke("TestService", "OptionalArguments", _args);
-  std::string _result;
-  decoder::decode(_result, _data, this->_client);
+  _args.push_back(encoder::encode_nullable(obj));
+  auto _data = this->_client->invoke("TestService", "OptionalArguments", _args);
+  std::string _result{};
+  if (!_data.is_null())
+    decoder::decode(_result, _data.value(), this->_client);
   return _result;
 }
 
@@ -902,159 +934,175 @@ inline void TestService::reset_invalid_operation_exception_later() {
 }
 
 inline TestService::TestClass TestService::return_null_when_not_allowed() {
-  std::string _data = this->_client->invoke("TestService", "ReturnNullWhenNotAllowed");
-  TestService::TestClass _result;
-  decoder::decode(_result, _data, this->_client);
+  auto _data = this->_client->invoke("TestService", "ReturnNullWhenNotAllowed");
+  TestService::TestClass _result{};
+  if (!_data.is_null())
+    decoder::decode(_result, _data.value(), this->_client);
   return _result;
 }
 
 inline std::set<int32_t> TestService::set_default(std::set<int32_t> x = std::set<int32_t>{1, 2, 3}) {
-  std::vector<std::string> _args;
+  std::vector<krpc::encoder::Value> _args;
   _args.push_back(encoder::encode(x));
-  std::string _data = this->_client->invoke("TestService", "SetDefault", _args);
-  std::set<int32_t> _result;
-  decoder::decode(_result, _data, this->_client);
+  auto _data = this->_client->invoke("TestService", "SetDefault", _args);
+  std::set<int32_t> _result{};
+  if (!_data.is_null())
+    decoder::decode(_result, _data.value(), this->_client);
   return _result;
 }
 
 inline int32_t TestService::string_to_int32(std::string value) {
-  std::vector<std::string> _args;
+  std::vector<krpc::encoder::Value> _args;
   _args.push_back(encoder::encode(value));
-  std::string _data = this->_client->invoke("TestService", "StringToInt32", _args);
-  int32_t _result;
-  decoder::decode(_result, _data, this->_client);
+  auto _data = this->_client->invoke("TestService", "StringToInt32", _args);
+  int32_t _result{};
+  if (!_data.is_null())
+    decoder::decode(_result, _data.value(), this->_client);
   return _result;
 }
 
 inline int32_t TestService::throw_argument_exception() {
-  std::string _data = this->_client->invoke("TestService", "ThrowArgumentException");
-  int32_t _result;
-  decoder::decode(_result, _data, this->_client);
+  auto _data = this->_client->invoke("TestService", "ThrowArgumentException");
+  int32_t _result{};
+  if (!_data.is_null())
+    decoder::decode(_result, _data.value(), this->_client);
   return _result;
 }
 
 inline int32_t TestService::throw_argument_null_exception(std::string foo) {
-  std::vector<std::string> _args;
+  std::vector<krpc::encoder::Value> _args;
   _args.push_back(encoder::encode(foo));
-  std::string _data = this->_client->invoke("TestService", "ThrowArgumentNullException", _args);
-  int32_t _result;
-  decoder::decode(_result, _data, this->_client);
+  auto _data = this->_client->invoke("TestService", "ThrowArgumentNullException", _args);
+  int32_t _result{};
+  if (!_data.is_null())
+    decoder::decode(_result, _data.value(), this->_client);
   return _result;
 }
 
 inline int32_t TestService::throw_argument_out_of_range_exception(int32_t foo) {
-  std::vector<std::string> _args;
+  std::vector<krpc::encoder::Value> _args;
   _args.push_back(encoder::encode(foo));
-  std::string _data = this->_client->invoke("TestService", "ThrowArgumentOutOfRangeException", _args);
-  int32_t _result;
-  decoder::decode(_result, _data, this->_client);
+  auto _data = this->_client->invoke("TestService", "ThrowArgumentOutOfRangeException", _args);
+  int32_t _result{};
+  if (!_data.is_null())
+    decoder::decode(_result, _data.value(), this->_client);
   return _result;
 }
 
 inline int32_t TestService::throw_custom_exception() {
-  std::string _data = this->_client->invoke("TestService", "ThrowCustomException");
-  int32_t _result;
-  decoder::decode(_result, _data, this->_client);
+  auto _data = this->_client->invoke("TestService", "ThrowCustomException");
+  int32_t _result{};
+  if (!_data.is_null())
+    decoder::decode(_result, _data.value(), this->_client);
   return _result;
 }
 
 inline int32_t TestService::throw_custom_exception_later() {
-  std::string _data = this->_client->invoke("TestService", "ThrowCustomExceptionLater");
-  int32_t _result;
-  decoder::decode(_result, _data, this->_client);
+  auto _data = this->_client->invoke("TestService", "ThrowCustomExceptionLater");
+  int32_t _result{};
+  if (!_data.is_null())
+    decoder::decode(_result, _data.value(), this->_client);
   return _result;
 }
 
 inline int32_t TestService::throw_invalid_operation_exception() {
-  std::string _data = this->_client->invoke("TestService", "ThrowInvalidOperationException");
-  int32_t _result;
-  decoder::decode(_result, _data, this->_client);
+  auto _data = this->_client->invoke("TestService", "ThrowInvalidOperationException");
+  int32_t _result{};
+  if (!_data.is_null())
+    decoder::decode(_result, _data.value(), this->_client);
   return _result;
 }
 
 inline int32_t TestService::throw_invalid_operation_exception_later() {
-  std::string _data = this->_client->invoke("TestService", "ThrowInvalidOperationExceptionLater");
-  int32_t _result;
-  decoder::decode(_result, _data, this->_client);
+  auto _data = this->_client->invoke("TestService", "ThrowInvalidOperationExceptionLater");
+  int32_t _result{};
+  if (!_data.is_null())
+    decoder::decode(_result, _data.value(), this->_client);
   return _result;
 }
 
 inline std::tuple<int32_t, bool> TestService::tuple_default(std::tuple<int32_t, bool> x = std::tuple<int32_t, bool>{1, false}) {
-  std::vector<std::string> _args;
+  std::vector<krpc::encoder::Value> _args;
   _args.push_back(encoder::encode(x));
-  std::string _data = this->_client->invoke("TestService", "TupleDefault", _args);
-  std::tuple<int32_t, bool> _result;
-  decoder::decode(_result, _data, this->_client);
+  auto _data = this->_client->invoke("TestService", "TupleDefault", _args);
+  std::tuple<int32_t, bool> _result{};
+  if (!_data.is_null())
+    decoder::decode(_result, _data.value(), this->_client);
   return _result;
 }
 
 inline std::string TestService::deprecated_property() {
-  std::string _data = this->_client->invoke("TestService", "get_DeprecatedProperty");
-  std::string _result;
-  decoder::decode(_result, _data, this->_client);
+  auto _data = this->_client->invoke("TestService", "get_DeprecatedProperty");
+  std::string _result{};
+  if (!_data.is_null())
+    decoder::decode(_result, _data.value(), this->_client);
   return _result;
 }
 
 inline void TestService::set_deprecated_property(std::string value) {
-  std::vector<std::string> _args;
+  std::vector<krpc::encoder::Value> _args;
   _args.push_back(encoder::encode(value));
   this->_client->invoke("TestService", "set_DeprecatedProperty", _args);
 }
 
 inline TestService::TestClass TestService::nullable_object() {
-  std::string _data = this->_client->invoke("TestService", "get_NullableObject");
-  TestService::TestClass _result;
-  decoder::decode(_result, _data, this->_client);
+  auto _data = this->_client->invoke("TestService", "get_NullableObject");
+  TestService::TestClass _result{};
+  if (!_data.is_null())
+    decoder::decode(_result, _data.value(), this->_client);
   return _result;
 }
 
 inline void TestService::set_nullable_object(TestService::TestClass value) {
-  std::vector<std::string> _args;
-  _args.push_back(encoder::encode(value));
+  std::vector<krpc::encoder::Value> _args;
+  _args.push_back(encoder::encode_nullable(value));
   this->_client->invoke("TestService", "set_NullableObject", _args);
 }
 
 inline TestService::TestClass TestService::object_property() {
-  std::string _data = this->_client->invoke("TestService", "get_ObjectProperty");
-  TestService::TestClass _result;
-  decoder::decode(_result, _data, this->_client);
+  auto _data = this->_client->invoke("TestService", "get_ObjectProperty");
+  TestService::TestClass _result{};
+  if (!_data.is_null())
+    decoder::decode(_result, _data.value(), this->_client);
   return _result;
 }
 
 inline void TestService::set_object_property(TestService::TestClass value) {
-  std::vector<std::string> _args;
-  _args.push_back(encoder::encode(value));
+  std::vector<krpc::encoder::Value> _args;
+  _args.push_back(encoder::encode_nullable(value));
   this->_client->invoke("TestService", "set_ObjectProperty", _args);
 }
 
 inline std::string TestService::string_property() {
-  std::string _data = this->_client->invoke("TestService", "get_StringProperty");
-  std::string _result;
-  decoder::decode(_result, _data, this->_client);
+  auto _data = this->_client->invoke("TestService", "get_StringProperty");
+  std::string _result{};
+  if (!_data.is_null())
+    decoder::decode(_result, _data.value(), this->_client);
   return _result;
 }
 
 inline void TestService::set_string_property(std::string value) {
-  std::vector<std::string> _args;
+  std::vector<krpc::encoder::Value> _args;
   _args.push_back(encoder::encode(value));
   this->_client->invoke("TestService", "set_StringProperty", _args);
 }
 
 inline void TestService::set_string_property_private_get(std::string value) {
-  std::vector<std::string> _args;
+  std::vector<krpc::encoder::Value> _args;
   _args.push_back(encoder::encode(value));
   this->_client->invoke("TestService", "set_StringPropertyPrivateGet", _args);
 }
 
 inline std::string TestService::string_property_private_set() {
-  std::string _data = this->_client->invoke("TestService", "get_StringPropertyPrivateSet");
-  std::string _result;
-  decoder::decode(_result, _data, this->_client);
+  auto _data = this->_client->invoke("TestService", "get_StringPropertyPrivateSet");
+  std::string _result{};
+  if (!_data.is_null())
+    decoder::decode(_result, _data.value(), this->_client);
   return _result;
 }
 
 inline ::krpc::Stream<std::string> TestService::add_multiple_values_stream(float x, int32_t y, int64_t z) {
-  std::vector<std::string> _args;
+  std::vector<krpc::encoder::Value> _args;
   _args.push_back(encoder::encode(x));
   _args.push_back(encoder::encode(y));
   _args.push_back(encoder::encode(z));
@@ -1062,106 +1110,106 @@ inline ::krpc::Stream<std::string> TestService::add_multiple_values_stream(float
 }
 
 inline ::krpc::Stream<std::vector<TestService::TestClass>> TestService::add_to_object_list_stream(std::vector<TestService::TestClass> l, std::string value) {
-  std::vector<std::string> _args;
+  std::vector<krpc::encoder::Value> _args;
   _args.push_back(encoder::encode(l));
   _args.push_back(encoder::encode(value));
   return ::krpc::Stream<std::vector<TestService::TestClass>>(this->_client, this->_client->build_call("TestService", "AddToObjectList", _args));
 }
 
 inline ::krpc::Stream<int32_t> TestService::blocking_procedure_stream(int32_t n, int32_t sum = 0) {
-  std::vector<std::string> _args;
+  std::vector<krpc::encoder::Value> _args;
   _args.push_back(encoder::encode(n));
   _args.push_back(encoder::encode(sum));
   return ::krpc::Stream<int32_t>(this->_client, this->_client->build_call("TestService", "BlockingProcedure", _args));
 }
 
 inline ::krpc::Stream<std::string> TestService::bool_to_string_stream(bool value) {
-  std::vector<std::string> _args;
+  std::vector<krpc::encoder::Value> _args;
   _args.push_back(encoder::encode(value));
   return ::krpc::Stream<std::string>(this->_client, this->_client->build_call("TestService", "BoolToString", _args));
 }
 
 inline ::krpc::Stream<std::string> TestService::bytes_to_hex_string_stream(std::string value) {
-  std::vector<std::string> _args;
+  std::vector<krpc::encoder::Value> _args;
   _args.push_back(encoder::encode(value));
   return ::krpc::Stream<std::string>(this->_client, this->_client->build_call("TestService", "BytesToHexString", _args));
 }
 
 inline ::krpc::Stream<int32_t> TestService::counter_stream(std::string id = "", int32_t divisor = 1) {
-  std::vector<std::string> _args;
+  std::vector<krpc::encoder::Value> _args;
   _args.push_back(encoder::encode(id));
   _args.push_back(encoder::encode(divisor));
   return ::krpc::Stream<int32_t>(this->_client, this->_client->build_call("TestService", "Counter", _args));
 }
 
 inline ::krpc::Stream<TestService::TestClass> TestService::create_test_object_stream(std::string value) {
-  std::vector<std::string> _args;
+  std::vector<krpc::encoder::Value> _args;
   _args.push_back(encoder::encode(value));
   return ::krpc::Stream<TestService::TestClass>(this->_client, this->_client->build_call("TestService", "CreateTestObject", _args));
 }
 
 inline ::krpc::Stream<std::string> TestService::deprecated_procedure_stream(float value) {
-  std::vector<std::string> _args;
+  std::vector<krpc::encoder::Value> _args;
   _args.push_back(encoder::encode(value));
   return ::krpc::Stream<std::string>(this->_client, this->_client->build_call("TestService", "DeprecatedProcedure", _args));
 }
 
 inline ::krpc::Stream<std::string> TestService::deprecated_procedure_no_message_stream(float value) {
-  std::vector<std::string> _args;
+  std::vector<krpc::encoder::Value> _args;
   _args.push_back(encoder::encode(value));
   return ::krpc::Stream<std::string>(this->_client, this->_client->build_call("TestService", "DeprecatedProcedureNoMessage", _args));
 }
 
 inline ::krpc::Stream<std::map<int32_t, bool>> TestService::dictionary_default_stream(std::map<int32_t, bool> x = std::map<int32_t, bool>{{1, false}, {2, true}}) {
-  std::vector<std::string> _args;
+  std::vector<krpc::encoder::Value> _args;
   _args.push_back(encoder::encode(x));
   return ::krpc::Stream<std::map<int32_t, bool>>(this->_client, this->_client->build_call("TestService", "DictionaryDefault", _args));
 }
 
 inline ::krpc::Stream<std::string> TestService::double_to_string_stream(double value) {
-  std::vector<std::string> _args;
+  std::vector<krpc::encoder::Value> _args;
   _args.push_back(encoder::encode(value));
   return ::krpc::Stream<std::string>(this->_client, this->_client->build_call("TestService", "DoubleToString", _args));
 }
 
-inline ::krpc::Stream<int32_t> TestService::echo_nullable_int_stream(int32_t value) {
-  std::vector<std::string> _args;
-  _args.push_back(encoder::encode(value));
-  return ::krpc::Stream<int32_t>(this->_client, this->_client->build_call("TestService", "EchoNullableInt", _args));
+inline ::krpc::Stream<std::optional<int32_t>> TestService::echo_nullable_int_stream(std::optional<int32_t> value) {
+  std::vector<krpc::encoder::Value> _args;
+  _args.push_back(encoder::encode_nullable(value));
+  return ::krpc::Stream<std::optional<int32_t>>(this->_client, this->_client->build_call("TestService", "EchoNullableInt", _args));
 }
 
-inline ::krpc::Stream<std::vector<int32_t>> TestService::echo_nullable_list_stream(std::vector<int32_t> l) {
-  std::vector<std::string> _args;
-  _args.push_back(encoder::encode(l));
-  return ::krpc::Stream<std::vector<int32_t>>(this->_client, this->_client->build_call("TestService", "EchoNullableList", _args));
+inline ::krpc::Stream<std::optional<std::vector<int32_t> >> TestService::echo_nullable_list_stream(std::optional<std::vector<int32_t> > l) {
+  std::vector<krpc::encoder::Value> _args;
+  _args.push_back(encoder::encode_nullable(l));
+  return ::krpc::Stream<std::optional<std::vector<int32_t> >>(this->_client, this->_client->build_call("TestService", "EchoNullableList", _args));
 }
 
-inline ::krpc::Stream<std::string> TestService::echo_nullable_string_stream(std::string value) {
-  std::vector<std::string> _args;
-  _args.push_back(encoder::encode(value));
-  return ::krpc::Stream<std::string>(this->_client, this->_client->build_call("TestService", "EchoNullableString", _args));
+inline ::krpc::Stream<std::optional<std::string>> TestService::echo_nullable_string_stream(std::optional<std::string> value) {
+  std::vector<krpc::encoder::Value> _args;
+  _args.push_back(encoder::encode_nullable(value));
+  return ::krpc::Stream<std::optional<std::string>>(this->_client, this->_client->build_call("TestService", "EchoNullableString", _args));
 }
 
 inline ::krpc::Stream<TestService::TestClass> TestService::echo_test_object_stream(TestService::TestClass value) {
-  std::vector<std::string> _args;
-  _args.push_back(encoder::encode(value));
+  std::vector<krpc::encoder::Value> _args;
+  _args.push_back(encoder::encode_nullable(value));
   return ::krpc::Stream<TestService::TestClass>(this->_client, this->_client->build_call("TestService", "EchoTestObject", _args));
 }
 
 inline ::krpc::Stream<std::vector<std::string>> TestService::empty_list_default_stream(std::vector<std::string> x = std::vector<std::string>{}) {
-  std::vector<std::string> _args;
+  std::vector<krpc::encoder::Value> _args;
   _args.push_back(encoder::encode(x));
   return ::krpc::Stream<std::vector<std::string>>(this->_client, this->_client->build_call("TestService", "EmptyListDefault", _args));
 }
 
 inline ::krpc::Stream<TestService::TestEnum> TestService::enum_default_arg_stream(TestService::TestEnum x = static_cast<TestService::TestEnum>(2)) {
-  std::vector<std::string> _args;
+  std::vector<krpc::encoder::Value> _args;
   _args.push_back(encoder::encode(x));
   return ::krpc::Stream<TestService::TestEnum>(this->_client, this->_client->build_call("TestService", "EnumDefaultArg", _args));
 }
 
 inline ::krpc::Stream<TestService::TestEnum> TestService::enum_echo_stream(TestService::TestEnum x) {
-  std::vector<std::string> _args;
+  std::vector<krpc::encoder::Value> _args;
   _args.push_back(encoder::encode(x));
   return ::krpc::Stream<TestService::TestEnum>(this->_client, this->_client->build_call("TestService", "EnumEcho", _args));
 }
@@ -1171,84 +1219,84 @@ inline ::krpc::Stream<TestService::TestEnum> TestService::enum_return_stream() {
 }
 
 inline ::krpc::Stream<std::string> TestService::float_to_string_stream(float value) {
-  std::vector<std::string> _args;
+  std::vector<krpc::encoder::Value> _args;
   _args.push_back(encoder::encode(value));
   return ::krpc::Stream<std::string>(this->_client, this->_client->build_call("TestService", "FloatToString", _args));
 }
 
 inline ::krpc::Stream<std::map<std::string, int32_t>> TestService::increment_dictionary_stream(std::map<std::string, int32_t> d) {
-  std::vector<std::string> _args;
+  std::vector<krpc::encoder::Value> _args;
   _args.push_back(encoder::encode(d));
   return ::krpc::Stream<std::map<std::string, int32_t>>(this->_client, this->_client->build_call("TestService", "IncrementDictionary", _args));
 }
 
 inline ::krpc::Stream<std::vector<int32_t>> TestService::increment_list_stream(std::vector<int32_t> l) {
-  std::vector<std::string> _args;
+  std::vector<krpc::encoder::Value> _args;
   _args.push_back(encoder::encode(l));
   return ::krpc::Stream<std::vector<int32_t>>(this->_client, this->_client->build_call("TestService", "IncrementList", _args));
 }
 
 inline ::krpc::Stream<std::map<std::string, std::vector<int32_t> >> TestService::increment_nested_collection_stream(std::map<std::string, std::vector<int32_t> > d) {
-  std::vector<std::string> _args;
+  std::vector<krpc::encoder::Value> _args;
   _args.push_back(encoder::encode(d));
   return ::krpc::Stream<std::map<std::string, std::vector<int32_t> >>(this->_client, this->_client->build_call("TestService", "IncrementNestedCollection", _args));
 }
 
 inline ::krpc::Stream<std::set<int32_t>> TestService::increment_set_stream(std::set<int32_t> h) {
-  std::vector<std::string> _args;
+  std::vector<krpc::encoder::Value> _args;
   _args.push_back(encoder::encode(h));
   return ::krpc::Stream<std::set<int32_t>>(this->_client, this->_client->build_call("TestService", "IncrementSet", _args));
 }
 
 inline ::krpc::Stream<std::tuple<int32_t, int64_t>> TestService::increment_tuple_stream(std::tuple<int32_t, int64_t> t) {
-  std::vector<std::string> _args;
+  std::vector<krpc::encoder::Value> _args;
   _args.push_back(encoder::encode(t));
   return ::krpc::Stream<std::tuple<int32_t, int64_t>>(this->_client, this->_client->build_call("TestService", "IncrementTuple", _args));
 }
 
 inline ::krpc::Stream<std::string> TestService::int32_to_string_stream(int32_t value) {
-  std::vector<std::string> _args;
+  std::vector<krpc::encoder::Value> _args;
   _args.push_back(encoder::encode(value));
   return ::krpc::Stream<std::string>(this->_client, this->_client->build_call("TestService", "Int32ToString", _args));
 }
 
 inline ::krpc::Stream<std::string> TestService::int64_to_string_stream(int64_t value) {
-  std::vector<std::string> _args;
+  std::vector<krpc::encoder::Value> _args;
   _args.push_back(encoder::encode(value));
   return ::krpc::Stream<std::string>(this->_client, this->_client->build_call("TestService", "Int64ToString", _args));
 }
 
 inline ::krpc::Stream<std::vector<int32_t>> TestService::list_default_stream(std::vector<int32_t> x = std::vector<int32_t>{1, 2, 3}) {
-  std::vector<std::string> _args;
+  std::vector<krpc::encoder::Value> _args;
   _args.push_back(encoder::encode(x));
   return ::krpc::Stream<std::vector<int32_t>>(this->_client, this->_client->build_call("TestService", "ListDefault", _args));
 }
 
 inline ::krpc::Stream<TestService::TestClass> TestService::not_nullable_object_stream(TestService::TestClass value) {
-  std::vector<std::string> _args;
+  std::vector<krpc::encoder::Value> _args;
   _args.push_back(encoder::encode(value));
   return ::krpc::Stream<TestService::TestClass>(this->_client, this->_client->build_call("TestService", "NotNullableObject", _args));
 }
 
 inline ::krpc::Stream<::krpc::Event> TestService::on_timer_stream(uint32_t milliseconds, uint32_t repeats = 1) {
-  std::vector<std::string> _args;
+  std::vector<krpc::encoder::Value> _args;
   _args.push_back(encoder::encode(milliseconds));
   _args.push_back(encoder::encode(repeats));
   return ::krpc::Stream<::krpc::Event>(this->_client, this->_client->build_call("TestService", "OnTimer", _args));
 }
 
 inline ::krpc::Stream<::krpc::Event> TestService::on_timer_using_lambda_stream(uint32_t milliseconds) {
-  std::vector<std::string> _args;
+  std::vector<krpc::encoder::Value> _args;
   _args.push_back(encoder::encode(milliseconds));
   return ::krpc::Stream<::krpc::Event>(this->_client, this->_client->build_call("TestService", "OnTimerUsingLambda", _args));
 }
 
 inline ::krpc::Stream<std::string> TestService::optional_arguments_stream(std::string x, std::string y = "foo", std::string z = "bar", TestService::TestClass obj = TestService::TestClass()) {
-  std::vector<std::string> _args;
+  std::vector<krpc::encoder::Value> _args;
   _args.push_back(encoder::encode(x));
   _args.push_back(encoder::encode(y));
   _args.push_back(encoder::encode(z));
-  _args.push_back(encoder::encode(obj));
+  _args.push_back(encoder::encode_nullable(obj));
   return ::krpc::Stream<std::string>(this->_client, this->_client->build_call("TestService", "OptionalArguments", _args));
 }
 
@@ -1257,13 +1305,13 @@ inline ::krpc::Stream<TestService::TestClass> TestService::return_null_when_not_
 }
 
 inline ::krpc::Stream<std::set<int32_t>> TestService::set_default_stream(std::set<int32_t> x = std::set<int32_t>{1, 2, 3}) {
-  std::vector<std::string> _args;
+  std::vector<krpc::encoder::Value> _args;
   _args.push_back(encoder::encode(x));
   return ::krpc::Stream<std::set<int32_t>>(this->_client, this->_client->build_call("TestService", "SetDefault", _args));
 }
 
 inline ::krpc::Stream<int32_t> TestService::string_to_int32_stream(std::string value) {
-  std::vector<std::string> _args;
+  std::vector<krpc::encoder::Value> _args;
   _args.push_back(encoder::encode(value));
   return ::krpc::Stream<int32_t>(this->_client, this->_client->build_call("TestService", "StringToInt32", _args));
 }
@@ -1273,13 +1321,13 @@ inline ::krpc::Stream<int32_t> TestService::throw_argument_exception_stream() {
 }
 
 inline ::krpc::Stream<int32_t> TestService::throw_argument_null_exception_stream(std::string foo) {
-  std::vector<std::string> _args;
+  std::vector<krpc::encoder::Value> _args;
   _args.push_back(encoder::encode(foo));
   return ::krpc::Stream<int32_t>(this->_client, this->_client->build_call("TestService", "ThrowArgumentNullException", _args));
 }
 
 inline ::krpc::Stream<int32_t> TestService::throw_argument_out_of_range_exception_stream(int32_t foo) {
-  std::vector<std::string> _args;
+  std::vector<krpc::encoder::Value> _args;
   _args.push_back(encoder::encode(foo));
   return ::krpc::Stream<int32_t>(this->_client, this->_client->build_call("TestService", "ThrowArgumentOutOfRangeException", _args));
 }
@@ -1301,7 +1349,7 @@ inline ::krpc::Stream<int32_t> TestService::throw_invalid_operation_exception_la
 }
 
 inline ::krpc::Stream<std::tuple<int32_t, bool>> TestService::tuple_default_stream(std::tuple<int32_t, bool> x = std::tuple<int32_t, bool>{1, false}) {
-  std::vector<std::string> _args;
+  std::vector<krpc::encoder::Value> _args;
   _args.push_back(encoder::encode(x));
   return ::krpc::Stream<std::tuple<int32_t, bool>>(this->_client, this->_client->build_call("TestService", "TupleDefault", _args));
 }
@@ -1327,7 +1375,7 @@ inline ::krpc::Stream<std::string> TestService::string_property_private_set_stre
 }
 
 inline ::krpc::schema::ProcedureCall TestService::add_multiple_values_call(float x, int32_t y, int64_t z) {
-  std::vector<std::string> _args;
+  std::vector<krpc::encoder::Value> _args;
   _args.push_back(encoder::encode(x));
   _args.push_back(encoder::encode(y));
   _args.push_back(encoder::encode(z));
@@ -1335,106 +1383,106 @@ inline ::krpc::schema::ProcedureCall TestService::add_multiple_values_call(float
 }
 
 inline ::krpc::schema::ProcedureCall TestService::add_to_object_list_call(std::vector<TestService::TestClass> l, std::string value) {
-  std::vector<std::string> _args;
+  std::vector<krpc::encoder::Value> _args;
   _args.push_back(encoder::encode(l));
   _args.push_back(encoder::encode(value));
   return this->_client->build_call("TestService", "AddToObjectList", _args);
 }
 
 inline ::krpc::schema::ProcedureCall TestService::blocking_procedure_call(int32_t n, int32_t sum = 0) {
-  std::vector<std::string> _args;
+  std::vector<krpc::encoder::Value> _args;
   _args.push_back(encoder::encode(n));
   _args.push_back(encoder::encode(sum));
   return this->_client->build_call("TestService", "BlockingProcedure", _args);
 }
 
 inline ::krpc::schema::ProcedureCall TestService::bool_to_string_call(bool value) {
-  std::vector<std::string> _args;
+  std::vector<krpc::encoder::Value> _args;
   _args.push_back(encoder::encode(value));
   return this->_client->build_call("TestService", "BoolToString", _args);
 }
 
 inline ::krpc::schema::ProcedureCall TestService::bytes_to_hex_string_call(std::string value) {
-  std::vector<std::string> _args;
+  std::vector<krpc::encoder::Value> _args;
   _args.push_back(encoder::encode(value));
   return this->_client->build_call("TestService", "BytesToHexString", _args);
 }
 
 inline ::krpc::schema::ProcedureCall TestService::counter_call(std::string id = "", int32_t divisor = 1) {
-  std::vector<std::string> _args;
+  std::vector<krpc::encoder::Value> _args;
   _args.push_back(encoder::encode(id));
   _args.push_back(encoder::encode(divisor));
   return this->_client->build_call("TestService", "Counter", _args);
 }
 
 inline ::krpc::schema::ProcedureCall TestService::create_test_object_call(std::string value) {
-  std::vector<std::string> _args;
+  std::vector<krpc::encoder::Value> _args;
   _args.push_back(encoder::encode(value));
   return this->_client->build_call("TestService", "CreateTestObject", _args);
 }
 
 inline ::krpc::schema::ProcedureCall TestService::deprecated_procedure_call(float value) {
-  std::vector<std::string> _args;
+  std::vector<krpc::encoder::Value> _args;
   _args.push_back(encoder::encode(value));
   return this->_client->build_call("TestService", "DeprecatedProcedure", _args);
 }
 
 inline ::krpc::schema::ProcedureCall TestService::deprecated_procedure_no_message_call(float value) {
-  std::vector<std::string> _args;
+  std::vector<krpc::encoder::Value> _args;
   _args.push_back(encoder::encode(value));
   return this->_client->build_call("TestService", "DeprecatedProcedureNoMessage", _args);
 }
 
 inline ::krpc::schema::ProcedureCall TestService::dictionary_default_call(std::map<int32_t, bool> x = std::map<int32_t, bool>{{1, false}, {2, true}}) {
-  std::vector<std::string> _args;
+  std::vector<krpc::encoder::Value> _args;
   _args.push_back(encoder::encode(x));
   return this->_client->build_call("TestService", "DictionaryDefault", _args);
 }
 
 inline ::krpc::schema::ProcedureCall TestService::double_to_string_call(double value) {
-  std::vector<std::string> _args;
+  std::vector<krpc::encoder::Value> _args;
   _args.push_back(encoder::encode(value));
   return this->_client->build_call("TestService", "DoubleToString", _args);
 }
 
-inline ::krpc::schema::ProcedureCall TestService::echo_nullable_int_call(int32_t value) {
-  std::vector<std::string> _args;
-  _args.push_back(encoder::encode(value));
+inline ::krpc::schema::ProcedureCall TestService::echo_nullable_int_call(std::optional<int32_t> value) {
+  std::vector<krpc::encoder::Value> _args;
+  _args.push_back(encoder::encode_nullable(value));
   return this->_client->build_call("TestService", "EchoNullableInt", _args);
 }
 
-inline ::krpc::schema::ProcedureCall TestService::echo_nullable_list_call(std::vector<int32_t> l) {
-  std::vector<std::string> _args;
-  _args.push_back(encoder::encode(l));
+inline ::krpc::schema::ProcedureCall TestService::echo_nullable_list_call(std::optional<std::vector<int32_t> > l) {
+  std::vector<krpc::encoder::Value> _args;
+  _args.push_back(encoder::encode_nullable(l));
   return this->_client->build_call("TestService", "EchoNullableList", _args);
 }
 
-inline ::krpc::schema::ProcedureCall TestService::echo_nullable_string_call(std::string value) {
-  std::vector<std::string> _args;
-  _args.push_back(encoder::encode(value));
+inline ::krpc::schema::ProcedureCall TestService::echo_nullable_string_call(std::optional<std::string> value) {
+  std::vector<krpc::encoder::Value> _args;
+  _args.push_back(encoder::encode_nullable(value));
   return this->_client->build_call("TestService", "EchoNullableString", _args);
 }
 
 inline ::krpc::schema::ProcedureCall TestService::echo_test_object_call(TestService::TestClass value) {
-  std::vector<std::string> _args;
-  _args.push_back(encoder::encode(value));
+  std::vector<krpc::encoder::Value> _args;
+  _args.push_back(encoder::encode_nullable(value));
   return this->_client->build_call("TestService", "EchoTestObject", _args);
 }
 
 inline ::krpc::schema::ProcedureCall TestService::empty_list_default_call(std::vector<std::string> x = std::vector<std::string>{}) {
-  std::vector<std::string> _args;
+  std::vector<krpc::encoder::Value> _args;
   _args.push_back(encoder::encode(x));
   return this->_client->build_call("TestService", "EmptyListDefault", _args);
 }
 
 inline ::krpc::schema::ProcedureCall TestService::enum_default_arg_call(TestService::TestEnum x = static_cast<TestService::TestEnum>(2)) {
-  std::vector<std::string> _args;
+  std::vector<krpc::encoder::Value> _args;
   _args.push_back(encoder::encode(x));
   return this->_client->build_call("TestService", "EnumDefaultArg", _args);
 }
 
 inline ::krpc::schema::ProcedureCall TestService::enum_echo_call(TestService::TestEnum x) {
-  std::vector<std::string> _args;
+  std::vector<krpc::encoder::Value> _args;
   _args.push_back(encoder::encode(x));
   return this->_client->build_call("TestService", "EnumEcho", _args);
 }
@@ -1444,84 +1492,84 @@ inline ::krpc::schema::ProcedureCall TestService::enum_return_call() {
 }
 
 inline ::krpc::schema::ProcedureCall TestService::float_to_string_call(float value) {
-  std::vector<std::string> _args;
+  std::vector<krpc::encoder::Value> _args;
   _args.push_back(encoder::encode(value));
   return this->_client->build_call("TestService", "FloatToString", _args);
 }
 
 inline ::krpc::schema::ProcedureCall TestService::increment_dictionary_call(std::map<std::string, int32_t> d) {
-  std::vector<std::string> _args;
+  std::vector<krpc::encoder::Value> _args;
   _args.push_back(encoder::encode(d));
   return this->_client->build_call("TestService", "IncrementDictionary", _args);
 }
 
 inline ::krpc::schema::ProcedureCall TestService::increment_list_call(std::vector<int32_t> l) {
-  std::vector<std::string> _args;
+  std::vector<krpc::encoder::Value> _args;
   _args.push_back(encoder::encode(l));
   return this->_client->build_call("TestService", "IncrementList", _args);
 }
 
 inline ::krpc::schema::ProcedureCall TestService::increment_nested_collection_call(std::map<std::string, std::vector<int32_t> > d) {
-  std::vector<std::string> _args;
+  std::vector<krpc::encoder::Value> _args;
   _args.push_back(encoder::encode(d));
   return this->_client->build_call("TestService", "IncrementNestedCollection", _args);
 }
 
 inline ::krpc::schema::ProcedureCall TestService::increment_set_call(std::set<int32_t> h) {
-  std::vector<std::string> _args;
+  std::vector<krpc::encoder::Value> _args;
   _args.push_back(encoder::encode(h));
   return this->_client->build_call("TestService", "IncrementSet", _args);
 }
 
 inline ::krpc::schema::ProcedureCall TestService::increment_tuple_call(std::tuple<int32_t, int64_t> t) {
-  std::vector<std::string> _args;
+  std::vector<krpc::encoder::Value> _args;
   _args.push_back(encoder::encode(t));
   return this->_client->build_call("TestService", "IncrementTuple", _args);
 }
 
 inline ::krpc::schema::ProcedureCall TestService::int32_to_string_call(int32_t value) {
-  std::vector<std::string> _args;
+  std::vector<krpc::encoder::Value> _args;
   _args.push_back(encoder::encode(value));
   return this->_client->build_call("TestService", "Int32ToString", _args);
 }
 
 inline ::krpc::schema::ProcedureCall TestService::int64_to_string_call(int64_t value) {
-  std::vector<std::string> _args;
+  std::vector<krpc::encoder::Value> _args;
   _args.push_back(encoder::encode(value));
   return this->_client->build_call("TestService", "Int64ToString", _args);
 }
 
 inline ::krpc::schema::ProcedureCall TestService::list_default_call(std::vector<int32_t> x = std::vector<int32_t>{1, 2, 3}) {
-  std::vector<std::string> _args;
+  std::vector<krpc::encoder::Value> _args;
   _args.push_back(encoder::encode(x));
   return this->_client->build_call("TestService", "ListDefault", _args);
 }
 
 inline ::krpc::schema::ProcedureCall TestService::not_nullable_object_call(TestService::TestClass value) {
-  std::vector<std::string> _args;
+  std::vector<krpc::encoder::Value> _args;
   _args.push_back(encoder::encode(value));
   return this->_client->build_call("TestService", "NotNullableObject", _args);
 }
 
 inline ::krpc::schema::ProcedureCall TestService::on_timer_call(uint32_t milliseconds, uint32_t repeats = 1) {
-  std::vector<std::string> _args;
+  std::vector<krpc::encoder::Value> _args;
   _args.push_back(encoder::encode(milliseconds));
   _args.push_back(encoder::encode(repeats));
   return this->_client->build_call("TestService", "OnTimer", _args);
 }
 
 inline ::krpc::schema::ProcedureCall TestService::on_timer_using_lambda_call(uint32_t milliseconds) {
-  std::vector<std::string> _args;
+  std::vector<krpc::encoder::Value> _args;
   _args.push_back(encoder::encode(milliseconds));
   return this->_client->build_call("TestService", "OnTimerUsingLambda", _args);
 }
 
 inline ::krpc::schema::ProcedureCall TestService::optional_arguments_call(std::string x, std::string y = "foo", std::string z = "bar", TestService::TestClass obj = TestService::TestClass()) {
-  std::vector<std::string> _args;
+  std::vector<krpc::encoder::Value> _args;
   _args.push_back(encoder::encode(x));
   _args.push_back(encoder::encode(y));
   _args.push_back(encoder::encode(z));
-  _args.push_back(encoder::encode(obj));
+  _args.push_back(encoder::encode_nullable(obj));
   return this->_client->build_call("TestService", "OptionalArguments", _args);
 }
 
@@ -1538,13 +1586,13 @@ inline ::krpc::schema::ProcedureCall TestService::return_null_when_not_allowed_c
 }
 
 inline ::krpc::schema::ProcedureCall TestService::set_default_call(std::set<int32_t> x = std::set<int32_t>{1, 2, 3}) {
-  std::vector<std::string> _args;
+  std::vector<krpc::encoder::Value> _args;
   _args.push_back(encoder::encode(x));
   return this->_client->build_call("TestService", "SetDefault", _args);
 }
 
 inline ::krpc::schema::ProcedureCall TestService::string_to_int32_call(std::string value) {
-  std::vector<std::string> _args;
+  std::vector<krpc::encoder::Value> _args;
   _args.push_back(encoder::encode(value));
   return this->_client->build_call("TestService", "StringToInt32", _args);
 }
@@ -1554,13 +1602,13 @@ inline ::krpc::schema::ProcedureCall TestService::throw_argument_exception_call(
 }
 
 inline ::krpc::schema::ProcedureCall TestService::throw_argument_null_exception_call(std::string foo) {
-  std::vector<std::string> _args;
+  std::vector<krpc::encoder::Value> _args;
   _args.push_back(encoder::encode(foo));
   return this->_client->build_call("TestService", "ThrowArgumentNullException", _args);
 }
 
 inline ::krpc::schema::ProcedureCall TestService::throw_argument_out_of_range_exception_call(int32_t foo) {
-  std::vector<std::string> _args;
+  std::vector<krpc::encoder::Value> _args;
   _args.push_back(encoder::encode(foo));
   return this->_client->build_call("TestService", "ThrowArgumentOutOfRangeException", _args);
 }
@@ -1582,7 +1630,7 @@ inline ::krpc::schema::ProcedureCall TestService::throw_invalid_operation_except
 }
 
 inline ::krpc::schema::ProcedureCall TestService::tuple_default_call(std::tuple<int32_t, bool> x = std::tuple<int32_t, bool>{1, false}) {
-  std::vector<std::string> _args;
+  std::vector<krpc::encoder::Value> _args;
   _args.push_back(encoder::encode(x));
   return this->_client->build_call("TestService", "TupleDefault", _args);
 }
@@ -1592,7 +1640,7 @@ inline ::krpc::schema::ProcedureCall TestService::deprecated_property_call() {
 }
 
 inline ::krpc::schema::ProcedureCall TestService::set_deprecated_property_call(std::string value) {
-  std::vector<std::string> _args;
+  std::vector<krpc::encoder::Value> _args;
   _args.push_back(encoder::encode(value));
   return this->_client->build_call("TestService", "set_DeprecatedProperty", _args);
 }
@@ -1602,8 +1650,8 @@ inline ::krpc::schema::ProcedureCall TestService::nullable_object_call() {
 }
 
 inline ::krpc::schema::ProcedureCall TestService::set_nullable_object_call(TestService::TestClass value) {
-  std::vector<std::string> _args;
-  _args.push_back(encoder::encode(value));
+  std::vector<krpc::encoder::Value> _args;
+  _args.push_back(encoder::encode_nullable(value));
   return this->_client->build_call("TestService", "set_NullableObject", _args);
 }
 
@@ -1612,8 +1660,8 @@ inline ::krpc::schema::ProcedureCall TestService::object_property_call() {
 }
 
 inline ::krpc::schema::ProcedureCall TestService::set_object_property_call(TestService::TestClass value) {
-  std::vector<std::string> _args;
-  _args.push_back(encoder::encode(value));
+  std::vector<krpc::encoder::Value> _args;
+  _args.push_back(encoder::encode_nullable(value));
   return this->_client->build_call("TestService", "set_ObjectProperty", _args);
 }
 
@@ -1622,13 +1670,13 @@ inline ::krpc::schema::ProcedureCall TestService::string_property_call() {
 }
 
 inline ::krpc::schema::ProcedureCall TestService::set_string_property_call(std::string value) {
-  std::vector<std::string> _args;
+  std::vector<krpc::encoder::Value> _args;
   _args.push_back(encoder::encode(value));
   return this->_client->build_call("TestService", "set_StringProperty", _args);
 }
 
 inline ::krpc::schema::ProcedureCall TestService::set_string_property_private_get_call(std::string value) {
-  std::vector<std::string> _args;
+  std::vector<krpc::encoder::Value> _args;
   _args.push_back(encoder::encode(value));
   return this->_client->build_call("TestService", "set_StringPropertyPrivateGet", _args);
 }
@@ -1641,22 +1689,23 @@ inline TestService::DeprecatedClass::DeprecatedClass(Client* client, uint64_t id
   Object(client, "TestService::DeprecatedClass", id) {}
 
 inline std::string TestService::DeprecatedClass::deprecated_method() {
-  std::vector<std::string> _args;
+  std::vector<krpc::encoder::Value> _args;
   _args.push_back(encoder::encode(*this));
-  std::string _data = this->_client->invoke("TestService", "DeprecatedClass_DeprecatedMethod", _args);
-  std::string _result;
-  decoder::decode(_result, _data, this->_client);
+  auto _data = this->_client->invoke("TestService", "DeprecatedClass_DeprecatedMethod", _args);
+  std::string _result{};
+  if (!_data.is_null())
+    decoder::decode(_result, _data.value(), this->_client);
   return _result;
 }
 
 inline ::krpc::Stream<std::string> TestService::DeprecatedClass::deprecated_method_stream() {
-  std::vector<std::string> _args;
+  std::vector<krpc::encoder::Value> _args;
   _args.push_back(encoder::encode(*this));
   return ::krpc::Stream<std::string>(this->_client, this->_client->build_call("TestService", "DeprecatedClass_DeprecatedMethod", _args));
 }
 
 inline ::krpc::schema::ProcedureCall TestService::DeprecatedClass::deprecated_method_call() {
-  std::vector<std::string> _args;
+  std::vector<krpc::encoder::Value> _args;
   _args.push_back(encoder::encode(*this));
   return this->_client->build_call("TestService", "DeprecatedClass_DeprecatedMethod", _args);
 }
@@ -1665,278 +1714,288 @@ inline TestService::TestClass::TestClass(Client* client, uint64_t id):
   Object(client, "TestService::TestClass", id) {}
 
 inline TestService::TestClass TestService::TestClass::echo_nullable_object(TestService::TestClass value) {
-  std::vector<std::string> _args;
+  std::vector<krpc::encoder::Value> _args;
   _args.push_back(encoder::encode(*this));
-  _args.push_back(encoder::encode(value));
-  std::string _data = this->_client->invoke("TestService", "TestClass_EchoNullableObject", _args);
-  TestService::TestClass _result;
-  decoder::decode(_result, _data, this->_client);
+  _args.push_back(encoder::encode_nullable(value));
+  auto _data = this->_client->invoke("TestService", "TestClass_EchoNullableObject", _args);
+  TestService::TestClass _result{};
+  if (!_data.is_null())
+    decoder::decode(_result, _data.value(), this->_client);
   return _result;
 }
 
 inline std::string TestService::TestClass::float_to_string(float x) {
-  std::vector<std::string> _args;
+  std::vector<krpc::encoder::Value> _args;
   _args.push_back(encoder::encode(*this));
   _args.push_back(encoder::encode(x));
-  std::string _data = this->_client->invoke("TestService", "TestClass_FloatToString", _args);
-  std::string _result;
-  decoder::decode(_result, _data, this->_client);
+  auto _data = this->_client->invoke("TestService", "TestClass_FloatToString", _args);
+  std::string _result{};
+  if (!_data.is_null())
+    decoder::decode(_result, _data.value(), this->_client);
   return _result;
 }
 
 inline std::string TestService::TestClass::get_value() {
-  std::vector<std::string> _args;
+  std::vector<krpc::encoder::Value> _args;
   _args.push_back(encoder::encode(*this));
-  std::string _data = this->_client->invoke("TestService", "TestClass_GetValue", _args);
-  std::string _result;
-  decoder::decode(_result, _data, this->_client);
+  auto _data = this->_client->invoke("TestService", "TestClass_GetValue", _args);
+  std::string _result{};
+  if (!_data.is_null())
+    decoder::decode(_result, _data.value(), this->_client);
   return _result;
 }
 
 inline std::string TestService::TestClass::object_to_string(TestService::TestClass other) {
-  std::vector<std::string> _args;
+  std::vector<krpc::encoder::Value> _args;
   _args.push_back(encoder::encode(*this));
-  _args.push_back(encoder::encode(other));
-  std::string _data = this->_client->invoke("TestService", "TestClass_ObjectToString", _args);
-  std::string _result;
-  decoder::decode(_result, _data, this->_client);
+  _args.push_back(encoder::encode_nullable(other));
+  auto _data = this->_client->invoke("TestService", "TestClass_ObjectToString", _args);
+  std::string _result{};
+  if (!_data.is_null())
+    decoder::decode(_result, _data.value(), this->_client);
   return _result;
 }
 
 inline std::string TestService::TestClass::optional_arguments(std::string x, std::string y = "foo", std::string z = "bar", TestService::TestClass obj = TestService::TestClass()) {
-  std::vector<std::string> _args;
+  std::vector<krpc::encoder::Value> _args;
   _args.push_back(encoder::encode(*this));
   _args.push_back(encoder::encode(x));
   _args.push_back(encoder::encode(y));
   _args.push_back(encoder::encode(z));
-  _args.push_back(encoder::encode(obj));
-  std::string _data = this->_client->invoke("TestService", "TestClass_OptionalArguments", _args);
-  std::string _result;
-  decoder::decode(_result, _data, this->_client);
+  _args.push_back(encoder::encode_nullable(obj));
+  auto _data = this->_client->invoke("TestService", "TestClass_OptionalArguments", _args);
+  std::string _result{};
+  if (!_data.is_null())
+    decoder::decode(_result, _data.value(), this->_client);
   return _result;
 }
 
 inline int32_t TestService::TestClass::int_property() {
-  std::vector<std::string> _args;
+  std::vector<krpc::encoder::Value> _args;
   _args.push_back(encoder::encode(*this));
-  std::string _data = this->_client->invoke("TestService", "TestClass_get_IntProperty", _args);
-  int32_t _result;
-  decoder::decode(_result, _data, this->_client);
+  auto _data = this->_client->invoke("TestService", "TestClass_get_IntProperty", _args);
+  int32_t _result{};
+  if (!_data.is_null())
+    decoder::decode(_result, _data.value(), this->_client);
   return _result;
 }
 
 inline void TestService::TestClass::set_int_property(int32_t value) {
-  std::vector<std::string> _args;
+  std::vector<krpc::encoder::Value> _args;
   _args.push_back(encoder::encode(*this));
   _args.push_back(encoder::encode(value));
   this->_client->invoke("TestService", "TestClass_set_IntProperty", _args);
 }
 
 inline TestService::TestClass TestService::TestClass::object_property() {
-  std::vector<std::string> _args;
+  std::vector<krpc::encoder::Value> _args;
   _args.push_back(encoder::encode(*this));
-  std::string _data = this->_client->invoke("TestService", "TestClass_get_ObjectProperty", _args);
-  TestService::TestClass _result;
-  decoder::decode(_result, _data, this->_client);
+  auto _data = this->_client->invoke("TestService", "TestClass_get_ObjectProperty", _args);
+  TestService::TestClass _result{};
+  if (!_data.is_null())
+    decoder::decode(_result, _data.value(), this->_client);
   return _result;
 }
 
 inline void TestService::TestClass::set_object_property(TestService::TestClass value) {
-  std::vector<std::string> _args;
+  std::vector<krpc::encoder::Value> _args;
   _args.push_back(encoder::encode(*this));
-  _args.push_back(encoder::encode(value));
+  _args.push_back(encoder::encode_nullable(value));
   this->_client->invoke("TestService", "TestClass_set_ObjectProperty", _args);
 }
 
 inline void TestService::TestClass::set_string_property_private_get(std::string value) {
-  std::vector<std::string> _args;
+  std::vector<krpc::encoder::Value> _args;
   _args.push_back(encoder::encode(*this));
   _args.push_back(encoder::encode(value));
   this->_client->invoke("TestService", "TestClass_set_StringPropertyPrivateGet", _args);
 }
 
 inline std::string TestService::TestClass::string_property_private_set() {
-  std::vector<std::string> _args;
+  std::vector<krpc::encoder::Value> _args;
   _args.push_back(encoder::encode(*this));
-  std::string _data = this->_client->invoke("TestService", "TestClass_get_StringPropertyPrivateSet", _args);
-  std::string _result;
-  decoder::decode(_result, _data, this->_client);
+  auto _data = this->_client->invoke("TestService", "TestClass_get_StringPropertyPrivateSet", _args);
+  std::string _result{};
+  if (!_data.is_null())
+    decoder::decode(_result, _data.value(), this->_client);
   return _result;
 }
 
 inline std::string TestService::TestClass::static_method(Client& _client, std::string a = "", std::string b = "") {
-    std::vector<std::string> _args;
+    std::vector<krpc::encoder::Value> _args;
   _args.push_back(encoder::encode(a));
   _args.push_back(encoder::encode(b));
-  std::string _data = _client.invoke("TestService", "TestClass_static_StaticMethod", _args);
-    std::string _result;
-  decoder::decode(_result, _data, &_client);
+  auto _data = _client.invoke("TestService", "TestClass_static_StaticMethod", _args);
+    std::string _result{};
+  if (!_data.is_null())
+    decoder::decode(_result, _data.value(), &_client);
   return _result;
 }
 
 inline TestService::TestClass TestService::TestClass::static_nullable_object(Client& _client, TestService::TestClass value) {
-    std::vector<std::string> _args;
-  _args.push_back(encoder::encode(value));
-  std::string _data = _client.invoke("TestService", "TestClass_static_StaticNullableObject", _args);
-    TestService::TestClass _result;
-  decoder::decode(_result, _data, &_client);
+    std::vector<krpc::encoder::Value> _args;
+  _args.push_back(encoder::encode_nullable(value));
+  auto _data = _client.invoke("TestService", "TestClass_static_StaticNullableObject", _args);
+    TestService::TestClass _result{};
+  if (!_data.is_null())
+    decoder::decode(_result, _data.value(), &_client);
   return _result;
 }
 
 inline ::krpc::Stream<TestService::TestClass> TestService::TestClass::echo_nullable_object_stream(TestService::TestClass value) {
-  std::vector<std::string> _args;
+  std::vector<krpc::encoder::Value> _args;
   _args.push_back(encoder::encode(*this));
-  _args.push_back(encoder::encode(value));
+  _args.push_back(encoder::encode_nullable(value));
   return ::krpc::Stream<TestService::TestClass>(this->_client, this->_client->build_call("TestService", "TestClass_EchoNullableObject", _args));
 }
 
 inline ::krpc::Stream<std::string> TestService::TestClass::float_to_string_stream(float x) {
-  std::vector<std::string> _args;
+  std::vector<krpc::encoder::Value> _args;
   _args.push_back(encoder::encode(*this));
   _args.push_back(encoder::encode(x));
   return ::krpc::Stream<std::string>(this->_client, this->_client->build_call("TestService", "TestClass_FloatToString", _args));
 }
 
 inline ::krpc::Stream<std::string> TestService::TestClass::get_value_stream() {
-  std::vector<std::string> _args;
+  std::vector<krpc::encoder::Value> _args;
   _args.push_back(encoder::encode(*this));
   return ::krpc::Stream<std::string>(this->_client, this->_client->build_call("TestService", "TestClass_GetValue", _args));
 }
 
 inline ::krpc::Stream<std::string> TestService::TestClass::object_to_string_stream(TestService::TestClass other) {
-  std::vector<std::string> _args;
+  std::vector<krpc::encoder::Value> _args;
   _args.push_back(encoder::encode(*this));
-  _args.push_back(encoder::encode(other));
+  _args.push_back(encoder::encode_nullable(other));
   return ::krpc::Stream<std::string>(this->_client, this->_client->build_call("TestService", "TestClass_ObjectToString", _args));
 }
 
 inline ::krpc::Stream<std::string> TestService::TestClass::optional_arguments_stream(std::string x, std::string y = "foo", std::string z = "bar", TestService::TestClass obj = TestService::TestClass()) {
-  std::vector<std::string> _args;
+  std::vector<krpc::encoder::Value> _args;
   _args.push_back(encoder::encode(*this));
   _args.push_back(encoder::encode(x));
   _args.push_back(encoder::encode(y));
   _args.push_back(encoder::encode(z));
-  _args.push_back(encoder::encode(obj));
+  _args.push_back(encoder::encode_nullable(obj));
   return ::krpc::Stream<std::string>(this->_client, this->_client->build_call("TestService", "TestClass_OptionalArguments", _args));
 }
 
 inline ::krpc::Stream<int32_t> TestService::TestClass::int_property_stream() {
-  std::vector<std::string> _args;
+  std::vector<krpc::encoder::Value> _args;
   _args.push_back(encoder::encode(*this));
   return ::krpc::Stream<int32_t>(this->_client, this->_client->build_call("TestService", "TestClass_get_IntProperty", _args));
 }
 
 inline ::krpc::Stream<TestService::TestClass> TestService::TestClass::object_property_stream() {
-  std::vector<std::string> _args;
+  std::vector<krpc::encoder::Value> _args;
   _args.push_back(encoder::encode(*this));
   return ::krpc::Stream<TestService::TestClass>(this->_client, this->_client->build_call("TestService", "TestClass_get_ObjectProperty", _args));
 }
 
 inline ::krpc::Stream<std::string> TestService::TestClass::string_property_private_set_stream() {
-  std::vector<std::string> _args;
+  std::vector<krpc::encoder::Value> _args;
   _args.push_back(encoder::encode(*this));
   return ::krpc::Stream<std::string>(this->_client, this->_client->build_call("TestService", "TestClass_get_StringPropertyPrivateSet", _args));
 }
 
 inline ::krpc::Stream<std::string> TestService::TestClass::static_method_stream(Client& _client, std::string a = "", std::string b = "") {
-  std::vector<std::string> _args;
+  std::vector<krpc::encoder::Value> _args;
   _args.push_back(encoder::encode(a));
   _args.push_back(encoder::encode(b));
   return ::krpc::Stream<std::string>(&_client, _client.build_call("TestService", "TestClass_static_StaticMethod", _args));
 }
 
 inline ::krpc::Stream<TestService::TestClass> TestService::TestClass::static_nullable_object_stream(Client& _client, TestService::TestClass value) {
-  std::vector<std::string> _args;
-  _args.push_back(encoder::encode(value));
+  std::vector<krpc::encoder::Value> _args;
+  _args.push_back(encoder::encode_nullable(value));
   return ::krpc::Stream<TestService::TestClass>(&_client, _client.build_call("TestService", "TestClass_static_StaticNullableObject", _args));
 }
 
 inline ::krpc::schema::ProcedureCall TestService::TestClass::echo_nullable_object_call(TestService::TestClass value) {
-  std::vector<std::string> _args;
+  std::vector<krpc::encoder::Value> _args;
   _args.push_back(encoder::encode(*this));
-  _args.push_back(encoder::encode(value));
+  _args.push_back(encoder::encode_nullable(value));
   return this->_client->build_call("TestService", "TestClass_EchoNullableObject", _args);
 }
 
 inline ::krpc::schema::ProcedureCall TestService::TestClass::float_to_string_call(float x) {
-  std::vector<std::string> _args;
+  std::vector<krpc::encoder::Value> _args;
   _args.push_back(encoder::encode(*this));
   _args.push_back(encoder::encode(x));
   return this->_client->build_call("TestService", "TestClass_FloatToString", _args);
 }
 
 inline ::krpc::schema::ProcedureCall TestService::TestClass::get_value_call() {
-  std::vector<std::string> _args;
+  std::vector<krpc::encoder::Value> _args;
   _args.push_back(encoder::encode(*this));
   return this->_client->build_call("TestService", "TestClass_GetValue", _args);
 }
 
 inline ::krpc::schema::ProcedureCall TestService::TestClass::object_to_string_call(TestService::TestClass other) {
-  std::vector<std::string> _args;
+  std::vector<krpc::encoder::Value> _args;
   _args.push_back(encoder::encode(*this));
-  _args.push_back(encoder::encode(other));
+  _args.push_back(encoder::encode_nullable(other));
   return this->_client->build_call("TestService", "TestClass_ObjectToString", _args);
 }
 
 inline ::krpc::schema::ProcedureCall TestService::TestClass::optional_arguments_call(std::string x, std::string y = "foo", std::string z = "bar", TestService::TestClass obj = TestService::TestClass()) {
-  std::vector<std::string> _args;
+  std::vector<krpc::encoder::Value> _args;
   _args.push_back(encoder::encode(*this));
   _args.push_back(encoder::encode(x));
   _args.push_back(encoder::encode(y));
   _args.push_back(encoder::encode(z));
-  _args.push_back(encoder::encode(obj));
+  _args.push_back(encoder::encode_nullable(obj));
   return this->_client->build_call("TestService", "TestClass_OptionalArguments", _args);
 }
 
 inline ::krpc::schema::ProcedureCall TestService::TestClass::int_property_call() {
-  std::vector<std::string> _args;
+  std::vector<krpc::encoder::Value> _args;
   _args.push_back(encoder::encode(*this));
   return this->_client->build_call("TestService", "TestClass_get_IntProperty", _args);
 }
 
 inline ::krpc::schema::ProcedureCall TestService::TestClass::set_int_property_call(int32_t value) {
-  std::vector<std::string> _args;
+  std::vector<krpc::encoder::Value> _args;
   _args.push_back(encoder::encode(*this));
   _args.push_back(encoder::encode(value));
   return this->_client->build_call("TestService", "TestClass_set_IntProperty", _args);
 }
 
 inline ::krpc::schema::ProcedureCall TestService::TestClass::object_property_call() {
-  std::vector<std::string> _args;
+  std::vector<krpc::encoder::Value> _args;
   _args.push_back(encoder::encode(*this));
   return this->_client->build_call("TestService", "TestClass_get_ObjectProperty", _args);
 }
 
 inline ::krpc::schema::ProcedureCall TestService::TestClass::set_object_property_call(TestService::TestClass value) {
-  std::vector<std::string> _args;
+  std::vector<krpc::encoder::Value> _args;
   _args.push_back(encoder::encode(*this));
-  _args.push_back(encoder::encode(value));
+  _args.push_back(encoder::encode_nullable(value));
   return this->_client->build_call("TestService", "TestClass_set_ObjectProperty", _args);
 }
 
 inline ::krpc::schema::ProcedureCall TestService::TestClass::set_string_property_private_get_call(std::string value) {
-  std::vector<std::string> _args;
+  std::vector<krpc::encoder::Value> _args;
   _args.push_back(encoder::encode(*this));
   _args.push_back(encoder::encode(value));
   return this->_client->build_call("TestService", "TestClass_set_StringPropertyPrivateGet", _args);
 }
 
 inline ::krpc::schema::ProcedureCall TestService::TestClass::string_property_private_set_call() {
-  std::vector<std::string> _args;
+  std::vector<krpc::encoder::Value> _args;
   _args.push_back(encoder::encode(*this));
   return this->_client->build_call("TestService", "TestClass_get_StringPropertyPrivateSet", _args);
 }
 
 inline ::krpc::schema::ProcedureCall TestService::TestClass::static_method_call(Client& _client, std::string a = "", std::string b = "") {
-  std::vector<std::string> _args;
+  std::vector<krpc::encoder::Value> _args;
   _args.push_back(encoder::encode(a));
   _args.push_back(encoder::encode(b));
   return _client.build_call("TestService", "TestClass_static_StaticMethod", _args);
 }
 
 inline ::krpc::schema::ProcedureCall TestService::TestClass::static_nullable_object_call(Client& _client, TestService::TestClass value) {
-  std::vector<std::string> _args;
-  _args.push_back(encoder::encode(value));
+  std::vector<krpc::encoder::Value> _args;
+  _args.push_back(encoder::encode_nullable(value));
   return _client.build_call("TestService", "TestClass_static_StaticNullableObject", _args);
 }
 }  // namespace services

--- a/tools/krpctools/krpctools/test/clientgen-TestService-csharp.txt
+++ b/tools/krpctools/krpctools/test/clientgen-TestService-csharp.txt
@@ -173,6 +173,36 @@ namespace KRPC.Client.Services.TestService
             return (string)global::KRPC.Client.Encoder.Decode (_data, typeof(string), connection);
         }
 
+        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "EchoNullableInt")]
+        public int EchoNullableInt (int value)
+        {
+            var _args = new ByteString[] {
+                global::KRPC.Client.Encoder.Encode (value, typeof(int))
+            };
+            ByteString _data = connection.Invoke ("TestService", "EchoNullableInt", _args);
+            return (int)global::KRPC.Client.Encoder.Decode (_data, typeof(int), connection);
+        }
+
+        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "EchoNullableList")]
+        public global::System.Collections.Generic.IList<int> EchoNullableList (global::System.Collections.Generic.IList<int> l)
+        {
+            var _args = new ByteString[] {
+                global::KRPC.Client.Encoder.Encode (l, typeof(global::System.Collections.Generic.IList<int>))
+            };
+            ByteString _data = connection.Invoke ("TestService", "EchoNullableList", _args);
+            return (global::System.Collections.Generic.IList<int>)global::KRPC.Client.Encoder.Decode (_data, typeof(global::System.Collections.Generic.IList<int>), connection);
+        }
+
+        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "EchoNullableString")]
+        public string EchoNullableString (string value)
+        {
+            var _args = new ByteString[] {
+                global::KRPC.Client.Encoder.Encode (value, typeof(string))
+            };
+            ByteString _data = connection.Invoke ("TestService", "EchoNullableString", _args);
+            return (string)global::KRPC.Client.Encoder.Decode (_data, typeof(string), connection);
+        }
+
         [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "EchoTestObject")]
         public global::KRPC.Client.Services.TestService.TestClass EchoTestObject (global::KRPC.Client.Services.TestService.TestClass value)
         {
@@ -181,6 +211,16 @@ namespace KRPC.Client.Services.TestService
             };
             ByteString _data = connection.Invoke ("TestService", "EchoTestObject", _args);
             return (global::KRPC.Client.Services.TestService.TestClass)global::KRPC.Client.Encoder.Decode (_data, typeof(global::KRPC.Client.Services.TestService.TestClass), connection);
+        }
+
+        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "EmptyListDefault")]
+        public global::System.Collections.Generic.IList<string> EmptyListDefault (global::System.Collections.Generic.IList<string> x = null)
+        {
+            var _args = new ByteString[] {
+                global::KRPC.Client.Encoder.Encode (x ?? new global::System.Collections.Generic.List<string> {  }, typeof(global::System.Collections.Generic.IList<string>))
+            };
+            ByteString _data = connection.Invoke ("TestService", "EmptyListDefault", _args);
+            return (global::System.Collections.Generic.IList<string>)global::KRPC.Client.Encoder.Decode (_data, typeof(global::System.Collections.Generic.IList<string>), connection);
         }
 
         [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "EnumDefaultArg")]
@@ -301,6 +341,16 @@ namespace KRPC.Client.Services.TestService
             };
             ByteString _data = connection.Invoke ("TestService", "ListDefault", _args);
             return (global::System.Collections.Generic.IList<int>)global::KRPC.Client.Encoder.Decode (_data, typeof(global::System.Collections.Generic.IList<int>), connection);
+        }
+
+        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "NotNullableObject")]
+        public global::KRPC.Client.Services.TestService.TestClass NotNullableObject (global::KRPC.Client.Services.TestService.TestClass value)
+        {
+            var _args = new ByteString[] {
+                global::KRPC.Client.Encoder.Encode (value, typeof(global::KRPC.Client.Services.TestService.TestClass))
+            };
+            ByteString _data = connection.Invoke ("TestService", "NotNullableObject", _args);
+            return (global::KRPC.Client.Services.TestService.TestClass)global::KRPC.Client.Encoder.Decode (_data, typeof(global::KRPC.Client.Services.TestService.TestClass), connection);
         }
 
         [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "OnTimer")]
@@ -456,6 +506,20 @@ namespace KRPC.Client.Services.TestService
                     global::KRPC.Client.Encoder.Encode (value, typeof(string))
                 };
                 connection.Invoke ("TestService", "set_DeprecatedProperty", _args);
+            }
+        }
+
+        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "get_NullableObject")]
+        public global::KRPC.Client.Services.TestService.TestClass NullableObject {
+            get {
+                ByteString _data = connection.Invoke ("TestService", "get_NullableObject");
+                return (global::KRPC.Client.Services.TestService.TestClass)global::KRPC.Client.Encoder.Decode (_data, typeof(global::KRPC.Client.Services.TestService.TestClass), connection);
+            }
+            set {
+                var _args = new ByteString[] {
+                    global::KRPC.Client.Encoder.Encode (value, typeof(global::KRPC.Client.Services.TestService.TestClass))
+                };
+                connection.Invoke ("TestService", "set_NullableObject", _args);
             }
         }
 
@@ -658,6 +722,17 @@ namespace KRPC.Client.Services.TestService
         {
         }
 
+        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "TestClass_EchoNullableObject")]
+        public global::KRPC.Client.Services.TestService.TestClass EchoNullableObject (global::KRPC.Client.Services.TestService.TestClass value)
+        {
+            var _args = new ByteString[] {
+                global::KRPC.Client.Encoder.Encode (this, typeof(TestService.TestClass)),
+                global::KRPC.Client.Encoder.Encode (value, typeof(global::KRPC.Client.Services.TestService.TestClass))
+            };
+            ByteString _data = connection.Invoke ("TestService", "TestClass_EchoNullableObject", _args);
+            return (global::KRPC.Client.Services.TestService.TestClass)global::KRPC.Client.Encoder.Decode (_data, typeof(global::KRPC.Client.Services.TestService.TestClass), connection);
+        }
+
         [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "TestClass_FloatToString")]
         public string FloatToString (float x)
         {
@@ -719,6 +794,19 @@ namespace KRPC.Client.Services.TestService
             };
             ByteString _data = connection.Invoke ("TestService", "TestClass_static_StaticMethod", _args);
             return (string)global::KRPC.Client.Encoder.Decode (_data, typeof(string), connection);
+        }
+
+        /// <param name="connection">A connection object.</param>
+        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "TestClass_static_StaticNullableObject")]
+        public static global::KRPC.Client.Services.TestService.TestClass StaticNullableObject (IConnection connection, global::KRPC.Client.Services.TestService.TestClass value)
+        {
+            if (connection == null)
+                throw new ArgumentNullException (nameof (connection));
+            var _args = new ByteString[] {
+                global::KRPC.Client.Encoder.Encode (value, typeof(global::KRPC.Client.Services.TestService.TestClass))
+            };
+            ByteString _data = connection.Invoke ("TestService", "TestClass_static_StaticNullableObject", _args);
+            return (global::KRPC.Client.Services.TestService.TestClass)global::KRPC.Client.Encoder.Decode (_data, typeof(global::KRPC.Client.Services.TestService.TestClass), connection);
         }
 
         /// <summary>

--- a/tools/krpctools/krpctools/test/clientgen-TestService-csharp.txt
+++ b/tools/krpctools/krpctools/test/clientgen-TestService-csharp.txt
@@ -58,8 +58,8 @@ namespace KRPC.Client.Services.TestService
                 global::KRPC.Client.Encoder.Encode (y, typeof(int)),
                 global::KRPC.Client.Encoder.Encode (z, typeof(long))
             };
-            ByteString _data = connection.Invoke ("TestService", "AddMultipleValues", _args);
-            return (string)global::KRPC.Client.Encoder.Decode (_data, typeof(string), connection);
+            var _result = connection.Invoke ("TestService", "AddMultipleValues", _args);
+            return (string)global::KRPC.Client.Encoder.Decode (_result.Value, typeof(string), connection);
         }
 
         [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "AddToObjectList")]
@@ -69,8 +69,8 @@ namespace KRPC.Client.Services.TestService
                 global::KRPC.Client.Encoder.Encode (l, typeof(global::System.Collections.Generic.IList<global::KRPC.Client.Services.TestService.TestClass>)),
                 global::KRPC.Client.Encoder.Encode (value, typeof(string))
             };
-            ByteString _data = connection.Invoke ("TestService", "AddToObjectList", _args);
-            return (global::System.Collections.Generic.IList<global::KRPC.Client.Services.TestService.TestClass>)global::KRPC.Client.Encoder.Decode (_data, typeof(global::System.Collections.Generic.IList<global::KRPC.Client.Services.TestService.TestClass>), connection);
+            var _result = connection.Invoke ("TestService", "AddToObjectList", _args);
+            return (global::System.Collections.Generic.IList<global::KRPC.Client.Services.TestService.TestClass>)global::KRPC.Client.Encoder.Decode (_result.Value, typeof(global::System.Collections.Generic.IList<global::KRPC.Client.Services.TestService.TestClass>), connection);
         }
 
         [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "BlockingProcedure")]
@@ -80,8 +80,8 @@ namespace KRPC.Client.Services.TestService
                 global::KRPC.Client.Encoder.Encode (n, typeof(int)),
                 global::KRPC.Client.Encoder.Encode (sum, typeof(int))
             };
-            ByteString _data = connection.Invoke ("TestService", "BlockingProcedure", _args);
-            return (int)global::KRPC.Client.Encoder.Decode (_data, typeof(int), connection);
+            var _result = connection.Invoke ("TestService", "BlockingProcedure", _args);
+            return (int)global::KRPC.Client.Encoder.Decode (_result.Value, typeof(int), connection);
         }
 
         [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "BoolToString")]
@@ -90,8 +90,8 @@ namespace KRPC.Client.Services.TestService
             var _args = new ByteString[] {
                 global::KRPC.Client.Encoder.Encode (value, typeof(bool))
             };
-            ByteString _data = connection.Invoke ("TestService", "BoolToString", _args);
-            return (string)global::KRPC.Client.Encoder.Decode (_data, typeof(string), connection);
+            var _result = connection.Invoke ("TestService", "BoolToString", _args);
+            return (string)global::KRPC.Client.Encoder.Decode (_result.Value, typeof(string), connection);
         }
 
         [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "BytesToHexString")]
@@ -100,8 +100,8 @@ namespace KRPC.Client.Services.TestService
             var _args = new ByteString[] {
                 global::KRPC.Client.Encoder.Encode (value, typeof(byte[]))
             };
-            ByteString _data = connection.Invoke ("TestService", "BytesToHexString", _args);
-            return (string)global::KRPC.Client.Encoder.Decode (_data, typeof(string), connection);
+            var _result = connection.Invoke ("TestService", "BytesToHexString", _args);
+            return (string)global::KRPC.Client.Encoder.Decode (_result.Value, typeof(string), connection);
         }
 
         [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "Counter")]
@@ -111,8 +111,8 @@ namespace KRPC.Client.Services.TestService
                 global::KRPC.Client.Encoder.Encode (id, typeof(string)),
                 global::KRPC.Client.Encoder.Encode (divisor, typeof(int))
             };
-            ByteString _data = connection.Invoke ("TestService", "Counter", _args);
-            return (int)global::KRPC.Client.Encoder.Decode (_data, typeof(int), connection);
+            var _result = connection.Invoke ("TestService", "Counter", _args);
+            return (int)global::KRPC.Client.Encoder.Decode (_result.Value, typeof(int), connection);
         }
 
         [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "CreateTestObject")]
@@ -121,8 +121,8 @@ namespace KRPC.Client.Services.TestService
             var _args = new ByteString[] {
                 global::KRPC.Client.Encoder.Encode (value, typeof(string))
             };
-            ByteString _data = connection.Invoke ("TestService", "CreateTestObject", _args);
-            return (global::KRPC.Client.Services.TestService.TestClass)global::KRPC.Client.Encoder.Decode (_data, typeof(global::KRPC.Client.Services.TestService.TestClass), connection);
+            var _result = connection.Invoke ("TestService", "CreateTestObject", _args);
+            return (global::KRPC.Client.Services.TestService.TestClass)global::KRPC.Client.Encoder.Decode (_result.Value, typeof(global::KRPC.Client.Services.TestService.TestClass), connection);
         }
 
         /// <summary>
@@ -135,8 +135,8 @@ namespace KRPC.Client.Services.TestService
             var _args = new ByteString[] {
                 global::KRPC.Client.Encoder.Encode (value, typeof(float))
             };
-            ByteString _data = connection.Invoke ("TestService", "DeprecatedProcedure", _args);
-            return (string)global::KRPC.Client.Encoder.Decode (_data, typeof(string), connection);
+            var _result = connection.Invoke ("TestService", "DeprecatedProcedure", _args);
+            return (string)global::KRPC.Client.Encoder.Decode (_result.Value, typeof(string), connection);
         }
 
         /// <summary>
@@ -149,8 +149,8 @@ namespace KRPC.Client.Services.TestService
             var _args = new ByteString[] {
                 global::KRPC.Client.Encoder.Encode (value, typeof(float))
             };
-            ByteString _data = connection.Invoke ("TestService", "DeprecatedProcedureNoMessage", _args);
-            return (string)global::KRPC.Client.Encoder.Decode (_data, typeof(string), connection);
+            var _result = connection.Invoke ("TestService", "DeprecatedProcedureNoMessage", _args);
+            return (string)global::KRPC.Client.Encoder.Decode (_result.Value, typeof(string), connection);
         }
 
         [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "DictionaryDefault")]
@@ -159,8 +159,8 @@ namespace KRPC.Client.Services.TestService
             var _args = new ByteString[] {
                 global::KRPC.Client.Encoder.Encode (x ?? new global::System.Collections.Generic.Dictionary<int,bool> {{ 1, false }, { 2, true }}, typeof(global::System.Collections.Generic.IDictionary<int,bool>))
             };
-            ByteString _data = connection.Invoke ("TestService", "DictionaryDefault", _args);
-            return (global::System.Collections.Generic.IDictionary<int,bool>)global::KRPC.Client.Encoder.Decode (_data, typeof(global::System.Collections.Generic.IDictionary<int,bool>), connection);
+            var _result = connection.Invoke ("TestService", "DictionaryDefault", _args);
+            return (global::System.Collections.Generic.IDictionary<int,bool>)global::KRPC.Client.Encoder.Decode (_result.Value, typeof(global::System.Collections.Generic.IDictionary<int,bool>), connection);
         }
 
         [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "DoubleToString")]
@@ -169,18 +169,20 @@ namespace KRPC.Client.Services.TestService
             var _args = new ByteString[] {
                 global::KRPC.Client.Encoder.Encode (value, typeof(double))
             };
-            ByteString _data = connection.Invoke ("TestService", "DoubleToString", _args);
-            return (string)global::KRPC.Client.Encoder.Decode (_data, typeof(string), connection);
+            var _result = connection.Invoke ("TestService", "DoubleToString", _args);
+            return (string)global::KRPC.Client.Encoder.Decode (_result.Value, typeof(string), connection);
         }
 
         [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "EchoNullableInt")]
-        public int EchoNullableInt (int value)
+        public int? EchoNullableInt (int? value)
         {
             var _args = new ByteString[] {
-                global::KRPC.Client.Encoder.Encode (value, typeof(int))
+                global::KRPC.Client.Encoder.Encode (value, typeof(int?))
             };
-            ByteString _data = connection.Invoke ("TestService", "EchoNullableInt", _args);
-            return (int)global::KRPC.Client.Encoder.Decode (_data, typeof(int), connection);
+            var _result = connection.Invoke ("TestService", "EchoNullableInt", _args);
+            if (_result.IsNull)
+                return null;
+            return (int?)global::KRPC.Client.Encoder.Decode (_result.Value, typeof(int?), connection);
         }
 
         [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "EchoNullableList")]
@@ -189,8 +191,10 @@ namespace KRPC.Client.Services.TestService
             var _args = new ByteString[] {
                 global::KRPC.Client.Encoder.Encode (l, typeof(global::System.Collections.Generic.IList<int>))
             };
-            ByteString _data = connection.Invoke ("TestService", "EchoNullableList", _args);
-            return (global::System.Collections.Generic.IList<int>)global::KRPC.Client.Encoder.Decode (_data, typeof(global::System.Collections.Generic.IList<int>), connection);
+            var _result = connection.Invoke ("TestService", "EchoNullableList", _args);
+            if (_result.IsNull)
+                return null;
+            return (global::System.Collections.Generic.IList<int>)global::KRPC.Client.Encoder.Decode (_result.Value, typeof(global::System.Collections.Generic.IList<int>), connection);
         }
 
         [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "EchoNullableString")]
@@ -199,8 +203,10 @@ namespace KRPC.Client.Services.TestService
             var _args = new ByteString[] {
                 global::KRPC.Client.Encoder.Encode (value, typeof(string))
             };
-            ByteString _data = connection.Invoke ("TestService", "EchoNullableString", _args);
-            return (string)global::KRPC.Client.Encoder.Decode (_data, typeof(string), connection);
+            var _result = connection.Invoke ("TestService", "EchoNullableString", _args);
+            if (_result.IsNull)
+                return null;
+            return (string)global::KRPC.Client.Encoder.Decode (_result.Value, typeof(string), connection);
         }
 
         [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "EchoTestObject")]
@@ -209,8 +215,10 @@ namespace KRPC.Client.Services.TestService
             var _args = new ByteString[] {
                 global::KRPC.Client.Encoder.Encode (value, typeof(global::KRPC.Client.Services.TestService.TestClass))
             };
-            ByteString _data = connection.Invoke ("TestService", "EchoTestObject", _args);
-            return (global::KRPC.Client.Services.TestService.TestClass)global::KRPC.Client.Encoder.Decode (_data, typeof(global::KRPC.Client.Services.TestService.TestClass), connection);
+            var _result = connection.Invoke ("TestService", "EchoTestObject", _args);
+            if (_result.IsNull)
+                return null;
+            return (global::KRPC.Client.Services.TestService.TestClass)global::KRPC.Client.Encoder.Decode (_result.Value, typeof(global::KRPC.Client.Services.TestService.TestClass), connection);
         }
 
         [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "EmptyListDefault")]
@@ -219,8 +227,8 @@ namespace KRPC.Client.Services.TestService
             var _args = new ByteString[] {
                 global::KRPC.Client.Encoder.Encode (x ?? new global::System.Collections.Generic.List<string> {  }, typeof(global::System.Collections.Generic.IList<string>))
             };
-            ByteString _data = connection.Invoke ("TestService", "EmptyListDefault", _args);
-            return (global::System.Collections.Generic.IList<string>)global::KRPC.Client.Encoder.Decode (_data, typeof(global::System.Collections.Generic.IList<string>), connection);
+            var _result = connection.Invoke ("TestService", "EmptyListDefault", _args);
+            return (global::System.Collections.Generic.IList<string>)global::KRPC.Client.Encoder.Decode (_result.Value, typeof(global::System.Collections.Generic.IList<string>), connection);
         }
 
         [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "EnumDefaultArg")]
@@ -229,8 +237,8 @@ namespace KRPC.Client.Services.TestService
             var _args = new ByteString[] {
                 global::KRPC.Client.Encoder.Encode (x, typeof(global::KRPC.Client.Services.TestService.TestEnum))
             };
-            ByteString _data = connection.Invoke ("TestService", "EnumDefaultArg", _args);
-            return (global::KRPC.Client.Services.TestService.TestEnum)global::KRPC.Client.Encoder.Decode (_data, typeof(global::KRPC.Client.Services.TestService.TestEnum), connection);
+            var _result = connection.Invoke ("TestService", "EnumDefaultArg", _args);
+            return (global::KRPC.Client.Services.TestService.TestEnum)global::KRPC.Client.Encoder.Decode (_result.Value, typeof(global::KRPC.Client.Services.TestService.TestEnum), connection);
         }
 
         [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "EnumEcho")]
@@ -239,15 +247,15 @@ namespace KRPC.Client.Services.TestService
             var _args = new ByteString[] {
                 global::KRPC.Client.Encoder.Encode (x, typeof(global::KRPC.Client.Services.TestService.TestEnum))
             };
-            ByteString _data = connection.Invoke ("TestService", "EnumEcho", _args);
-            return (global::KRPC.Client.Services.TestService.TestEnum)global::KRPC.Client.Encoder.Decode (_data, typeof(global::KRPC.Client.Services.TestService.TestEnum), connection);
+            var _result = connection.Invoke ("TestService", "EnumEcho", _args);
+            return (global::KRPC.Client.Services.TestService.TestEnum)global::KRPC.Client.Encoder.Decode (_result.Value, typeof(global::KRPC.Client.Services.TestService.TestEnum), connection);
         }
 
         [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "EnumReturn")]
         public global::KRPC.Client.Services.TestService.TestEnum EnumReturn ()
         {
-            ByteString _data = connection.Invoke ("TestService", "EnumReturn");
-            return (global::KRPC.Client.Services.TestService.TestEnum)global::KRPC.Client.Encoder.Decode (_data, typeof(global::KRPC.Client.Services.TestService.TestEnum), connection);
+            var _result = connection.Invoke ("TestService", "EnumReturn");
+            return (global::KRPC.Client.Services.TestService.TestEnum)global::KRPC.Client.Encoder.Decode (_result.Value, typeof(global::KRPC.Client.Services.TestService.TestEnum), connection);
         }
 
         /// <summary>
@@ -259,8 +267,8 @@ namespace KRPC.Client.Services.TestService
             var _args = new ByteString[] {
                 global::KRPC.Client.Encoder.Encode (value, typeof(float))
             };
-            ByteString _data = connection.Invoke ("TestService", "FloatToString", _args);
-            return (string)global::KRPC.Client.Encoder.Decode (_data, typeof(string), connection);
+            var _result = connection.Invoke ("TestService", "FloatToString", _args);
+            return (string)global::KRPC.Client.Encoder.Decode (_result.Value, typeof(string), connection);
         }
 
         [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "IncrementDictionary")]
@@ -269,8 +277,8 @@ namespace KRPC.Client.Services.TestService
             var _args = new ByteString[] {
                 global::KRPC.Client.Encoder.Encode (d, typeof(global::System.Collections.Generic.IDictionary<string,int>))
             };
-            ByteString _data = connection.Invoke ("TestService", "IncrementDictionary", _args);
-            return (global::System.Collections.Generic.IDictionary<string,int>)global::KRPC.Client.Encoder.Decode (_data, typeof(global::System.Collections.Generic.IDictionary<string,int>), connection);
+            var _result = connection.Invoke ("TestService", "IncrementDictionary", _args);
+            return (global::System.Collections.Generic.IDictionary<string,int>)global::KRPC.Client.Encoder.Decode (_result.Value, typeof(global::System.Collections.Generic.IDictionary<string,int>), connection);
         }
 
         [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "IncrementList")]
@@ -279,8 +287,8 @@ namespace KRPC.Client.Services.TestService
             var _args = new ByteString[] {
                 global::KRPC.Client.Encoder.Encode (l, typeof(global::System.Collections.Generic.IList<int>))
             };
-            ByteString _data = connection.Invoke ("TestService", "IncrementList", _args);
-            return (global::System.Collections.Generic.IList<int>)global::KRPC.Client.Encoder.Decode (_data, typeof(global::System.Collections.Generic.IList<int>), connection);
+            var _result = connection.Invoke ("TestService", "IncrementList", _args);
+            return (global::System.Collections.Generic.IList<int>)global::KRPC.Client.Encoder.Decode (_result.Value, typeof(global::System.Collections.Generic.IList<int>), connection);
         }
 
         [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "IncrementNestedCollection")]
@@ -289,8 +297,8 @@ namespace KRPC.Client.Services.TestService
             var _args = new ByteString[] {
                 global::KRPC.Client.Encoder.Encode (d, typeof(global::System.Collections.Generic.IDictionary<string,global::System.Collections.Generic.IList<int>>))
             };
-            ByteString _data = connection.Invoke ("TestService", "IncrementNestedCollection", _args);
-            return (global::System.Collections.Generic.IDictionary<string,global::System.Collections.Generic.IList<int>>)global::KRPC.Client.Encoder.Decode (_data, typeof(global::System.Collections.Generic.IDictionary<string,global::System.Collections.Generic.IList<int>>), connection);
+            var _result = connection.Invoke ("TestService", "IncrementNestedCollection", _args);
+            return (global::System.Collections.Generic.IDictionary<string,global::System.Collections.Generic.IList<int>>)global::KRPC.Client.Encoder.Decode (_result.Value, typeof(global::System.Collections.Generic.IDictionary<string,global::System.Collections.Generic.IList<int>>), connection);
         }
 
         [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "IncrementSet")]
@@ -299,8 +307,8 @@ namespace KRPC.Client.Services.TestService
             var _args = new ByteString[] {
                 global::KRPC.Client.Encoder.Encode (h, typeof(genericCollectionsAlias::ISet<int>))
             };
-            ByteString _data = connection.Invoke ("TestService", "IncrementSet", _args);
-            return (genericCollectionsAlias::ISet<int>)global::KRPC.Client.Encoder.Decode (_data, typeof(genericCollectionsAlias::ISet<int>), connection);
+            var _result = connection.Invoke ("TestService", "IncrementSet", _args);
+            return (genericCollectionsAlias::ISet<int>)global::KRPC.Client.Encoder.Decode (_result.Value, typeof(genericCollectionsAlias::ISet<int>), connection);
         }
 
         [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "IncrementTuple")]
@@ -309,8 +317,8 @@ namespace KRPC.Client.Services.TestService
             var _args = new ByteString[] {
                 global::KRPC.Client.Encoder.Encode (t, typeof(systemAlias::Tuple<int,long>))
             };
-            ByteString _data = connection.Invoke ("TestService", "IncrementTuple", _args);
-            return (systemAlias::Tuple<int,long>)global::KRPC.Client.Encoder.Decode (_data, typeof(systemAlias::Tuple<int,long>), connection);
+            var _result = connection.Invoke ("TestService", "IncrementTuple", _args);
+            return (systemAlias::Tuple<int,long>)global::KRPC.Client.Encoder.Decode (_result.Value, typeof(systemAlias::Tuple<int,long>), connection);
         }
 
         [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "Int32ToString")]
@@ -319,8 +327,8 @@ namespace KRPC.Client.Services.TestService
             var _args = new ByteString[] {
                 global::KRPC.Client.Encoder.Encode (value, typeof(int))
             };
-            ByteString _data = connection.Invoke ("TestService", "Int32ToString", _args);
-            return (string)global::KRPC.Client.Encoder.Decode (_data, typeof(string), connection);
+            var _result = connection.Invoke ("TestService", "Int32ToString", _args);
+            return (string)global::KRPC.Client.Encoder.Decode (_result.Value, typeof(string), connection);
         }
 
         [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "Int64ToString")]
@@ -329,8 +337,8 @@ namespace KRPC.Client.Services.TestService
             var _args = new ByteString[] {
                 global::KRPC.Client.Encoder.Encode (value, typeof(long))
             };
-            ByteString _data = connection.Invoke ("TestService", "Int64ToString", _args);
-            return (string)global::KRPC.Client.Encoder.Decode (_data, typeof(string), connection);
+            var _result = connection.Invoke ("TestService", "Int64ToString", _args);
+            return (string)global::KRPC.Client.Encoder.Decode (_result.Value, typeof(string), connection);
         }
 
         [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "ListDefault")]
@@ -339,8 +347,8 @@ namespace KRPC.Client.Services.TestService
             var _args = new ByteString[] {
                 global::KRPC.Client.Encoder.Encode (x ?? new global::System.Collections.Generic.List<int> { 1, 2, 3 }, typeof(global::System.Collections.Generic.IList<int>))
             };
-            ByteString _data = connection.Invoke ("TestService", "ListDefault", _args);
-            return (global::System.Collections.Generic.IList<int>)global::KRPC.Client.Encoder.Decode (_data, typeof(global::System.Collections.Generic.IList<int>), connection);
+            var _result = connection.Invoke ("TestService", "ListDefault", _args);
+            return (global::System.Collections.Generic.IList<int>)global::KRPC.Client.Encoder.Decode (_result.Value, typeof(global::System.Collections.Generic.IList<int>), connection);
         }
 
         [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "NotNullableObject")]
@@ -349,8 +357,8 @@ namespace KRPC.Client.Services.TestService
             var _args = new ByteString[] {
                 global::KRPC.Client.Encoder.Encode (value, typeof(global::KRPC.Client.Services.TestService.TestClass))
             };
-            ByteString _data = connection.Invoke ("TestService", "NotNullableObject", _args);
-            return (global::KRPC.Client.Services.TestService.TestClass)global::KRPC.Client.Encoder.Decode (_data, typeof(global::KRPC.Client.Services.TestService.TestClass), connection);
+            var _result = connection.Invoke ("TestService", "NotNullableObject", _args);
+            return (global::KRPC.Client.Services.TestService.TestClass)global::KRPC.Client.Encoder.Decode (_result.Value, typeof(global::KRPC.Client.Services.TestService.TestClass), connection);
         }
 
         [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "OnTimer")]
@@ -360,8 +368,8 @@ namespace KRPC.Client.Services.TestService
                 global::KRPC.Client.Encoder.Encode (milliseconds, typeof(uint)),
                 global::KRPC.Client.Encoder.Encode (repeats, typeof(uint))
             };
-            ByteString _data = connection.Invoke ("TestService", "OnTimer", _args);
-            return (global::KRPC.Client.Event)global::KRPC.Client.Encoder.Decode (_data, typeof(global::KRPC.Client.Event), connection);
+            var _result = connection.Invoke ("TestService", "OnTimer", _args);
+            return (global::KRPC.Client.Event)global::KRPC.Client.Encoder.Decode (_result.Value, typeof(global::KRPC.Client.Event), connection);
         }
 
         [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "OnTimerUsingLambda")]
@@ -370,8 +378,8 @@ namespace KRPC.Client.Services.TestService
             var _args = new ByteString[] {
                 global::KRPC.Client.Encoder.Encode (milliseconds, typeof(uint))
             };
-            ByteString _data = connection.Invoke ("TestService", "OnTimerUsingLambda", _args);
-            return (global::KRPC.Client.Event)global::KRPC.Client.Encoder.Decode (_data, typeof(global::KRPC.Client.Event), connection);
+            var _result = connection.Invoke ("TestService", "OnTimerUsingLambda", _args);
+            return (global::KRPC.Client.Event)global::KRPC.Client.Encoder.Decode (_result.Value, typeof(global::KRPC.Client.Event), connection);
         }
 
         [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "OptionalArguments")]
@@ -383,8 +391,8 @@ namespace KRPC.Client.Services.TestService
                 global::KRPC.Client.Encoder.Encode (z, typeof(string)),
                 global::KRPC.Client.Encoder.Encode (obj, typeof(global::KRPC.Client.Services.TestService.TestClass))
             };
-            ByteString _data = connection.Invoke ("TestService", "OptionalArguments", _args);
-            return (string)global::KRPC.Client.Encoder.Decode (_data, typeof(string), connection);
+            var _result = connection.Invoke ("TestService", "OptionalArguments", _args);
+            return (string)global::KRPC.Client.Encoder.Decode (_result.Value, typeof(string), connection);
         }
 
         [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "ResetCustomExceptionLater")]
@@ -402,8 +410,8 @@ namespace KRPC.Client.Services.TestService
         [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "ReturnNullWhenNotAllowed")]
         public global::KRPC.Client.Services.TestService.TestClass ReturnNullWhenNotAllowed ()
         {
-            ByteString _data = connection.Invoke ("TestService", "ReturnNullWhenNotAllowed");
-            return (global::KRPC.Client.Services.TestService.TestClass)global::KRPC.Client.Encoder.Decode (_data, typeof(global::KRPC.Client.Services.TestService.TestClass), connection);
+            var _result = connection.Invoke ("TestService", "ReturnNullWhenNotAllowed");
+            return (global::KRPC.Client.Services.TestService.TestClass)global::KRPC.Client.Encoder.Decode (_result.Value, typeof(global::KRPC.Client.Services.TestService.TestClass), connection);
         }
 
         [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "SetDefault")]
@@ -412,8 +420,8 @@ namespace KRPC.Client.Services.TestService
             var _args = new ByteString[] {
                 global::KRPC.Client.Encoder.Encode (x ?? new global::System.Collections.Generic.HashSet<int> { 1, 2, 3 }, typeof(genericCollectionsAlias::ISet<int>))
             };
-            ByteString _data = connection.Invoke ("TestService", "SetDefault", _args);
-            return (genericCollectionsAlias::ISet<int>)global::KRPC.Client.Encoder.Decode (_data, typeof(genericCollectionsAlias::ISet<int>), connection);
+            var _result = connection.Invoke ("TestService", "SetDefault", _args);
+            return (genericCollectionsAlias::ISet<int>)global::KRPC.Client.Encoder.Decode (_result.Value, typeof(genericCollectionsAlias::ISet<int>), connection);
         }
 
         [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "StringToInt32")]
@@ -422,15 +430,15 @@ namespace KRPC.Client.Services.TestService
             var _args = new ByteString[] {
                 global::KRPC.Client.Encoder.Encode (value, typeof(string))
             };
-            ByteString _data = connection.Invoke ("TestService", "StringToInt32", _args);
-            return (int)global::KRPC.Client.Encoder.Decode (_data, typeof(int), connection);
+            var _result = connection.Invoke ("TestService", "StringToInt32", _args);
+            return (int)global::KRPC.Client.Encoder.Decode (_result.Value, typeof(int), connection);
         }
 
         [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "ThrowArgumentException")]
         public int ThrowArgumentException ()
         {
-            ByteString _data = connection.Invoke ("TestService", "ThrowArgumentException");
-            return (int)global::KRPC.Client.Encoder.Decode (_data, typeof(int), connection);
+            var _result = connection.Invoke ("TestService", "ThrowArgumentException");
+            return (int)global::KRPC.Client.Encoder.Decode (_result.Value, typeof(int), connection);
         }
 
         [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "ThrowArgumentNullException")]
@@ -439,8 +447,8 @@ namespace KRPC.Client.Services.TestService
             var _args = new ByteString[] {
                 global::KRPC.Client.Encoder.Encode (foo, typeof(string))
             };
-            ByteString _data = connection.Invoke ("TestService", "ThrowArgumentNullException", _args);
-            return (int)global::KRPC.Client.Encoder.Decode (_data, typeof(int), connection);
+            var _result = connection.Invoke ("TestService", "ThrowArgumentNullException", _args);
+            return (int)global::KRPC.Client.Encoder.Decode (_result.Value, typeof(int), connection);
         }
 
         [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "ThrowArgumentOutOfRangeException")]
@@ -449,36 +457,36 @@ namespace KRPC.Client.Services.TestService
             var _args = new ByteString[] {
                 global::KRPC.Client.Encoder.Encode (foo, typeof(int))
             };
-            ByteString _data = connection.Invoke ("TestService", "ThrowArgumentOutOfRangeException", _args);
-            return (int)global::KRPC.Client.Encoder.Decode (_data, typeof(int), connection);
+            var _result = connection.Invoke ("TestService", "ThrowArgumentOutOfRangeException", _args);
+            return (int)global::KRPC.Client.Encoder.Decode (_result.Value, typeof(int), connection);
         }
 
         [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "ThrowCustomException")]
         public int ThrowCustomException ()
         {
-            ByteString _data = connection.Invoke ("TestService", "ThrowCustomException");
-            return (int)global::KRPC.Client.Encoder.Decode (_data, typeof(int), connection);
+            var _result = connection.Invoke ("TestService", "ThrowCustomException");
+            return (int)global::KRPC.Client.Encoder.Decode (_result.Value, typeof(int), connection);
         }
 
         [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "ThrowCustomExceptionLater")]
         public int ThrowCustomExceptionLater ()
         {
-            ByteString _data = connection.Invoke ("TestService", "ThrowCustomExceptionLater");
-            return (int)global::KRPC.Client.Encoder.Decode (_data, typeof(int), connection);
+            var _result = connection.Invoke ("TestService", "ThrowCustomExceptionLater");
+            return (int)global::KRPC.Client.Encoder.Decode (_result.Value, typeof(int), connection);
         }
 
         [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "ThrowInvalidOperationException")]
         public int ThrowInvalidOperationException ()
         {
-            ByteString _data = connection.Invoke ("TestService", "ThrowInvalidOperationException");
-            return (int)global::KRPC.Client.Encoder.Decode (_data, typeof(int), connection);
+            var _result = connection.Invoke ("TestService", "ThrowInvalidOperationException");
+            return (int)global::KRPC.Client.Encoder.Decode (_result.Value, typeof(int), connection);
         }
 
         [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "ThrowInvalidOperationExceptionLater")]
         public int ThrowInvalidOperationExceptionLater ()
         {
-            ByteString _data = connection.Invoke ("TestService", "ThrowInvalidOperationExceptionLater");
-            return (int)global::KRPC.Client.Encoder.Decode (_data, typeof(int), connection);
+            var _result = connection.Invoke ("TestService", "ThrowInvalidOperationExceptionLater");
+            return (int)global::KRPC.Client.Encoder.Decode (_result.Value, typeof(int), connection);
         }
 
         [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "TupleDefault")]
@@ -487,8 +495,8 @@ namespace KRPC.Client.Services.TestService
             var _args = new ByteString[] {
                 global::KRPC.Client.Encoder.Encode (x ?? new systemAlias::Tuple<int,bool> (1, false), typeof(systemAlias::Tuple<int,bool>))
             };
-            ByteString _data = connection.Invoke ("TestService", "TupleDefault", _args);
-            return (systemAlias::Tuple<int,bool>)global::KRPC.Client.Encoder.Decode (_data, typeof(systemAlias::Tuple<int,bool>), connection);
+            var _result = connection.Invoke ("TestService", "TupleDefault", _args);
+            return (systemAlias::Tuple<int,bool>)global::KRPC.Client.Encoder.Decode (_result.Value, typeof(systemAlias::Tuple<int,bool>), connection);
         }
 
         /// <summary>
@@ -498,8 +506,8 @@ namespace KRPC.Client.Services.TestService
         [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "get_DeprecatedProperty")]
         public string DeprecatedProperty {
             get {
-                ByteString _data = connection.Invoke ("TestService", "get_DeprecatedProperty");
-                return (string)global::KRPC.Client.Encoder.Decode (_data, typeof(string), connection);
+                var _result = connection.Invoke ("TestService", "get_DeprecatedProperty");
+                return (string)global::KRPC.Client.Encoder.Decode (_result.Value, typeof(string), connection);
             }
             set {
                 var _args = new ByteString[] {
@@ -512,8 +520,10 @@ namespace KRPC.Client.Services.TestService
         [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "get_NullableObject")]
         public global::KRPC.Client.Services.TestService.TestClass NullableObject {
             get {
-                ByteString _data = connection.Invoke ("TestService", "get_NullableObject");
-                return (global::KRPC.Client.Services.TestService.TestClass)global::KRPC.Client.Encoder.Decode (_data, typeof(global::KRPC.Client.Services.TestService.TestClass), connection);
+                var _result = connection.Invoke ("TestService", "get_NullableObject");
+                if (_result.IsNull)
+                    return null;
+                return (global::KRPC.Client.Services.TestService.TestClass)global::KRPC.Client.Encoder.Decode (_result.Value, typeof(global::KRPC.Client.Services.TestService.TestClass), connection);
             }
             set {
                 var _args = new ByteString[] {
@@ -526,8 +536,10 @@ namespace KRPC.Client.Services.TestService
         [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "get_ObjectProperty")]
         public global::KRPC.Client.Services.TestService.TestClass ObjectProperty {
             get {
-                ByteString _data = connection.Invoke ("TestService", "get_ObjectProperty");
-                return (global::KRPC.Client.Services.TestService.TestClass)global::KRPC.Client.Encoder.Decode (_data, typeof(global::KRPC.Client.Services.TestService.TestClass), connection);
+                var _result = connection.Invoke ("TestService", "get_ObjectProperty");
+                if (_result.IsNull)
+                    return null;
+                return (global::KRPC.Client.Services.TestService.TestClass)global::KRPC.Client.Encoder.Decode (_result.Value, typeof(global::KRPC.Client.Services.TestService.TestClass), connection);
             }
             set {
                 var _args = new ByteString[] {
@@ -543,8 +555,8 @@ namespace KRPC.Client.Services.TestService
         [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "get_StringProperty")]
         public string StringProperty {
             get {
-                ByteString _data = connection.Invoke ("TestService", "get_StringProperty");
-                return (string)global::KRPC.Client.Encoder.Decode (_data, typeof(string), connection);
+                var _result = connection.Invoke ("TestService", "get_StringProperty");
+                return (string)global::KRPC.Client.Encoder.Decode (_result.Value, typeof(string), connection);
             }
             set {
                 var _args = new ByteString[] {
@@ -566,8 +578,8 @@ namespace KRPC.Client.Services.TestService
         [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "get_StringPropertyPrivateSet")]
         public string StringPropertyPrivateSet {
             get {
-                ByteString _data = connection.Invoke ("TestService", "get_StringPropertyPrivateSet");
-                return (string)global::KRPC.Client.Encoder.Decode (_data, typeof(string), connection);
+                var _result = connection.Invoke ("TestService", "get_StringPropertyPrivateSet");
+                return (string)global::KRPC.Client.Encoder.Decode (_result.Value, typeof(string), connection);
             }
         }
     }
@@ -705,8 +717,8 @@ namespace KRPC.Client.Services.TestService
             var _args = new ByteString[] {
                 global::KRPC.Client.Encoder.Encode (this, typeof(TestService.DeprecatedClass))
             };
-            ByteString _data = connection.Invoke ("TestService", "DeprecatedClass_DeprecatedMethod", _args);
-            return (string)global::KRPC.Client.Encoder.Decode (_data, typeof(string), connection);
+            var _result = connection.Invoke ("TestService", "DeprecatedClass_DeprecatedMethod", _args);
+            return (string)global::KRPC.Client.Encoder.Decode (_result.Value, typeof(string), connection);
         }
     }
 
@@ -729,8 +741,10 @@ namespace KRPC.Client.Services.TestService
                 global::KRPC.Client.Encoder.Encode (this, typeof(TestService.TestClass)),
                 global::KRPC.Client.Encoder.Encode (value, typeof(global::KRPC.Client.Services.TestService.TestClass))
             };
-            ByteString _data = connection.Invoke ("TestService", "TestClass_EchoNullableObject", _args);
-            return (global::KRPC.Client.Services.TestService.TestClass)global::KRPC.Client.Encoder.Decode (_data, typeof(global::KRPC.Client.Services.TestService.TestClass), connection);
+            var _result = connection.Invoke ("TestService", "TestClass_EchoNullableObject", _args);
+            if (_result.IsNull)
+                return null;
+            return (global::KRPC.Client.Services.TestService.TestClass)global::KRPC.Client.Encoder.Decode (_result.Value, typeof(global::KRPC.Client.Services.TestService.TestClass), connection);
         }
 
         [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "TestClass_FloatToString")]
@@ -740,8 +754,8 @@ namespace KRPC.Client.Services.TestService
                 global::KRPC.Client.Encoder.Encode (this, typeof(TestService.TestClass)),
                 global::KRPC.Client.Encoder.Encode (x, typeof(float))
             };
-            ByteString _data = connection.Invoke ("TestService", "TestClass_FloatToString", _args);
-            return (string)global::KRPC.Client.Encoder.Decode (_data, typeof(string), connection);
+            var _result = connection.Invoke ("TestService", "TestClass_FloatToString", _args);
+            return (string)global::KRPC.Client.Encoder.Decode (_result.Value, typeof(string), connection);
         }
 
         /// <summary>
@@ -753,8 +767,8 @@ namespace KRPC.Client.Services.TestService
             var _args = new ByteString[] {
                 global::KRPC.Client.Encoder.Encode (this, typeof(TestService.TestClass))
             };
-            ByteString _data = connection.Invoke ("TestService", "TestClass_GetValue", _args);
-            return (string)global::KRPC.Client.Encoder.Decode (_data, typeof(string), connection);
+            var _result = connection.Invoke ("TestService", "TestClass_GetValue", _args);
+            return (string)global::KRPC.Client.Encoder.Decode (_result.Value, typeof(string), connection);
         }
 
         [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "TestClass_ObjectToString")]
@@ -764,8 +778,8 @@ namespace KRPC.Client.Services.TestService
                 global::KRPC.Client.Encoder.Encode (this, typeof(TestService.TestClass)),
                 global::KRPC.Client.Encoder.Encode (other, typeof(global::KRPC.Client.Services.TestService.TestClass))
             };
-            ByteString _data = connection.Invoke ("TestService", "TestClass_ObjectToString", _args);
-            return (string)global::KRPC.Client.Encoder.Decode (_data, typeof(string), connection);
+            var _result = connection.Invoke ("TestService", "TestClass_ObjectToString", _args);
+            return (string)global::KRPC.Client.Encoder.Decode (_result.Value, typeof(string), connection);
         }
 
         [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "TestClass_OptionalArguments")]
@@ -778,8 +792,8 @@ namespace KRPC.Client.Services.TestService
                 global::KRPC.Client.Encoder.Encode (z, typeof(string)),
                 global::KRPC.Client.Encoder.Encode (obj, typeof(global::KRPC.Client.Services.TestService.TestClass))
             };
-            ByteString _data = connection.Invoke ("TestService", "TestClass_OptionalArguments", _args);
-            return (string)global::KRPC.Client.Encoder.Decode (_data, typeof(string), connection);
+            var _result = connection.Invoke ("TestService", "TestClass_OptionalArguments", _args);
+            return (string)global::KRPC.Client.Encoder.Decode (_result.Value, typeof(string), connection);
         }
 
         /// <param name="connection">A connection object.</param>
@@ -792,8 +806,8 @@ namespace KRPC.Client.Services.TestService
                 global::KRPC.Client.Encoder.Encode (a, typeof(string)),
                 global::KRPC.Client.Encoder.Encode (b, typeof(string))
             };
-            ByteString _data = connection.Invoke ("TestService", "TestClass_static_StaticMethod", _args);
-            return (string)global::KRPC.Client.Encoder.Decode (_data, typeof(string), connection);
+            var _result = connection.Invoke ("TestService", "TestClass_static_StaticMethod", _args);
+            return (string)global::KRPC.Client.Encoder.Decode (_result.Value, typeof(string), connection);
         }
 
         /// <param name="connection">A connection object.</param>
@@ -805,8 +819,10 @@ namespace KRPC.Client.Services.TestService
             var _args = new ByteString[] {
                 global::KRPC.Client.Encoder.Encode (value, typeof(global::KRPC.Client.Services.TestService.TestClass))
             };
-            ByteString _data = connection.Invoke ("TestService", "TestClass_static_StaticNullableObject", _args);
-            return (global::KRPC.Client.Services.TestService.TestClass)global::KRPC.Client.Encoder.Decode (_data, typeof(global::KRPC.Client.Services.TestService.TestClass), connection);
+            var _result = connection.Invoke ("TestService", "TestClass_static_StaticNullableObject", _args);
+            if (_result.IsNull)
+                return null;
+            return (global::KRPC.Client.Services.TestService.TestClass)global::KRPC.Client.Encoder.Decode (_result.Value, typeof(global::KRPC.Client.Services.TestService.TestClass), connection);
         }
 
         /// <summary>
@@ -818,8 +834,8 @@ namespace KRPC.Client.Services.TestService
                 var _args = new ByteString[] {
                     global::KRPC.Client.Encoder.Encode (this, typeof(TestService.TestClass))
                 };
-                ByteString _data = connection.Invoke ("TestService", "TestClass_get_IntProperty", _args);
-                return (int)global::KRPC.Client.Encoder.Decode (_data, typeof(int), connection);
+                var _result = connection.Invoke ("TestService", "TestClass_get_IntProperty", _args);
+                return (int)global::KRPC.Client.Encoder.Decode (_result.Value, typeof(int), connection);
             }
             set {
                 var _args = new ByteString[] {
@@ -836,8 +852,10 @@ namespace KRPC.Client.Services.TestService
                 var _args = new ByteString[] {
                     global::KRPC.Client.Encoder.Encode (this, typeof(TestService.TestClass))
                 };
-                ByteString _data = connection.Invoke ("TestService", "TestClass_get_ObjectProperty", _args);
-                return (global::KRPC.Client.Services.TestService.TestClass)global::KRPC.Client.Encoder.Decode (_data, typeof(global::KRPC.Client.Services.TestService.TestClass), connection);
+                var _result = connection.Invoke ("TestService", "TestClass_get_ObjectProperty", _args);
+                if (_result.IsNull)
+                    return null;
+                return (global::KRPC.Client.Services.TestService.TestClass)global::KRPC.Client.Encoder.Decode (_result.Value, typeof(global::KRPC.Client.Services.TestService.TestClass), connection);
             }
             set {
                 var _args = new ByteString[] {
@@ -864,8 +882,8 @@ namespace KRPC.Client.Services.TestService
                 var _args = new ByteString[] {
                     global::KRPC.Client.Encoder.Encode (this, typeof(TestService.TestClass))
                 };
-                ByteString _data = connection.Invoke ("TestService", "TestClass_get_StringPropertyPrivateSet", _args);
-                return (string)global::KRPC.Client.Encoder.Decode (_data, typeof(string), connection);
+                var _result = connection.Invoke ("TestService", "TestClass_get_StringPropertyPrivateSet", _args);
+                return (string)global::KRPC.Client.Encoder.Decode (_result.Value, typeof(string), connection);
             }
         }
     }

--- a/tools/krpctools/krpctools/test/clientgen-TestService-java.txt
+++ b/tools/krpctools/krpctools/test/clientgen-TestService-java.txt
@@ -187,6 +187,36 @@ public class TestService {
     }
 
     @SuppressWarnings({ "unchecked" })
+    @RPCInfo(service = "TestService", procedure = "EchoNullableInt", types = _Types.class)
+    public int echoNullableInt(int value) throws RPCException {
+        ByteString[] _args = new ByteString[] {
+            Encoder.encode(value, krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.SINT32))
+        };
+        ByteString _data = this.connection.invoke("TestService", "EchoNullableInt", _args);
+        return (int) Encoder.decode(_data, krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.SINT32), this.connection);
+    }
+
+    @SuppressWarnings({ "unchecked" })
+    @RPCInfo(service = "TestService", procedure = "EchoNullableList", types = _Types.class)
+    public java.util.List<Integer> echoNullableList(java.util.List<Integer> l) throws RPCException {
+        ByteString[] _args = new ByteString[] {
+            Encoder.encode(l, krpc.client.Types.createList(krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.SINT32)))
+        };
+        ByteString _data = this.connection.invoke("TestService", "EchoNullableList", _args);
+        return (java.util.List<Integer>) Encoder.decode(_data, krpc.client.Types.createList(krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.SINT32)), this.connection);
+    }
+
+    @SuppressWarnings({ "unchecked" })
+    @RPCInfo(service = "TestService", procedure = "EchoNullableString", types = _Types.class)
+    public String echoNullableString(String value) throws RPCException {
+        ByteString[] _args = new ByteString[] {
+            Encoder.encode(value, krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.STRING))
+        };
+        ByteString _data = this.connection.invoke("TestService", "EchoNullableString", _args);
+        return (String) Encoder.decode(_data, krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.STRING), this.connection);
+    }
+
+    @SuppressWarnings({ "unchecked" })
     @RPCInfo(service = "TestService", procedure = "EchoTestObject", types = _Types.class)
     public krpc.client.services.TestService.TestClass echoTestObject(krpc.client.services.TestService.TestClass value) throws RPCException {
         ByteString[] _args = new ByteString[] {
@@ -194,6 +224,16 @@ public class TestService {
         };
         ByteString _data = this.connection.invoke("TestService", "EchoTestObject", _args);
         return (krpc.client.services.TestService.TestClass) Encoder.decode(_data, krpc.client.Types.createClass("TestService", "TestClass"), this.connection);
+    }
+
+    @SuppressWarnings({ "unchecked" })
+    @RPCInfo(service = "TestService", procedure = "EmptyListDefault", types = _Types.class)
+    public java.util.List<String> emptyListDefault(java.util.List<String> x) throws RPCException {
+        ByteString[] _args = new ByteString[] {
+            Encoder.encode(x, krpc.client.Types.createList(krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.STRING)))
+        };
+        ByteString _data = this.connection.invoke("TestService", "EmptyListDefault", _args);
+        return (java.util.List<String>) Encoder.decode(_data, krpc.client.Types.createList(krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.STRING)), this.connection);
     }
 
     @SuppressWarnings({ "unchecked" })
@@ -314,6 +354,16 @@ public class TestService {
         };
         ByteString _data = this.connection.invoke("TestService", "ListDefault", _args);
         return (java.util.List<Integer>) Encoder.decode(_data, krpc.client.Types.createList(krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.SINT32)), this.connection);
+    }
+
+    @SuppressWarnings({ "unchecked" })
+    @RPCInfo(service = "TestService", procedure = "NotNullableObject", types = _Types.class)
+    public krpc.client.services.TestService.TestClass notNullableObject(krpc.client.services.TestService.TestClass value) throws RPCException {
+        ByteString[] _args = new ByteString[] {
+            Encoder.encode(value, krpc.client.Types.createClass("TestService", "TestClass"))
+        };
+        ByteString _data = this.connection.invoke("TestService", "NotNullableObject", _args);
+        return (krpc.client.services.TestService.TestClass) Encoder.decode(_data, krpc.client.Types.createClass("TestService", "TestClass"), this.connection);
     }
 
     @SuppressWarnings({ "unchecked" })
@@ -480,6 +530,22 @@ public class TestService {
             Encoder.encode(value, krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.STRING))
         };
         this.connection.invoke("TestService", "set_DeprecatedProperty", _args);
+    }
+
+    @SuppressWarnings({ "unchecked" })
+    @RPCInfo(service = "TestService", procedure = "get_NullableObject", types = _Types.class)
+    public krpc.client.services.TestService.TestClass getNullableObject() throws RPCException {
+        ByteString _data = this.connection.invoke("TestService", "get_NullableObject");
+        return (krpc.client.services.TestService.TestClass) Encoder.decode(_data, krpc.client.Types.createClass("TestService", "TestClass"), this.connection);
+    }
+
+    @SuppressWarnings({ "unchecked" })
+    @RPCInfo(service = "TestService", procedure = "set_NullableObject", types = _Types.class)
+    public void setNullableObject(krpc.client.services.TestService.TestClass value) throws RPCException {
+        ByteString[] _args = new ByteString[] {
+            Encoder.encode(value, krpc.client.Types.createClass("TestService", "TestClass"))
+        };
+        this.connection.invoke("TestService", "set_NullableObject", _args);
     }
 
     @SuppressWarnings({ "unchecked" })
@@ -665,6 +731,18 @@ public class TestService {
         }
 
         @SuppressWarnings({ "unchecked" })
+        @RPCInfo(service = "TestService", procedure = "TestClass_EchoNullableObject", types = _Types.class)
+        public krpc.client.services.TestService.TestClass echoNullableObject(krpc.client.services.TestService.TestClass value) throws RPCException
+        {
+            ByteString[] _args = new ByteString[] {
+                Encoder.encode(this, krpc.client.Types.createClass("TestService", "TestClass")),
+                Encoder.encode(value, krpc.client.Types.createClass("TestService", "TestClass"))
+            };
+            ByteString _data = this.connection.invoke("TestService", "TestClass_EchoNullableObject", _args);
+            return (krpc.client.services.TestService.TestClass) Encoder.decode(_data, krpc.client.Types.createClass("TestService", "TestClass"), this.connection);
+        }
+
+        @SuppressWarnings({ "unchecked" })
         @RPCInfo(service = "TestService", procedure = "TestClass_FloatToString", types = _Types.class)
         public String floatToString(float x) throws RPCException
         {
@@ -800,6 +878,17 @@ public class TestService {
             ByteString _data = connection.invoke("TestService", "TestClass_static_StaticMethod", _args);
             return (String) Encoder.decode(_data, krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.STRING), connection);
         }
+
+        @SuppressWarnings({ "unchecked" })
+        @RPCInfo(service = "TestService", procedure = "TestClass_static_StaticNullableObject", types = _Types.class)
+        public static krpc.client.services.TestService.TestClass staticNullableObject(Connection connection, krpc.client.services.TestService.TestClass value) throws RPCException
+        {
+            ByteString[] _args = new ByteString[] {
+                Encoder.encode(value, krpc.client.Types.createClass("TestService", "TestClass"))
+            };
+            ByteString _data = connection.invoke("TestService", "TestClass_static_StaticNullableObject", _args);
+            return (krpc.client.services.TestService.TestClass) Encoder.decode(_data, krpc.client.Types.createClass("TestService", "TestClass"), connection);
+        }
     }
 
     public static class _Types {
@@ -840,8 +929,16 @@ public class TestService {
             PARAMETER_TYPES.put("DictionaryDefault", new krpc.schema.KRPC.Type[] { krpc.client.Types.createDictionary(krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.SINT32), krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.BOOL)) });
             RETURN_TYPES.put("DoubleToString", krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.STRING));
             PARAMETER_TYPES.put("DoubleToString", new krpc.schema.KRPC.Type[] { krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.DOUBLE) });
+            RETURN_TYPES.put("EchoNullableInt", krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.SINT32));
+            PARAMETER_TYPES.put("EchoNullableInt", new krpc.schema.KRPC.Type[] { krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.SINT32) });
+            RETURN_TYPES.put("EchoNullableList", krpc.client.Types.createList(krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.SINT32)));
+            PARAMETER_TYPES.put("EchoNullableList", new krpc.schema.KRPC.Type[] { krpc.client.Types.createList(krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.SINT32)) });
+            RETURN_TYPES.put("EchoNullableString", krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.STRING));
+            PARAMETER_TYPES.put("EchoNullableString", new krpc.schema.KRPC.Type[] { krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.STRING) });
             RETURN_TYPES.put("EchoTestObject", krpc.client.Types.createClass("TestService", "TestClass"));
             PARAMETER_TYPES.put("EchoTestObject", new krpc.schema.KRPC.Type[] { krpc.client.Types.createClass("TestService", "TestClass") });
+            RETURN_TYPES.put("EmptyListDefault", krpc.client.Types.createList(krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.STRING)));
+            PARAMETER_TYPES.put("EmptyListDefault", new krpc.schema.KRPC.Type[] { krpc.client.Types.createList(krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.STRING)) });
             RETURN_TYPES.put("EnumDefaultArg", krpc.client.Types.createEnumeration("TestService", "TestEnum"));
             PARAMETER_TYPES.put("EnumDefaultArg", new krpc.schema.KRPC.Type[] { krpc.client.Types.createEnumeration("TestService", "TestEnum") });
             RETURN_TYPES.put("EnumEcho", krpc.client.Types.createEnumeration("TestService", "TestEnum"));
@@ -866,6 +963,8 @@ public class TestService {
             PARAMETER_TYPES.put("Int64ToString", new krpc.schema.KRPC.Type[] { krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.SINT64) });
             RETURN_TYPES.put("ListDefault", krpc.client.Types.createList(krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.SINT32)));
             PARAMETER_TYPES.put("ListDefault", new krpc.schema.KRPC.Type[] { krpc.client.Types.createList(krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.SINT32)) });
+            RETURN_TYPES.put("NotNullableObject", krpc.client.Types.createClass("TestService", "TestClass"));
+            PARAMETER_TYPES.put("NotNullableObject", new krpc.schema.KRPC.Type[] { krpc.client.Types.createClass("TestService", "TestClass") });
             RETURN_TYPES.put("OnTimer", krpc.client.Types.createMessage(krpc.schema.KRPC.Type.TypeCode.EVENT));
             PARAMETER_TYPES.put("OnTimer", new krpc.schema.KRPC.Type[] { krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.UINT32), krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.UINT32) });
             RETURN_TYPES.put("OnTimerUsingLambda", krpc.client.Types.createMessage(krpc.schema.KRPC.Type.TypeCode.EVENT));
@@ -902,8 +1001,15 @@ public class TestService {
             PARAMETER_TYPES.put("get_DeprecatedProperty", new krpc.schema.KRPC.Type[] {  });
             RETURN_TYPES.put("set_DeprecatedProperty", null);
             PARAMETER_TYPES.put("set_DeprecatedProperty", new krpc.schema.KRPC.Type[] { krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.STRING) });
+            RETURN_TYPES.put("get_NullableObject", krpc.client.Types.createClass("TestService", "TestClass"));
+            PARAMETER_TYPES.put("get_NullableObject", new krpc.schema.KRPC.Type[] {  });
+            RETURN_TYPES.put("set_NullableObject", null);
+            PARAMETER_TYPES.put("set_NullableObject", new krpc.schema.KRPC.Type[] { krpc.client.Types.createClass("TestService", "TestClass") });
             RETURN_TYPES.put("get_ObjectProperty", krpc.client.Types.createClass("TestService", "TestClass"));
             PARAMETER_TYPES.put("get_ObjectProperty", new krpc.schema.KRPC.Type[] {  });
+        }
+
+        private static void initTypes1() {
             RETURN_TYPES.put("set_ObjectProperty", null);
             PARAMETER_TYPES.put("set_ObjectProperty", new krpc.schema.KRPC.Type[] { krpc.client.Types.createClass("TestService", "TestClass") });
             RETURN_TYPES.put("get_StringProperty", krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.STRING));
@@ -916,11 +1022,10 @@ public class TestService {
             PARAMETER_TYPES.put("get_StringPropertyPrivateSet", new krpc.schema.KRPC.Type[] {  });
             RETURN_TYPES.put("DeprecatedClass_DeprecatedMethod", krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.STRING));
             PARAMETER_TYPES.put("DeprecatedClass_DeprecatedMethod", new krpc.schema.KRPC.Type[] { krpc.client.Types.createClass("TestService", "DeprecatedClass") });
+            RETURN_TYPES.put("TestClass_EchoNullableObject", krpc.client.Types.createClass("TestService", "TestClass"));
+            PARAMETER_TYPES.put("TestClass_EchoNullableObject", new krpc.schema.KRPC.Type[] { krpc.client.Types.createClass("TestService", "TestClass"), krpc.client.Types.createClass("TestService", "TestClass") });
             RETURN_TYPES.put("TestClass_FloatToString", krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.STRING));
             PARAMETER_TYPES.put("TestClass_FloatToString", new krpc.schema.KRPC.Type[] { krpc.client.Types.createClass("TestService", "TestClass"), krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.FLOAT) });
-        }
-
-        private static void initTypes1() {
             RETURN_TYPES.put("TestClass_GetValue", krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.STRING));
             PARAMETER_TYPES.put("TestClass_GetValue", new krpc.schema.KRPC.Type[] { krpc.client.Types.createClass("TestService", "TestClass") });
             RETURN_TYPES.put("TestClass_ObjectToString", krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.STRING));
@@ -941,6 +1046,8 @@ public class TestService {
             PARAMETER_TYPES.put("TestClass_get_StringPropertyPrivateSet", new krpc.schema.KRPC.Type[] { krpc.client.Types.createClass("TestService", "TestClass") });
             RETURN_TYPES.put("TestClass_static_StaticMethod", krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.STRING));
             PARAMETER_TYPES.put("TestClass_static_StaticMethod", new krpc.schema.KRPC.Type[] { krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.STRING), krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.STRING) });
+            RETURN_TYPES.put("TestClass_static_StaticNullableObject", krpc.client.Types.createClass("TestService", "TestClass"));
+            PARAMETER_TYPES.put("TestClass_static_StaticNullableObject", new krpc.schema.KRPC.Type[] { krpc.client.Types.createClass("TestService", "TestClass") });
         }
 
         public static krpc.schema.KRPC.Type getReturnType(String procedure) {

--- a/tools/krpctools/krpctools/test/clientgen-TestService-java.txt
+++ b/tools/krpctools/krpctools/test/clientgen-TestService-java.txt
@@ -69,8 +69,8 @@ public class TestService {
             Encoder.encode(y, krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.SINT32)),
             Encoder.encode(z, krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.SINT64))
         };
-        ByteString _data = this.connection.invoke("TestService", "AddMultipleValues", _args);
-        return (String) Encoder.decode(_data, krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.STRING), this.connection);
+        krpc.schema.KRPC.ProcedureResult _data = this.connection.invoke("TestService", "AddMultipleValues", _args);
+        return (String) Encoder.decode(_data.getValue(), krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.STRING), this.connection);
     }
 
     @SuppressWarnings({ "unchecked" })
@@ -80,8 +80,8 @@ public class TestService {
             Encoder.encode(l, krpc.client.Types.createList(krpc.client.Types.createClass("TestService", "TestClass"))),
             Encoder.encode(value, krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.STRING))
         };
-        ByteString _data = this.connection.invoke("TestService", "AddToObjectList", _args);
-        return (java.util.List<krpc.client.services.TestService.TestClass>) Encoder.decode(_data, krpc.client.Types.createList(krpc.client.Types.createClass("TestService", "TestClass")), this.connection);
+        krpc.schema.KRPC.ProcedureResult _data = this.connection.invoke("TestService", "AddToObjectList", _args);
+        return (java.util.List<krpc.client.services.TestService.TestClass>) Encoder.decode(_data.getValue(), krpc.client.Types.createList(krpc.client.Types.createClass("TestService", "TestClass")), this.connection);
     }
 
     @SuppressWarnings({ "unchecked" })
@@ -91,8 +91,8 @@ public class TestService {
             Encoder.encode(n, krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.SINT32)),
             Encoder.encode(sum, krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.SINT32))
         };
-        ByteString _data = this.connection.invoke("TestService", "BlockingProcedure", _args);
-        return (int) Encoder.decode(_data, krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.SINT32), this.connection);
+        krpc.schema.KRPC.ProcedureResult _data = this.connection.invoke("TestService", "BlockingProcedure", _args);
+        return (int) Encoder.decode(_data.getValue(), krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.SINT32), this.connection);
     }
 
     @SuppressWarnings({ "unchecked" })
@@ -101,8 +101,8 @@ public class TestService {
         ByteString[] _args = new ByteString[] {
             Encoder.encode(value, krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.BOOL))
         };
-        ByteString _data = this.connection.invoke("TestService", "BoolToString", _args);
-        return (String) Encoder.decode(_data, krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.STRING), this.connection);
+        krpc.schema.KRPC.ProcedureResult _data = this.connection.invoke("TestService", "BoolToString", _args);
+        return (String) Encoder.decode(_data.getValue(), krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.STRING), this.connection);
     }
 
     @SuppressWarnings({ "unchecked" })
@@ -111,8 +111,8 @@ public class TestService {
         ByteString[] _args = new ByteString[] {
             Encoder.encode(value, krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.BYTES))
         };
-        ByteString _data = this.connection.invoke("TestService", "BytesToHexString", _args);
-        return (String) Encoder.decode(_data, krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.STRING), this.connection);
+        krpc.schema.KRPC.ProcedureResult _data = this.connection.invoke("TestService", "BytesToHexString", _args);
+        return (String) Encoder.decode(_data.getValue(), krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.STRING), this.connection);
     }
 
     @SuppressWarnings({ "unchecked" })
@@ -122,8 +122,8 @@ public class TestService {
             Encoder.encode(id, krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.STRING)),
             Encoder.encode(divisor, krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.SINT32))
         };
-        ByteString _data = this.connection.invoke("TestService", "Counter", _args);
-        return (int) Encoder.decode(_data, krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.SINT32), this.connection);
+        krpc.schema.KRPC.ProcedureResult _data = this.connection.invoke("TestService", "Counter", _args);
+        return (int) Encoder.decode(_data.getValue(), krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.SINT32), this.connection);
     }
 
     @SuppressWarnings({ "unchecked" })
@@ -132,8 +132,8 @@ public class TestService {
         ByteString[] _args = new ByteString[] {
             Encoder.encode(value, krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.STRING))
         };
-        ByteString _data = this.connection.invoke("TestService", "CreateTestObject", _args);
-        return (krpc.client.services.TestService.TestClass) Encoder.decode(_data, krpc.client.Types.createClass("TestService", "TestClass"), this.connection);
+        krpc.schema.KRPC.ProcedureResult _data = this.connection.invoke("TestService", "CreateTestObject", _args);
+        return (krpc.client.services.TestService.TestClass) Encoder.decode(_data.getValue(), krpc.client.Types.createClass("TestService", "TestClass"), this.connection);
     }
 
     /**
@@ -148,8 +148,8 @@ public class TestService {
         ByteString[] _args = new ByteString[] {
             Encoder.encode(value, krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.FLOAT))
         };
-        ByteString _data = this.connection.invoke("TestService", "DeprecatedProcedure", _args);
-        return (String) Encoder.decode(_data, krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.STRING), this.connection);
+        krpc.schema.KRPC.ProcedureResult _data = this.connection.invoke("TestService", "DeprecatedProcedure", _args);
+        return (String) Encoder.decode(_data.getValue(), krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.STRING), this.connection);
     }
 
     /**
@@ -162,8 +162,8 @@ public class TestService {
         ByteString[] _args = new ByteString[] {
             Encoder.encode(value, krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.FLOAT))
         };
-        ByteString _data = this.connection.invoke("TestService", "DeprecatedProcedureNoMessage", _args);
-        return (String) Encoder.decode(_data, krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.STRING), this.connection);
+        krpc.schema.KRPC.ProcedureResult _data = this.connection.invoke("TestService", "DeprecatedProcedureNoMessage", _args);
+        return (String) Encoder.decode(_data.getValue(), krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.STRING), this.connection);
     }
 
     @SuppressWarnings({ "unchecked" })
@@ -172,8 +172,8 @@ public class TestService {
         ByteString[] _args = new ByteString[] {
             Encoder.encode(x, krpc.client.Types.createDictionary(krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.SINT32), krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.BOOL)))
         };
-        ByteString _data = this.connection.invoke("TestService", "DictionaryDefault", _args);
-        return (java.util.Map<Integer,Boolean>) Encoder.decode(_data, krpc.client.Types.createDictionary(krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.SINT32), krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.BOOL)), this.connection);
+        krpc.schema.KRPC.ProcedureResult _data = this.connection.invoke("TestService", "DictionaryDefault", _args);
+        return (java.util.Map<Integer,Boolean>) Encoder.decode(_data.getValue(), krpc.client.Types.createDictionary(krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.SINT32), krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.BOOL)), this.connection);
     }
 
     @SuppressWarnings({ "unchecked" })
@@ -182,18 +182,21 @@ public class TestService {
         ByteString[] _args = new ByteString[] {
             Encoder.encode(value, krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.DOUBLE))
         };
-        ByteString _data = this.connection.invoke("TestService", "DoubleToString", _args);
-        return (String) Encoder.decode(_data, krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.STRING), this.connection);
+        krpc.schema.KRPC.ProcedureResult _data = this.connection.invoke("TestService", "DoubleToString", _args);
+        return (String) Encoder.decode(_data.getValue(), krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.STRING), this.connection);
     }
 
     @SuppressWarnings({ "unchecked" })
     @RPCInfo(service = "TestService", procedure = "EchoNullableInt", types = _Types.class)
-    public int echoNullableInt(int value) throws RPCException {
+    public Integer echoNullableInt(Integer value) throws RPCException {
         ByteString[] _args = new ByteString[] {
             Encoder.encode(value, krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.SINT32))
         };
-        ByteString _data = this.connection.invoke("TestService", "EchoNullableInt", _args);
-        return (int) Encoder.decode(_data, krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.SINT32), this.connection);
+        krpc.schema.KRPC.ProcedureResult _data = this.connection.invoke("TestService", "EchoNullableInt", _args);
+        if (_data.getIsNull()) {
+          return null;
+        }
+        return (Integer) Encoder.decode(_data.getValue(), krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.SINT32), this.connection);
     }
 
     @SuppressWarnings({ "unchecked" })
@@ -202,8 +205,11 @@ public class TestService {
         ByteString[] _args = new ByteString[] {
             Encoder.encode(l, krpc.client.Types.createList(krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.SINT32)))
         };
-        ByteString _data = this.connection.invoke("TestService", "EchoNullableList", _args);
-        return (java.util.List<Integer>) Encoder.decode(_data, krpc.client.Types.createList(krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.SINT32)), this.connection);
+        krpc.schema.KRPC.ProcedureResult _data = this.connection.invoke("TestService", "EchoNullableList", _args);
+        if (_data.getIsNull()) {
+          return null;
+        }
+        return (java.util.List<Integer>) Encoder.decode(_data.getValue(), krpc.client.Types.createList(krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.SINT32)), this.connection);
     }
 
     @SuppressWarnings({ "unchecked" })
@@ -212,8 +218,11 @@ public class TestService {
         ByteString[] _args = new ByteString[] {
             Encoder.encode(value, krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.STRING))
         };
-        ByteString _data = this.connection.invoke("TestService", "EchoNullableString", _args);
-        return (String) Encoder.decode(_data, krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.STRING), this.connection);
+        krpc.schema.KRPC.ProcedureResult _data = this.connection.invoke("TestService", "EchoNullableString", _args);
+        if (_data.getIsNull()) {
+          return null;
+        }
+        return (String) Encoder.decode(_data.getValue(), krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.STRING), this.connection);
     }
 
     @SuppressWarnings({ "unchecked" })
@@ -222,8 +231,11 @@ public class TestService {
         ByteString[] _args = new ByteString[] {
             Encoder.encode(value, krpc.client.Types.createClass("TestService", "TestClass"))
         };
-        ByteString _data = this.connection.invoke("TestService", "EchoTestObject", _args);
-        return (krpc.client.services.TestService.TestClass) Encoder.decode(_data, krpc.client.Types.createClass("TestService", "TestClass"), this.connection);
+        krpc.schema.KRPC.ProcedureResult _data = this.connection.invoke("TestService", "EchoTestObject", _args);
+        if (_data.getIsNull()) {
+          return null;
+        }
+        return (krpc.client.services.TestService.TestClass) Encoder.decode(_data.getValue(), krpc.client.Types.createClass("TestService", "TestClass"), this.connection);
     }
 
     @SuppressWarnings({ "unchecked" })
@@ -232,8 +244,8 @@ public class TestService {
         ByteString[] _args = new ByteString[] {
             Encoder.encode(x, krpc.client.Types.createList(krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.STRING)))
         };
-        ByteString _data = this.connection.invoke("TestService", "EmptyListDefault", _args);
-        return (java.util.List<String>) Encoder.decode(_data, krpc.client.Types.createList(krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.STRING)), this.connection);
+        krpc.schema.KRPC.ProcedureResult _data = this.connection.invoke("TestService", "EmptyListDefault", _args);
+        return (java.util.List<String>) Encoder.decode(_data.getValue(), krpc.client.Types.createList(krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.STRING)), this.connection);
     }
 
     @SuppressWarnings({ "unchecked" })
@@ -242,8 +254,8 @@ public class TestService {
         ByteString[] _args = new ByteString[] {
             Encoder.encode(x, krpc.client.Types.createEnumeration("TestService", "TestEnum"))
         };
-        ByteString _data = this.connection.invoke("TestService", "EnumDefaultArg", _args);
-        return (krpc.client.services.TestService.TestEnum) Encoder.decode(_data, krpc.client.Types.createEnumeration("TestService", "TestEnum"), this.connection);
+        krpc.schema.KRPC.ProcedureResult _data = this.connection.invoke("TestService", "EnumDefaultArg", _args);
+        return (krpc.client.services.TestService.TestEnum) Encoder.decode(_data.getValue(), krpc.client.Types.createEnumeration("TestService", "TestEnum"), this.connection);
     }
 
     @SuppressWarnings({ "unchecked" })
@@ -252,15 +264,15 @@ public class TestService {
         ByteString[] _args = new ByteString[] {
             Encoder.encode(x, krpc.client.Types.createEnumeration("TestService", "TestEnum"))
         };
-        ByteString _data = this.connection.invoke("TestService", "EnumEcho", _args);
-        return (krpc.client.services.TestService.TestEnum) Encoder.decode(_data, krpc.client.Types.createEnumeration("TestService", "TestEnum"), this.connection);
+        krpc.schema.KRPC.ProcedureResult _data = this.connection.invoke("TestService", "EnumEcho", _args);
+        return (krpc.client.services.TestService.TestEnum) Encoder.decode(_data.getValue(), krpc.client.Types.createEnumeration("TestService", "TestEnum"), this.connection);
     }
 
     @SuppressWarnings({ "unchecked" })
     @RPCInfo(service = "TestService", procedure = "EnumReturn", types = _Types.class)
     public krpc.client.services.TestService.TestEnum enumReturn() throws RPCException {
-        ByteString _data = this.connection.invoke("TestService", "EnumReturn");
-        return (krpc.client.services.TestService.TestEnum) Encoder.decode(_data, krpc.client.Types.createEnumeration("TestService", "TestEnum"), this.connection);
+        krpc.schema.KRPC.ProcedureResult _data = this.connection.invoke("TestService", "EnumReturn");
+        return (krpc.client.services.TestService.TestEnum) Encoder.decode(_data.getValue(), krpc.client.Types.createEnumeration("TestService", "TestEnum"), this.connection);
     }
 
     /**
@@ -272,8 +284,8 @@ public class TestService {
         ByteString[] _args = new ByteString[] {
             Encoder.encode(value, krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.FLOAT))
         };
-        ByteString _data = this.connection.invoke("TestService", "FloatToString", _args);
-        return (String) Encoder.decode(_data, krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.STRING), this.connection);
+        krpc.schema.KRPC.ProcedureResult _data = this.connection.invoke("TestService", "FloatToString", _args);
+        return (String) Encoder.decode(_data.getValue(), krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.STRING), this.connection);
     }
 
     @SuppressWarnings({ "unchecked" })
@@ -282,8 +294,8 @@ public class TestService {
         ByteString[] _args = new ByteString[] {
             Encoder.encode(d, krpc.client.Types.createDictionary(krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.STRING), krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.SINT32)))
         };
-        ByteString _data = this.connection.invoke("TestService", "IncrementDictionary", _args);
-        return (java.util.Map<String,Integer>) Encoder.decode(_data, krpc.client.Types.createDictionary(krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.STRING), krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.SINT32)), this.connection);
+        krpc.schema.KRPC.ProcedureResult _data = this.connection.invoke("TestService", "IncrementDictionary", _args);
+        return (java.util.Map<String,Integer>) Encoder.decode(_data.getValue(), krpc.client.Types.createDictionary(krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.STRING), krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.SINT32)), this.connection);
     }
 
     @SuppressWarnings({ "unchecked" })
@@ -292,8 +304,8 @@ public class TestService {
         ByteString[] _args = new ByteString[] {
             Encoder.encode(l, krpc.client.Types.createList(krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.SINT32)))
         };
-        ByteString _data = this.connection.invoke("TestService", "IncrementList", _args);
-        return (java.util.List<Integer>) Encoder.decode(_data, krpc.client.Types.createList(krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.SINT32)), this.connection);
+        krpc.schema.KRPC.ProcedureResult _data = this.connection.invoke("TestService", "IncrementList", _args);
+        return (java.util.List<Integer>) Encoder.decode(_data.getValue(), krpc.client.Types.createList(krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.SINT32)), this.connection);
     }
 
     @SuppressWarnings({ "unchecked" })
@@ -302,8 +314,8 @@ public class TestService {
         ByteString[] _args = new ByteString[] {
             Encoder.encode(d, krpc.client.Types.createDictionary(krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.STRING), krpc.client.Types.createList(krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.SINT32))))
         };
-        ByteString _data = this.connection.invoke("TestService", "IncrementNestedCollection", _args);
-        return (java.util.Map<String,java.util.List<Integer>>) Encoder.decode(_data, krpc.client.Types.createDictionary(krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.STRING), krpc.client.Types.createList(krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.SINT32))), this.connection);
+        krpc.schema.KRPC.ProcedureResult _data = this.connection.invoke("TestService", "IncrementNestedCollection", _args);
+        return (java.util.Map<String,java.util.List<Integer>>) Encoder.decode(_data.getValue(), krpc.client.Types.createDictionary(krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.STRING), krpc.client.Types.createList(krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.SINT32))), this.connection);
     }
 
     @SuppressWarnings({ "unchecked" })
@@ -312,8 +324,8 @@ public class TestService {
         ByteString[] _args = new ByteString[] {
             Encoder.encode(h, krpc.client.Types.createSet(krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.SINT32)))
         };
-        ByteString _data = this.connection.invoke("TestService", "IncrementSet", _args);
-        return (java.util.Set<Integer>) Encoder.decode(_data, krpc.client.Types.createSet(krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.SINT32)), this.connection);
+        krpc.schema.KRPC.ProcedureResult _data = this.connection.invoke("TestService", "IncrementSet", _args);
+        return (java.util.Set<Integer>) Encoder.decode(_data.getValue(), krpc.client.Types.createSet(krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.SINT32)), this.connection);
     }
 
     @SuppressWarnings({ "unchecked" })
@@ -322,8 +334,8 @@ public class TestService {
         ByteString[] _args = new ByteString[] {
             Encoder.encode(t, krpc.client.Types.createTuple(krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.SINT32),krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.SINT64)))
         };
-        ByteString _data = this.connection.invoke("TestService", "IncrementTuple", _args);
-        return (org.javatuples.Pair<Integer,Long>) Encoder.decode(_data, krpc.client.Types.createTuple(krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.SINT32),krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.SINT64)), this.connection);
+        krpc.schema.KRPC.ProcedureResult _data = this.connection.invoke("TestService", "IncrementTuple", _args);
+        return (org.javatuples.Pair<Integer,Long>) Encoder.decode(_data.getValue(), krpc.client.Types.createTuple(krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.SINT32),krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.SINT64)), this.connection);
     }
 
     @SuppressWarnings({ "unchecked" })
@@ -332,8 +344,8 @@ public class TestService {
         ByteString[] _args = new ByteString[] {
             Encoder.encode(value, krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.SINT32))
         };
-        ByteString _data = this.connection.invoke("TestService", "Int32ToString", _args);
-        return (String) Encoder.decode(_data, krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.STRING), this.connection);
+        krpc.schema.KRPC.ProcedureResult _data = this.connection.invoke("TestService", "Int32ToString", _args);
+        return (String) Encoder.decode(_data.getValue(), krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.STRING), this.connection);
     }
 
     @SuppressWarnings({ "unchecked" })
@@ -342,8 +354,8 @@ public class TestService {
         ByteString[] _args = new ByteString[] {
             Encoder.encode(value, krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.SINT64))
         };
-        ByteString _data = this.connection.invoke("TestService", "Int64ToString", _args);
-        return (String) Encoder.decode(_data, krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.STRING), this.connection);
+        krpc.schema.KRPC.ProcedureResult _data = this.connection.invoke("TestService", "Int64ToString", _args);
+        return (String) Encoder.decode(_data.getValue(), krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.STRING), this.connection);
     }
 
     @SuppressWarnings({ "unchecked" })
@@ -352,8 +364,8 @@ public class TestService {
         ByteString[] _args = new ByteString[] {
             Encoder.encode(x, krpc.client.Types.createList(krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.SINT32)))
         };
-        ByteString _data = this.connection.invoke("TestService", "ListDefault", _args);
-        return (java.util.List<Integer>) Encoder.decode(_data, krpc.client.Types.createList(krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.SINT32)), this.connection);
+        krpc.schema.KRPC.ProcedureResult _data = this.connection.invoke("TestService", "ListDefault", _args);
+        return (java.util.List<Integer>) Encoder.decode(_data.getValue(), krpc.client.Types.createList(krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.SINT32)), this.connection);
     }
 
     @SuppressWarnings({ "unchecked" })
@@ -362,8 +374,8 @@ public class TestService {
         ByteString[] _args = new ByteString[] {
             Encoder.encode(value, krpc.client.Types.createClass("TestService", "TestClass"))
         };
-        ByteString _data = this.connection.invoke("TestService", "NotNullableObject", _args);
-        return (krpc.client.services.TestService.TestClass) Encoder.decode(_data, krpc.client.Types.createClass("TestService", "TestClass"), this.connection);
+        krpc.schema.KRPC.ProcedureResult _data = this.connection.invoke("TestService", "NotNullableObject", _args);
+        return (krpc.client.services.TestService.TestClass) Encoder.decode(_data.getValue(), krpc.client.Types.createClass("TestService", "TestClass"), this.connection);
     }
 
     @SuppressWarnings({ "unchecked" })
@@ -373,8 +385,8 @@ public class TestService {
             Encoder.encode(milliseconds, krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.UINT32)),
             Encoder.encode(repeats, krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.UINT32))
         };
-        ByteString _data = this.connection.invoke("TestService", "OnTimer", _args);
-        return (krpc.client.Event) Encoder.decode(_data, krpc.client.Types.createMessage(krpc.schema.KRPC.Type.TypeCode.EVENT), this.connection);
+        krpc.schema.KRPC.ProcedureResult _data = this.connection.invoke("TestService", "OnTimer", _args);
+        return (krpc.client.Event) Encoder.decode(_data.getValue(), krpc.client.Types.createMessage(krpc.schema.KRPC.Type.TypeCode.EVENT), this.connection);
     }
 
     @SuppressWarnings({ "unchecked" })
@@ -383,8 +395,8 @@ public class TestService {
         ByteString[] _args = new ByteString[] {
             Encoder.encode(milliseconds, krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.UINT32))
         };
-        ByteString _data = this.connection.invoke("TestService", "OnTimerUsingLambda", _args);
-        return (krpc.client.Event) Encoder.decode(_data, krpc.client.Types.createMessage(krpc.schema.KRPC.Type.TypeCode.EVENT), this.connection);
+        krpc.schema.KRPC.ProcedureResult _data = this.connection.invoke("TestService", "OnTimerUsingLambda", _args);
+        return (krpc.client.Event) Encoder.decode(_data.getValue(), krpc.client.Types.createMessage(krpc.schema.KRPC.Type.TypeCode.EVENT), this.connection);
     }
 
     @SuppressWarnings({ "unchecked" })
@@ -396,8 +408,8 @@ public class TestService {
             Encoder.encode(z, krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.STRING)),
             Encoder.encode(obj, krpc.client.Types.createClass("TestService", "TestClass"))
         };
-        ByteString _data = this.connection.invoke("TestService", "OptionalArguments", _args);
-        return (String) Encoder.decode(_data, krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.STRING), this.connection);
+        krpc.schema.KRPC.ProcedureResult _data = this.connection.invoke("TestService", "OptionalArguments", _args);
+        return (String) Encoder.decode(_data.getValue(), krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.STRING), this.connection);
     }
 
     @SuppressWarnings({ "unchecked" })
@@ -415,8 +427,8 @@ public class TestService {
     @SuppressWarnings({ "unchecked" })
     @RPCInfo(service = "TestService", procedure = "ReturnNullWhenNotAllowed", types = _Types.class)
     public krpc.client.services.TestService.TestClass returnNullWhenNotAllowed() throws RPCException {
-        ByteString _data = this.connection.invoke("TestService", "ReturnNullWhenNotAllowed");
-        return (krpc.client.services.TestService.TestClass) Encoder.decode(_data, krpc.client.Types.createClass("TestService", "TestClass"), this.connection);
+        krpc.schema.KRPC.ProcedureResult _data = this.connection.invoke("TestService", "ReturnNullWhenNotAllowed");
+        return (krpc.client.services.TestService.TestClass) Encoder.decode(_data.getValue(), krpc.client.Types.createClass("TestService", "TestClass"), this.connection);
     }
 
     @SuppressWarnings({ "unchecked" })
@@ -425,8 +437,8 @@ public class TestService {
         ByteString[] _args = new ByteString[] {
             Encoder.encode(x, krpc.client.Types.createSet(krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.SINT32)))
         };
-        ByteString _data = this.connection.invoke("TestService", "SetDefault", _args);
-        return (java.util.Set<Integer>) Encoder.decode(_data, krpc.client.Types.createSet(krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.SINT32)), this.connection);
+        krpc.schema.KRPC.ProcedureResult _data = this.connection.invoke("TestService", "SetDefault", _args);
+        return (java.util.Set<Integer>) Encoder.decode(_data.getValue(), krpc.client.Types.createSet(krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.SINT32)), this.connection);
     }
 
     @SuppressWarnings({ "unchecked" })
@@ -435,15 +447,15 @@ public class TestService {
         ByteString[] _args = new ByteString[] {
             Encoder.encode(value, krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.STRING))
         };
-        ByteString _data = this.connection.invoke("TestService", "StringToInt32", _args);
-        return (int) Encoder.decode(_data, krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.SINT32), this.connection);
+        krpc.schema.KRPC.ProcedureResult _data = this.connection.invoke("TestService", "StringToInt32", _args);
+        return (int) Encoder.decode(_data.getValue(), krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.SINT32), this.connection);
     }
 
     @SuppressWarnings({ "unchecked" })
     @RPCInfo(service = "TestService", procedure = "ThrowArgumentException", types = _Types.class)
     public int throwArgumentException() throws RPCException {
-        ByteString _data = this.connection.invoke("TestService", "ThrowArgumentException");
-        return (int) Encoder.decode(_data, krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.SINT32), this.connection);
+        krpc.schema.KRPC.ProcedureResult _data = this.connection.invoke("TestService", "ThrowArgumentException");
+        return (int) Encoder.decode(_data.getValue(), krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.SINT32), this.connection);
     }
 
     @SuppressWarnings({ "unchecked" })
@@ -452,8 +464,8 @@ public class TestService {
         ByteString[] _args = new ByteString[] {
             Encoder.encode(foo, krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.STRING))
         };
-        ByteString _data = this.connection.invoke("TestService", "ThrowArgumentNullException", _args);
-        return (int) Encoder.decode(_data, krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.SINT32), this.connection);
+        krpc.schema.KRPC.ProcedureResult _data = this.connection.invoke("TestService", "ThrowArgumentNullException", _args);
+        return (int) Encoder.decode(_data.getValue(), krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.SINT32), this.connection);
     }
 
     @SuppressWarnings({ "unchecked" })
@@ -462,36 +474,36 @@ public class TestService {
         ByteString[] _args = new ByteString[] {
             Encoder.encode(foo, krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.SINT32))
         };
-        ByteString _data = this.connection.invoke("TestService", "ThrowArgumentOutOfRangeException", _args);
-        return (int) Encoder.decode(_data, krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.SINT32), this.connection);
+        krpc.schema.KRPC.ProcedureResult _data = this.connection.invoke("TestService", "ThrowArgumentOutOfRangeException", _args);
+        return (int) Encoder.decode(_data.getValue(), krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.SINT32), this.connection);
     }
 
     @SuppressWarnings({ "unchecked" })
     @RPCInfo(service = "TestService", procedure = "ThrowCustomException", types = _Types.class)
     public int throwCustomException() throws RPCException {
-        ByteString _data = this.connection.invoke("TestService", "ThrowCustomException");
-        return (int) Encoder.decode(_data, krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.SINT32), this.connection);
+        krpc.schema.KRPC.ProcedureResult _data = this.connection.invoke("TestService", "ThrowCustomException");
+        return (int) Encoder.decode(_data.getValue(), krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.SINT32), this.connection);
     }
 
     @SuppressWarnings({ "unchecked" })
     @RPCInfo(service = "TestService", procedure = "ThrowCustomExceptionLater", types = _Types.class)
     public int throwCustomExceptionLater() throws RPCException {
-        ByteString _data = this.connection.invoke("TestService", "ThrowCustomExceptionLater");
-        return (int) Encoder.decode(_data, krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.SINT32), this.connection);
+        krpc.schema.KRPC.ProcedureResult _data = this.connection.invoke("TestService", "ThrowCustomExceptionLater");
+        return (int) Encoder.decode(_data.getValue(), krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.SINT32), this.connection);
     }
 
     @SuppressWarnings({ "unchecked" })
     @RPCInfo(service = "TestService", procedure = "ThrowInvalidOperationException", types = _Types.class)
     public int throwInvalidOperationException() throws RPCException {
-        ByteString _data = this.connection.invoke("TestService", "ThrowInvalidOperationException");
-        return (int) Encoder.decode(_data, krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.SINT32), this.connection);
+        krpc.schema.KRPC.ProcedureResult _data = this.connection.invoke("TestService", "ThrowInvalidOperationException");
+        return (int) Encoder.decode(_data.getValue(), krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.SINT32), this.connection);
     }
 
     @SuppressWarnings({ "unchecked" })
     @RPCInfo(service = "TestService", procedure = "ThrowInvalidOperationExceptionLater", types = _Types.class)
     public int throwInvalidOperationExceptionLater() throws RPCException {
-        ByteString _data = this.connection.invoke("TestService", "ThrowInvalidOperationExceptionLater");
-        return (int) Encoder.decode(_data, krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.SINT32), this.connection);
+        krpc.schema.KRPC.ProcedureResult _data = this.connection.invoke("TestService", "ThrowInvalidOperationExceptionLater");
+        return (int) Encoder.decode(_data.getValue(), krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.SINT32), this.connection);
     }
 
     @SuppressWarnings({ "unchecked" })
@@ -500,8 +512,8 @@ public class TestService {
         ByteString[] _args = new ByteString[] {
             Encoder.encode(x, krpc.client.Types.createTuple(krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.SINT32),krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.BOOL)))
         };
-        ByteString _data = this.connection.invoke("TestService", "TupleDefault", _args);
-        return (org.javatuples.Pair<Integer,Boolean>) Encoder.decode(_data, krpc.client.Types.createTuple(krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.SINT32),krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.BOOL)), this.connection);
+        krpc.schema.KRPC.ProcedureResult _data = this.connection.invoke("TestService", "TupleDefault", _args);
+        return (org.javatuples.Pair<Integer,Boolean>) Encoder.decode(_data.getValue(), krpc.client.Types.createTuple(krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.SINT32),krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.BOOL)), this.connection);
     }
 
     /**
@@ -513,8 +525,8 @@ public class TestService {
     @SuppressWarnings({ "unchecked" })
     @RPCInfo(service = "TestService", procedure = "get_DeprecatedProperty", types = _Types.class)
     public String getDeprecatedProperty() throws RPCException {
-        ByteString _data = this.connection.invoke("TestService", "get_DeprecatedProperty");
-        return (String) Encoder.decode(_data, krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.STRING), this.connection);
+        krpc.schema.KRPC.ProcedureResult _data = this.connection.invoke("TestService", "get_DeprecatedProperty");
+        return (String) Encoder.decode(_data.getValue(), krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.STRING), this.connection);
     }
 
     /**
@@ -535,8 +547,11 @@ public class TestService {
     @SuppressWarnings({ "unchecked" })
     @RPCInfo(service = "TestService", procedure = "get_NullableObject", types = _Types.class)
     public krpc.client.services.TestService.TestClass getNullableObject() throws RPCException {
-        ByteString _data = this.connection.invoke("TestService", "get_NullableObject");
-        return (krpc.client.services.TestService.TestClass) Encoder.decode(_data, krpc.client.Types.createClass("TestService", "TestClass"), this.connection);
+        krpc.schema.KRPC.ProcedureResult _data = this.connection.invoke("TestService", "get_NullableObject");
+        if (_data.getIsNull()) {
+          return null;
+        }
+        return (krpc.client.services.TestService.TestClass) Encoder.decode(_data.getValue(), krpc.client.Types.createClass("TestService", "TestClass"), this.connection);
     }
 
     @SuppressWarnings({ "unchecked" })
@@ -551,8 +566,11 @@ public class TestService {
     @SuppressWarnings({ "unchecked" })
     @RPCInfo(service = "TestService", procedure = "get_ObjectProperty", types = _Types.class)
     public krpc.client.services.TestService.TestClass getObjectProperty() throws RPCException {
-        ByteString _data = this.connection.invoke("TestService", "get_ObjectProperty");
-        return (krpc.client.services.TestService.TestClass) Encoder.decode(_data, krpc.client.Types.createClass("TestService", "TestClass"), this.connection);
+        krpc.schema.KRPC.ProcedureResult _data = this.connection.invoke("TestService", "get_ObjectProperty");
+        if (_data.getIsNull()) {
+          return null;
+        }
+        return (krpc.client.services.TestService.TestClass) Encoder.decode(_data.getValue(), krpc.client.Types.createClass("TestService", "TestClass"), this.connection);
     }
 
     @SuppressWarnings({ "unchecked" })
@@ -570,8 +588,8 @@ public class TestService {
     @SuppressWarnings({ "unchecked" })
     @RPCInfo(service = "TestService", procedure = "get_StringProperty", types = _Types.class)
     public String getStringProperty() throws RPCException {
-        ByteString _data = this.connection.invoke("TestService", "get_StringProperty");
-        return (String) Encoder.decode(_data, krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.STRING), this.connection);
+        krpc.schema.KRPC.ProcedureResult _data = this.connection.invoke("TestService", "get_StringProperty");
+        return (String) Encoder.decode(_data.getValue(), krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.STRING), this.connection);
     }
 
     /**
@@ -598,8 +616,8 @@ public class TestService {
     @SuppressWarnings({ "unchecked" })
     @RPCInfo(service = "TestService", procedure = "get_StringPropertyPrivateSet", types = _Types.class)
     public String getStringPropertyPrivateSet() throws RPCException {
-        ByteString _data = this.connection.invoke("TestService", "get_StringPropertyPrivateSet");
-        return (String) Encoder.decode(_data, krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.STRING), this.connection);
+        krpc.schema.KRPC.ProcedureResult _data = this.connection.invoke("TestService", "get_StringPropertyPrivateSet");
+        return (String) Encoder.decode(_data.getValue(), krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.STRING), this.connection);
     }
 
     /**
@@ -714,8 +732,8 @@ public class TestService {
             ByteString[] _args = new ByteString[] {
                 Encoder.encode(this, krpc.client.Types.createClass("TestService", "DeprecatedClass"))
             };
-            ByteString _data = this.connection.invoke("TestService", "DeprecatedClass_DeprecatedMethod", _args);
-            return (String) Encoder.decode(_data, krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.STRING), this.connection);
+            krpc.schema.KRPC.ProcedureResult _data = this.connection.invoke("TestService", "DeprecatedClass_DeprecatedMethod", _args);
+            return (String) Encoder.decode(_data.getValue(), krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.STRING), this.connection);
         }
     }
 
@@ -738,8 +756,11 @@ public class TestService {
                 Encoder.encode(this, krpc.client.Types.createClass("TestService", "TestClass")),
                 Encoder.encode(value, krpc.client.Types.createClass("TestService", "TestClass"))
             };
-            ByteString _data = this.connection.invoke("TestService", "TestClass_EchoNullableObject", _args);
-            return (krpc.client.services.TestService.TestClass) Encoder.decode(_data, krpc.client.Types.createClass("TestService", "TestClass"), this.connection);
+            krpc.schema.KRPC.ProcedureResult _data = this.connection.invoke("TestService", "TestClass_EchoNullableObject", _args);
+            if (_data.getIsNull()) {
+              return null;
+            }
+            return (krpc.client.services.TestService.TestClass) Encoder.decode(_data.getValue(), krpc.client.Types.createClass("TestService", "TestClass"), this.connection);
         }
 
         @SuppressWarnings({ "unchecked" })
@@ -750,8 +771,8 @@ public class TestService {
                 Encoder.encode(this, krpc.client.Types.createClass("TestService", "TestClass")),
                 Encoder.encode(x, krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.FLOAT))
             };
-            ByteString _data = this.connection.invoke("TestService", "TestClass_FloatToString", _args);
-            return (String) Encoder.decode(_data, krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.STRING), this.connection);
+            krpc.schema.KRPC.ProcedureResult _data = this.connection.invoke("TestService", "TestClass_FloatToString", _args);
+            return (String) Encoder.decode(_data.getValue(), krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.STRING), this.connection);
         }
 
         /**
@@ -764,8 +785,8 @@ public class TestService {
             ByteString[] _args = new ByteString[] {
                 Encoder.encode(this, krpc.client.Types.createClass("TestService", "TestClass"))
             };
-            ByteString _data = this.connection.invoke("TestService", "TestClass_GetValue", _args);
-            return (String) Encoder.decode(_data, krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.STRING), this.connection);
+            krpc.schema.KRPC.ProcedureResult _data = this.connection.invoke("TestService", "TestClass_GetValue", _args);
+            return (String) Encoder.decode(_data.getValue(), krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.STRING), this.connection);
         }
 
         @SuppressWarnings({ "unchecked" })
@@ -776,8 +797,8 @@ public class TestService {
                 Encoder.encode(this, krpc.client.Types.createClass("TestService", "TestClass")),
                 Encoder.encode(other, krpc.client.Types.createClass("TestService", "TestClass"))
             };
-            ByteString _data = this.connection.invoke("TestService", "TestClass_ObjectToString", _args);
-            return (String) Encoder.decode(_data, krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.STRING), this.connection);
+            krpc.schema.KRPC.ProcedureResult _data = this.connection.invoke("TestService", "TestClass_ObjectToString", _args);
+            return (String) Encoder.decode(_data.getValue(), krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.STRING), this.connection);
         }
 
         @SuppressWarnings({ "unchecked" })
@@ -791,8 +812,8 @@ public class TestService {
                 Encoder.encode(z, krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.STRING)),
                 Encoder.encode(obj, krpc.client.Types.createClass("TestService", "TestClass"))
             };
-            ByteString _data = this.connection.invoke("TestService", "TestClass_OptionalArguments", _args);
-            return (String) Encoder.decode(_data, krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.STRING), this.connection);
+            krpc.schema.KRPC.ProcedureResult _data = this.connection.invoke("TestService", "TestClass_OptionalArguments", _args);
+            return (String) Encoder.decode(_data.getValue(), krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.STRING), this.connection);
         }
 
         /**
@@ -805,8 +826,8 @@ public class TestService {
             ByteString[] _args = new ByteString[] {
                 Encoder.encode(this, krpc.client.Types.createClass("TestService", "TestClass"))
             };
-            ByteString _data = this.connection.invoke("TestService", "TestClass_get_IntProperty", _args);
-            return (int) Encoder.decode(_data, krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.SINT32), this.connection);
+            krpc.schema.KRPC.ProcedureResult _data = this.connection.invoke("TestService", "TestClass_get_IntProperty", _args);
+            return (int) Encoder.decode(_data.getValue(), krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.SINT32), this.connection);
         }
 
         /**
@@ -830,8 +851,11 @@ public class TestService {
             ByteString[] _args = new ByteString[] {
                 Encoder.encode(this, krpc.client.Types.createClass("TestService", "TestClass"))
             };
-            ByteString _data = this.connection.invoke("TestService", "TestClass_get_ObjectProperty", _args);
-            return (krpc.client.services.TestService.TestClass) Encoder.decode(_data, krpc.client.Types.createClass("TestService", "TestClass"), this.connection);
+            krpc.schema.KRPC.ProcedureResult _data = this.connection.invoke("TestService", "TestClass_get_ObjectProperty", _args);
+            if (_data.getIsNull()) {
+              return null;
+            }
+            return (krpc.client.services.TestService.TestClass) Encoder.decode(_data.getValue(), krpc.client.Types.createClass("TestService", "TestClass"), this.connection);
         }
 
         @SuppressWarnings({ "unchecked" })
@@ -863,8 +887,8 @@ public class TestService {
             ByteString[] _args = new ByteString[] {
                 Encoder.encode(this, krpc.client.Types.createClass("TestService", "TestClass"))
             };
-            ByteString _data = this.connection.invoke("TestService", "TestClass_get_StringPropertyPrivateSet", _args);
-            return (String) Encoder.decode(_data, krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.STRING), this.connection);
+            krpc.schema.KRPC.ProcedureResult _data = this.connection.invoke("TestService", "TestClass_get_StringPropertyPrivateSet", _args);
+            return (String) Encoder.decode(_data.getValue(), krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.STRING), this.connection);
         }
 
         @SuppressWarnings({ "unchecked" })
@@ -875,8 +899,8 @@ public class TestService {
                 Encoder.encode(a, krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.STRING)),
                 Encoder.encode(b, krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.STRING))
             };
-            ByteString _data = connection.invoke("TestService", "TestClass_static_StaticMethod", _args);
-            return (String) Encoder.decode(_data, krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.STRING), connection);
+            krpc.schema.KRPC.ProcedureResult _data = connection.invoke("TestService", "TestClass_static_StaticMethod", _args);
+            return (String) Encoder.decode(_data.getValue(), krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.STRING), connection);
         }
 
         @SuppressWarnings({ "unchecked" })
@@ -886,8 +910,11 @@ public class TestService {
             ByteString[] _args = new ByteString[] {
                 Encoder.encode(value, krpc.client.Types.createClass("TestService", "TestClass"))
             };
-            ByteString _data = connection.invoke("TestService", "TestClass_static_StaticNullableObject", _args);
-            return (krpc.client.services.TestService.TestClass) Encoder.decode(_data, krpc.client.Types.createClass("TestService", "TestClass"), connection);
+            krpc.schema.KRPC.ProcedureResult _data = connection.invoke("TestService", "TestClass_static_StaticNullableObject", _args);
+            if (_data.getIsNull()) {
+              return null;
+            }
+            return (krpc.client.services.TestService.TestClass) Encoder.decode(_data.getValue(), krpc.client.Types.createClass("TestService", "TestClass"), connection);
         }
     }
 

--- a/tools/krpctools/krpctools/test/clientgen-TestService-python.txt
+++ b/tools/krpctools/krpctools/test/clientgen-TestService-python.txt
@@ -143,7 +143,7 @@ class TestClass(ClassBase):
         )
 
     @object_property.setter
-    def object_property(self, value: TestClass) -> None:
+    def object_property(self, value: Optional[TestClass]) -> None:
         return self._client._invoke(
             "TestService",
             "TestClass_set_ObjectProperty",
@@ -203,6 +203,29 @@ class TestClass(ClassBase):
             ["self"],
             [self._client._types.class_type("TestService", "TestClass")],
             self._client._types.string_type
+        )
+
+    def echo_nullable_object(self, value: Optional[TestClass]) -> Optional[TestClass]:
+        return self._client._invoke(
+            "TestService",
+            "TestClass_EchoNullableObject",
+            [self, value],
+            ["self", "value"],
+            [self._client._types.class_type("TestService", "TestClass"), self._client._types.class_type("TestService", "TestClass")],
+            self._client._types.class_type("TestService", "TestClass")
+        )
+
+    def _return_type_echo_nullable_object(self) -> TypeBase:
+        return self._client._types.class_type("TestService", "TestClass")
+
+    def _build_call_echo_nullable_object(self, value: Optional[TestClass]) -> KRPC_pb2.ProcedureCall:
+        return self._client._build_call(
+            "TestService",
+            "TestClass_EchoNullableObject",
+            [self, value],
+            ["self", "value"],
+            [self._client._types.class_type("TestService", "TestClass"), self._client._types.class_type("TestService", "TestClass")],
+            self._client._types.class_type("TestService", "TestClass")
         )
 
     def float_to_string(self, x: float) -> str:
@@ -277,7 +300,7 @@ class TestClass(ClassBase):
             self._client._types.string_type
         )
 
-    def optional_arguments(self, x: str, y: str = 'foo', z: str = 'bar', obj: TestClass = None) -> str:
+    def optional_arguments(self, x: str, y: str = 'foo', z: str = 'bar', obj: Optional[TestClass] = None) -> str:
         return self._client._invoke(
             "TestService",
             "TestClass_OptionalArguments",
@@ -290,7 +313,7 @@ class TestClass(ClassBase):
     def _return_type_optional_arguments(self) -> TypeBase:
         return self._client._types.string_type
 
-    def _build_call_optional_arguments(self, x: str, y: str = 'foo', z: str = 'bar', obj: TestClass = None) -> KRPC_pb2.ProcedureCall:
+    def _build_call_optional_arguments(self, x: str, y: str = 'foo', z: str = 'bar', obj: Optional[TestClass] = None) -> KRPC_pb2.ProcedureCall:
         return self._client._build_call(
             "TestService",
             "TestClass_OptionalArguments",
@@ -327,6 +350,35 @@ class TestClass(ClassBase):
             ["a", "b"],
             [self._client._types.string_type, self._client._types.string_type],
             self._client._types.string_type
+        )
+
+    @StaticMethod
+    def static_nullable_object(cls, value: Optional[TestClass]) -> Optional[TestClass]:
+        self = cls
+        return cls._client._invoke(
+            "TestService",
+            "TestClass_static_StaticNullableObject",
+            [value],
+            ["value"],
+            [self._client._types.class_type("TestService", "TestClass")],
+            self._client._types.class_type("TestService", "TestClass")
+        )
+
+    @StaticMethod
+    def _return_type_static_nullable_object(cls) -> TypeBase:
+        self = cls
+        return self._client._types.class_type("TestService", "TestClass")
+
+    @StaticMethod
+    def _build_call_static_nullable_object(cls, value: Optional[TestClass]) -> KRPC_pb2.ProcedureCall:
+        self = cls
+        return self._client._build_call(
+            "TestService",
+            "TestClass_static_StaticNullableObject",
+            [value],
+            ["value"],
+            [self._client._types.class_type("TestService", "TestClass")],
+            self._client._types.class_type("TestService", "TestClass")
         )
 
 
@@ -424,6 +476,41 @@ class TestService:
         )
 
     @property
+    def nullable_object(self) -> Optional[TestClass]:
+        return self._client._invoke(
+            "TestService",
+            "get_NullableObject",
+            [],
+            [],
+            [],
+            self._client._types.class_type("TestService", "TestClass")
+        )
+
+    @nullable_object.setter
+    def nullable_object(self, value: Optional[TestClass]) -> None:
+        return self._client._invoke(
+            "TestService",
+            "set_NullableObject",
+            [value],
+            ["value"],
+            [self._client._types.class_type("TestService", "TestClass")],
+            None
+        )
+
+    def _return_type_nullable_object(self) -> TypeBase:
+        return self._client._types.class_type("TestService", "TestClass")
+
+    def _build_call_nullable_object(self) -> KRPC_pb2.ProcedureCall:
+        return self._client._build_call(
+            "TestService",
+            "get_NullableObject",
+            [],
+            [],
+            [],
+            self._client._types.class_type("TestService", "TestClass")
+        )
+
+    @property
     def object_property(self) -> Optional[TestClass]:
         return self._client._invoke(
             "TestService",
@@ -435,7 +522,7 @@ class TestService:
         )
 
     @object_property.setter
-    def object_property(self, value: TestClass) -> None:
+    def object_property(self, value: Optional[TestClass]) -> None:
         return self._client._invoke(
             "TestService",
             "set_ObjectProperty",
@@ -800,6 +887,75 @@ class TestService:
             self._client._types.string_type
         )
 
+    def echo_nullable_int(self, value: Optional[int]) -> Optional[int]:
+        return self._client._invoke(
+            "TestService",
+            "EchoNullableInt",
+            [value],
+            ["value"],
+            [self._client._types.sint32_type],
+            self._client._types.sint32_type
+        )
+
+    def _return_type_echo_nullable_int(self) -> TypeBase:
+        return self._client._types.sint32_type
+
+    def _build_call_echo_nullable_int(self, value: Optional[int]) -> KRPC_pb2.ProcedureCall:
+        return self._client._build_call(
+            "TestService",
+            "EchoNullableInt",
+            [value],
+            ["value"],
+            [self._client._types.sint32_type],
+            self._client._types.sint32_type
+        )
+
+    def echo_nullable_list(self, l: Optional[List[int]]) -> Optional[List[int]]:
+        return self._client._invoke(
+            "TestService",
+            "EchoNullableList",
+            [l],
+            ["l"],
+            [self._client._types.list_type(self._client._types.sint32_type)],
+            self._client._types.list_type(self._client._types.sint32_type)
+        )
+
+    def _return_type_echo_nullable_list(self) -> TypeBase:
+        return self._client._types.list_type(self._client._types.sint32_type)
+
+    def _build_call_echo_nullable_list(self, l: Optional[List[int]]) -> KRPC_pb2.ProcedureCall:
+        return self._client._build_call(
+            "TestService",
+            "EchoNullableList",
+            [l],
+            ["l"],
+            [self._client._types.list_type(self._client._types.sint32_type)],
+            self._client._types.list_type(self._client._types.sint32_type)
+        )
+
+    def echo_nullable_string(self, value: Optional[str]) -> Optional[str]:
+        return self._client._invoke(
+            "TestService",
+            "EchoNullableString",
+            [value],
+            ["value"],
+            [self._client._types.string_type],
+            self._client._types.string_type
+        )
+
+    def _return_type_echo_nullable_string(self) -> TypeBase:
+        return self._client._types.string_type
+
+    def _build_call_echo_nullable_string(self, value: Optional[str]) -> KRPC_pb2.ProcedureCall:
+        return self._client._build_call(
+            "TestService",
+            "EchoNullableString",
+            [value],
+            ["value"],
+            [self._client._types.string_type],
+            self._client._types.string_type
+        )
+
     def echo_test_object(self, value: Optional[TestClass]) -> Optional[TestClass]:
         return self._client._invoke(
             "TestService",
@@ -821,6 +977,29 @@ class TestService:
             ["value"],
             [self._client._types.class_type("TestService", "TestClass")],
             self._client._types.class_type("TestService", "TestClass")
+        )
+
+    def empty_list_default(self, x: List[str] = []) -> List[str]:
+        return self._client._invoke(
+            "TestService",
+            "EmptyListDefault",
+            [x],
+            ["x"],
+            [self._client._types.list_type(self._client._types.string_type)],
+            self._client._types.list_type(self._client._types.string_type)
+        )
+
+    def _return_type_empty_list_default(self) -> TypeBase:
+        return self._client._types.list_type(self._client._types.string_type)
+
+    def _build_call_empty_list_default(self, x: List[str] = []) -> KRPC_pb2.ProcedureCall:
+        return self._client._build_call(
+            "TestService",
+            "EmptyListDefault",
+            [x],
+            ["x"],
+            [self._client._types.list_type(self._client._types.string_type)],
+            self._client._types.list_type(self._client._types.string_type)
         )
 
     def enum_default_arg(self, x: TestEnum = TestEnum(2)) -> TestEnum:
@@ -1102,6 +1281,29 @@ class TestService:
             self._client._types.list_type(self._client._types.sint32_type)
         )
 
+    def not_nullable_object(self, value: TestClass) -> TestClass:
+        return self._client._invoke(
+            "TestService",
+            "NotNullableObject",
+            [value],
+            ["value"],
+            [self._client._types.class_type("TestService", "TestClass")],
+            self._client._types.class_type("TestService", "TestClass")
+        )
+
+    def _return_type_not_nullable_object(self) -> TypeBase:
+        return self._client._types.class_type("TestService", "TestClass")
+
+    def _build_call_not_nullable_object(self, value: TestClass) -> KRPC_pb2.ProcedureCall:
+        return self._client._build_call(
+            "TestService",
+            "NotNullableObject",
+            [value],
+            ["value"],
+            [self._client._types.class_type("TestService", "TestClass")],
+            self._client._types.class_type("TestService", "TestClass")
+        )
+
     def on_timer(self, milliseconds: int, repeats: int = 1) -> Event:
         return self._client._invoke(
             "TestService",
@@ -1148,7 +1350,7 @@ class TestService:
             self._client._types.event_type
         )
 
-    def optional_arguments(self, x: str, y: str = 'foo', z: str = 'bar', obj: TestClass = None) -> str:
+    def optional_arguments(self, x: str, y: str = 'foo', z: str = 'bar', obj: Optional[TestClass] = None) -> str:
         return self._client._invoke(
             "TestService",
             "OptionalArguments",
@@ -1161,7 +1363,7 @@ class TestService:
     def _return_type_optional_arguments(self) -> TypeBase:
         return self._client._types.string_type
 
-    def _build_call_optional_arguments(self, x: str, y: str = 'foo', z: str = 'bar', obj: TestClass = None) -> KRPC_pb2.ProcedureCall:
+    def _build_call_optional_arguments(self, x: str, y: str = 'foo', z: str = 'bar', obj: Optional[TestClass] = None) -> KRPC_pb2.ProcedureCall:
         return self._client._build_call(
             "TestService",
             "OptionalArguments",

--- a/tools/krpctools/krpctools/test/docgen-TestService-cnano.rst
+++ b/tools/krpctools/krpctools/test/docgen-TestService-cnano.rst
@@ -171,7 +171,59 @@ Service documentation string.
 
 
 
+.. function:: krpc_error_t krpc_TestService_EchoNullableInt(krpc_connection_t connection, int32_t * result, int32_t value)
+
+
+
+   :Parameters:
+
+
+
+   
+
+
+
+
+.. function:: krpc_error_t krpc_TestService_EchoNullableList(krpc_connection_t connection, krpc_list_int32_t * result, const krpc_list_int32_t * l)
+
+
+
+   :Parameters:
+
+
+
+   
+
+
+
+
+.. function:: krpc_error_t krpc_TestService_EchoNullableString(krpc_connection_t connection, char * * result, const char * value)
+
+
+
+   :Parameters:
+
+
+
+   
+
+
+
+
 .. function:: krpc_error_t krpc_TestService_EchoTestObject(krpc_connection_t connection, krpc_TestService_TestClass_t * result, krpc_TestService_TestClass_t value)
+
+
+
+   :Parameters:
+
+
+
+   
+
+
+
+
+.. function:: krpc_error_t krpc_TestService_EmptyListDefault(krpc_connection_t connection, krpc_list_string_t * result, const krpc_list_string_t * x)
 
 
 
@@ -329,6 +381,29 @@ Service documentation string.
 
 
    :Parameters:
+
+
+
+   
+
+
+
+
+.. function:: krpc_error_t krpc_TestService_NotNullableObject(krpc_connection_t connection, krpc_TestService_TestClass_t * result, krpc_TestService_TestClass_t value)
+
+
+
+   :Parameters:
+
+
+
+   
+
+
+
+
+.. function:: krpc_error_t krpc_TestService_NullableObject(krpc_connection_t connection, krpc_TestService_TestClass_t * result)
+.. function:: void krpc_TestService_set_NullableObject(krpc_TestService_TestClass_t value)
 
 
 
@@ -568,6 +643,16 @@ Service documentation string.
 
    Class documentation string.
 
+   .. function:: krpc_error_t krpc_TestService_TestClass_EchoNullableObject(krpc_connection_t connection, krpc_TestService_TestClass_t * result, krpc_TestService_TestClass_t value)
+
+
+
+      :Parameters:
+
+
+
+   
+
    .. function:: krpc_error_t krpc_TestService_TestClass_FloatToString(krpc_connection_t connection, char * * result, float x)
 
 
@@ -628,6 +713,16 @@ Service documentation string.
 
       :Parameters:
 
+
+
+
+   
+
+   .. function:: krpc_error_t krpc_TestService_TestClass_StaticNullableObject(krpc_connection_t connection, krpc_TestService_TestClass_t * result, krpc_TestService_TestClass_t value)
+
+
+
+      :Parameters:
 
 
 

--- a/tools/krpctools/krpctools/test/docgen-TestService-cpp.rst
+++ b/tools/krpctools/krpctools/test/docgen-TestService-cpp.rst
@@ -141,7 +141,47 @@
 
    
 
+   .. function:: int32_t echo_nullable_int(int32_t value)
+
+
+
+      :Parameters:
+
+
+
+   
+
+   .. function:: std::vector<int32_t> echo_nullable_list(std::vector<int32_t> l)
+
+
+
+      :Parameters:
+
+
+
+   
+
+   .. function:: std::string echo_nullable_string(std::string value)
+
+
+
+      :Parameters:
+
+
+
+   
+
    .. function:: TestClass echo_test_object(TestClass value)
+
+
+
+      :Parameters:
+
+
+
+   
+
+   .. function:: std::vector<std::string> empty_list_default(std::vector<std::string> x = std::vector<std::string>())
 
 
 
@@ -268,6 +308,23 @@
 
    
 
+   .. function:: TestClass not_nullable_object(TestClass value)
+
+
+
+      :Parameters:
+
+
+
+   
+
+   .. function:: TestClass nullable_object()
+   .. function:: void set_nullable_object(TestClass value)
+
+
+
+   
+
    .. function:: TestClass object_property()
    .. function:: void set_object_property(TestClass value)
 
@@ -296,7 +353,7 @@
 
    
 
-   .. function:: std::string optional_arguments(std::string x, std::string y = "foo", std::string z = "bar", TestClass obj = TestClass())
+   .. function:: std::string optional_arguments(std::string x, std::string y = "foo", std::string z = "bar", TestClass obj)
 
 
 
@@ -440,6 +497,16 @@
 
    Class documentation string.
 
+   .. function:: TestClass echo_nullable_object(TestClass value)
+
+
+
+      :Parameters:
+
+
+
+   
+
    .. function:: std::string float_to_string(float x)
 
 
@@ -481,7 +548,7 @@
 
    
 
-   .. function:: std::string optional_arguments(std::string x, std::string y = "foo", std::string z = "bar", TestClass obj = TestClass())
+   .. function:: std::string optional_arguments(std::string x, std::string y = "foo", std::string z = "bar", TestClass obj)
 
 
 
@@ -500,6 +567,16 @@
 
       :Parameters:
 
+
+
+
+   
+
+   .. function:: static TestClass static_nullable_object(Client& connection, TestClass value)
+
+
+
+      :Parameters:
 
 
 

--- a/tools/krpctools/krpctools/test/docgen-TestService-csharp.rst
+++ b/tools/krpctools/krpctools/test/docgen-TestService-csharp.rst
@@ -135,7 +135,47 @@
 
       :Game Scenes: All
 
+   .. method:: int EchoNullableInt(int value)
+
+
+
+      :parameters:
+
+
+
+      :Game Scenes: All
+
+   .. method:: System.Collections.Generic.IList<int> EchoNullableList(System.Collections.Generic.IList<int> l)
+
+
+
+      :parameters:
+
+
+
+      :Game Scenes: All
+
+   .. method:: string EchoNullableString(string value)
+
+
+
+      :parameters:
+
+
+
+      :Game Scenes: All
+
    .. method:: TestClass EchoTestObject(TestClass value)
+
+
+
+      :parameters:
+
+
+
+      :Game Scenes: All
+
+   .. method:: System.Collections.Generic.IList<string> EmptyListDefault(System.Collections.Generic.IList<string> x = {  })
 
 
 
@@ -262,6 +302,22 @@
 
       :Game Scenes: All
 
+   .. method:: TestClass NotNullableObject(TestClass value)
+
+
+
+      :parameters:
+
+
+
+      :Game Scenes: All
+
+   .. property:: TestClass NullableObject { get; set; }
+
+
+
+      :Game Scenes: All
+
    .. property:: TestClass ObjectProperty { get; set; }
 
 
@@ -289,7 +345,7 @@
 
       :Game Scenes: All
 
-   .. method:: string OptionalArguments(string x, string y = "foo", string z = "bar", TestClass obj = null)
+   .. method:: string OptionalArguments(string x, string y = "foo", string z = "bar", TestClass obj)
 
 
 
@@ -432,6 +488,16 @@
 
    Class documentation string.
 
+   .. method:: TestClass EchoNullableObject(TestClass value)
+
+
+
+      :parameters:
+
+
+
+      :Game Scenes: All
+
    .. method:: string FloatToString(float x)
 
 
@@ -471,7 +537,7 @@
 
       :Game Scenes: All
 
-   .. method:: string OptionalArguments(string x, string y = "foo", string z = "bar", TestClass obj = null)
+   .. method:: string OptionalArguments(string x, string y = "foo", string z = "bar", TestClass obj)
 
 
 
@@ -490,6 +556,16 @@
 
       :parameters:
 
+
+
+
+      :Game Scenes: All
+
+   .. method:: static TestClass StaticNullableObject(IConnection connection, TestClass value)
+
+
+
+      :parameters:
 
 
 

--- a/tools/krpctools/krpctools/test/docgen-TestService-java.rst
+++ b/tools/krpctools/krpctools/test/docgen-TestService-java.rst
@@ -104,11 +104,39 @@
       :param double value:
    
 
+   .. method:: int echoNullableInt(int value)
+
+
+
+      :param int value:
+   
+
+   .. method:: java.util.List<Integer> echoNullableList(java.util.List<Integer> l)
+
+
+
+      :param java.util.List<Integer> l:
+   
+
+   .. method:: String echoNullableString(String value)
+
+
+
+      :param String value:
+   
+
    .. method:: TestClass echoTestObject(TestClass value)
 
 
 
       :param TestClass value:
+   
+
+   .. method:: java.util.List<String> emptyListDefault(java.util.List<String> x)
+
+
+
+      :param java.util.List<String> x:
    
 
    .. method:: TestEnum enumDefaultArg(TestEnum x)
@@ -192,6 +220,21 @@
 
 
       :param java.util.List<Integer> x:
+   
+
+   .. method:: TestClass notNullableObject(TestClass value)
+
+
+
+      :param TestClass value:
+   
+
+   .. method:: TestClass getNullableObject()
+
+   .. method:: void setNullableObject(TestClass value)
+
+
+
    
 
    .. method:: TestClass getObjectProperty()
@@ -337,6 +380,13 @@
 
    Class documentation string.
 
+   .. method:: TestClass echoNullableObject(TestClass value)
+
+
+
+      :param TestClass value:
+   
+
    .. method:: String floatToString(float x)
 
 
@@ -389,6 +439,13 @@
 
       :param String a:
       :param String b:
+   
+
+   .. method:: static TestClass staticNullableObject(Connection connection, TestClass value)
+
+
+
+      :param TestClass value:
    
 
    .. method:: void setStringPropertyPrivateGet(String value)

--- a/tools/krpctools/krpctools/test/docgen-TestService-lua.rst
+++ b/tools/krpctools/krpctools/test/docgen-TestService-lua.rst
@@ -140,12 +140,52 @@ Service documentation string.
 
 
 
+.. staticmethod:: echo_nullable_int(value)
+
+
+
+   :param number value:
+   :rtype: number
+
+
+
+
+.. staticmethod:: echo_nullable_list(l)
+
+
+
+   :param List l:
+   :rtype: List
+
+
+
+
+.. staticmethod:: echo_nullable_string(value)
+
+
+
+   :param string value:
+   :rtype: string
+
+
+
+
 .. staticmethod:: echo_test_object(value)
 
 
 
    :param TestService.TestClass value:
    :rtype: :class:`TestService.TestClass`
+
+
+
+
+.. staticmethod:: empty_list_default([x = []])
+
+
+
+   :param List x:
+   :rtype: List
 
 
 
@@ -269,6 +309,26 @@ Service documentation string.
 
 
 
+.. staticmethod:: not_nullable_object(value)
+
+
+
+   :param TestService.TestClass value:
+   :rtype: :class:`TestService.TestClass`
+
+
+
+
+.. attribute:: nullable_object: TestService.TestClass
+
+
+
+   :Attribute: Can be read or written
+   :rtype: :class:`TestService.TestClass`
+
+
+
+
 .. attribute:: object_property: TestService.TestClass
 
 
@@ -300,7 +360,7 @@ Service documentation string.
 
 
 
-.. staticmethod:: optional_arguments(x, [y = 'foo'], [z = 'bar'], [obj = None])
+.. staticmethod:: optional_arguments(x, [y = 'foo'], [z = 'bar'], obj)
 
 
 
@@ -468,6 +528,13 @@ Service documentation string.
 
    Class documentation string.
 
+   .. method:: echo_nullable_object(value)
+
+
+
+      :param TestService.TestClass value:
+      :rtype: :class:`TestService.TestClass`
+
    .. method:: float_to_string(x)
 
 
@@ -502,7 +569,7 @@ Service documentation string.
       :param TestService.TestClass other:
       :rtype: string
 
-   .. method:: optional_arguments(x, [y = 'foo'], [z = 'bar'], [obj = None])
+   .. method:: optional_arguments(x, [y = 'foo'], [z = 'bar'], obj)
 
 
 
@@ -519,6 +586,13 @@ Service documentation string.
       :param string a:
       :param string b:
       :rtype: string
+
+   .. staticmethod:: static_nullable_object(value)
+
+
+
+      :param TestService.TestClass value:
+      :rtype: :class:`TestService.TestClass`
 
    .. attribute:: string_property_private_get: string
 

--- a/tools/krpctools/krpctools/test/docgen-TestService-python.rst
+++ b/tools/krpctools/krpctools/test/docgen-TestService-python.rst
@@ -152,12 +152,56 @@ Service documentation string.
 
 
 
+.. staticmethod:: echo_nullable_int(value)
+
+
+
+   :param int value:
+   :rtype: int
+   
+
+
+
+
+.. staticmethod:: echo_nullable_list(l)
+
+
+
+   :param list l:
+   :rtype: list(int)
+   
+
+
+
+
+.. staticmethod:: echo_nullable_string(value)
+
+
+
+   :param str value:
+   :rtype: str
+   
+
+
+
+
 .. staticmethod:: echo_test_object(value)
 
 
 
    :param TestClass value:
    :rtype: :class:`TestClass`
+   
+
+
+
+
+.. staticmethod:: empty_list_default([x = []])
+
+
+
+   :param list x:
+   :rtype: list(str)
    
 
 
@@ -294,6 +338,28 @@ Service documentation string.
 
 
 
+.. staticmethod:: not_nullable_object(value)
+
+
+
+   :param TestClass value:
+   :rtype: :class:`TestClass`
+   
+
+
+
+
+.. attribute:: nullable_object
+
+
+
+   :Attribute: Can be read or written
+   :rtype: :class:`TestClass`
+   
+
+
+
+
 .. attribute:: object_property
 
 
@@ -328,7 +394,7 @@ Service documentation string.
 
 
 
-.. staticmethod:: optional_arguments(x, [y = 'foo'], [z = 'bar'], [obj = None])
+.. staticmethod:: optional_arguments(x, [y = 'foo'], [z = 'bar'], obj)
 
 
 
@@ -513,6 +579,14 @@ Service documentation string.
 
    Class documentation string.
 
+   .. method:: echo_nullable_object(value)
+
+
+
+      :param TestClass value:
+      :rtype: :class:`TestClass`
+   
+
    .. method:: float_to_string(x)
 
 
@@ -552,7 +626,7 @@ Service documentation string.
       :rtype: str
    
 
-   .. method:: optional_arguments(x, [y = 'foo'], [z = 'bar'], [obj = None])
+   .. method:: optional_arguments(x, [y = 'foo'], [z = 'bar'], obj)
 
 
 
@@ -570,6 +644,14 @@ Service documentation string.
       :param str a:
       :param str b:
       :rtype: str
+   
+
+   .. staticmethod:: static_nullable_object(value)
+
+
+
+      :param TestClass value:
+      :rtype: :class:`TestClass`
    
 
    .. attribute:: string_property_private_get

--- a/tools/krpctools/krpctools/utils.py
+++ b/tools/krpctools/krpctools/utils.py
@@ -57,6 +57,9 @@ def _as_protobuf_type(types, type_info):
 
 
 def decode_default_value(value, typ):
+    if value is None:
+        # A JSON null default value means the default is null
+        return None
     value = base64.b64decode(value)
     value = array.array("B", value).tobytes()
     # Note: following is a workaround for decoding EnumerationType,


### PR DESCRIPTION
Methods can now return `null`, and any parameter can take `null` as a value or default, for every type rather than only class instances. Server and all six clients (Python, C#, C++, Java, Lua, cnano) updated.

**This is a protocol breaking change.** The legacy sentinel is gone with no compatibility path. Class object used to use `0` to represent `null`. Documentation updated for third-party client authors in the service-extension and messaging-protocol guides.

Fixes #843
Design doc: https://github.com/krpc/krpc-docs/blob/main/design/protocol/nullable-values.md

Also reverts `LaunchVessel.crew` workaround in #824.