### PR TITLE
Give `SpaceCenter.LaunchVessel` explicit, ordered crew semantics

### DIFF
--- a/service/SpaceCenter/CHANGELOG.md
+++ b/service/SpaceCenter/CHANGELOG.md
@@ -1,7 +1,12 @@
 ## [v0.7.0] - unreleased
 
 - Space center
-  - `SpaceCenter.LaunchVessel` now accepts an optional `crew` parameter (#1017)
+  - **Breaking:** `SpaceCenter.LaunchVessel` takes its `crew` parameter as an exact
+    instruction, and the parameter is optional again. A `null` crew (the default) uses the
+    craft's default crew assignments; an empty list, which previously also used the default
+    assignments, launches with no crew; and a populated list seats exactly the named Kerbals,
+    in the order given. An unknown or unavailable Kerbal name, or a craft with too few seats,
+    raises an exception without launching (#1017)
 
 ## [v0.6.0]
 

--- a/service/SpaceCenter/src/Services/SpaceCenter.cs
+++ b/service/SpaceCenter/src/Services/SpaceCenter.cs
@@ -279,6 +279,20 @@ namespace KRPC.SpaceCenter.Services
         /// </summary>
         sealed class LaunchConfig {
             public LaunchConfig(string craftDirectory, string name, string launchSite, bool recover, IList<string> crew, string flagUrl) {
+                // Resolve the requested crew before touching any game state, so an unknown or
+                // unavailable Kerbal aborts the launch without side effects.
+                List<ProtoCrewMember> requestedCrew = null;
+                if (crew != null && crew.Count > 0) {
+                    requestedCrew = new List<ProtoCrewMember>();
+                    foreach (var crewName in crew) {
+                        var kerbal = GetKerbal(crewName);
+                        if (kerbal == null)
+                            throw new ArgumentException("No Kerbal named '" + crewName + "'");
+                        if (kerbal.InternalCrewMember.rosterStatus != ProtoCrewMember.RosterStatus.Available)
+                            throw new ArgumentException("Kerbal '" + crewName + "' is not available");
+                        requestedCrew.Add(kerbal.InternalCrewMember);
+                    }
+                }
                 LaunchSite = launchSite;
                 Recover = recover;
                 FlagUrl = string.IsNullOrEmpty(flagUrl) ? EditorLogic.FlagURL : flagUrl;
@@ -296,27 +310,21 @@ namespace KRPC.SpaceCenter.Services
                 manifest = VesselCrewManifest.FromConfigNode(template.config);
                 if (manifest == null)
                     throw new InvalidOperationException("Failed to load manifest from vessel template");
-                if (crew == null || crew.Count == 0) {
+                if (crew == null) {
+                    // Use the craft's default crew assignments.
                     manifest = HighLogic.CurrentGame.CrewRoster.DefaultCrewForVessel(template.config, manifest, true, false);
-                } else {
+                } else if (crew.Count == 0) {
+                    // Launch with no crew. An empty roster with auto-hire disabled leaves every
+                    // seat unfilled.
                     var crewRoster = new KerbalRoster(HighLogic.CurrentGame.Mode);
-                    foreach (var crewName in crew) {
-                        var kerbal = GetKerbal(crewName);
-                        if (kerbal != null && kerbal.InternalCrewMember.rosterStatus == ProtoCrewMember.RosterStatus.Available) {
-                            crewRoster.AddCrewMember(kerbal.InternalCrewMember);
-                        }
-                    }
-                    manifest = crewRoster.DefaultCrewForVessel(template.config, manifest, true, false);
-                    if (manifest == null)
-                        throw new InvalidOperationException("Failed to load manifest");
-                    if (manifest.CrewCount < crewRoster.Count) {
-                        foreach (var crewMember in crewRoster.Crew) {
-                            if (!manifest.Contains(crewMember)) {
-                                if (!AddCrewToManifest(manifest, crewMember)) {
-                                    Debug.LogError($"Failed to add {crewMember.name} to a seat");
-                                }
-                            }
-                        }
+                    manifest = crewRoster.DefaultCrewForVessel(template.config, manifest, false, false);
+                } else {
+                    // Place exactly the named Kerbals, in the order given. Each takes the next
+                    // empty seat, scanning parts in manifest order then seats by index, so a
+                    // Kerbal's position in the list maps deterministically onto the craft's seats.
+                    foreach (var crewMember in requestedCrew) {
+                        if (!AddCrewToManifest(manifest, crewMember))
+                            throw new ArgumentException("The craft does not have enough seats for the requested crew");
                     }
                 }
                 if (manifest == null)
@@ -386,17 +394,30 @@ namespace KRPC.SpaceCenter.Services
         /// in the save directory, without the ".craft" file extension.</param>
         /// <param name="launchSite">Name of the launch site. For example <c>"LaunchPad"</c> or
         /// <c>"Runway"</c>.</param>
+        /// <param name="crew">The Kerbals to place in the craft, by name. Controls how the craft is
+        /// crewed, as described in the remarks.</param>
         /// <param name="recover">If true and there is a vessel on the launch site,
         /// recover it before launching.</param>
-        /// <param name="crew">If not <c>null</c>, a list of names of Kerbals to place in the craft. Otherwise the crew will use default assignments.</param>
         /// <param name="flagUrl">If not <c>null</c>, the asset URL of the mission flag to use for the launch.</param>
         /// <remarks>
+        /// The <paramref name="crew"/> parameter controls how the craft is crewed:
+        /// <list type="bullet">
+        /// <item><description>If <c>null</c>, the craft's default crew assignments are used.
+        /// </description></item>
+        /// <item><description>If an empty list, the craft is launched with no crew.
+        /// </description></item>
+        /// <item><description>Otherwise, the named Kerbals are placed in the craft in the order
+        /// given: the first name takes the first seat, the second name the next seat, and so on,
+        /// scanning the craft's parts in order. No other Kerbals are hired to fill remaining seats.
+        /// An exception is thrown, without launching, if a name does not match an available Kerbal
+        /// or the craft has too few seats for the requested crew.</description></item>
+        /// </list>
         /// Throws an exception if any of the games pre-flight checks fail.
         /// </remarks>
         [KRPCProcedure]
         public static void LaunchVessel (
-            string craftDirectory, string name, string launchSite, bool recover = true,
-            IList<string> crew = null, string flagUrl = "")
+            string craftDirectory, string name, string launchSite, IList<string> crew = null,
+            bool recover = true, string flagUrl = "")
         {
             CloseDialogs();
             var config = new LaunchConfig(craftDirectory, name, launchSite, recover, crew, flagUrl);
@@ -486,7 +507,7 @@ namespace KRPC.SpaceCenter.Services
         [KRPCProcedure]
         public static void LaunchVesselFromVAB (string name, bool recover = true)
         {
-            LaunchVessel ("VAB", name, "LaunchPad", recover);
+            LaunchVessel ("VAB", name, "LaunchPad", recover: recover);
         }
 
         /// <summary>
@@ -503,7 +524,7 @@ namespace KRPC.SpaceCenter.Services
         [KRPCProcedure]
         public static void LaunchVesselFromSPH (string name, bool recover = true)
         {
-            LaunchVessel ("SPH", name, "Runway", recover);
+            LaunchVessel ("SPH", name, "Runway", recover: recover);
         }
 
         /// <summary>

--- a/service/SpaceCenter/test/test_launch_crew.py
+++ b/service/SpaceCenter/test/test_launch_crew.py
@@ -1,0 +1,159 @@
+import unittest
+
+import krpctest
+
+
+class TestLaunchCrew(krpctest.TestCase):
+    """Test the crew parameter of SpaceCenter.LaunchVessel: default assignments
+    when null, no crew when empty, and exactly the named Kerbals, in order, when
+    populated."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.new_save()
+        cls.remove_other_vessels()
+        cls.sc = cls.connect().space_center
+        # Stage the craft launched directly through the RPC in these tests.
+        cls._stage_craft("Basic", "VAB", None)
+        cls._stage_craft("Multi", "VAB", None)
+        # Deterministic, available crew to launch with. Distinct names per test keep
+        # the tests independent of one another's launched (and so assigned) Kerbals.
+        for name in (
+            "Alpha Kerman",
+            "Busy Kerman",
+            "Crowd One Kerman",
+            "Crowd Two Kerman",
+            "Order One Kerman",
+            "Order Two Kerman",
+            "Order Three Kerman",
+            "Order Four Kerman",
+            "Excess One Kerman",
+            "Excess Two Kerman",
+            "Excess Three Kerman",
+        ):
+            if cls.sc.get_kerbal(name) is None:
+                cls.sc.create_kerbal(name, "Pilot", True)
+
+    def launch(self, name, crew=None):
+        # crew is left unset (the default, None) to request the default crew, or set
+        # to a list to request specific crew. An empty list requests no crew.
+        if crew is None:
+            self.sc.launch_vessel("VAB", name, "LaunchPad")
+        else:
+            self.sc.launch_vessel("VAB", name, "LaunchPad", crew)
+        return self.sc.active_vessel
+
+    def crew_names(self, vessel):
+        return sorted(member.name for member in vessel.crew)
+
+    def test_default_crew(self):
+        vessel = self.launch("Basic")
+        self.assertEqual(1, vessel.crew_count)
+        self.assertTrue(vessel.crew[0].name.endswith(" Kerman"))
+
+    def test_no_crew(self):
+        # Multi has crew seats but also probe cores, so it stays controllable with no
+        # crew and launches without a control-warning dialog. An empty crew list
+        # leaves every seat empty.
+        vessel = self.launch("Multi", [])
+        self.assertEqual(2, vessel.crew_capacity)
+        self.assertEqual(0, vessel.crew_count)
+        self.assertEqual([], vessel.crew)
+
+    def test_named_crew(self):
+        vessel = self.launch("Basic", ["Alpha Kerman"])
+        self.assertEqual(["Alpha Kerman"], self.crew_names(vessel))
+
+    def test_unknown_crew_raises(self):
+        before = self.sc.active_vessel
+        self.assertRaises(
+            ValueError,
+            self.sc.launch_vessel,
+            "VAB",
+            "Basic",
+            "LaunchPad",
+            ["Ghost Kerman"],
+        )
+        # The launch is aborted before any vessel is created.
+        self.assertEqual(before, self.sc.active_vessel)
+
+    def test_unavailable_crew_raises(self):
+        self.launch("Basic", ["Busy Kerman"])
+        # Busy Kerman is now assigned to a vessel, so is unavailable for another launch.
+        self.assertTrue(self.sc.get_kerbal("Busy Kerman").on_mission)
+        self.assertRaises(
+            ValueError,
+            self.sc.launch_vessel,
+            "VAB",
+            "Basic",
+            "LaunchPad",
+            ["Busy Kerman"],
+        )
+
+    def test_too_many_crew_raises(self):
+        # Basic has a single seat, so two crew do not fit.
+        self.assertRaises(
+            ValueError,
+            self.sc.launch_vessel,
+            "VAB",
+            "Basic",
+            "LaunchPad",
+            ["Crowd One Kerman", "Crowd Two Kerman"],
+        )
+
+    def test_too_many_crew_for_seats_raises(self):
+        # Multi has two seats, so three crew do not fit.
+        self.assertRaises(
+            ValueError,
+            self.sc.launch_vessel,
+            "VAB",
+            "Multi",
+            "LaunchPad",
+            ["Excess One Kerman", "Excess Two Kerman", "Excess Three Kerman"],
+        )
+
+    def test_crew_order(self):
+        # Multi has two single-seat pods. Seating follows the order of the crew list,
+        # so the Kerbal listed first always takes the same seat and the one listed
+        # second the other seat. Two launches with different crew show this without
+        # either needing to be freed from the first vessel.
+        first = self.seat_map(
+            self.launch("Multi", ["Order One Kerman", "Order Two Kerman"])
+        )
+        second = self.seat_map(
+            self.launch("Multi", ["Order Three Kerman", "Order Four Kerman"])
+        )
+
+        # The craft has two distinct seats, and both launches fill the same two.
+        self.assertEqual(2, len(first))
+        self.assertEqual(set(first), set(second))
+
+        first_seat = {name: seat for seat, name in first.items()}
+        second_seat = {name: seat for seat, name in second.items()}
+        # The first-listed Kerbal takes the same seat in both launches, as does the
+        # second-listed one, and the two seats differ.
+        self.assertEqual(
+            first_seat["Order One Kerman"], second_seat["Order Three Kerman"]
+        )
+        self.assertEqual(
+            first_seat["Order Two Kerman"], second_seat["Order Four Kerman"]
+        )
+        self.assertNotEqual(
+            first_seat["Order One Kerman"], first_seat["Order Two Kerman"]
+        )
+
+    def seat_map(self, vessel):
+        # Map each crewed seat, keyed by the crewed part's index in the vessel's part
+        # list (stable across launches of the same craft), to the Kerbal in it.
+        seats = {}
+        index = 0
+        for part in vessel.parts.all:
+            if part.crew_capacity > 0:
+                if part.crew:
+                    seats[index] = part.crew[0].name
+                index += 1
+        return seats
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/krpctest/krpctest/testcase.py
+++ b/tools/krpctest/krpctest/testcase.py
@@ -163,7 +163,7 @@ class TestCase(AssertionsMixin):
         if launch_site is None:
             space_center.launch_vessel_from_vab(name)
         else:
-            space_center.launch_vessel("VAB", name, launch_site, [])
+            space_center.launch_vessel("VAB", name, launch_site)
         # Ensure the crew are all pilots, for full control
         cls.set_crew_to_pilot()
 
@@ -176,7 +176,7 @@ class TestCase(AssertionsMixin):
         if launch_site is None:
             space_center.launch_vessel_from_sph(name)
         else:
-            space_center.launch_vessel("SPH", name, launch_site, [])
+            space_center.launch_vessel("SPH", name, launch_site)
         # Ensure the crew are all pilots, for full control
         cls.set_crew_to_pilot()
 


### PR DESCRIPTION
**Problem.** `SpaceCenter.LaunchVessel` took its `crew` list as a hint rather than an instruction. A null or empty list both fell back to the craft's default crew assignments, so there was no way to launch uncrewed. A populated list was fed to `KerbalRoster.DefaultCrewForVessel`, which picks seats itself, so the order of the list said nothing about where the Kerbals ended up. Names that did not match an available Kerbal were silently dropped, and the craft launched with whoever was left. The parameter was also non-optional, as a workaround for the protocol's inability to send a null list (#824), so every caller had to pass one.

**Change.** `crew` is optional and nullable again, now that the protocol supports null values (#1017), and the three cases are distinct. Null uses the craft's default crew assignments. An empty list launches with no crew. A populated list seats exactly the named Kerbals in the order given: each takes the next empty seat while scanning the craft's parts in manifest order and then seats by index, so a Kerbal's position in the list maps deterministically onto the craft. No extra Kerbals are hired to fill what is left.

The requested crew are resolved and validated before the launch touches any game state, so an unknown or unavailable Kerbal, or a craft with fewer seats than requested crew, raises an exception and leaves the game untouched instead of launching with the wrong crew.

**Testing.** `service/SpaceCenter/test/test_launch_crew.py` covers the three crew modes, seating order across two launches of the same craft, and each of the failure cases.
