### PR TITLE
Keep a connection usable when a request cannot be decoded

### DIFF
--- a/client/python/krpc/test/test_objects.py
+++ b/client/python/krpc/test/test_objects.py
@@ -58,6 +58,23 @@ class TestObjects(ServerTestCase, unittest.TestCase):
         # pylint: disable=comparison-with-itself
         self.assertTrue(obj1 >= obj1)
 
+    def test_invalid_object_id(self) -> None:
+        # A call naming an object identifier the server does not have fails as an
+        # argument error, and the connection is left able to make further calls
+        obj = self.conn.test_service.TestClass(self.conn, 1000000)
+        with self.assertRaises(ValueError) as cm:
+            obj.get_value()
+        self.assertTrue(str(cm.exception).startswith("Instance not found"))
+        self.assertEqual(
+            "value=jeb", self.conn.test_service.create_test_object("jeb").get_value()
+        )
+
+        # An object passed as an argument is no different
+        with self.assertRaises(ValueError) as cm:
+            self.conn.test_service.echo_test_object(obj)
+        self.assertTrue(str(cm.exception).startswith("Instance not found"))
+        self.assertEqual("3.14159", self.conn.test_service.float_to_string(3.14159))
+
     def test_memory_allocation(self) -> None:
         obj1 = self.conn.test_service.create_test_object("jeb")
         obj2 = self.conn.test_service.create_test_object("jeb")

--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -2,6 +2,8 @@
 - Support for nullable values across all types (#1017)
 - **Breaking:** Null values are now signaled by an `is_null` field rather than by an object id
   of 0, and nullability is enforced uniformly for every type. Class-typed arguments are no longer implicitly nullable (#1017)
+- Fix a request that names an object the server no longer has leaving the connection stuck, with
+  every later call failing; the failure is now reported to the client as the error it is (#1019)
 
 ## [v0.6.0]
 - Add `Version` property to `Core`, set by the server plugin on startup (#848)

--- a/core/src/Core.cs
+++ b/core/src/Core.cs
@@ -676,6 +676,22 @@ namespace KRPC
         HashSet<IClient<Request,Response>> pollRequestsCurrentClients = new HashSet<IClient<Request, Response>> ();
 
         /// <summary>
+        /// Send a response carrying nothing but an error, for a request that could not be
+        /// turned into a call to make.
+        /// </summary>
+        static void SendErrorResponse (IClient<Request,Response> client, Error error)
+        {
+            var response = new Response ();
+            response.Error = error;
+            try {
+                client.Stream.Write (response);
+                Logger.WriteLine ("Sent error response to client " + client.Address + " (" + error + ")", Logger.Severity.Debug);
+            } catch (ServerException exn) {
+                Logger.WriteLine ("Failed to send error response to client " + client.Address + Environment.NewLine + exn, Logger.Severity.Error);
+            }
+        }
+
+        /// <summary>
         /// Poll connected clients for new requests.
         /// Adds a continuation to the queue for any client with a new request,
         /// if a continuation is not already being processed for the client.
@@ -717,17 +733,17 @@ namespace KRPC
                     Logger.WriteLine ("Error receiving request from client " + client.Address + ": " + e.Message, Logger.Severity.Error);
                     client.Stream.Close ();
                     continue;
+                } catch (KRPC.Server.Message.RequestDecodeException e) {
+                    // The request arrived intact but names something the server cannot
+                    // give, such as an object it has reclaimed. That is a failed call
+                    // rather than a broken connection, so it is reported as the error it
+                    // is and the client carries on.
+                    SendErrorResponse (client, KRPC.Service.Services.Instance.HandleException (e.InnerException ?? e));
                 } catch (System.Exception e) {
-                    var response = new Response ();
-                    response.Error = new Error ("Error receiving message" + Environment.NewLine + e.Message, e.StackTrace);
                     if (Logger.ShouldLog (Logger.Severity.Debug))
                         Logger.WriteLine (e.Message + Environment.NewLine + e.StackTrace, Logger.Severity.Error);
-                    try {
-                        client.Stream.Write (response);
-                        Logger.WriteLine ("Sent error response to client " + client.Address + " (" + response.Error + ")", Logger.Severity.Debug);
-                    } catch (ServerException exn) {
-                        Logger.WriteLine ("Failed to send error response to client " + client.Address + Environment.NewLine + exn, Logger.Severity.Error);
-                    }
+                    SendErrorResponse (client, new Error (
+                        "Error receiving message" + Environment.NewLine + e.Message, e.StackTrace));
                 }
                 item = item.Next;
             }

--- a/core/src/KRPC.Core.csproj
+++ b/core/src/KRPC.Core.csproj
@@ -49,6 +49,7 @@
     <Compile Include="Server\IStream.cs" />
     <Compile Include="Server\Message\MalformedRequestException.cs" />
     <Compile Include="Server\Message\NoRequestException.cs" />
+    <Compile Include="Server\Message\RequestDecodeException.cs" />
     <Compile Include="Server\Message\RPCClient.cs" />
     <Compile Include="Server\Message\RPCServer.cs" />
     <Compile Include="Server\Message\RPCStream.cs" />

--- a/core/src/Server/Message/RPCStream.cs
+++ b/core/src/Server/Message/RPCStream.cs
@@ -139,6 +139,12 @@ namespace KRPC.Server.Message
             } catch (MalformedRequestException) {
                 Close ();
                 throw;
+            } catch (RequestDecodeException e) {
+                // The request arrived in full and only what it names is wrong, so drop the
+                // bytes it occupied before letting the error be reported. The connection is
+                // then still in step with the client, which can carry on making calls.
+                ConsumeReceiveBuffer (e.BytesRead);
+                throw;
             }
 
             // Sanity check the bytes read by the class implementing Read()
@@ -147,17 +153,22 @@ namespace KRPC.Server.Message
                 throw new InvalidOperationException ("Read too many bytes");
             }
 
-            // Update the buffer
-            // Note: shuffling the buffer by copying should happen rarely as Read() usually consumes the entire buffer
-            if (read == receiveBufferSize)
+            ConsumeReceiveBuffer (read);
+
+            // Return whether a request was decoded and is available
+            return (bufferedRequest != null);
+        }
+
+        /// Drop the given number of bytes from the front of the receive buffer.
+        /// Note: shuffling the buffer by copying should happen rarely as Read() usually consumes the entire buffer
+        void ConsumeReceiveBuffer (int read)
+        {
+            if (read >= receiveBufferSize)
                 receiveBufferSize = 0;
             else if (read > 0 && receiveBufferSize > 0) {
                 Array.Copy (receiveBuffer, read, receiveBuffer, 0, receiveBufferSize - read);
                 receiveBufferSize -= read;
             }
-
-            // Return whether a request was decoded and is available
-            return (bufferedRequest != null);
         }
     }
 }

--- a/core/src/Server/Message/RequestDecodeException.cs
+++ b/core/src/Server/Message/RequestDecodeException.cs
@@ -1,0 +1,27 @@
+using System;
+
+namespace KRPC.Server.Message
+{
+    /// <summary>
+    /// Thrown when a request was received in full, but could not be turned into the call
+    /// it names - for example because it names an object the server no longer has.
+    /// </summary>
+    /// <remarks>
+    /// Carries the number of bytes the request occupied, so that the stream can drop them
+    /// and stay in step with the client. Without that, the same bytes are decoded again on
+    /// the next poll, and the client never gets another call through.
+    /// </remarks>
+    sealed class RequestDecodeException : Exception
+    {
+        public RequestDecodeException (int bytesRead, Exception innerException) :
+            base (innerException == null ? string.Empty : innerException.Message, innerException)
+        {
+            BytesRead = bytesRead;
+        }
+
+        /// <summary>
+        /// The number of bytes the request that could not be decoded occupied.
+        /// </summary>
+        public int BytesRead { get; private set; }
+    }
+}

--- a/core/src/Server/ProtocolBuffers/RPCStream.cs
+++ b/core/src/Server/ProtocolBuffers/RPCStream.cs
@@ -25,8 +25,13 @@ namespace KRPC.Server.ProtocolBuffers
                 Schema.KRPC.Request message = null;
                 var read = Utils.ReadMessage<Schema.KRPC.Request>(
                     ref message, Schema.KRPC.Request.Parser, data, offset, length);
-                if (message != null)
-                    request = message.ToMessage ();
+                if (message != null) {
+                    try {
+                        request = message.ToMessage ();
+                    } catch (System.Exception e) {
+                        throw new RequestDecodeException (read, e);
+                    }
+                }
                 return read;
             } catch (System.InvalidOperationException e) {
                 throw new MalformedRequestException (e.Message);

--- a/core/src/Server/SerialIO/RPCStream.cs
+++ b/core/src/Server/SerialIO/RPCStream.cs
@@ -39,7 +39,11 @@ namespace KRPC.Server.SerialIO
                     ((ByteServer)server).ClientConnectionRequest (bufferedData);
                     throw new ClientDisconnectedException ();
                 }
-                request = multiplexedRequest.Request.ToMessage ();
+                try {
+                    request = multiplexedRequest.Request.ToMessage ();
+                } catch (System.Exception e) {
+                    throw new RequestDecodeException (read, e);
+                }
                 return read;
             } catch (System.InvalidOperationException e) {
                 throw new MalformedRequestException (e.Message);

--- a/core/src/Server/WebSockets/RPCStream.cs
+++ b/core/src/Server/WebSockets/RPCStream.cs
@@ -139,7 +139,12 @@ namespace KRPC.Server.WebSockets
                             Stream.Write (Frame.Binary (payload).ToBytes ());
                         else {
                             try {
-                                request = Schema.KRPC.Request.Parser.ParseFrom (payload).ToMessage ();
+                                var message = Schema.KRPC.Request.Parser.ParseFrom (payload);
+                                try {
+                                    request = message.ToMessage ();
+                                } catch (System.Exception e) {
+                                    throw new RequestDecodeException (read + frame.Length, e);
+                                }
                             } catch (InvalidProtocolBufferException) {
                                 Logger.WriteLine ("WebSockets invalid message: failed to decode protobuf message", Logger.Severity.Error);
                                 Stream.Write (Frame.Close (1007, "Malformed protocol buffer message").ToBytes ());

--- a/core/test/Server/ProtocolBuffers/RPCStreamTest.cs
+++ b/core/test/Server/ProtocolBuffers/RPCStreamTest.cs
@@ -180,6 +180,50 @@ namespace KRPC.Test.Server.ProtocolBuffers
         }
 
         [Test]
+        public void ReadRequestThatCannotBeDecoded ()
+        {
+            // A request that arrives in full, but names an object identifier the server does
+            // not have, so the call it names cannot be built.
+            var call = new Schema.KRPC.ProcedureCall {
+                Service = "TestService",
+                Procedure = "DeleteTestObject"
+            };
+            call.Arguments.Add (new Schema.KRPC.Argument {
+                Position = 0,
+                Value = ByteString.CopyFrom (new byte [] { 42 })
+            });
+            var undecodableRequest = new Schema.KRPC.Request ();
+            undecodableRequest.Calls.Add (call);
+            byte[] undecodableRequestBytes;
+            using (var stream = new MemoryStream ()) {
+                var codedStream = new CodedOutputStream (stream, true);
+                codedStream.WriteMessage (undecodableRequest);
+                codedStream.Flush ();
+                undecodableRequestBytes = stream.ToArray ();
+            }
+
+            // Send it, followed by a request that can be decoded
+            var data = new byte [undecodableRequestBytes.Length + requestBytes.Length];
+            Array.Copy (undecodableRequestBytes, 0, data, 0, undecodableRequestBytes.Length);
+            Array.Copy (requestBytes, 0, data, undecodableRequestBytes.Length, requestBytes.Length);
+            var byteStream = new TestStream (data);
+            var rpcStream = new RPCStream (byteStream);
+
+            // The failure is reported, and the connection is left open
+            var exn = Assert.Throws<KRPC.Server.Message.RequestDecodeException> (() => rpcStream.Read ());
+            Assert.IsInstanceOf<ArgumentException> (exn.InnerException);
+            Assert.IsFalse (byteStream.Closed);
+
+            // The bytes of the failed request are gone, so the request behind it is read
+            Assert.IsTrue (rpcStream.DataAvailable);
+            Request request = rpcStream.Read ();
+            Assert.AreEqual (expectedRequest.Calls [0].Service, request.Calls [0].Service);
+            Assert.AreEqual (expectedRequest.Calls [0].Procedure, request.Calls [0].Procedure);
+            Assert.IsFalse (rpcStream.DataAvailable);
+            Assert.IsFalse (byteStream.Closed);
+        }
+
+        [Test]
         public void WriteSingleResponse ()
         {
             var stream = new MemoryStream ();


### PR DESCRIPTION
**Problem.** A request can arrive intact and still fail to become the call it names, most commonly when it names an object identifier the server has already reclaimed. The server treated that as a message it could not read: the bytes stayed in the receive buffer, so every later poll decoded the same request and failed on it again, and no further call from that client ever got through. A single stale object reference made the connection useless for the rest of its life.

**Fix.** Failures of this kind are now raised as a distinct exception that carries the number of bytes the request occupied, for all three transports. The stream drops those bytes before the failure propagates, so it stays in step with the client, and the server reports the failure through the normal service error handling rather than as a receive error. A client that used an object that is gone is told exactly that and carries on making calls.

**Testing.** Unit tests cover the protobuf stream consuming an undecodable request and remaining usable for the request that follows it. A Python client test checks the end to end behavior for an unknown object identifier, both as the instance a call is made on and as an argument, and that ordinary calls still work afterwards.
