### PR TITLE
Keep the object store while any server is still running

### DIFF
--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## [v0.7.0] - unreleased
+- Fix one server stopping emptying the object store that every server shares, which invalidated
+  the objects held by clients of the servers still running (#1020)
 - Support for nullable values across all types (#1017)
 - **Breaking:** Null values are now signaled by an `is_null` field rather than by an object id
   of 0, and nullability is enforced uniformly for every type. Class-typed arguments are no longer implicitly nullable (#1017)

--- a/core/src/Core.cs
+++ b/core/src/Core.cs
@@ -187,6 +187,11 @@ namespace KRPC
             server.OnStopped += (s, e) => {
                 Logger.WriteLine ("Server '" + ((Server.Server)s).Name + "' stopped");
                 AnyRunning = Servers.Any (x => x.Running);
+                // The object store is shared by every server, and its object identifiers
+                // are handed out from a single sequence, so it is only emptied once no
+                // server is left for a client to hold an identifier through.
+                if (!AnyRunning)
+                    ObjectStore.Clear ();
                 EventHandlerExtensions.Invoke (OnServerStopped, this, new ServerStoppedEventArgs ((Server.Server)s));
             };
             server.OnClientRequestingConnection += (s, e) => EventHandlerExtensions.Invoke (OnClientRequestingConnection, this, e);

--- a/core/src/Server/Server.cs
+++ b/core/src/Server/Server.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using KRPC.Service;
 using KRPC.Service.Messages;
 using KRPC.Utils;
 
@@ -111,7 +110,6 @@ namespace KRPC.Server
         {
             RPCServer.Stop ();
             StreamServer.Stop ();
-            ObjectStore.Clear ();
         }
 
         /// <summary>

--- a/core/test/CoreTest.cs
+++ b/core/test/CoreTest.cs
@@ -1,0 +1,66 @@
+using System;
+using KRPC.Server;
+using KRPC.Service;
+using KRPC.Service.Messages;
+using Moq;
+using NUnit.Framework;
+
+namespace KRPC.Test
+{
+    [TestFixture]
+    public class CoreTest
+    {
+        // A server whose running state is driven by the test, so that stopping it
+        // can be simulated without any network activity.
+        sealed class TestServer
+        {
+            readonly Mock<IServer<Request,Response>> rpcServer = new Mock<IServer<Request,Response>> ();
+            readonly Mock<IServer<NoMessage,StreamUpdate>> streamServer = new Mock<IServer<NoMessage,StreamUpdate>> ();
+            bool running;
+
+            public TestServer ()
+            {
+                rpcServer.SetupGet (x => x.Running).Returns (() => running);
+                streamServer.SetupGet (x => x.Running).Returns (() => running);
+                rpcServer.Setup (x => x.Start ()).Callback (() => {
+                    running = true;
+                    rpcServer.Raise (x => x.OnStarted += null, EventArgs.Empty);
+                });
+                rpcServer.Setup (x => x.Stop ()).Callback (() => {
+                    running = false;
+                    rpcServer.Raise (x => x.OnStopped += null, EventArgs.Empty);
+                });
+                Server = new KRPC.Server.Server (
+                    Guid.NewGuid (), Protocol.ProtocolBuffersOverTCP, "TestServer",
+                    rpcServer.Object, streamServer.Object);
+            }
+
+            public KRPC.Server.Server Server { get; private set; }
+        }
+
+        [Test]
+        public void TheObjectStoreOutlivesAServerThatStops ()
+        {
+            var core = Core.Instance;
+            var first = new TestServer ().Server;
+            var second = new TestServer ().Server;
+            core.Add (first);
+            core.Add (second);
+            try {
+                first.Start ();
+                second.Start ();
+                var obj = new object ();
+                var id = ObjectStore.Instance.AddInstance (obj);
+
+                first.Stop ();
+                Assert.AreSame (obj, ObjectStore.Instance.GetInstance (id));
+
+                second.Stop ();
+                Assert.Throws<ArgumentException> (() => ObjectStore.Instance.GetInstance (id));
+            } finally {
+                core.Remove (first.Id);
+                core.Remove (second.Id);
+            }
+        }
+    }
+}

--- a/core/test/KRPC.Core.Test.csproj
+++ b/core/test/KRPC.Core.Test.csproj
@@ -39,6 +39,7 @@
       <Link>TestAssemblyInfo.cs</Link>
     </Compile>
     <Compile Include="ConfigurationTest.cs" />
+    <Compile Include="CoreTest.cs" />
     <Compile Include="Server\ClientRequestingConnectionArgsTest.cs" />
     <Compile Include="Server\HTTP\RequestTest.cs" />
     <Compile Include="Server\HTTP\ResponseTest.cs" />


### PR DESCRIPTION
**Problem.** The object store is a single store shared by every server, and its object identifiers come from one sequence, but `Server.Stop` emptied it. With more than one server running, stopping either one invalidated every object held by clients of the servers still running.

**Identifier reuse.** Clearing the store also restarts the identifier sequence at 1. A client of a still-running server passing an identifier from before the stop would therefore be handed a different object rather than an error, once the store had handed that identifier out again.

**Fix.** The core is the only thing that knows about every server, so it empties the store once no server is left running, from the handler that already recalculates whether any is. Hooking the stopped event rather than `StopAll` covers every way a server stops, including the in-game stop button and a server being removed or replaced.

**Testing.** A unit test runs two servers, registers an object, and checks it survives the first server stopping and is gone once the second stops. It fails with the clear back in `Server.Stop`.