### PR TITLE
Keep the Alt+L staging shortcut in step with Control.StageLock

### DIFF
--- a/service/SpaceCenter/CHANGELOG.md
+++ b/service/SpaceCenter/CHANGELOG.md
@@ -12,6 +12,10 @@
   - `Vessel.Recover` now recovers non-active vessels without switching to
      the space center scene, and the mission completion dialog is auto-closed. (#1021)
 
+- Control
+  - Setting `Control.StageLock` now leaves the in-game Alt+L shortcut in step with it, so the
+    next press of Alt+L locks or unlocks staging rather than being absorbed (#1022)
+
 ## [v0.6.0]
 
 - Space center

--- a/service/SpaceCenter/src/Services/Control.cs
+++ b/service/SpaceCenter/src/Services/Control.cs
@@ -693,6 +693,11 @@ namespace KRPC.SpaceCenter.Services
                     InputLockManager.SetControlLock(ControlTypes.STAGING, "manualStageLock");
                 else
                     InputLockManager.RemoveControlLock("manualStageLock");
+                // Alt+L toggles this flag alongside the input lock, and decides from it whether the
+                // next press locks or unlocks. Setting it keeps the keybinding in step, so the next
+                // press does the opposite of what was set here rather than repeating it.
+                if (FlightInputHandler.fetch != null)
+                    FlightInputHandler.fetch.stageLock = value;
             }
         }
 

--- a/service/SpaceCenter/test/test_control.py
+++ b/service/SpaceCenter/test/test_control.py
@@ -339,6 +339,16 @@ class TestControlStaging(krpctest.TestCase):
         stage -= 1
         self.assertEqual(stage, self.control.current_stage)
 
+    def test_stage_lock_tracks_alt_l_toggle(self):
+        # Alt+L decides whether the next press locks or unlocks by reading the game's own flag,
+        # so setting stage_lock has to move it too or the keybinding takes an extra press to
+        # respond.
+        tools = self.connect().testing_tools
+        self.control.stage_lock = True
+        self.assertTrue(tools.flight_input_stage_lock)
+        self.control.stage_lock = False
+        self.assertFalse(tools.flight_input_stage_lock)
+
     def test_staging(self):
         for i in reversed(range(12)):
             self.assertEqual(i, self.control.current_stage)

--- a/tools/TestingTools/src/TestingTools.cs
+++ b/tools/TestingTools/src/TestingTools.cs
@@ -113,6 +113,16 @@ namespace TestingTools
         }
 
         /// <summary>
+        /// The game's own staging lock flag, which Alt+L toggles alongside the "manualStageLock"
+        /// input lock and then reads to decide whether the next press locks or unlocks. Nothing
+        /// else in the game reads it, so it is only reachable from here.
+        /// </summary>
+        [KRPCProperty]
+        public static bool FlightInputStageLock {
+            get { return FlightInputHandler.fetch != null && FlightInputHandler.fetch.stageLock; }
+        }
+
+        /// <summary>
         /// Remove all vessels except the active vessel.
         /// </summary>
         [KRPCProcedure]


### PR DESCRIPTION
**Root cause.** KSP tracks its own staging lock flag, `FlightInputHandler.stageLock`, alongside the `manualStageLock` input lock. Alt+L toggles the flag and then reads it to decide whether to apply or remove the lock. `Control.StageLock` set only the input lock, leaving the flag untouched, so the two drifted apart and the next press of Alt+L was absorbed re-applying the state already in effect. A second press was needed before the shortcut responded.

**Fix.** The setter writes the flag as well as the input lock. `TestingTools` gains a `FlightInputStageLock` property to read it: that flag is written in exactly one place in the game assembly, the Alt+L handler, and read nowhere else, so a client-side test has no other way to observe it.

**Testing.** New in-game test `test_stage_lock_tracks_alt_l_toggle` in `TestControlStaging` checks the flag follows `stage_lock` in both directions. It fails with the setter change reverted.