### PR TITLE
Fix stages breaking after a Revert to Launch

### DIFF
--- a/service/SpaceCenter/CHANGELOG.md
+++ b/service/SpaceCenter/CHANGELOG.md
@@ -12,6 +12,12 @@
   - `Vessel.Recover` now recovers non-active vessels without switching to
      the space center scene, and the mission completion dialog is auto-closed. (#1021)
 
+- Staging
+  - Fix stages from `Vessel.Stages`, `Vessel.StageAt`, `Vessel.DecoupleStages` and
+    `Vessel.DecoupleStageAt` breaking after a Revert to Launch, reporting that delta-v had
+    not been calculated for the vessel. Stages requested after the revert were affected
+    too, so the game had to be restarted to get working stages back (#1023)
+
 - Control
   - Setting `Control.StageLock` now leaves the in-game Alt+L shortcut in step with it, so the
     next press of Alt+L locks or unlocks staging rather than being absorbed (#1022)

--- a/service/SpaceCenter/src/Services/Stage.cs
+++ b/service/SpaceCenter/src/Services/Stage.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using KRPC.Service.Attributes;
+using KRPC.SpaceCenter.ExtensionMethods;
 using KRPC.Utils;
 using Parts = KRPC.SpaceCenter.Services.Parts;
 
@@ -23,29 +24,29 @@ namespace KRPC.SpaceCenter.Services
     public class Stage : Equatable<Stage>
     {
         /// <summary>
-        /// The internal vessel object.
+        /// The id of the vessel the stage belongs to.
         /// </summary>
-        readonly global::Vessel internalVessel;
+        readonly Guid vesselId;
 
         /// <summary>
         /// The stage number.
         /// </summary>
         readonly int stageNumber;
-        
+
         /// <summary>
         /// Whether this is a decouple stage.
         /// </summary>
         readonly bool decoupleStage;
 
         /// <summary>
-        /// Initializes a stage object by storing the vessel, stage number, 
+        /// Initializes a stage object by storing the vessel id, stage number,
         /// and whether it is a decouple stage, while rejecting a null vessel.
         /// </summary>
         internal Stage (global::Vessel vessel, int number, bool decouple)
         {
             if (ReferenceEquals (vessel, null))
                 throw new ArgumentNullException (nameof (vessel));
-            internalVessel = vessel;
+            vesselId = vessel.id;
             stageNumber = number;
             decoupleStage = decouple;
         }
@@ -56,7 +57,7 @@ namespace KRPC.SpaceCenter.Services
         public override bool Equals (Stage other)
         {
             return !ReferenceEquals (other, null) &&
-                   internalVessel.id == other.internalVessel.id &&
+                   vesselId == other.vesselId &&
                    stageNumber == other.stageNumber &&
                    decoupleStage == other.decoupleStage;
         }
@@ -66,7 +67,15 @@ namespace KRPC.SpaceCenter.Services
         /// </summary>
         public override int GetHashCode ()
         {
-            return internalVessel.id.GetHashCode () ^ stageNumber.GetHashCode () ^ decoupleStage.GetHashCode ();
+            return vesselId.GetHashCode () ^ stageNumber.GetHashCode () ^ decoupleStage.GetHashCode ();
+        }
+
+        /// <summary>
+        /// The KSP vessel. Looked up by id on each use, so a stage keeps working across a
+        /// scene reload that destroys the vessel and recreates it under the same id.
+        /// </summary>
+        public global::Vessel InternalVessel {
+            get { return FlightGlobalsExtensions.GetVesselById (vesselId); }
         }
 
         /// <summary>
@@ -83,7 +92,7 @@ namespace KRPC.SpaceCenter.Services
         {
             get
             {
-                var vesselParts = new Parts.Parts (internalVessel);
+                var vesselParts = new Parts.Parts (InternalVessel);
                 if (decoupleStage)
                     return vesselParts.All.Where (part => part.DecoupleStage == stageNumber).ToList ();
                 return vesselParts.All.Where (part => part.Stage == stageNumber).ToList ();
@@ -104,7 +113,7 @@ namespace KRPC.SpaceCenter.Services
         [KRPCMethod]
         public Resources Resources (bool cumulative = true)
         {
-            return new Resources (internalVessel, stageNumber, cumulative, decoupleStage);
+            return new Resources (InternalVessel, stageNumber, cumulative, decoupleStage);
         }
 
         /// <summary>
@@ -220,7 +229,7 @@ namespace KRPC.SpaceCenter.Services
         {
             if (decoupleStage)
                 throw new InvalidOperationException ("Delta-v information is not available for a decouple stage.");
-            var dv = internalVessel.VesselDeltaV;
+            var dv = InternalVessel.VesselDeltaV;
             if (dv == null || !dv.IsReady)
                 throw new InvalidOperationException ("Delta-v has not been calculated for this vessel yet.");
             var stageInfo = dv.GetStage (stageNumber);

--- a/service/SpaceCenter/test/test_stage.py
+++ b/service/SpaceCenter/test/test_stage.py
@@ -71,3 +71,92 @@ class TestStage(krpctest.TestCase):
         legacy = self.vessel.resources_in_decouple_stage(0, False)
         new_way = self.vessel.decouple_stage_at(0).resources(False)
         assert_resources_equivalent(self, legacy, new_way)
+
+
+class TestStageRevertToLaunch(krpctest.TestCase):
+    # Regression for stages breaking after a Revert to Launch. The revert destroys the
+    # vessel and recreates it under the same id, so a stage that holds the vessel object
+    # is left pointing at the destroyed one and reports that delta-v has not been
+    # calculated. Because stages compare equal on vessel id, stage number and kind, the
+    # broken stage stays in the object store and is handed back to every later call, so
+    # even a freshly requested stage is affected.
+
+    @classmethod
+    def setUpClass(cls):
+        cls.new_save()
+        cls.remove_other_vessels()
+        cls.launch_vessel_from_vab("Staging")
+
+    def wait_for_flight(self):
+        conn = self.connect()
+
+        def in_flight():
+            try:
+                return (
+                    conn.krpc.game_scene == conn.krpc.GameScene.flight
+                    and conn.space_center.active_vessel is not None
+                    and conn.space_center.active_vessel.parts.root is not None
+                )
+            except RuntimeError:
+                return False
+
+        self.wait_until(in_flight, timeout=60, message="flight scene after revert")
+
+    def wait_for_delta_v(self, vessel):
+        # The recreated vessel builds its delta-v simulation over the first few frames of
+        # the reloaded scene, so wait for it before reading any stage. This uses the
+        # vessel-level figure, which resolves the vessel by id and so is unaffected by
+        # what this test is checking.
+        def ready():
+            try:
+                return vessel.vacuum_delta_v > 0
+            except RuntimeError:
+                return False
+
+        self.wait_until(ready, timeout=30, message="delta-v after revert")
+
+    def stage_state(self, stage, decouple_stage):
+        # Everything a stage exposes that has to survive the reload: the delta-v figures
+        # the bug report is about, the part list, and the resource collection.
+        return (
+            round(stage.vacuum_delta_v),
+            round(stage.vacuum_thrust),
+            len(stage.parts),
+            len(decouple_stage.parts),
+            sorted(decouple_stage.resources().names),
+        )
+
+    def test_stages_after_revert_to_launch(self):
+        space_center = self.connect().space_center
+        vessel = space_center.active_vessel
+        # Pick stages that actually carry the data being checked, so that reading zeros
+        # after the revert is a failure rather than the craft's own layout.
+        stage = max(vessel.stages, key=lambda s: s.vacuum_delta_v)
+        decouple_stage = max(vessel.decouple_stages, key=lambda s: len(s.parts))
+        stage_number = stage.number
+        decouple_stage_number = decouple_stage.number
+        before = self.stage_state(stage, decouple_stage)
+        self.assertGreater(before[0], 0)
+        self.assertGreater(before[2], 0)
+        self.assertGreater(before[3], 0)
+
+        self.assertTrue(space_center.can_revert_to_launch)
+        space_center.revert_to_launch()
+        self.wait_for_flight()
+
+        space_center = self.connect().space_center
+        vessel = space_center.active_vessel
+        self.wait_for_delta_v(vessel)
+
+        # Stage handles kept across the reload, as a client that does not reconnect has.
+        self.assertEqual(before, self.stage_state(stage, decouple_stage))
+
+        # And stages requested after the reload, which the object store hands back as the
+        # same instances because they compare equal to the ones from before it.
+        self.assertEqual(
+            before,
+            self.stage_state(
+                vessel.stage_at(stage_number),
+                vessel.decouple_stage_at(decouple_stage_number),
+            ),
+        )


### PR DESCRIPTION
**Problem.** After a Revert to Launch, every stage obtained from `Vessel.Stages`, `Vessel.StageAt`, `Vessel.DecoupleStages` or `Vessel.DecoupleStageAt` reported that delta-v had not been calculated for the vessel, and its thrust, mass and part members were equally broken. Requesting a fresh stage after the revert did not help: stages compare equal on vessel id, stage number and kind, so the object store handed back the same broken instance. Restarting the game was the only way to get working stages again.

**Root cause.** `Stage` held the KSP vessel object it was created with. A revert destroys the vessel and recreates it under the same id, leaving the stored reference pointing at the destroyed one.

**Fix.** Resolve the vessel by id on each access, as the other vessel-scoped classes already do.

**Testing.** A new in-game test reverts to launch and checks that the delta-v, thrust, part and resource data of both a normal and a decouple stage survive, for stage handles held across the reload and for stages requested afterwards. It fails before the fix and passes after it.
