### PR TITLE
Measure bounding boxes against a part's own model

### DIFF
--- a/service/SpaceCenter/CHANGELOG.md
+++ b/service/SpaceCenter/CHANGELOG.md
@@ -22,6 +22,12 @@
   - Setting `Control.StageLock` now leaves the in-game Alt+L shortcut in step with it, so the
     next press of Alt+L locks or unlocks staging rather than being absorbed (#1022)
 
+- Parts
+  - `Part.BoundingBox` and `Vessel.BoundingBox` now measure only the meshes of a part's own
+    model. The boxes no longer take in the models of physicsless child parts, nor any object
+    another mod has attached to a part, which could stretch a box to an arbitrary size (#1024)
+  - Computing a bounding box no longer duplicates the meshes of every part it measures (#1024)
+
 ## [v0.6.0]
 
 - Space center

--- a/service/SpaceCenter/src/ExtensionMethods/PartExtensions.cs
+++ b/service/SpaceCenter/src/ExtensionMethods/PartExtensions.cs
@@ -120,7 +120,7 @@ namespace KRPC.SpaceCenter.ExtensionMethods
         /// Computes the axis-aligned bounding box for a part in the given reference frame.
         /// </summary>
         /// <remarks>
-        /// This is an expensive calculation. It iterates over the parts collider meshes
+        /// This is an expensive calculation. It iterates over the meshes of the parts model
         /// to compute a tight axis-aligned bounding box.
         /// It does not use part.collider.bounds, as this is aligned to world space and
         /// would not provide a tight bounding box in the given reference frame.
@@ -128,10 +128,22 @@ namespace KRPC.SpaceCenter.ExtensionMethods
         public static Bounds GetBounds (this Part part, ReferenceFrame referenceFrame)
         {
             var bounds = new Bounds (referenceFrame.PositionFromWorldSpace (part.WCoM), Vector3.zero);
-            var meshes = part.GetComponentsInChildren<MeshFilter> ();
-            for (int i = 0; i < meshes.Length; i++) {
+            // Only the parts own model, the same subtree KSP measures a part against. Searching
+            // the whole part transform instead would pick up the models of physicsless child
+            // parts, which hang off it, along with any object a mod parents to the part.
+            var meshes = part.FindModelComponents<MeshFilter> ();
+            for (int i = 0; i < meshes.Count; i++) {
                 var mesh = meshes [i];
-                var vertices = mesh.mesh.bounds.ToVertices ();
+                // The model subtree is walked in full, so meshes that are currently switched
+                // off - a hidden part variant, a stowed animation state - have to be skipped.
+                if (!mesh.gameObject.activeInHierarchy)
+                    continue;
+                // sharedMesh, not mesh: the latter instantiates a private copy of the mesh
+                // on the first access and leaves the part rendering that copy.
+                var geometry = mesh.sharedMesh;
+                if (geometry == null)
+                    continue;
+                var vertices = geometry.bounds.ToVertices ();
                 for (int j = 0; j < vertices.Length; j++) {
                     // mesh space -> world space -> reference frame space
                     var vertex = referenceFrame.PositionFromWorldSpace (mesh.transform.TransformPoint (vertices [j]));

--- a/service/SpaceCenter/src/Services/Parts/Part.cs
+++ b/service/SpaceCenter/src/Services/Parts/Part.cs
@@ -796,9 +796,10 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// <param name="referenceFrame">The reference frame that the returned
         /// position vectors are in.</param>
         /// <remarks>
-        /// This is computed from the collision mesh of the part.
-        /// If the part is not collidable, the box has zero volume and is centered on
-        /// the <see cref="Position"/> of the part.
+        /// This is computed from the meshes that make up the parts model, and covers only
+        /// this part - the models of any child parts are excluded.
+        /// If the part has no visible model, the box has zero volume and is centered on
+        /// the <see cref="CenterOfMass"/> of the part.
         /// </remarks>
         [KRPCMethod]
         public TupleT3 BoundingBox (ReferenceFrame referenceFrame)


### PR DESCRIPTION
**Root cause.** `Part.BoundingBox` and `Vessel.BoundingBox` collected every `MeshFilter` under the part transform, so a part's box grew to cover the models of any physicsless child parts hanging off it, and any object another mod had attached to the part. A single stray mesh with large bounds, of which the flight scene holds hundreds, was enough to stretch a whole vessel's box past the point where float precision left anything of the real geometry.

**Fix.** Measure a part against its own model subtree, which is what KSP itself measures a part against, skipping meshes that are currently switched off such as a hidden part variant or a stowed animation state. Reading `sharedMesh` rather than `mesh` also stops a bounding box computation from instantiating a private copy of every mesh it touches.
