### PR TITLE
Add ResourceTransfer.Cancel

### DIFF
--- a/doc/order.txt
+++ b/doc/order.txt
@@ -1238,6 +1238,7 @@ SpaceCenter.ResourceFlowMode.Adjacent
 SpaceCenter.ResourceFlowMode.None
 SpaceCenter.ResourceTransfer
 SpaceCenter.ResourceTransfer.Start
+SpaceCenter.ResourceTransfer.Cancel
 SpaceCenter.ResourceTransfer.Amount
 SpaceCenter.ResourceTransfer.Complete
 SpaceCenter.Node

--- a/service/SpaceCenter/CHANGELOG.md
+++ b/service/SpaceCenter/CHANGELOG.md
@@ -28,6 +28,10 @@
     another mod has attached to a part, which could stretch a box to an arbitrary size (#1024)
   - Computing a bounding box no longer duplicates the meshes of every part it measures (#1024)
 
+- Resources
+  - Add `ResourceTransfer.Cancel` to stop a transfer before it finishes; no more of the
+    resource is moved and the transfer is marked as complete (#1028)
+
 ## [v0.6.0]
 
 - Space center

--- a/service/SpaceCenter/src/Services/ResourceTransfer.cs
+++ b/service/SpaceCenter/src/Services/ResourceTransfer.cs
@@ -42,8 +42,9 @@ namespace KRPC.SpaceCenter.Services
         /// <param name="resource">The name of the resource to transfer.</param>
         /// <param name="maxAmount">The maximum amount of resource to transfer.</param>
         /// <remarks>
-        /// The transfer is canceled if the client that started it disconnects;
-        /// a canceled transfer is marked as complete.
+        /// Use <see cref="Cancel"/> to stop the transfer before it finishes. The transfer is
+        /// also canceled if the client that started it disconnects. A canceled transfer is
+        /// marked as complete.
         /// </remarks>
         [KRPCMethod]
         public static ResourceTransfer Start (Parts.Part fromPart, Parts.Part toPart, string resource, float maxAmount)
@@ -91,17 +92,19 @@ namespace KRPC.SpaceCenter.Services
         public float TotalAmount { get; private set; }
 
         /// <summary>
-        /// Whether the transfer has completed. Also becomes true if the transfer is
-        /// canceled because the client that started it disconnected.
+        /// Whether the transfer has completed. Also becomes true if the transfer is canceled,
+        /// either by calling <see cref="Cancel"/> or because the client that started it
+        /// disconnected.
         /// </summary>
         [KRPCProperty]
         public bool Complete { get; private set; }
 
         /// <summary>
-        /// Cancel the transfer. No more resource is moved and the transfer is marked
-        /// as complete.
+        /// Cancel the transfer. No more of the resource is moved and
+        /// <see cref="Complete"/> becomes true.
         /// </summary>
-        internal void Cancel ()
+        [KRPCMethod]
+        public void Cancel ()
         {
             Complete = true;
         }

--- a/service/SpaceCenter/test/test_resource_transfer.py
+++ b/service/SpaceCenter/test/test_resource_transfer.py
@@ -110,6 +110,66 @@ class TestResourceTransfer(krpctest.TestCase):
         self.assertTrue("Destination part cannot store" in str(cm.exception))
 
 
+class TestResourceTransferCancel(krpctest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.new_save()
+        cls.launch_vessel_from_vab("ResourceTransfer")
+        cls.remove_other_vessels()
+        cls.sc = cls.connect().space_center
+        cls.parts = cls.sc.active_vessel.parts
+
+    def test_cancel(self):
+        from_part = self.parts.with_name("fuelTank")[0]
+        to_part = self.parts.with_name("fuelTankSmallFlat")[0]
+
+        # A transfer that would take several seconds to complete
+        transfer = self.sc.ResourceTransfer.start(
+            from_part, to_part, "Oxidizer", float("inf")
+        )
+        self.wait(0.5)
+        self.assertFalse(transfer.complete)
+
+        transfer.cancel()
+        self.assertTrue(transfer.complete)
+
+        # Some, but not all, of the resource was moved before the transfer was
+        # cancelled (the destination has free space, so the transfer would still
+        # be running had it not been cancelled)...
+        amount = transfer.amount
+        self.assertGreater(amount, 0.1)
+        self.assertLess(
+            to_part.resources.amount("Oxidizer"), to_part.resources.max("Oxidizer")
+        )
+        # ...and no more is moved afterwards
+        from_amount = from_part.resources.amount("Oxidizer")
+        to_amount = to_part.resources.amount("Oxidizer")
+        self.wait(1)
+        self.assertAlmostEqual(amount, transfer.amount, places=3)
+        self.assertAlmostEqual(
+            from_amount, from_part.resources.amount("Oxidizer"), places=2
+        )
+        self.assertAlmostEqual(
+            to_amount, to_part.resources.amount("Oxidizer"), places=2
+        )
+
+    def test_cancel_when_complete(self):
+        from_part = self.parts.with_name("rcsTankRadialLong")[0]
+        to_part = self.parts.with_name("radialRCSTank")[0]
+        transfer = self.sc.ResourceTransfer.start(
+            from_part, to_part, "MonoPropellant", 5
+        )
+        while not transfer.complete:
+            self.wait()
+        amount = transfer.amount
+        self.assertAlmostEqual(5, amount)
+
+        # Cancelling a transfer that has already finished changes nothing
+        transfer.cancel()
+        self.assertTrue(transfer.complete)
+        self.assertAlmostEqual(amount, transfer.amount)
+
+
 class TestResourceTransferDisconnect(krpctest.TestCase):
     @classmethod
     def setUpClass(cls):


### PR DESCRIPTION
Once `SpaceCenter.ResourceTransfer.Start` has been called there is no way to stop the transfer early: it runs until the requested amount has moved, the source runs dry, or the destination fills up.

The cancel method already existed internally, backing the client-disconnect cleanup, so this exposes it over RPC and documents it. A canceled transfer is marked as complete, exactly as it already is when the owning client disconnects.

**Testing.** The new in-game tests cancel a transfer that is still running, then check that neither the transfer amount nor either tank changes over the following second while the destination still has free space, which is what shows the transfer would otherwise have kept going. A second test cancels a transfer that has already completed. The whole of `test_resource_transfer.py` passes in game, so the existing transfer and disconnect tests are unaffected.

Fixes #1027