### PR TITLE
Add reference frames for the navball speed modes

### DIFF
--- a/doc/order.txt
+++ b/doc/order.txt
@@ -235,6 +235,9 @@ SpaceCenter.Vessel.ReferenceFrame
 SpaceCenter.Vessel.OrbitalReferenceFrame
 SpaceCenter.Vessel.SurfaceReferenceFrame
 SpaceCenter.Vessel.SurfaceVelocityReferenceFrame
+SpaceCenter.Vessel.OrbitSpeedReferenceFrame
+SpaceCenter.Vessel.SurfaceSpeedReferenceFrame
+SpaceCenter.Vessel.TargetSpeedReferenceFrame
 SpaceCenter.Vessel.Position
 SpaceCenter.Vessel.BoundingBox
 SpaceCenter.Vessel.Velocity

--- a/doc/src/scripts/tutorials/reference-frames/NavballSpeed.c
+++ b/doc/src/scripts/tutorials/reference-frames/NavballSpeed.c
@@ -1,0 +1,30 @@
+#include <unistd.h>
+#include <math.h>
+#include <krpc_cnano.h>
+#include <krpc_cnano/services/space_center.h>
+
+int main() {
+  krpc_connection_t conn;
+  krpc_open(&conn, "COM0");
+  krpc_connect(conn, "Navball speed");
+
+  krpc_SpaceCenter_Vessel_t vessel;
+  krpc_SpaceCenter_ActiveVessel(conn, &vessel);
+
+  krpc_SpaceCenter_ReferenceFrame_t obt_frame;
+  krpc_SpaceCenter_ReferenceFrame_t srf_frame;
+  krpc_SpaceCenter_Vessel_OrbitSpeedReferenceFrame(conn, &obt_frame, vessel);
+  krpc_SpaceCenter_Vessel_SurfaceSpeedReferenceFrame(conn, &srf_frame, vessel);
+
+  while (true) {
+    double obt_speed;
+    double srf_speed;
+    krpc_SpaceCenter_Flight_t flight;
+    krpc_SpaceCenter_Vessel_Flight(conn, &flight, vessel, obt_frame);
+    krpc_SpaceCenter_Flight_Speed(conn, &obt_speed, flight);
+    krpc_SpaceCenter_Vessel_Flight(conn, &flight, vessel, srf_frame);
+    krpc_SpaceCenter_Flight_Speed(conn, &srf_speed, flight);
+    printf("Orbital speed = %.1f m/s, Surface speed = %.1f m/s\n", obt_speed, srf_speed);
+    sleep(1);
+  }
+}

--- a/doc/src/scripts/tutorials/reference-frames/NavballSpeed.cpp
+++ b/doc/src/scripts/tutorials/reference-frames/NavballSpeed.cpp
@@ -1,0 +1,22 @@
+#include <iostream>
+#include <iomanip>
+#include <thread>
+#include <krpc.hpp>
+#include <krpc/services/space_center.hpp>
+
+int main() {
+  krpc::Client conn = krpc::connect("Navball speed");
+  krpc::services::SpaceCenter spaceCenter(&conn);
+  auto vessel = spaceCenter.active_vessel();
+  auto obt_frame = vessel.orbit_speed_reference_frame();
+  auto srf_frame = vessel.surface_speed_reference_frame();
+
+  while (true) {
+    auto obt_speed = vessel.flight(obt_frame).speed();
+    auto srf_speed = vessel.flight(srf_frame).speed();
+    std::cout << std::fixed << std::setprecision(1)
+              << "Orbital speed = " << obt_speed << " m/s, "
+              << "Surface speed = " << srf_speed << " m/s" << std::endl;
+    std::this_thread::sleep_for(std::chrono::seconds(1));
+  }
+}

--- a/doc/src/scripts/tutorials/reference-frames/NavballSpeed.cs
+++ b/doc/src/scripts/tutorials/reference-frames/NavballSpeed.cs
@@ -1,0 +1,22 @@
+using System;
+using KRPC.Client;
+using KRPC.Client.Services.SpaceCenter;
+
+class NavballSpeed
+{
+    public static void Main ()
+    {
+        var connection = new Connection (name : "Navball speed");
+        var vessel = connection.SpaceCenter ().ActiveVessel;
+        var obtFrame = vessel.OrbitSpeedReferenceFrame;
+        var srfFrame = vessel.SurfaceSpeedReferenceFrame;
+        while (true) {
+            var obtSpeed = vessel.Flight (obtFrame).Speed;
+            var srfSpeed = vessel.Flight (srfFrame).Speed;
+            Console.WriteLine (
+                "Orbital speed = {0:F1} m/s, Surface speed = {1:F1} m/s",
+                obtSpeed, srfSpeed);
+            System.Threading.Thread.Sleep (1000);
+        }
+    }
+}

--- a/doc/src/scripts/tutorials/reference-frames/NavballSpeed.java
+++ b/doc/src/scripts/tutorials/reference-frames/NavballSpeed.java
@@ -1,0 +1,26 @@
+import krpc.client.Connection;
+import krpc.client.RPCException;
+import krpc.client.services.SpaceCenter;
+import krpc.client.services.SpaceCenter.ReferenceFrame;
+import krpc.client.services.SpaceCenter.Vessel;
+
+import java.io.IOException;
+
+public class NavballSpeed {
+    public static void main(String[] args)
+        throws IOException, RPCException, InterruptedException {
+        Connection connection = Connection.newInstance("Navball speed");
+        SpaceCenter spaceCenter = SpaceCenter.newInstance(connection);
+        Vessel vessel = spaceCenter.getActiveVessel();
+        ReferenceFrame obtFrame = vessel.getOrbitSpeedReferenceFrame();
+        ReferenceFrame srfFrame = vessel.getSurfaceSpeedReferenceFrame();
+        while (true) {
+            double obtSpeed = vessel.flight(obtFrame).getSpeed();
+            double srfSpeed = vessel.flight(srfFrame).getSpeed();
+            System.out.printf(
+              "Orbital speed = %.1f m/s, Surface speed = %.1f m/s\n",
+              obtSpeed, srfSpeed);
+            Thread.sleep(1000);
+        }
+    }
+}

--- a/doc/src/scripts/tutorials/reference-frames/NavballSpeed.lua
+++ b/doc/src/scripts/tutorials/reference-frames/NavballSpeed.lua
@@ -1,0 +1,15 @@
+local krpc = require 'krpc'
+local platform = require 'krpc.platform'
+local conn = krpc.connect('Navball speed')
+local vessel = conn.space_center.active_vessel
+local obt_frame = vessel.orbit_speed_reference_frame
+local srf_frame = vessel.surface_speed_reference_frame
+
+while true do
+    obt_speed = vessel:flight(obt_frame).speed
+    srf_speed = vessel:flight(srf_frame).speed
+    print(string.format(
+      'Orbital speed = %.1f m/s, Surface speed = %.1f m/s',
+      obt_speed, srf_speed))
+    platform.sleep(1)
+end

--- a/doc/src/scripts/tutorials/reference-frames/NavballSpeed.py
+++ b/doc/src/scripts/tutorials/reference-frames/NavballSpeed.py
@@ -1,0 +1,13 @@
+import time
+import krpc
+
+conn = krpc.connect(name="Navball speed")
+vessel = conn.space_center.active_vessel
+obt_frame = vessel.orbit_speed_reference_frame
+srf_frame = vessel.surface_speed_reference_frame
+
+while True:
+    obt_speed = vessel.flight(obt_frame).speed
+    srf_speed = vessel.flight(srf_frame).speed
+    print("Orbital speed = %.1f m/s, Surface speed = %.1f m/s" % (obt_speed, srf_speed))
+    time.sleep(1)

--- a/doc/src/tutorials/reference-frames.rst
+++ b/doc/src/tutorials/reference-frames.rst
@@ -180,6 +180,9 @@ kRPC provides the following reference frames:
       * :csharp:prop:`Vessel.OrbitalReferenceFrame`
       * :csharp:prop:`Vessel.SurfaceReferenceFrame`
       * :csharp:prop:`Vessel.SurfaceVelocityReferenceFrame`
+      * :csharp:prop:`Vessel.OrbitSpeedReferenceFrame`
+      * :csharp:prop:`Vessel.SurfaceSpeedReferenceFrame`
+      * :csharp:prop:`Vessel.TargetSpeedReferenceFrame`
       * :csharp:prop:`CelestialBody.ReferenceFrame`
       * :csharp:prop:`CelestialBody.NonRotatingReferenceFrame`
       * :csharp:prop:`CelestialBody.OrbitalReferenceFrame`
@@ -196,6 +199,9 @@ kRPC provides the following reference frames:
       * :cpp:func:`Vessel::orbital_reference_frame`
       * :cpp:func:`Vessel::surface_reference_frame`
       * :cpp:func:`Vessel::surface_velocity_reference_frame`
+      * :cpp:func:`Vessel::orbit_speed_reference_frame`
+      * :cpp:func:`Vessel::surface_speed_reference_frame`
+      * :cpp:func:`Vessel::target_speed_reference_frame`
       * :cpp:func:`CelestialBody::reference_frame`
       * :cpp:func:`CelestialBody::non_rotating_reference_frame`
       * :cpp:func:`CelestialBody::orbital_reference_frame`
@@ -212,6 +218,9 @@ kRPC provides the following reference frames:
       * :c:func:`krpc_SpaceCenter_Vessel_OrbitalReferenceFrame`
       * :c:func:`krpc_SpaceCenter_Vessel_SurfaceReferenceFrame`
       * :c:func:`krpc_SpaceCenter_Vessel_SurfaceVelocityReferenceFrame`
+      * :c:func:`krpc_SpaceCenter_Vessel_OrbitSpeedReferenceFrame`
+      * :c:func:`krpc_SpaceCenter_Vessel_SurfaceSpeedReferenceFrame`
+      * :c:func:`krpc_SpaceCenter_Vessel_TargetSpeedReferenceFrame`
       * :c:func:`krpc_SpaceCenter_CelestialBody_ReferenceFrame`
       * :c:func:`krpc_SpaceCenter_CelestialBody_NonRotatingReferenceFrame`
       * :c:func:`krpc_SpaceCenter_CelestialBody_OrbitalReferenceFrame`
@@ -228,6 +237,9 @@ kRPC provides the following reference frames:
       * :java:meth:`Vessel.getOrbitalReferenceFrame`
       * :java:meth:`Vessel.getSurfaceReferenceFrame`
       * :java:meth:`Vessel.getSurfaceVelocityReferenceFrame`
+      * :java:meth:`Vessel.getOrbitSpeedReferenceFrame`
+      * :java:meth:`Vessel.getSurfaceSpeedReferenceFrame`
+      * :java:meth:`Vessel.getTargetSpeedReferenceFrame`
       * :java:meth:`CelestialBody.getReferenceFrame`
       * :java:meth:`CelestialBody.getNonRotatingReferenceFrame`
       * :java:meth:`CelestialBody.getOrbitalReferenceFrame`
@@ -244,6 +256,9 @@ kRPC provides the following reference frames:
       * :lua:attr:`SpaceCenter.Vessel.orbital_reference_frame`
       * :lua:attr:`SpaceCenter.Vessel.surface_reference_frame`
       * :lua:attr:`SpaceCenter.Vessel.surface_velocity_reference_frame`
+      * :lua:attr:`SpaceCenter.Vessel.orbit_speed_reference_frame`
+      * :lua:attr:`SpaceCenter.Vessel.surface_speed_reference_frame`
+      * :lua:attr:`SpaceCenter.Vessel.target_speed_reference_frame`
       * :lua:attr:`SpaceCenter.CelestialBody.reference_frame`
       * :lua:attr:`SpaceCenter.CelestialBody.non_rotating_reference_frame`
       * :lua:attr:`SpaceCenter.CelestialBody.orbital_reference_frame`
@@ -260,6 +275,9 @@ kRPC provides the following reference frames:
       * :py:attr:`Vessel.orbital_reference_frame`
       * :py:attr:`Vessel.surface_reference_frame`
       * :py:attr:`Vessel.surface_velocity_reference_frame`
+      * :py:attr:`Vessel.orbit_speed_reference_frame`
+      * :py:attr:`Vessel.surface_speed_reference_frame`
+      * :py:attr:`Vessel.target_speed_reference_frame`
       * :py:attr:`CelestialBody.reference_frame`
       * :py:attr:`CelestialBody.non_rotating_reference_frame`
       * :py:attr:`CelestialBody.orbital_reference_frame`
@@ -612,6 +630,11 @@ rotates with the body.
       .. literalinclude:: /scripts/tutorials/reference-frames/VesselSpeed.py
          :language: python
 
+.. seealso:: :attr:`Vessel.orbit_speed_reference_frame` and
+   :attr:`Vessel.surface_speed_reference_frame` give the same two speeds
+   directly, in frames centered on the vessel and oriented like the navball is in
+   each mode. See :ref:`tutorial-reference-frames-navball-speed`.
+
 .. _tutorial-reference-frames-vessel-velocity:
 
 Vessel Velocity
@@ -661,6 +684,77 @@ the body.
 
       .. literalinclude:: /scripts/tutorials/reference-frames/VesselVelocity.py
          :language: python
+
+.. seealso:: :attr:`Vessel.surface_speed_reference_frame` gives the same velocity
+   without constructing a frame, although in its own prograde/normal/radial axes
+   rather than as upwards, north and east components. See
+   :ref:`tutorial-reference-frames-navball-speed`.
+
+.. _tutorial-reference-frames-navball-speed:
+
+Navball speed modes
+^^^^^^^^^^^^^^^^^^^
+
+The navball measures speed against one of three things, depending on the speed
+mode it is in: the body being orbited ('orbit' mode), the surface of that body
+('surface' mode) or the vessel's target ('target' mode).
+:attr:`Vessel.orbit_speed_reference_frame`,
+:attr:`Vessel.surface_speed_reference_frame` and
+:attr:`Vessel.target_speed_reference_frame` are reference frames that move with
+each of these in turn.
+
+The velocity of the vessel in one of them is therefore the velocity the navball
+shows in that mode, and :attr:`Flight.speed` is the speed it displays.
+
+Each frame is also oriented like the navball is in that mode, in the same
+arrangement as :attr:`Vessel.orbital_reference_frame`: the y-axis points where
+the prograde marker does, the z-axis where the normal marker does and the x-axis
+in the anti-radial direction, towards the body. A direction of
+``(0,1,0)`` in the frame is therefore prograde and ``(0,-1,0)`` is
+retrograde, whichever mode the frame is for, and the velocity of the vessel in
+the frame points along its y-axis.
+
+Because the velocity gives these frames their orientation, they are singular
+when it is zero: the surface speed frame cannot be used by a vessel that is
+stationary on the ground, nor the target speed frame by one that has matched
+velocity with its target.
+
+This example prints the speeds the navball shows in orbit and surface modes:
+
+.. tabs::
+
+   .. tab:: C#
+
+      .. literalinclude:: /scripts/tutorials/reference-frames/NavballSpeed.cs
+         :language: csharp
+
+   .. tab:: C++
+
+      .. literalinclude:: /scripts/tutorials/reference-frames/NavballSpeed.cpp
+         :language: cpp
+
+   .. tab:: C
+
+      .. literalinclude:: /scripts/tutorials/reference-frames/NavballSpeed.c
+         :language: c
+
+   .. tab:: Java
+
+      .. literalinclude:: /scripts/tutorials/reference-frames/NavballSpeed.java
+         :language: java
+
+   .. tab:: Lua
+
+      .. literalinclude:: /scripts/tutorials/reference-frames/NavballSpeed.lua
+         :language: lua
+
+   .. tab:: Python
+
+      .. literalinclude:: /scripts/tutorials/reference-frames/NavballSpeed.py
+         :language: python
+
+.. note:: :attr:`Vessel.target_speed_reference_frame` requires a target to be
+   set, and raises an error otherwise.
 
 Angle of attack
 ^^^^^^^^^^^^^^^

--- a/service/SpaceCenter/CHANGELOG.md
+++ b/service/SpaceCenter/CHANGELOG.md
@@ -11,6 +11,13 @@
 - Vessels and crew
   - `Vessel.Recover` now recovers non-active vessels without switching to
      the space center scene, and the mission completion dialog is auto-closed. (#1021)
+  - Add `Vessel.OrbitSpeedReferenceFrame`, `Vessel.SurfaceSpeedReferenceFrame` and
+    `Vessel.TargetSpeedReferenceFrame`, one per navball speed mode. The velocity of the
+    vessel in one of these frames is the velocity the navball shows in that mode, and its
+    magnitude the speed displayed. Each frame is oriented with the prograde/normal/radial
+    directions the navball marks in that mode, arranged as in
+    `Vessel.OrbitalReferenceFrame`, so a direction of (0,1,0) in the frame is prograde
+    (#1029)
 
 - Staging
   - Fix stages from `Vessel.Stages`, `Vessel.StageAt`, `Vessel.DecoupleStages` and

--- a/service/SpaceCenter/src/Services/ReferenceFrame.cs
+++ b/service/SpaceCenter/src/Services/ReferenceFrame.cs
@@ -214,6 +214,9 @@ namespace KRPC.SpaceCenter.Services
                 case ReferenceFrameType.VesselOrbital:
                 case ReferenceFrameType.VesselSurface:
                 case ReferenceFrameType.VesselSurfaceVelocity:
+                case ReferenceFrameType.VesselOrbitSpeed:
+                case ReferenceFrameType.VesselSurfaceSpeed:
+                case ReferenceFrameType.VesselTargetSpeed:
                     return InternalVessel.transform;
                 case ReferenceFrameType.Maneuver:
                 case ReferenceFrameType.ManeuverOrbital:
@@ -248,6 +251,36 @@ namespace KRPC.SpaceCenter.Services
                     throw new InvalidOperationException ("Reference frame has no part");
                 return FlightGlobals.FindPartByID (partId);
             }
+        }
+
+        // The target of the vessel this frame is attached to (another vessel, a
+        // celestial body or a docking port), as set in-game. There is a single target,
+        // shared by the active vessel, so this is only meaningful for that vessel.
+        static ITargetable InternalTarget {
+            get {
+                var target = FlightGlobals.fetch.VesselTarget;
+                if (target == null)
+                    throw new InvalidOperationException ("Reference frame has no target; the vessel's target is not set");
+                return target;
+            }
+        }
+
+        // The velocity of the vessel this frame is attached to, relative to its target, in
+        // world space. This is the velocity the navball shows in 'target' mode. It is
+        // measured against the same target velocity that the frame moves with, so the
+        // vessel's velocity in the frame points exactly along it.
+        Vector3d TargetRelativeVelocity {
+            get { return InternalVessel.GetOrbit ().GetVel () - InternalTarget.GetWorldVelocity (); }
+        }
+
+        // The navball speed mode frames take their orientation from the velocity they
+        // measure, so they are singular when it is zero -- as is the navball's prograde
+        // marker, which the game stops drawing at zero speed.
+        static void CheckSpeedNotSingular (Vector3d velocity, string name, string description)
+        {
+            if (velocity.sqrMagnitude < 0.01d)
+                throw new InvalidOperationException (
+                    name + " reference frame is singular when " + description + " is near zero");
         }
 
         internal static ReferenceFrame Object (global::CelestialBody body)
@@ -285,6 +318,21 @@ namespace KRPC.SpaceCenter.Services
         internal static ReferenceFrame SurfaceVelocity (global::Vessel vessel)
         {
             return new ReferenceFrame (ReferenceFrameType.VesselSurfaceVelocity, vessel: vessel);
+        }
+
+        internal static ReferenceFrame OrbitSpeed (global::Vessel vessel)
+        {
+            return new ReferenceFrame (ReferenceFrameType.VesselOrbitSpeed, vessel: vessel);
+        }
+
+        internal static ReferenceFrame SurfaceSpeed (global::Vessel vessel)
+        {
+            return new ReferenceFrame (ReferenceFrameType.VesselSurfaceSpeed, vessel: vessel);
+        }
+
+        internal static ReferenceFrame TargetSpeed (global::Vessel vessel)
+        {
+            return new ReferenceFrame (ReferenceFrameType.VesselTargetSpeed, vessel: vessel);
         }
 
         internal static ReferenceFrame Object (global::Vessel vessel, ManeuverNode node)
@@ -403,6 +451,9 @@ namespace KRPC.SpaceCenter.Services
                 case ReferenceFrameType.VesselOrbital:
                 case ReferenceFrameType.VesselSurface:
                 case ReferenceFrameType.VesselSurfaceVelocity:
+                case ReferenceFrameType.VesselOrbitSpeed:
+                case ReferenceFrameType.VesselSurfaceSpeed:
+                case ReferenceFrameType.VesselTargetSpeed:
                     return InternalVessel.CoM;
                 case ReferenceFrameType.Maneuver:
                 case ReferenceFrameType.ManeuverOrbital:
@@ -459,6 +510,14 @@ namespace KRPC.SpaceCenter.Services
                         throw new InvalidOperationException (
                             "VesselSurfaceVelocity reference frame is singular when surface velocity is near zero");
                     break;
+                case ReferenceFrameType.VesselSurfaceSpeed:
+                    CheckSpeedNotSingular (
+                        InternalVessel.srf_velocity, "VesselSurfaceSpeed", "surface velocity");
+                    break;
+                case ReferenceFrameType.VesselTargetSpeed:
+                    CheckSpeedNotSingular (
+                        TargetRelativeVelocity, "VesselTargetSpeed", "velocity relative to the target");
+                    break;
                 default:
                     break;
                 }
@@ -499,6 +558,15 @@ namespace KRPC.SpaceCenter.Services
         }
 
         /// <summary>
+        /// Vector from the center of the body being orbited to the given vessel, in world
+        /// space. Points in the zenith direction.
+        /// </summary>
+        static Vector3d ToZenith (global::Vessel vessel)
+        {
+            return vessel.CoM - vessel.mainBody.position;
+        }
+
+        /// <summary>
         /// Returns the up vector for the reference frame in world coordinates.
         /// The direction in which the y-axis points.
         /// The vector is not normalized.
@@ -515,6 +583,7 @@ namespace KRPC.SpaceCenter.Services
                 case ReferenceFrameType.Vessel:
                     return InternalVessel.ReferenceTransform.up;
                 case ReferenceFrameType.VesselOrbital:
+                case ReferenceFrameType.VesselOrbitSpeed:
                     return InternalVessel.GetOrbit ().GetVel ();
                 case ReferenceFrameType.VesselSurface:
                     {
@@ -522,7 +591,10 @@ namespace KRPC.SpaceCenter.Services
                         return Vector3d.Exclude (right, ToNorthPole (InternalVessel).normalized);
                     }
                 case ReferenceFrameType.VesselSurfaceVelocity:
+                case ReferenceFrameType.VesselSurfaceSpeed:
                     return InternalVessel.srf_velocity;
+                case ReferenceFrameType.VesselTargetSpeed:
+                    return TargetRelativeVelocity;
                 case ReferenceFrameType.Maneuver:
                     return node.GetBurnVector(node.patch);
                 case ReferenceFrameType.ManeuverOrbital:
@@ -565,12 +637,22 @@ namespace KRPC.SpaceCenter.Services
                 case ReferenceFrameType.Vessel:
                     return InternalVessel.ReferenceTransform.forward;
                 case ReferenceFrameType.VesselOrbital:
+                case ReferenceFrameType.VesselOrbitSpeed:
                     return InternalVessel.GetOrbit ().GetOrbitNormal ().SwapYZ ();
                 case ReferenceFrameType.VesselSurface:
                     {
                         var right = InternalVessel.CoM - InternalVessel.mainBody.position;
                         var northPole = ToNorthPole (InternalVessel).normalized;
                         return Vector3d.Cross (right, northPole);
+                    }
+                case ReferenceFrameType.VesselSurfaceSpeed:
+                case ReferenceFrameType.VesselTargetSpeed:
+                    {
+                        // Normal to the plane of the motion, in the same sense as the
+                        // orbital frame's normal: the velocity crossed with the zenith.
+                        // The remaining axis then points towards the body, opposite the
+                        // navball's radial out marker.
+                        return Vector3d.Cross (UpNotNormalized, ToZenith (InternalVessel));
                     }
                 case ReferenceFrameType.VesselSurfaceVelocity:
                     {
@@ -625,6 +707,20 @@ namespace KRPC.SpaceCenter.Services
                 case ReferenceFrameType.VesselSurface:
                 case ReferenceFrameType.VesselSurfaceVelocity:
                     return InternalVessel.GetOrbit ().GetVel ();
+                case ReferenceFrameType.VesselOrbitSpeed:
+                    // The body being orbited, not rotating with it. The vessel's velocity
+                    // relative to this is the navball's orbital velocity.
+                    return InternalVessel.mainBody.GetWorldVelocity ();
+                case ReferenceFrameType.VesselSurfaceSpeed: {
+                    // The point on the rotating body that the vessel is currently above,
+                    // so that the vessel's velocity relative to this is the navball's
+                    // surface velocity.
+                    var vessel = InternalVessel;
+                    var mainBody = vessel.mainBody;
+                    return mainBody.GetWorldVelocity () + mainBody.getRFrmVel (vessel.CoM);
+                }
+                case ReferenceFrameType.VesselTargetSpeed:
+                    return InternalTarget.GetWorldVelocity ();
                 case ReferenceFrameType.Maneuver:
                 case ReferenceFrameType.ManeuverOrbital:
                     return node.patch.getOrbitalVelocityAtUT (node.UT).SwapYZ () + node.patch.referenceBody.GetWorldVelocity ();
@@ -668,7 +764,8 @@ namespace KRPC.SpaceCenter.Services
                 }
                 case ReferenceFrameType.Vessel:
                     return InternalVessel.WorldAngularVelocity ();
-                case ReferenceFrameType.VesselOrbital: {
+                case ReferenceFrameType.VesselOrbital:
+                case ReferenceFrameType.VesselOrbitSpeed: {
                     var r = InternalVessel.CoM - InternalVessel.mainBody.position;
                     var v = InternalVessel.GetOrbit ().GetVel ();
                     return Vector3d.Cross (r, v) / r.sqrMagnitude;
@@ -708,6 +805,36 @@ namespace KRPC.SpaceCenter.Services
                     var a_srf = grav - Vector3d.Cross (vessel.mainBody.angularVelocity, v_orb);
                     return vessel.mainBody.angularVelocity + Vector3d.Cross (srf_vel, a_srf) / srf_vel.sqrMagnitude;
                 }
+                case ReferenceFrameType.VesselSurfaceSpeed: {
+                    var vessel = InternalVessel;
+                    var srfVelocity = vessel.srf_velocity;
+                    CheckSpeedNotSingular (srfVelocity, "VesselSurfaceSpeed", "surface velocity");
+                    // d(srf_vel)/dt ≈ grav − body.ω × v_orbital
+                    var grav = (Vector3d)FlightGlobals.getGeeForceAtPosition (vessel.CoM);
+                    var acceleration = grav - Vector3d.Cross (
+                        vessel.mainBody.angularVelocity, vessel.GetOrbit ().GetVel ());
+                    return SpeedModeAngularVelocity (vessel, srfVelocity, acceleration);
+                }
+                case ReferenceFrameType.VesselTargetSpeed: {
+                    var vessel = InternalVessel;
+                    var relativeVelocity = TargetRelativeVelocity;
+                    CheckSpeedNotSingular (
+                        relativeVelocity, "VesselTargetSpeed", "velocity relative to the target");
+                    // Vessel and target are both in free fall, so their relative velocity
+                    // turns with the difference in gravity between the two positions. Each
+                    // is taken against the body that object orbits, as the gravity of a
+                    // body at its own center -- where a targeted body sits -- is undefined.
+                    // Whatever pulls on both of them cancels in the difference. Thrust and
+                    // drag on either of them are not accounted for.
+                    var target = InternalTarget;
+                    var targetOrbit = target.GetOrbit ();
+                    var acceleration =
+                        (Vector3d)FlightGlobals.getGeeForceAtPosition (vessel.CoM, vessel.mainBody);
+                    if (targetOrbit != null)
+                        acceleration -= (Vector3d)FlightGlobals.getGeeForceAtPosition (
+                            target.GetTransform ().position, targetOrbit.referenceBody);
+                    return SpeedModeAngularVelocity (vessel, relativeVelocity, acceleration);
+                }
                 case ReferenceFrameType.Maneuver: {
                     // The burn vector is stored in prograde/normal/radial components, so it rotates
                     // with the orbital frame. The z-axis (arbitrary inertial projection) introduces
@@ -736,6 +863,32 @@ namespace KRPC.SpaceCenter.Services
                     throw new InvalidOperationException ();
                 }
             }
+        }
+
+        /// <summary>
+        /// The angular velocity, in world space, of a navball speed mode frame oriented by
+        /// the given velocity, which is changing at the given acceleration.
+        /// </summary>
+        /// <remarks>
+        /// The basis is ŷ along the velocity, ẑ along the velocity crossed with the zenith
+        /// and x̂ the remaining axis. For a basis whose axes obey ė = ω × e, the angular
+        /// velocity is ω = (ŷ × dŷ/dt) + ŷ (x̂ · dẑ/dt): the swing of the velocity direction,
+        /// plus the roll about it as the plane through the velocity and the zenith turns.
+        /// </remarks>
+        static Vector3d SpeedModeAngularVelocity (
+            global::Vessel vessel, Vector3d velocity, Vector3d acceleration)
+        {
+            var swing = Vector3d.Cross (velocity, acceleration) / velocity.sqrMagnitude;
+            // The zenith runs from the center of the body to the vessel, so it changes at
+            // the vessel's orbital velocity.
+            var zenith = ToZenith (vessel);
+            var zenithRate = vessel.GetOrbit ().GetVel ();
+            var normal = Vector3d.Cross (velocity, zenith);
+            var normalRate = Vector3d.Cross (acceleration, zenith) + Vector3d.Cross (velocity, zenithRate);
+            var y = velocity.normalized;
+            var x = Vector3d.Cross (y, normal.normalized);
+            var roll = Vector3d.Dot (x, normalRate) / normal.magnitude;
+            return swing + roll * y;
         }
 
         /// <summary>

--- a/service/SpaceCenter/src/Services/ReferenceFrameType.cs
+++ b/service/SpaceCenter/src/Services/ReferenceFrameType.cs
@@ -39,6 +39,25 @@ namespace KRPC.SpaceCenter.Services
         /// </summary>
         VesselSurfaceVelocity,
         /// <summary>
+        /// Centered on a vessel, oriented with its orbital prograde/normal/radial
+        /// directions, and moving with the body being orbited but not rotating with
+        /// it. The velocity measured against it is the navballs orbit speed mode.
+        /// </summary>
+        VesselOrbitSpeed,
+        /// <summary>
+        /// Centered on a vessel, oriented with the prograde/normal/radial directions
+        /// of its motion relative to the surface of the body being orbited, and moving
+        /// with that surface. The velocity measured against it is the navballs surface
+        /// speed mode.
+        /// </summary>
+        VesselSurfaceSpeed,
+        /// <summary>
+        /// Centered on a vessel, oriented with the prograde/normal/radial directions
+        /// of its motion relative to its target, and moving with that target. The
+        /// velocity measured against it is the navballs target speed mode.
+        /// </summary>
+        VesselTargetSpeed,
+        /// <summary>
         /// Centered on a maneuver node and oriented with the burn vector.
         /// </summary>
         Maneuver,

--- a/service/SpaceCenter/src/Services/Vessel.cs
+++ b/service/SpaceCenter/src/Services/Vessel.cs
@@ -1070,6 +1070,82 @@ namespace KRPC.SpaceCenter.Services
         }
 
         /// <summary>
+        /// The reference frame that the navball measures speed against in 'orbit' mode.
+        /// <list type="bullet">
+        /// <item><description>The origin is at the center of mass of the vessel.</description></item>
+        /// <item><description>The axes are those of <see cref="OrbitalReferenceFrame"/>, which are
+        /// the directions the navball marks in this mode: the x-axis points in the orbital
+        /// anti-radial direction, the y-axis in the orbital prograde direction and the z-axis in
+        /// the orbital normal direction.</description></item>
+        /// <item><description>The frame moves with the body being orbited, but does not rotate
+        /// with it.</description></item>
+        /// </list>
+        /// </summary>
+        /// <remarks>
+        /// The velocity of the vessel in this frame is the one the navball shows in 'orbit' mode:
+        /// <see cref="Flight.Speed"/> is the speed it displays, and <see cref="Flight.Velocity"/>
+        /// points along the y-axis, towards its prograde marker.
+        /// </remarks>
+        [KRPCProperty (GameScene = GameScene.Flight)]
+        public ReferenceFrame OrbitSpeedReferenceFrame {
+            get { return ReferenceFrame.OrbitSpeed (InternalVessel); }
+        }
+
+        /// <summary>
+        /// The reference frame that the navball measures speed against in 'surface' mode.
+        /// <list type="bullet">
+        /// <item><description>The origin is at the center of mass of the vessel.</description></item>
+        /// <item><description>The axes are the directions the navball marks in this mode, in the
+        /// same arrangement as <see cref="OrbitalReferenceFrame"/>: the y-axis points in the
+        /// direction the vessel is moving relative to the surface, which is where the prograde
+        /// marker points; the z-axis is normal to the plane of that motion; and the x-axis is
+        /// anti-radial, pointing towards the body and perpendicular to the other
+        /// two.</description></item>
+        /// <item><description>The frame moves with the surface of the body being orbited, so it
+        /// rotates with the body.</description></item>
+        /// </list>
+        /// </summary>
+        /// <remarks>
+        /// The velocity of the vessel in this frame is the one the navball shows in 'surface' mode:
+        /// <see cref="Flight.Speed"/> is the speed it displays, and <see cref="Flight.Velocity"/>
+        /// points along the y-axis, towards its prograde marker. The velocity gives the frame its
+        /// orientation, so, as with <see cref="SurfaceVelocityReferenceFrame"/>, the frame is
+        /// singular and raises an error when the vessel is stationary relative to the surface.
+        /// </remarks>
+        [KRPCProperty (GameScene = GameScene.Flight)]
+        public ReferenceFrame SurfaceSpeedReferenceFrame {
+            get { return ReferenceFrame.SurfaceSpeed (InternalVessel); }
+        }
+
+        /// <summary>
+        /// The reference frame that the navball measures speed against in 'target' mode.
+        /// <list type="bullet">
+        /// <item><description>The origin is at the center of mass of the vessel.</description></item>
+        /// <item><description>The axes are the directions the navball marks in this mode, in the
+        /// same arrangement as <see cref="OrbitalReferenceFrame"/>: the y-axis points in the
+        /// direction the vessel is moving relative to the target, which is where the prograde
+        /// marker points; the z-axis is normal to the plane of that motion; and the x-axis is
+        /// anti-radial, pointing towards the body being orbited and perpendicular to the other
+        /// two.</description></item>
+        /// <item><description>The frame moves with the vessels target.</description></item>
+        /// </list>
+        /// </summary>
+        /// <remarks>
+        /// The velocity of the vessel in this frame is the one the navball shows in 'target' mode:
+        /// <see cref="Flight.Speed"/> is the speed it displays, and <see cref="Flight.Velocity"/>
+        /// points along the y-axis, towards its prograde marker.
+        /// The target is the one set for the active vessel, via for example
+        /// <see cref="SpaceCenter.TargetVessel"/> or <see cref="SpaceCenter.TargetBody"/>.
+        /// This is undefined when no target is set. The velocity gives the frame its orientation,
+        /// so it is also singular, and raises an error, when the vessel matches the velocity of
+        /// its target.
+        /// </remarks>
+        [KRPCProperty (GameScene = GameScene.Flight)]
+        public ReferenceFrame TargetSpeedReferenceFrame {
+            get { return ReferenceFrame.TargetSpeed (InternalVessel); }
+        }
+
+        /// <summary>
         /// The position of the center of mass of the vessel, in the given reference frame.
         /// </summary>
         /// <returns>The position as a vector.</returns>

--- a/service/SpaceCenter/test/test_referenceframe.py
+++ b/service/SpaceCenter/test/test_referenceframe.py
@@ -16,6 +16,7 @@ from krpctest.geometry import (
     cross,
     dot,
     norm,
+    normalize,
     quaternion_conjugate,
     quaternion_mult,
     quaternion_vector_mult,
@@ -34,6 +35,7 @@ class TestReferenceFrame(krpctest.TestCase):
         cls.vessel = cls.space_center.active_vessel
         cls.bodies = cls.space_center.bodies
         cls.kerbin = cls.bodies["Kerbin"]
+        cls.mun = cls.bodies["Mun"]
         cls.root_part = cls.vessel.parts.root
         cls.docking_port = cls.vessel.parts.docking_ports[0]
         cls.thruster = cls.vessel.parts.engines[0].thrusters[0]
@@ -720,6 +722,217 @@ class TestReferenceFrame(krpctest.TestCase):
             self.assertAlmostEqual(vel, roundtrip, delta=0.5)
 
     # -------------------------------------------------------------------------
+    # Navball speed mode frame tests
+    #
+    # One frame per navball speed mode. Each is centered on the vessel, oriented
+    # with the prograde/normal/radial directions of the motion that mode measures
+    # (the directions the navball marks in it) and moving with what that motion is
+    # measured against. The vessel's velocity in the frame is therefore the
+    # velocity the navball shows, pointing along the frame's y-axis. The target
+    # mode tests set a target and clear it again, since the class-wide setup
+    # deliberately leaves no target set.
+    # -------------------------------------------------------------------------
+
+    def _speed_mode_frames(self):
+        """The orbit and surface speed frames. The target frame is excluded as it
+        needs a target set."""
+        return [
+            self.vessel.orbit_speed_reference_frame,
+            self.vessel.surface_speed_reference_frame,
+        ]
+
+    def _axes_in_non_rotating_frame(self, ref):
+        """The x, y and z axes of the given frame, as directions in Kerbin's
+        non-rotating reference frame."""
+        nonrot = self.kerbin.non_rotating_reference_frame
+        return [
+            vector(self.space_center.transform_direction(axis, ref, nonrot))
+            for axis in ((1, 0, 0), (0, 1, 0), (0, 0, 1))
+        ]
+
+    def _velocity_in_non_rotating_frame(self, ref):
+        """The vessel's velocity in the given frame, as a vector in Kerbin's
+        non-rotating reference frame."""
+        return vector(
+            self.space_center.transform_direction(
+                self.vessel.velocity(ref), ref, self.kerbin.non_rotating_reference_frame
+            )
+        )
+
+    def _check_velocity_frame_axes(self, ref, velocity):
+        """Check that the given frame is oriented by the given velocity, which is a
+        direction in Kerbin's non-rotating reference frame.
+
+        The y-axis points along the velocity, the z-axis is normal to the plane the
+        motion sweeps out (velocity crossed with the zenith) and the x-axis is
+        anti-radial, completing the frame the same way the orbital frame does.
+        """
+        nonrot = self.kerbin.non_rotating_reference_frame
+        zenith = self.vessel.position(nonrot)
+        x_axis, y_axis, z_axis = self._axes_in_non_rotating_frame(ref)
+        self.assertAlmostEqual(1, dot(y_axis, normalize(velocity)), places=3)
+        self.assertAlmostEqual(
+            1, dot(z_axis, normalize(cross(velocity, zenith))), places=3
+        )
+        self.assertAlmostEqual(tuple(cross(y_axis, z_axis)), tuple(x_axis), places=3)
+        # The x-axis points back towards the body, as the orbital frame's does
+        self.assertLess(dot(x_axis, normalize(zenith)), -0.9)
+
+    def test_speed_mode_frames_centered_on_vessel(self):
+        """The vessel is at the origin of every speed mode frame."""
+        for ref in self._speed_mode_frames():
+            self.assertAlmostEqual((0, 0, 0), self.vessel.position(ref), delta=1)
+
+    def test_speed_mode_frames_velocity_along_prograde_axis(self):
+        """The frames are oriented by the velocity they measure, so that velocity has
+        no x or z component -- it points along the y-axis, at the navball's prograde
+        marker."""
+        for ref in self._speed_mode_frames():
+            velocity = self.vessel.velocity(ref)
+            self.assertAlmostEqual(0, velocity[0], delta=1)
+            self.assertAlmostEqual(0, velocity[2], delta=1)
+            self.assertGreater(velocity[1], 0)
+
+    def test_orbit_speed_frame_uses_orbital_axes(self):
+        """The navball marks the orbital prograde/normal/radial directions in 'orbit'
+        mode, so the orbit speed frame is oriented like the orbital reference frame.
+        Only the velocity of the frame differs between the two."""
+        self.assertQuaternionsAlmostEqual(
+            self.vessel.rotation(self.vessel.orbital_reference_frame),
+            self.vessel.rotation(self.vessel.orbit_speed_reference_frame),
+            places=4,
+        )
+
+    def test_orbit_speed_frame_axes_are_navball_directions(self):
+        """The frame's axes point where the navball's markers do in 'orbit' mode: the
+        y-axis at prograde, the z-axis at normal and the x-axis at anti-radial."""
+        ref = self.vessel.orbit_speed_reference_frame
+        flight = self.vessel.flight(self.kerbin.non_rotating_reference_frame)
+        x_axis, y_axis, z_axis = self._axes_in_non_rotating_frame(ref)
+        self.assertAlmostEqual(1, dot(y_axis, vector(flight.prograde)), places=3)
+        self.assertAlmostEqual(1, dot(z_axis, vector(flight.normal)), places=3)
+        self.assertAlmostEqual(1, dot(x_axis, vector(flight.anti_radial)), places=3)
+
+    def test_surface_speed_frame_axes(self):
+        """The surface speed frame is oriented by the vessel's velocity relative to
+        the surface, which is where the navball's prograde marker points in 'surface'
+        mode."""
+        body_frame = self.kerbin.reference_frame
+        velocity = vector(
+            self.space_center.transform_direction(
+                self.vessel.velocity(body_frame),
+                body_frame,
+                self.kerbin.non_rotating_reference_frame,
+            )
+        )
+        self._check_velocity_frame_axes(
+            self.vessel.surface_speed_reference_frame, velocity
+        )
+
+    def test_orbit_speed_frame_gives_orbital_speed(self):
+        """The orbit speed frame moves with Kerbin without rotating with it, so the
+        vessel's speed in it is its orbital speed -- the navball's 'orbit' mode."""
+        speed = norm(self.vessel.velocity(self.vessel.orbit_speed_reference_frame))
+        self.assertAlmostEqual(self.vessel.orbit.speed, speed, delta=1)
+
+    def test_surface_speed_frame_gives_surface_speed(self):
+        """The surface speed frame moves with the point of the rotating body below the
+        vessel, so the vessel's speed in it is its surface speed -- the navball's
+        'surface' mode. Checked against Kerbin's rotating frame and against the
+        independently computed orbital − ω×r speed."""
+        speed = norm(self.vessel.velocity(self.vessel.surface_speed_reference_frame))
+        speed_body = norm(self.vessel.velocity(self.kerbin.reference_frame))
+        self.assertAlmostEqual(speed_body, speed, delta=1)
+        self.assertAlmostEqual(self._expected_surface_speed(), speed, delta=1)
+
+    def test_surface_speed_frame_velocity_is_the_navball_velocity(self):
+        """The velocity in the surface speed frame is the surface velocity, the vector
+        the navball's prograde marker follows in 'surface' mode.
+
+        Compared against transforming the velocity from Kerbin's rotating frame into
+        the speed frame, which is the same vector computed the long way round.
+        """
+        ref = self.vessel.surface_speed_reference_frame
+        body_frame = self.kerbin.reference_frame
+        expected = self.space_center.transform_direction(
+            self.vessel.velocity(body_frame), body_frame, ref
+        )
+        velocity = self.vessel.velocity(ref)
+        self.assertAlmostEqual(expected, velocity, delta=1)
+
+    def test_surface_speed_frame_off_equator(self):
+        """The body rotation term is taken at the vessel, in world space, so the
+        surface speed frame is correct away from the equator too. Checked at ~45°
+        latitude in an inclined orbit, where the co-rotation velocity is neither
+        aligned with nor perpendicular to the orbital velocity."""
+        # Inclination 45°, observed a quarter orbit past the ascending node
+        # (mean anomaly π/2) so the vessel sits near its peak latitude.
+        self.addCleanup(self.set_circular_orbit, "Kerbin", 100000)
+        self.set_orbit("Kerbin", 700000, 0, 45, 0, 0, math.pi / 2, 0)
+        expected = self._expected_surface_speed()
+        speed = norm(self.vessel.velocity(self.vessel.surface_speed_reference_frame))
+        self.assertAlmostEqual(expected, speed, delta=1)
+
+    def test_speed_mode_frames_differ_by_body_rotation(self):
+        """The orbit and surface speed frames differ by the velocity of the ground
+        beneath the vessel, so their velocities differ by ω×r. The two frames are
+        oriented differently, so the comparison is made in Kerbin's non-rotating
+        frame."""
+        nonrot = self.kerbin.non_rotating_reference_frame
+        r = vector(self.vessel.position(nonrot))
+        w = vector(self.kerbin.angular_velocity(nonrot))
+        orbit_velocity = self._velocity_in_non_rotating_frame(
+            self.vessel.orbit_speed_reference_frame
+        )
+        surface_velocity = self._velocity_in_non_rotating_frame(
+            self.vessel.surface_speed_reference_frame
+        )
+        self.assertAlmostEqual(
+            tuple(orbit_velocity - vector(cross(w, r))),
+            tuple(surface_velocity),
+            delta=1,
+        )
+
+    def test_target_speed_frame_gives_relative_speed(self):
+        """The target speed frame moves with the target, so the vessel's speed in it is
+        its speed relative to the target -- the navball's 'target' mode."""
+        self.space_center.target_body = self.mun
+        try:
+            nonrot = self.kerbin.non_rotating_reference_frame
+            expected = norm(
+                vector(self.vessel.velocity(nonrot)) - vector(self.mun.velocity(nonrot))
+            )
+            speed = norm(self.vessel.velocity(self.vessel.target_speed_reference_frame))
+            self.assertAlmostEqual(expected, speed, delta=1)
+        finally:
+            self.space_center.target_body = None
+
+    def test_target_speed_frame_axes(self):
+        """The target speed frame is oriented by the vessel's velocity relative to the
+        target, which is where the navball's prograde marker points in 'target' mode,
+        and the velocity in it points along the y-axis."""
+        self.space_center.target_body = self.mun
+        try:
+            nonrot = self.kerbin.non_rotating_reference_frame
+            velocity = vector(self.vessel.velocity(nonrot)) - vector(
+                self.mun.velocity(nonrot)
+            )
+            ref = self.vessel.target_speed_reference_frame
+            self._check_velocity_frame_axes(ref, velocity)
+            in_frame = self.vessel.velocity(ref)
+            self.assertAlmostEqual(0, in_frame[0], delta=1)
+            self.assertAlmostEqual(0, in_frame[2], delta=1)
+            self.assertGreater(in_frame[1], 0)
+        finally:
+            self.space_center.target_body = None
+
+    def test_target_speed_frame_requires_a_target(self):
+        """With no target set, using the target speed reference frame raises."""
+        self.space_center.target_body = None
+        ref = self.vessel.target_speed_reference_frame
+        self.assertRaises(RuntimeError, self.vessel.velocity, ref)
+
+    # -------------------------------------------------------------------------
     # Angular velocity tests
     # -------------------------------------------------------------------------
 
@@ -755,6 +968,69 @@ class TestReferenceFrame(krpctest.TestCase):
         orbital_angular_speed = 2 * math.pi / self.vessel.orbit.period
         expected = orbital_angular_speed - self.kerbin.rotational_speed
         self.assertAlmostEqual(expected, norm(ang_vel), delta=1e-4)
+
+    def _frame_angular_velocity(self, ref):
+        """The angular velocity of the given frame itself, as a vector in Kerbin's
+        non-rotating reference frame.
+
+        Taken from how fast Kerbin appears to rotate in the frame: that is Kerbin's
+        angular velocity less the frame's own, so the frame's is the difference.
+        """
+        nonrot = self.kerbin.non_rotating_reference_frame
+        relative = self.space_center.transform_direction(
+            self.kerbin.angular_velocity(ref), ref, nonrot
+        )
+        return vector(self.kerbin.angular_velocity(nonrot)) - vector(relative)
+
+    def _measured_angular_velocity(self, ref, dt=1):
+        """The angular velocity of the given frame, measured by how far its axes turn
+        over dt seconds, as a vector in Kerbin's non-rotating reference frame.
+
+        For a basis whose axes obey de/dt = ω × e, ω = ½ Σ e × de/dt.
+        """
+        before = self._axes_in_non_rotating_frame(ref)
+        start = self.space_center.ut
+        self.wait(dt)
+        after = self._axes_in_non_rotating_frame(ref)
+        elapsed = self.space_center.ut - start
+        angular_velocity = vector((0, 0, 0))
+        for axis, moved in zip(before, after):
+            rate = [(b - a) / elapsed for a, b in zip(axis, moved)]
+            angular_velocity = angular_velocity + vector(cross(axis, rate))
+        return 0.5 * angular_velocity
+
+    def test_orbit_speed_frame_angular_velocity(self):
+        """The orbit speed frame shares the orbital frame's axes, so it turns with it."""
+        self.assertAlmostEqual(
+            self.kerbin.angular_velocity(self.vessel.orbital_reference_frame),
+            self.kerbin.angular_velocity(self.vessel.orbit_speed_reference_frame),
+            delta=1e-5,
+        )
+
+    def test_surface_speed_frame_angular_velocity(self):
+        """The surface speed frame's angular velocity is the rate its own axes turn:
+        the swing of the surface velocity direction plus the roll about it as the plane
+        through that velocity and the zenith turns."""
+        ref = self.vessel.surface_speed_reference_frame
+        self.assertAlmostEqual(
+            tuple(self._measured_angular_velocity(ref)),
+            tuple(self._frame_angular_velocity(ref)),
+            delta=1e-4,
+        )
+
+    def test_target_speed_frame_angular_velocity(self):
+        """The target speed frame's axes turn with the velocity relative to the target,
+        which changes as the two fall through different gravity."""
+        self.space_center.target_body = self.mun
+        try:
+            ref = self.vessel.target_speed_reference_frame
+            self.assertAlmostEqual(
+                tuple(self._measured_angular_velocity(ref)),
+                tuple(self._frame_angular_velocity(ref)),
+                delta=1e-4,
+            )
+        finally:
+            self.space_center.target_body = None
 
     def test_kerbin_angular_velocity_in_surface_velocity_frame(self):
         """Kerbin's angular velocity in the surface velocity frame is dominated by the


### PR DESCRIPTION
The navball measures speed against a different thing in each of its three speed modes, and getting any of those velocities out of kRPC meant assembling a hybrid reference frame by hand -- with a subtlety, noted in the commit, that makes the obvious attempt silently report the orbital velocity instead.

`Vessel.OrbitSpeedReferenceFrame`, `Vessel.SurfaceSpeedReferenceFrame` and `Vessel.TargetSpeedReferenceFrame` are centered on the vessel and move with what their mode measures speed against, so the velocity of the vessel in one of them is the velocity the navball shows in that mode and `Flight.Speed` is the speed it displays.

Each frame also carries the prograde/normal/radial directions of the motion its mode measures, arranged as in `Vessel.OrbitalReferenceFrame`, so its axes point where the navball's markers do and a direction of `(0,1,0)` is prograde in any of them. Note that this is the opposite sense to `Vessel.SurfaceVelocityReferenceFrame`, whose x-axis is radial out and z-axis anti-normal; the speed mode frames follow the orbital frame instead, since that is the frame whose axes are named after the markers. Because the velocity is what orients them, the surface and target frames are singular, and raise, when the speed they measure is near zero, as the surface velocity frame already does.

**Testing.** New tests check each frame's axes against `Flight.Prograde`, `Flight.Normal` and `Flight.AntiRadial`, that the reported velocity lies along the y-axis and has the right magnitude in each mode, and that each frame's angular velocity agrees with the rate its axes are measured to turn over a second of game time.

Fixes #1025
