### PR TITLE
Add RPCs for the slope of the terrain

### DIFF
--- a/doc/order.txt
+++ b/doc/order.txt
@@ -333,6 +333,7 @@ SpaceCenter.Flight.BedrockAltitude
 SpaceCenter.Flight.Elevation
 SpaceCenter.Flight.Latitude
 SpaceCenter.Flight.Longitude
+SpaceCenter.Flight.SurfaceNormal
 SpaceCenter.Flight.Velocity
 SpaceCenter.Flight.Speed
 SpaceCenter.Flight.HorizontalSpeed

--- a/doc/order.txt
+++ b/doc/order.txt
@@ -297,6 +297,9 @@ SpaceCenter.CelestialBody.MSLPosition
 SpaceCenter.CelestialBody.SurfacePosition
 SpaceCenter.CelestialBody.BedrockPosition
 SpaceCenter.CelestialBody.PositionAtAltitude
+SpaceCenter.CelestialBody.MSLNormal
+SpaceCenter.CelestialBody.SurfaceNormal
+SpaceCenter.CelestialBody.BedrockNormal
 SpaceCenter.CelestialBody.AltitudeAtPosition
 SpaceCenter.CelestialBody.LatitudeAtPosition
 SpaceCenter.CelestialBody.LongitudeAtPosition

--- a/service/SpaceCenter/CHANGELOG.md
+++ b/service/SpaceCenter/CHANGELOG.md
@@ -25,6 +25,15 @@
     not been calculated for the vessel. Stages requested after the revert were affected
     too, so the game had to be restarted to get working stages back (#1023)
 
+- Orbits, nodes and bodies
+  - Add `CelestialBody.SurfaceNormal`, `CelestialBody.BedrockNormal` and `CelestialBody.MSLNormal`
+    to get the slope of the terrain at a given latitude and longitude, as a unit vector normal to
+    the surface, to the sea-bed, or to the sphere at sea level (#1030)
+
+- Flight and aerodynamics
+  - Add `Flight.SurfaceNormal` to get the slope of the terrain under a vessel, as a unit vector
+    normal to the surface (#1030)
+
 - Control
   - Setting `Control.StageLock` now leaves the in-game Alt+L shortcut in step with it, so the
     next press of Alt+L locks or unlocks staging rather than being absorbed (#1022)

--- a/service/SpaceCenter/src/Services/CelestialBody.cs
+++ b/service/SpaceCenter/src/Services/CelestialBody.cs
@@ -256,6 +256,117 @@ namespace KRPC.SpaceCenter.Services
         }
 
         /// <summary>
+        /// The normal to the sphere at mean sea level, at the given latitude and longitude,
+        /// in the given reference frame. This points straight up, away from the center of
+        /// the body, and takes no account of the shape of the terrain.
+        /// </summary>
+        /// <returns>The normal as a unit vector.</returns>
+        /// <param name="latitude">Latitude in degrees.</param>
+        /// <param name="longitude">Longitude in degrees.</param>
+        /// <param name="referenceFrame">Reference frame for the returned normal vector.</param>
+        [KRPCMethod]
+        public Tuple3 MSLNormal (double latitude, double longitude, ReferenceFrame referenceFrame)
+        {
+            return NormalIn (InternalBody.GetSurfaceNVector (latitude, longitude), referenceFrame);
+        }
+
+        /// <summary>
+        /// The normal to the surface at the given latitude and longitude, in the given reference
+        /// frame. This describes the slope of the terrain, and is the normal of the surface of
+        /// the water when over water.
+        /// </summary>
+        /// <returns>The normal as a unit vector.</returns>
+        /// <param name="latitude">Latitude in degrees.</param>
+        /// <param name="longitude">Longitude in degrees.</param>
+        /// <param name="referenceFrame">Reference frame for the returned normal vector.</param>
+        [KRPCMethod]
+        public Tuple3 SurfaceNormal (double latitude, double longitude, ReferenceFrame referenceFrame)
+        {
+            return NormalIn (SurfaceNormalWorldSpace (latitude, longitude), referenceFrame);
+        }
+
+        /// <summary>
+        /// The normal to the surface at the given latitude and longitude, in the given reference
+        /// frame. This describes the slope of the terrain, and is the normal of the sea-bed
+        /// when over water.
+        /// </summary>
+        /// <returns>The normal as a unit vector.</returns>
+        /// <param name="latitude">Latitude in degrees.</param>
+        /// <param name="longitude">Longitude in degrees.</param>
+        /// <param name="referenceFrame">Reference frame for the returned normal vector.</param>
+        [KRPCMethod]
+        public Tuple3 BedrockNormal (double latitude, double longitude, ReferenceFrame referenceFrame)
+        {
+            return NormalIn (TerrainNormal (latitude, longitude, BedrockHeight), referenceFrame);
+        }
+
+        static Tuple3 NormalIn (Vector3d worldNormal, ReferenceFrame referenceFrame)
+        {
+            return referenceFrame.DirectionFromWorldSpace (worldNormal).normalized.ToTuple ();
+        }
+
+        /// <summary>
+        /// The normal to the surface at the given latitude and longitude, as a unit vector
+        /// in world space.
+        /// </summary>
+        internal Vector3d SurfaceNormalWorldSpace (double latitude, double longitude)
+        {
+            // Where the terrain colliders exist, the mesh a vessel actually rests on is a better
+            // description of the slope than the height map the terrain is generated from.
+            var alt = Math.Max (0, BedrockHeight (latitude, longitude));
+            const double raySource = 1000;
+            const double raySecondPoint = 500;
+            Vector3d rayCastStart = InternalBody.GetWorldSurfacePosition (latitude, longitude, alt + raySource);
+            Vector3d rayCastStop = InternalBody.GetWorldSurfacePosition (latitude, longitude, alt + raySecondPoint);
+            RaycastHit hit;
+            // Casting a ray on the surface (layer 15 in KSP).
+            if (Physics.Raycast (rayCastStart, (rayCastStop - rayCastStart), out hit, float.MaxValue, 1 << 15)) {
+                // Ensure hit is on the topside of planet, near the rayCastStart, not on the far side.
+                if (Mathf.Abs (hit.distance) < 3000)
+                    return ((Vector3d)hit.normal).normalized;
+            }
+            return TerrainNormal (latitude, longitude, SurfaceHeight);
+        }
+
+        /// <summary>
+        /// The normal to the terrain at the given latitude and longitude, as a unit vector in
+        /// world space, taken from the plane through three nearby points on the terrain.
+        /// The height of the terrain at a latitude and longitude is given by
+        /// <paramref name="height"/>.
+        /// </summary>
+        Vector3d TerrainNormal (double latitude, double longitude, Func<double, double, double> height)
+        {
+            // How far apart to take the samples. Far enough that the height difference between
+            // them survives rounding, close enough to follow the local shape of the terrain.
+            const double sampleDistance = 10;
+            var up = InternalBody.GetSurfaceNVector (latitude, longitude);
+            // Any vector that is not parallel to the normal gives a pair of directions tangent to
+            // the sphere. The polar axis works everywhere except at the poles themselves.
+            Vector3d axis = InternalBody.bodyTransform.up;
+            if (Math.Abs (Vector3d.Dot (axis, up)) > 0.999)
+                axis = InternalBody.bodyTransform.forward;
+            var tangent = Vector3d.Cross (axis, up).normalized;
+            var bitangent = Vector3d.Cross (up, tangent).normalized;
+            var origin = TerrainPosition (latitude, longitude, height);
+            var normal = Vector3d.Cross (
+                             TerrainPositionBelow (origin + tangent * sampleDistance, height) - origin,
+                             TerrainPositionBelow (origin + bitangent * sampleDistance, height) - origin).normalized;
+            // The two edges span the terrain, so their cross product is normal to it, but which of
+            // the two opposite normals it is depends on how the terrain slopes.
+            return Vector3d.Dot (normal, up) < 0 ? -normal : normal;
+        }
+
+        Vector3d TerrainPosition (double latitude, double longitude, Func<double, double, double> height)
+        {
+            return InternalBody.GetWorldSurfacePosition (latitude, longitude, height (latitude, longitude));
+        }
+
+        Vector3d TerrainPositionBelow (Vector3d position, Func<double, double, double> height)
+        {
+            return TerrainPosition (InternalBody.GetLatitude (position), InternalBody.GetLongitude (position), height);
+        }
+
+        /// <summary>
         /// The latitude of the given position, in the given reference frame.
         /// </summary>
         /// <param name="position">Position as a vector.</param>

--- a/service/SpaceCenter/src/Services/Flight.cs
+++ b/service/SpaceCenter/src/Services/Flight.cs
@@ -345,6 +345,21 @@ namespace KRPC.SpaceCenter.Services
         }
 
         /// <summary>
+        /// The normal to the surface under the vessel, in the reference frame
+        /// <see cref="ReferenceFrame"/>. This describes the slope of the terrain,
+        /// and points straight up when the vessel is over water.
+        /// </summary>
+        /// <returns>The normal as a unit vector.</returns>
+        [KRPCProperty]
+        public Tuple3 SurfaceNormal {
+            get {
+                var body = new CelestialBody (InternalVessel.mainBody);
+                var normal = body.SurfaceNormalWorldSpace (Latitude, Longitude);
+                return referenceFrame.DirectionFromWorldSpace (normal).normalized.ToTuple ();
+            }
+        }
+
+        /// <summary>
         /// The velocity of the vessel, in the reference frame <see cref="ReferenceFrame"/>.
         /// </summary>
         /// <returns>The velocity as a vector. The vector points in the direction of travel,

--- a/service/SpaceCenter/test/test_body.py
+++ b/service/SpaceCenter/test/test_body.py
@@ -4,6 +4,13 @@ import unittest
 import krpctest
 from krpctest.geometry import dot, norm, normalize
 
+# Latitude and longitude pairs to sample the surface at, including both poles
+# where the lines of longitude meet
+SURFACE_COORDINATES = ((0, 0), (12, -34), (-56, 78), (0, 180), (90, 0), (-90, 45))
+
+# A point over one of Kerbin's oceans, where the sea-bed slopes
+OCEAN_COORDINATE = (-60, -150)
+
 
 class TestBody(krpctest.TestCase):
     @classmethod
@@ -266,6 +273,45 @@ class TestBody(krpctest.TestCase):
             self.assertAlmostEqual(
                 abs(rotational_speed + body.orbit.speed), norm(v), delta=500
             )
+
+    def test_msl_normal(self):
+        for body in self.space_center.bodies.values():
+            frame = body.reference_frame
+            for lat, lon in SURFACE_COORDINATES:
+                normal = body.msl_normal(lat, lon, frame)
+                self.assertAlmostEqual(1, norm(normal))
+                # In the body's own reference frame, sea level positions are
+                # measured from the center of the body, so are themselves
+                # normal to the sphere
+                self.assertAlmostEqual(
+                    normalize(body.msl_position(lat, lon, frame)), normal, places=4
+                )
+
+    def test_surface_normal(self):
+        for body in self.space_center.bodies.values():
+            frame = body.reference_frame
+            for lat, lon in SURFACE_COORDINATES:
+                up = body.msl_normal(lat, lon, frame)
+                for normal in (
+                    body.surface_normal(lat, lon, frame),
+                    body.bedrock_normal(lat, lon, frame),
+                ):
+                    self.assertAlmostEqual(1, norm(normal))
+                    # Terrain slopes away from the vertical, but always faces
+                    # away from the body rather than into it
+                    self.assertGreater(dot(normal, up), 0)
+
+    def test_surface_normal_over_water(self):
+        kerbin = self.space_center.bodies["Kerbin"]
+        frame = kerbin.reference_frame
+        lat, lon = OCEAN_COORDINATE
+        self.assertEqual(0, kerbin.surface_height(lat, lon))
+        self.assertLess(kerbin.bedrock_height(lat, lon), 0)
+        up = kerbin.msl_normal(lat, lon, frame)
+        # The surface of the water is flat, so points straight up
+        self.assertAlmostEqual(up, kerbin.surface_normal(lat, lon, frame), places=4)
+        # The sea-bed beneath it is not
+        self.assertLess(dot(up, kerbin.bedrock_normal(lat, lon, frame)), 0.9999)
 
     def test_rotation(self):
         for body in self.space_center.bodies.values():

--- a/service/SpaceCenter/test/test_flight.py
+++ b/service/SpaceCenter/test/test_flight.py
@@ -308,6 +308,22 @@ class TestFlightAtLaunchpad(krpctest.TestCase):
         self.assertAlmostEqual(-0.09694444, flight.latitude, places=3)
         self.assertAlmostEqual(-74.5575, flight.longitude, places=3)
 
+    def test_surface_normal(self):
+        body = self.vessel.orbit.body
+        frame = body.reference_frame
+        flight = self.vessel.flight(frame)
+        normal = flight.surface_normal
+        self.assertAlmostEqual(1, norm(normal))
+        # It is the normal of the surface at the position of the vessel
+        self.assertAlmostEqual(
+            body.surface_normal(flight.latitude, flight.longitude, frame),
+            normal,
+            places=6,
+        )
+        # The launchpad is level, so its normal points straight up
+        up = body.msl_normal(flight.latitude, flight.longitude, frame)
+        self.assertAlmostEqual(1, dot(up, normal), places=5)
+
     def test_ferram_aerospace_research(self):
         if self.far:
             flight = self.vessel.flight()


### PR DESCRIPTION
Adds RPCs for the slope of the ground, to sit alongside the existing height and position RPCs. `CelestialBody.SurfaceNormal`, `CelestialBody.BedrockNormal` and `CelestialBody.MSLNormal` give the normal to the terrain, to the sea-bed and to the sphere at sea level, at a latitude and longitude, as a unit vector in a given reference frame. `Flight.SurfaceNormal` gives the normal to the terrain under a vessel, in the reference frame the flight telemetry was requested in.

**Sampling the terrain.** Close to the active vessel the terrain colliders exist, so the surface normal is taken from a ray cast down onto them, and is the normal of the mesh a vessel would rest on. Elsewhere, and for the sea-bed, there is nothing to cast against, so the normal is that of the plane through three points on the terrain ten meters apart, sampled from the height map the terrain is generated from. The sea level normal needs no sampling at all, being the normal to the sphere.

**Testing.** Covered by integration tests that check the normals over land at a spread of latitudes and longitudes including both poles, on every body, and over one of Kerbin's oceans where the surface and the sea-bed part company.

Fixes #331
