### PR TITLE
Switch the IVA camera between crew members

### DIFF
--- a/doc/order.txt
+++ b/doc/order.txt
@@ -1343,6 +1343,8 @@ SpaceCenter.MitigationMode.Off
 SpaceCenter.MitigationMode.Forced
 SpaceCenter.Camera
 SpaceCenter.Camera.Mode
+SpaceCenter.Camera.NextCamera
+SpaceCenter.Camera.PreviousCamera
 SpaceCenter.Camera.Pitch
 SpaceCenter.Camera.Heading
 SpaceCenter.Camera.Distance
@@ -1367,8 +1369,6 @@ SpaceCenter.CameraMode.Locked
 SpaceCenter.CameraMode.Orbital
 SpaceCenter.CameraMode.IVA
 SpaceCenter.CameraMode.Map
-SpaceCenter.Camera.NextCamera
-SpaceCenter.Camera.PreviousCamera
 SpaceCenter.WaypointManager
 SpaceCenter.WaypointManager.Waypoints
 SpaceCenter.WaypointManager.AddWaypoint

--- a/service/SpaceCenter/CHANGELOG.md
+++ b/service/SpaceCenter/CHANGELOG.md
@@ -48,6 +48,18 @@
   - Add `ResourceTransfer.Cancel` to stop a transfer before it finishes; no more of the
     resource is moved and the transfer is marked as complete (#1028)
 
+- Camera
+  - `Camera.NextCamera` and `Camera.PreviousCamera` now move the IVA view between the crew of
+    the active vessel without ever dropping out of IVA mode, and pass over crew that the game
+    has not placed in an interior. Previously, moving to the crew member already in view, as
+    happens on a vessel with a single crew member, switched to the flight camera instead (#1031)
+  - Setting `Camera.FocussedCrewMember` to the crew member already in view no longer switches
+    to the flight camera. Setting it to a crew member who is not in the active vessel, or who
+    is not in the interior of a part, now raises an error rather than being ignored or failing
+    with a `NullReferenceException`, as does setting it to `null` (#1031)
+  - `Camera.FocussedCrewMember` returns `null` when no crew member is in view, instead of
+    failing with a `NullReferenceException` (#1031)
+
 ## [v0.6.0]
 
 - Space center

--- a/service/SpaceCenter/src/ExtensionMethods/InternalCameraExtensions.cs
+++ b/service/SpaceCenter/src/ExtensionMethods/InternalCameraExtensions.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 
@@ -66,18 +64,6 @@ namespace KRPC.SpaceCenter.ExtensionMethods
         /// Gets the default field of view of the internal camera.
         /// </summary>
         public static Func<InternalCamera, object> GetDefaultFoV => _getDefaultFoV.Value;
-
-        /// <summary>
-        /// Gets the index of the previous kerbal for the IVA camera
-        /// </summary>
-        /// <param name="ptc">List of ProtoCrewmembers</param>
-        /// <param name="cameraManager">Instance of the current CameraManager to get the active index.</param>
-        /// <returns></returns>
-        public static int GetPreviousIVA(List<ProtoCrewMember> ptc, CameraManager cameraManager)
-        {
-            int num = cameraManager.IVACameraActiveKerbalIndex;
-            return (num + ptc.Count() - 1) % ptc.Count;
-        }
 
     	private static Action<T, object> CreateFieldSetter<T>(string fieldName)
         {

--- a/service/SpaceCenter/src/Services/Camera.cs
+++ b/service/SpaceCenter/src/Services/Camera.cs
@@ -100,51 +100,115 @@ namespace KRPC.SpaceCenter.Services
         }
 
         /// <summary>
-        /// Switch to the next available camera
+        /// Switch to the next available camera.
+        /// In flight, this moves to the next flight camera mode. In IVA, it moves the
+        /// view to the next crew member in the active vessel.
         /// </summary>
         [KRPCMethod]
         public void NextCamera()
         {
-            CameraManager.Instance.NextCamera();
+            switch (CameraManager.Instance.currentCameraMode) {
+            case CameraManager.CameraMode.Flight:
+                SetFlightMode (1);
+                break;
+            case CameraManager.CameraMode.IVA:
+                CycleIVACrewMember (1);
+                break;
+            }
         }
 
         /// <summary>
-        /// Switch to the previous available camera
+        /// Switch to the previous available camera.
+        /// In flight, this moves to the previous flight camera mode. In IVA, it moves
+        /// the view to the previous crew member in the active vessel.
         /// </summary>
         [KRPCMethod]
         public void PreviousCamera()
         {
-            var cameraManager = CameraManager.Instance;
-            switch(cameraManager.currentCameraMode)
-            {
-                case CameraManager.CameraMode.Flight :
-                    if (InputLockManager.IsUnlocked(ControlTypes.CAMERAMODES))
-                    {
-                        var camera = FlightCamera.fetch;
-                        if (camera.targetMode != FlightCamera.TargetMode.Vessel || camera.vesselTarget != FlightGlobals.ActiveVessel)
-                        {
-                            camera.SetTargetVessel(FlightGlobals.ActiveVessel);
-                        }
-                        // There is 5 camera modes in the enum.
-                        // As KSP1's development has ceased its cheaper to hardcode it than compute it each time. - Sofie 10-07-2024
-                        camera.setMode((FlightCamera.Modes)((int)(camera.mode + 4) % 5));
-                    }
-                    break;
-                case CameraManager.CameraMode.IVA :
-                    List<ProtoCrewMember> vesselCrew = FlightGlobals.fetch.activeVessel.GetVesselCrew();
-                    if (vesselCrew.Count != 0)
-                    {
-                        if (cameraManager.IVACameraActiveKerbal == null || cameraManager.IVACameraActiveKerbalIndex == -1)
-                        {
-                            cameraManager.SetCameraIVA(vesselCrew[0].KerbalRef, true);
-                        }
-                        var newIndex = InternalCameraExtensions.GetPreviousIVA(vesselCrew, cameraManager);
-
-                        cameraManager.SetCameraIVA(vesselCrew[newIndex].KerbalRef, true);
-                        GameEvents.OnIVACameraKerbalChange.Fire(vesselCrew[newIndex].KerbalRef);
-                    }
-                    break;
+            switch (CameraManager.Instance.currentCameraMode) {
+            case CameraManager.CameraMode.Flight:
+                SetFlightMode (-1);
+                break;
+            case CameraManager.CameraMode.IVA:
+                CycleIVACrewMember (-1);
+                break;
             }
+        }
+
+        /// <summary>
+        /// The number of modes the flight camera cycles through.
+        /// </summary>
+        const int NumFlightCameraModes = 5;
+
+        /// <summary>
+        /// Move the flight camera the given number of places along its list of modes,
+        /// wrapping around the ends of the list. The camera is re-targeted at the active
+        /// vessel first, and nothing happens while camera mode switching is locked, as
+        /// the game does when cycling the modes itself.
+        /// </summary>
+        static void SetFlightMode (int step)
+        {
+            if (!InputLockManager.IsUnlocked (ControlTypes.CAMERAMODES))
+                return;
+            var camera = FlightCamera.fetch;
+            if (camera.targetMode != FlightCamera.TargetMode.Vessel || camera.vesselTarget != FlightGlobals.ActiveVessel)
+                camera.SetTargetVessel (FlightGlobals.ActiveVessel);
+            var mode = ((int)camera.mode + step + NumFlightCameraModes) % NumFlightCameraModes;
+            camera.setMode ((FlightCamera.Modes)mode);
+        }
+
+        /// <summary>
+        /// Move the IVA view the given number of places along the active vessel's crew
+        /// list from the crew member currently in view.
+        /// </summary>
+        static void CycleIVACrewMember (int step)
+        {
+            var crew = FlightGlobals.ActiveVessel.GetVesselCrew ();
+            var index = FindIVACrewMember (crew, step);
+            if (index != -1)
+                FocusIVACrewMember (crew [index].KerbalRef);
+        }
+
+        /// <summary>
+        /// The index in the crew list of the crew member the given number of places from
+        /// the one currently in view, wrapping around the ends of the list. Crew that the
+        /// game has not placed in an interior are skipped, as there is no view to move to.
+        /// Returns -1 if there is no crew member to move to.
+        /// </summary>
+        static int FindIVACrewMember (IList<ProtoCrewMember> crew, int step)
+        {
+            var count = crew.Count;
+            if (count == 0)
+                return -1;
+            // The camera manager reports an index of -1 when no crew member is in view.
+            // Starting from just off either end of the list then gives its first or last
+            // crew member, depending on the direction being stepped in.
+            var current = CameraManager.Instance.IVACameraActiveKerbalIndex;
+            if (current < 0 || current >= count)
+                current = step > 0 ? -1 : count;
+            for (var offset = 1; offset <= count; offset++) {
+                var index = (current + (offset * step)) % count;
+                if (index < 0)
+                    index += count;
+                if (crew [index].KerbalRef != null)
+                    return index;
+            }
+            return -1;
+        }
+
+        /// <summary>
+        /// Move the IVA view to a crew member, switching the camera to IVA mode if it is
+        /// not already. Selecting the crew member already in view does nothing, as the
+        /// game's camera manager takes that as a request to leave IVA.
+        /// </summary>
+        static void FocusIVACrewMember (Kerbal kerbal)
+        {
+            var cameraManager = CameraManager.Instance;
+            if (cameraManager.currentCameraMode == CameraManager.CameraMode.IVA &&
+                cameraManager.IVACameraActiveKerbal == kerbal)
+                return;
+            cameraManager.SetCameraIVA (kerbal, true);
+            GameEvents.OnIVACameraKerbalChange.Fire (kerbal);
         }
 
         /// <summary>
@@ -588,29 +652,33 @@ namespace KRPC.SpaceCenter.Services
         }
 
         /// <summary>
-        /// When the internal camera is active the kerbal that is in focus
+        /// In IVA mode, the crew member whose view the camera is showing.
+        /// Returns <c>null</c> if no crew member is in view.
         /// Returns an error if the camera is not in IVA mode.
+        /// Setting this moves the view to the given crew member, switching the camera to
+        /// IVA mode if it is not already. The crew member must be in the active vessel,
+        /// and in a part whose interior the game has placed them in.
         /// </summary>
         [KRPCProperty (Nullable = true)]
         public CrewMember FocussedCrewMember
         {
             get
             {
-                var camera = CameraManager.Instance;
-
-                if (camera.currentCameraMode == CameraManager.CameraMode.IVA)
-                {
-                    return new CrewMember(camera.IVACameraActiveKerbal.protoCrewMember);
-                }
-                throw new InvalidOperationException ("There is no focussed kerbal when the camera is not in IVA mode.");
+                if (CameraManager.Instance.currentCameraMode != CameraManager.CameraMode.IVA)
+                    throw new InvalidOperationException ("There is no focussed kerbal when the camera is not in IVA mode.");
+                var kerbal = CameraManager.Instance.IVACameraActiveKerbal;
+                return kerbal == null ? null : new CrewMember (kerbal.protoCrewMember);
             }
             set
             {
-                if (FlightGlobals.ActiveVessel.GetVesselCrew().Contains(value.InternalCrewMember))
-                {
-                    CameraManager.Instance.SetCameraIVA(value.InternalCrewMember.KerbalRef, true);
-                    GameEvents.OnIVACameraKerbalChange.Fire(value.InternalCrewMember.KerbalRef);
-                }
+                if (ReferenceEquals (value, null))
+                    throw new ArgumentNullException ("FocussedCrewMember");
+                var crewMember = value.InternalCrewMember;
+                if (!FlightGlobals.ActiveVessel.GetVesselCrew ().Contains (crewMember))
+                    throw new InvalidOperationException ("The crew member is not in the active vessel.");
+                if (crewMember.KerbalRef == null)
+                    throw new InvalidOperationException ("The crew member is not in the interior of a part.");
+                FocusIVACrewMember (crewMember.KerbalRef);
             }
         }
 

--- a/service/SpaceCenter/test/test_camera.py
+++ b/service/SpaceCenter/test/test_camera.py
@@ -44,9 +44,17 @@ class TestCamera(krpctest.TestCase):
         self.assertEqual(self.mode.automatic, self.camera.mode)
 
     def test_focussed_rejects_null(self):
-        # The focussed body and vessel are nullable for reads, but their setters reject null
+        # The focussed body, vessel and crew member are nullable for reads, but their
+        # setters reject null
         self.assertRaises(ValueError, setattr, self.camera, "focussed_body", None)
         self.assertRaises(ValueError, setattr, self.camera, "focussed_vessel", None)
+        self.assertRaises(
+            ValueError, setattr, self.camera, "focussed_crew_member", None
+        )
+
+    def test_focussed_crew_member_outside_iva(self):
+        self.assertEqual(self.mode.automatic, self.camera.mode)
+        self.assertRaises(RuntimeError, getattr, self.camera, "focussed_crew_member")
 
 
 class CameraTestBase:
@@ -123,6 +131,94 @@ class TestCameraIVA(krpctest.TestCase, CameraTestBase):
     def reset_distance(self):
         # The IVA camera has no distance
         pass
+
+    def test_cycle_single_crew_member(self):
+        # The vessel has a single crew member, so there is no other view to move to
+        # and the camera stays where it is. The game's camera manager takes a repeat
+        # selection of the crew member in view as a request to leave IVA.
+        member = self.camera.focussed_crew_member
+        for cycle in (self.camera.next_camera, self.camera.previous_camera):
+            cycle()
+            self.wait(1)
+            self.assertEqual(self.mode.iva, self.camera.mode)
+            self.assertEqual(member, self.camera.focussed_crew_member)
+
+
+class TestCameraIVACrew(krpctest.TestCase):
+    """Moving the IVA view between the crew of the active vessel. Multi has two
+    single-seat pods, so its two crew sit in separate interiors."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.new_save()
+        cls.remove_other_vessels()
+        space_center = cls.connect().space_center
+        cls.space_center = space_center
+        # Deterministic crew to launch with, and a Kerbal that stays in the roster so
+        # is never in the launched vessel.
+        for name in ("IVA One Kerman", "IVA Two Kerman", "IVA Absent Kerman"):
+            if space_center.get_kerbal(name) is None:
+                space_center.create_kerbal(name, "Pilot", True)
+        cls._stage_craft("Multi", "VAB", None)
+        space_center.launch_vessel(
+            "VAB", "Multi", "LaunchPad", ["IVA One Kerman", "IVA Two Kerman"]
+        )
+        cls.vessel = space_center.active_vessel
+        cls.camera = space_center.camera
+        cls.mode = space_center.CameraMode
+        cls.camera.mode = cls.mode.iva
+        cls.wait(2)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.camera.mode = cls.mode.automatic
+        cls.wait(2)
+
+    def setUp(self):
+        # Each test starts from the first crew member's view
+        self.camera.focussed_crew_member = self.vessel.crew[0]
+        self.wait(1)
+
+    def test_focussed_crew_member(self):
+        crew = self.vessel.crew
+        self.assertEqual(2, len(crew))
+        for member in crew:
+            self.camera.focussed_crew_member = member
+            self.wait(1)
+            self.assertEqual(self.mode.iva, self.camera.mode)
+            self.assertEqual(member, self.camera.focussed_crew_member)
+
+    def test_focussed_crew_member_unchanged(self):
+        # Selecting the crew member already in view leaves the camera where it is
+        member = self.camera.focussed_crew_member
+        self.camera.focussed_crew_member = member
+        self.wait(1)
+        self.assertEqual(self.mode.iva, self.camera.mode)
+        self.assertEqual(member, self.camera.focussed_crew_member)
+
+    def test_focussed_crew_member_not_in_vessel(self):
+        member = self.space_center.get_kerbal("IVA Absent Kerman")
+        self.assertNotIn(member, self.vessel.crew)
+        self.assertRaises(
+            RuntimeError, setattr, self.camera, "focussed_crew_member", member
+        )
+
+    def test_next_camera(self):
+        crew = self.vessel.crew
+        # Two crew, so the view moves to the other one and then wraps back around
+        for expected in (crew[1], crew[0]):
+            self.camera.next_camera()
+            self.wait(1)
+            self.assertEqual(self.mode.iva, self.camera.mode)
+            self.assertEqual(expected, self.camera.focussed_crew_member)
+
+    def test_previous_camera(self):
+        crew = self.vessel.crew
+        for expected in (crew[1], crew[0]):
+            self.camera.previous_camera()
+            self.wait(1)
+            self.assertEqual(self.mode.iva, self.camera.mode)
+            self.assertEqual(expected, self.camera.focussed_crew_member)
 
 
 class TestCameraMap(krpctest.TestCase, CameraTestBase, CameraDistanceTestBase):


### PR DESCRIPTION
**Problem.** The game's camera manager takes selecting the crew member already in view as a request to leave IVA. `Camera.NextCamera` and `Camera.PreviousCamera` therefore switched to the flight camera when asked to move to the crew member in view, as happens on a vessel with a single crew member, and so did setting `Camera.FocussedCrewMember` to that crew member. Cycling did not pass over crew that the game has not placed in an interior, which have no view to move to. Setting `Camera.FocussedCrewMember` to a crew member outside the active vessel was silently ignored, and reading it with no crew member in view failed with a `NullReferenceException`.

**Change.** The IVA crew is cycled here in both directions, wrapping around the crew list and skipping crew with no interior, and both the cycling methods and `Camera.FocussedCrewMember` go through a single focus helper that ignores a request for the crew member already in view. `Camera.FocussedCrewMember` returns `null` when no crew member is in view, and raises an error for a crew member that cannot be viewed rather than ignoring the request or throwing a `NullReferenceException`.

`NextCamera` and `PreviousCamera` were ordered after the `CameraMode` enumeration in `doc/order.txt`, which listed them apart from the class they belong to in the generated API documentation. They are now documented with the rest of the camera.

**Testing.** In-game tests in `service/SpaceCenter/test/test_camera.py` cover cycling in both directions on a two-crew vessel, cycling on a single-crew vessel, selecting the crew member already in view, and the errors raised for `null`, for a crew member outside the active vessel, and for reading the focussed crew member outside IVA mode.

Fixed #484 