### PR TITLE
Report the aerodynamic force FAR applies to the vessel

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -524,6 +524,42 @@ http_archive(
     url = "https://github.com/linuxgurugamer/AGExt/releases/download/2.4.1.4/AGExt-1.12.0-2.4.1.4.zip",
 )
 
+# Ferram Aerospace Research, an alternative aerodynamics model that replaces the stock one.
+# The SpaceCenter Flight class reads its aerodynamic force and its flight parameters through
+# FARAPI, so the tests need it installed to exercise that path. The archive also ships stock
+# example craft under Ships/, which are not installed.
+http_archive(
+    name = "far",
+    build_file_content = "filegroup(name = 'gamedata', srcs = glob(['GameData/FerramAerospaceResearch/**']), visibility = ['//visibility:public'])",
+    sha256 = "422c6b404e7d050844f9b41218205d0bb85aed1a6e66941019d55b0ed0a30e8e",
+    url = "https://github.com/KSPModStewards/Ferram-Aerospace-Research/releases/download/v0.16.1.2_Marangoni/FAR_0_16_1_2_Marangoni.zip",
+)
+
+# FAR's ModularFlightIntegrator dependency, which lets several mods hook the game's flight
+# integrator at once. It is a hard dependency: without it KSP does not load FAR's assembly at
+# all, so FARAPI is missing and kRPC reports FAR as not installed. Installed only alongside
+# FAR, never requested on its own. The archive holds the GameData subdir at its root, so add
+# the GameData prefix the other mod archives already have.
+http_archive(
+    name = "modular_flight_integrator",
+    add_prefix = "GameData",
+    build_file_content = "filegroup(name = 'gamedata', srcs = glob(['GameData/ModularFlightIntegrator/**']), visibility = ['//visibility:public'])",
+    sha256 = "0134c0950298e8703f27809f918fc57b6f9f7202a9ad988decbf1ac924fdd9e7",
+    url = "https://ksp.sarbian.com/jenkins/job/ModularFlightIntegrator/40/artifact/ModularFlightIntegrator-1.2.10.0.zip",
+)
+
+# FAR's other hard dependency: the Unity job-system assemblies (Unity.Mathematics and
+# friends) that KSP does not ship, which FAR's voxelizer is built against. Without them its
+# types fail to load and its flight GUI throws every frame instead of computing forces. This
+# is the KSPBurst-Lite package - the assemblies alone, without the 400MB Burst compiler,
+# which only makes them faster. It references Harmony, installed alongside it.
+http_archive(
+    name = "kspburst",
+    build_file_content = "filegroup(name = 'gamedata', srcs = glob(['GameData/000_KSPBurst/**']), visibility = ['//visibility:public'])",
+    sha256 = "83ad604b2a0b3f646f69fe7a6679f4955cbd6cd16613db89919ed460bd2a19dd",
+    url = "https://github.com/KSPModdingLibs/KSPBurst/releases/download/v1.7.4.9/KSPBurst_1.7.4.9.zip",
+)
+
 # SpaceTuxLibrary — LinuxGuruGamer's shared library bundle (KSP_Log, etc.), an AGExt dependency.
 http_archive(
     name = "spacetuxlibrary",

--- a/doc/order.txt
+++ b/doc/order.txt
@@ -363,6 +363,7 @@ SpaceCenter.Flight.SimulateAerodynamicForceAt
 SpaceCenter.Flight.SimulateAerodynamicTorqueAt
 SpaceCenter.Flight.SimulateAerodynamicWrenchAt
 SpaceCenter.Flight.Lift
+SpaceCenter.Flight.SideForce
 SpaceCenter.Flight.Drag
 SpaceCenter.Flight.AerodynamicAcceleration
 SpaceCenter.Flight.LiftAcceleration

--- a/service/SpaceCenter/CHANGELOG.md
+++ b/service/SpaceCenter/CHANGELOG.md
@@ -33,6 +33,27 @@
 - Flight and aerodynamics
   - Add `Flight.SurfaceNormal` to get the slope of the terrain under a vessel, as a unit vector
     normal to the surface (#1030)
+  - Fix `Flight.AerodynamicForce` and `Flight.AerodynamicAcceleration` turning with the roll
+    of the vessel when Ferram Aerospace Research is installed. They were rebuilt from FAR's
+    lift and drag coefficients, which are scalars measured against the vessel's own axes, and
+    now report the force FAR applies to the vessel (#1032)
+  - Add `Flight.SideForce`, the part of `Flight.AerodynamicForce` that acts across the air
+    stream and out of the vessel's side, which the air exerts on a vessel flying with
+    sideslip. `Flight.Lift`, `Flight.SideForce` and `Flight.Drag` are mutually perpendicular
+    and sum to `Flight.AerodynamicForce` (#1032)
+  - Fix `Flight.Lift` and `Flight.LiftAcceleration` reporting a force scaled by the cosine
+    squared of the sideslip angle, from a lift direction that was never normalized. A vessel
+    flying with no sideslip was unaffected; one flying at 20 degrees of sideslip had its lift
+    reported 12% low (#1032)
+  - `Flight.AerodynamicTorque` now works with Ferram Aerospace Research installed, reporting
+    the torque FAR applies about the vessel's center of mass. It previously refused,
+    reporting that it was unavailable (#1032)
+  - Fix `Flight.SimulateAerodynamicForceAt`, `Flight.SimulateAerodynamicTorqueAt` and
+    `Flight.SimulateAerodynamicWrenchAt` returning `NaN` with Ferram Aerospace Research
+    installed when asked for a state with no relative airflow. They now report no force and
+    no torque, as they do without FAR (#1032)
+  - Fix `Flight.StallFraction` returning `NaN` for a vessel with no lifting surfaces, which
+    has nothing that can stall; it now reports no stall (#1032)
 
 - Control
   - Setting `Control.StageLock` now leaves the in-game Alt+L shortcut in step with it, so the

--- a/service/SpaceCenter/src/ExternalAPI/FAR.cs
+++ b/service/SpaceCenter/src/ExternalAPI/FAR.cs
@@ -55,6 +55,13 @@ namespace KRPC.SpaceCenter.ExternalAPI
         /// </summary>
         public static Func<Vessel, Vector3> VesselAerodynamicForce { get; internal set; }
 
+        /// <summary>
+        /// The total aerodynamic torque FAR applied to the vessel about its center of mass on
+        /// the last physics frame, in world space, in kilonewton-meters. Zero for a vessel FAR
+        /// is not tracking.
+        /// </summary>
+        public static Func<Vessel, Vector3> VesselAerodynamicTorque { get; internal set; }
+
         public static double VesselMachNumber (Vessel vessel)
         {
             var aero = vessel.GetComponent ("FARVesselAero");

--- a/service/SpaceCenter/src/ExternalAPI/FAR.cs
+++ b/service/SpaceCenter/src/ExternalAPI/FAR.cs
@@ -47,6 +47,14 @@ namespace KRPC.SpaceCenter.ExternalAPI
 
         public static Func<Vessel, double> VesselStallFrac { get; internal set; }
 
+        /// <summary>
+        /// The total aerodynamic force FAR applied to the vessel on the last physics frame,
+        /// in world space, in kilonewtons. It is the sum of the per-part forces of FAR's own
+        /// aerodynamics model, so it carries the direction those forces actually act in.
+        /// Zero for a vessel FAR is not tracking.
+        /// </summary>
+        public static Func<Vessel, Vector3> VesselAerodynamicForce { get; internal set; }
+
         public static double VesselMachNumber (Vessel vessel)
         {
             var aero = vessel.GetComponent ("FARVesselAero");

--- a/service/SpaceCenter/src/Services/Flight.cs
+++ b/service/SpaceCenter/src/Services/Flight.cs
@@ -276,6 +276,17 @@ namespace KRPC.SpaceCenter.Services
         }
 
         /// <summary>
+        /// Whether an airflow is too slow for FAR to compute a force from. FAR normalizes the
+        /// airflow to get the direction the air comes from, which is not a number when the air
+        /// is still, so answer such a state directly instead of passing the NaN on. The stock
+        /// model needs no such guard: it multiplies by the airflow rather than dividing by it.
+        /// </summary>
+        static bool IsStillAir (Vector3d airflow)
+        {
+            return airflow.sqrMagnitude < 1e-6;
+        }
+
+        /// <summary>
         /// Check that FAR is not installed
         /// </summary>
         static void CheckNoFAR ()
@@ -712,6 +723,8 @@ namespace KRPC.SpaceCenter.Services
                 var altitude = (worldPosition - body.InternalBody.position).magnitude - body.InternalBody.Radius;
                 var adjustedVelocity = delta.Inverse ()
                     * (worldVelocity - body.InternalBody.getRFrmVel(worldPosition));
+                if (IsStillAir (adjustedVelocity))
+                    return referenceFrame.DirectionFromWorldSpace (Vector3d.zero).ToTuple ();
                 FAR.CalculateVesselAeroForces(vessel, out force, out torque, adjustedVelocity, altitude);
                 // CalculateVesselAeroForces returns kilonewtons; convert to newtons to
                 // match the stock path and this method's documented units.
@@ -783,12 +796,17 @@ namespace KRPC.SpaceCenter.Services
                     * (worldVelocity - body.InternalBody.getRFrmVel(worldPosition));
                 var altitude = (worldPosition - body.InternalBody.position).magnitude
                                - body.InternalBody.Radius;
-                FAR.CalculateVesselAeroForces(
-                    vessel, out farForce, out farTorque, adjustedVelocity, altitude);
-                // FAR returns kilonewtons and kilonewton-meters. Rotate the one
-                // evaluation into the hypothetical attitude and convert both to SI.
-                force = delta * (Vector3d)farForce * 1000d;
-                torque = delta * (Vector3d)farTorque * 1000d;
+                if (IsStillAir (adjustedVelocity)) {
+                    force = Vector3d.zero;
+                    torque = Vector3d.zero;
+                } else {
+                    FAR.CalculateVesselAeroForces(
+                        vessel, out farForce, out farTorque, adjustedVelocity, altitude);
+                    // FAR returns kilonewtons and kilonewton-meters. Rotate the one
+                    // evaluation into the hypothetical attitude and convert both to SI.
+                    force = delta * (Vector3d)farForce * 1000d;
+                    torque = delta * (Vector3d)farTorque * 1000d;
+                }
             }
             return new TupleT3(
                 referenceFrame.DirectionFromWorldSpace(force).ToTuple(),
@@ -1047,7 +1065,12 @@ namespace KRPC.SpaceCenter.Services
         public float StallFraction {
             get {
                 CheckFAR ();
-                return (float)FAR.VesselStallFrac (InternalVessel);
+                // FAR averages how far each of the vessel's lifting surfaces is stalled,
+                // weighted by their area, which is zero over zero for a vessel that has
+                // none. Nothing on such a vessel can stall, so report no stall rather than
+                // passing the NaN on.
+                var stall = FAR.VesselStallFrac (InternalVessel);
+                return double.IsNaN (stall) ? 0f : (float)stall;
             }
         }
 

--- a/service/SpaceCenter/src/Services/Flight.cs
+++ b/service/SpaceCenter/src/Services/Flight.cs
@@ -164,11 +164,14 @@ namespace KRPC.SpaceCenter.Services
         /// center-of-pressure points they are applied at. Also includes the first-order
         /// equivalent of the per-part rigidbody angular drag the engine applies
         /// (-rb.angularDrag * I_part * omega), which damps rotation without ever
-        /// appearing as a force.
+        /// appearing as a force. Ferram Aerospace Research applies its own per-part forces and
+        /// reports the torque they exert about the center of mass directly, in
+        /// kilonewton-meters.
         /// </summary>
         Vector3d WorldAerodynamicTorque {
             get {
-                CheckNoFAR ();
+                if (FAR.IsAvailable)
+                    return (Vector3d)FAR.VesselAerodynamicTorque (InternalVessel) * 1000d;
                 var com = WorldCoM;
                 Vector3d torque = Vector3d.zero;
                 foreach (var part in InternalVessel.Parts) {
@@ -676,21 +679,15 @@ namespace KRPC.SpaceCenter.Services
         /// <returns>A vector pointing along the axis of the torque, with its magnitude
         /// equal to the strength of the torque in newton-meters.</returns>
         /// <remarks>
-        /// This is the live counterpart to <see cref="AerodynamicForce"/>: it reconstructs
-        /// the per-part aerodynamic forces and application points that the game applied on
-        /// the current physics frame and levers them about the center of mass, rather than
-        /// re-simulating them for hypothetical conditions the way
+        /// This is the live counterpart to <see cref="AerodynamicForce"/>: it is the torque
+        /// the aerodynamics model applied on the current physics frame, taken about the
+        /// center of mass, rather than one re-simulated for hypothetical conditions the way
         /// <see cref="SimulateAerodynamicTorqueAt"/> does. It is intended for validating the
-        /// simulator against the live game state. Not available when
-        /// <a href="https://forum.kerbalspaceprogram.com/index.php?/topic/19321-130-ferram-aerospace-research-v0159-liebe-82117/">Ferram Aerospace Research</a>
-        /// is installed, as FAR does not expose a live per-frame torque.
+        /// simulator against the live game state.
         /// </remarks>
         [KRPCProperty]
         public Tuple3 AerodynamicTorque {
-            get {
-                CheckNoFAR ();
-                return referenceFrame.DirectionFromWorldSpace (WorldAerodynamicTorque).ToTuple ();
-            }
+            get { return referenceFrame.DirectionFromWorldSpace (WorldAerodynamicTorque).ToTuple (); }
         }
 
         /// <summary>

--- a/service/SpaceCenter/src/Services/Flight.cs
+++ b/service/SpaceCenter/src/Services/Flight.cs
@@ -138,11 +138,17 @@ namespace KRPC.SpaceCenter.Services
         }
 
         /// <summary>
-        /// Total aerodynamic forces acting on vessel in world space.
+        /// Total aerodynamic force acting on the vessel in world space, in Newtons. With the
+        /// stock model this is the sum of the lift and drag the game applied to every part.
+        /// Ferram Aerospace Research replaces that model wholesale and sums its own per-part
+        /// forces about the center of mass, in kilonewtons, so take the force it reports
+        /// rather than rebuilding one from its lift and drag coefficients, which are scalars
+        /// carrying no direction.
         /// </summary>
         Vector3d WorldAerodynamicForce {
             get {
-                CheckNoFAR ();
+                if (FAR.IsAvailable)
+                    return (Vector3d)FAR.VesselAerodynamicForce (InternalVessel) * 1000d;
                 return WorldPartsLift + WorldPartsDrag;
             }
         }
@@ -219,35 +225,6 @@ namespace KRPC.SpaceCenter.Services
         }
 
         /// <summary>
-        /// Reference area used for lift and drag calculations
-        /// </summary>
-        double ReferenceArea {
-            get { return InternalVessel.WetMass () / (BallisticCoefficient * DragCoefficient); }
-        }
-
-        /// <summary>
-        /// Direction of the lift force acting on the vessel (perpendicular to air stream and up wrt roll angle) in world space.
-        /// </summary>
-        Vector3d WorldLiftDirection {
-            get {
-                var vessel = InternalVessel;
-                return -Vector3d.Cross (vessel.transform.right, vessel.srf_velocity.normalized);
-            }
-        }
-
-        /// <summary>
-        /// Magnitude of the lift force acting on the vessel, in Newtons.
-        /// </summary>
-        double LiftMagnitude {
-            get {
-                if (FAR.IsAvailable)
-                    return LiftCoefficient * ReferenceArea * DynamicPressure;
-                else
-                    return Vector3d.Dot (WorldAerodynamicForce, WorldLiftDirection);
-            }
-        }
-
-        /// <summary>
         /// Direction of the drag force acting on the vessel (opposite direction to air stream) in world space.
         /// </summary>
         Vector3d WorldDragDirection {
@@ -255,15 +232,51 @@ namespace KRPC.SpaceCenter.Services
         }
 
         /// <summary>
-        /// Magnitude of the drag force acting on the vessel.
+        /// Direction of the lift force acting on the vessel in world space: across the air
+        /// stream, in the plane the vessel's nose and its top sit in. Perpendicular to the
+        /// air stream and to the vessel's right, which is what makes it the lift direction of
+        /// the classical wind axes rather than an arbitrary crosswise direction. Zero for a
+        /// vessel flying exactly sideways, where that plane holds no such direction.
         /// </summary>
-        double DragMagnitude {
+        Vector3d WorldLiftDirection {
             get {
-                if (FAR.IsAvailable)
-                    return DragCoefficient * ReferenceArea * DynamicPressure;
-                else
-                    return Vector3d.Dot (WorldAerodynamicForce, WorldDragDirection);
+                var vessel = InternalVessel;
+                return -Vector3d.Cross (vessel.transform.right, vessel.srf_velocity.normalized).normalized;
             }
+        }
+
+        /// <summary>
+        /// The part of the aerodynamic force that acts along the air stream, in world space,
+        /// in Newtons.
+        /// </summary>
+        Vector3d WorldDrag {
+            get {
+                var direction = WorldDragDirection;
+                return Vector3d.Dot (WorldAerodynamicForce, direction) * direction;
+            }
+        }
+
+        /// <summary>
+        /// The part of the aerodynamic force that acts across the air stream and towards the
+        /// top of the vessel, in world space, in Newtons.
+        /// </summary>
+        Vector3d WorldLift {
+            get {
+                var direction = WorldLiftDirection;
+                return Vector3d.Dot (WorldAerodynamicForce, direction) * direction;
+            }
+        }
+
+        /// <summary>
+        /// The part of the aerodynamic force that acts across the air stream and out of the
+        /// vessel's side, in world space, in Newtons. The drag, lift and side directions are
+        /// mutually perpendicular, so this is what the total force has left once the drag and
+        /// lift are taken out of it, and taking it as the remainder keeps the three summing
+        /// back to <see cref="WorldAerodynamicForce"/> even for a vessel flying so far
+        /// sideways that there is no lift direction to speak of.
+        /// </summary>
+        Vector3d WorldSideForce {
+            get { return WorldAerodynamicForce - WorldDrag - WorldLift; }
         }
 
         /// <summary>
@@ -644,14 +657,15 @@ namespace KRPC.SpaceCenter.Services
         /// </summary>
         /// <returns>A vector pointing in the direction that the force acts,
         /// with its magnitude equal to the strength of the force in Newtons.</returns>
+        /// <remarks>
+        /// This is the force the aerodynamics model actually applied to the vessel on the
+        /// last physics frame, summed over its parts, so it points where the air pushes the
+        /// vessel whatever the vessel's orientation. It equals <see cref="Lift"/> plus
+        /// <see cref="SideForce"/> plus <see cref="Drag"/>.
+        /// </remarks>
         [KRPCProperty]
         public Tuple3 AerodynamicForce {
-            get {
-                if (FAR.IsAvailable)
-                    return referenceFrame.DirectionFromWorldSpace (WorldDragDirection * DragMagnitude + WorldLiftDirection * LiftMagnitude).ToTuple ();
-                else
-                    return referenceFrame.DirectionFromWorldSpace (WorldAerodynamicForce).ToTuple ();
-            }
+            get { return referenceFrame.DirectionFromWorldSpace (WorldAerodynamicForce).ToTuple (); }
         }
 
         /// <summary>
@@ -863,9 +877,32 @@ namespace KRPC.SpaceCenter.Services
         /// </summary>
         /// <returns>A vector pointing in the direction that the force acts,
         /// with its magnitude equal to the strength of the force in Newtons.</returns>
+        /// <remarks>
+        /// The part of <see cref="AerodynamicForce"/> that acts across the air stream and
+        /// towards the top of the vessel: perpendicular to the air stream, in the plane the
+        /// vessel's nose and its top sit in. A vessel flying with sideslip is also pushed out
+        /// of that plane, and that part of the force is <see cref="SideForce"/>. Zero for a
+        /// vessel flying exactly sideways, which has no such plane to speak of.
+        /// </remarks>
         [KRPCProperty]
         public Tuple3 Lift {
-            get { return (referenceFrame.DirectionFromWorldSpace (WorldLiftDirection) * LiftMagnitude).ToTuple (); }
+            get { return referenceFrame.DirectionFromWorldSpace (WorldLift).ToTuple (); }
+        }
+
+        /// <summary>
+        /// The aerodynamic side force currently acting on the vessel.
+        /// </summary>
+        /// <returns>A vector pointing in the direction that the force acts,
+        /// with its magnitude equal to the strength of the force in Newtons.</returns>
+        /// <remarks>
+        /// The part of <see cref="AerodynamicForce"/> that acts across the air stream and out
+        /// of the vessel's side, which is what the air does to a vessel flying with sideslip.
+        /// It is perpendicular to both <see cref="Lift"/> and <see cref="Drag"/>, and the
+        /// three of them sum to <see cref="AerodynamicForce"/>.
+        /// </remarks>
+        [KRPCProperty]
+        public Tuple3 SideForce {
+            get { return referenceFrame.DirectionFromWorldSpace (WorldSideForce).ToTuple (); }
         }
 
         /// <summary>
@@ -873,9 +910,13 @@ namespace KRPC.SpaceCenter.Services
         /// </summary>
         /// <returns>A vector pointing in the direction of the force, with its magnitude
         /// equal to the strength of the force in Newtons.</returns>
+        /// <remarks>
+        /// The part of <see cref="AerodynamicForce"/> along the air stream, opposing the
+        /// vessel's motion through the air.
+        /// </remarks>
         [KRPCProperty]
         public Tuple3 Drag {
-            get { return (referenceFrame.DirectionFromWorldSpace (WorldDragDirection) * DragMagnitude).ToTuple (); }
+            get { return referenceFrame.DirectionFromWorldSpace (WorldDrag).ToTuple (); }
         }
 
         /// <summary>
@@ -889,12 +930,7 @@ namespace KRPC.SpaceCenter.Services
         public Tuple3 AerodynamicAcceleration {
             get {
                 var mass = new Vessel (InternalVessel).Mass;
-                Vector3d worldForce;
-                if (FAR.IsAvailable)
-                    worldForce = WorldDragDirection * DragMagnitude + WorldLiftDirection * LiftMagnitude;
-                else
-                    worldForce = WorldAerodynamicForce;
-                return referenceFrame.DirectionFromWorldSpace (worldForce / mass).ToTuple ();
+                return referenceFrame.DirectionFromWorldSpace (WorldAerodynamicForce / mass).ToTuple ();
             }
         }
 
@@ -909,7 +945,7 @@ namespace KRPC.SpaceCenter.Services
         public Tuple3 LiftAcceleration {
             get {
                 var mass = new Vessel (InternalVessel).Mass;
-                return (referenceFrame.DirectionFromWorldSpace (WorldLiftDirection) * (LiftMagnitude / mass)).ToTuple ();
+                return referenceFrame.DirectionFromWorldSpace (WorldLift / mass).ToTuple ();
             }
         }
 
@@ -924,7 +960,7 @@ namespace KRPC.SpaceCenter.Services
         public Tuple3 DragAcceleration {
             get {
                 var mass = new Vessel (InternalVessel).Mass;
-                return (referenceFrame.DirectionFromWorldSpace (WorldDragDirection) * (DragMagnitude / mass)).ToTuple ();
+                return referenceFrame.DirectionFromWorldSpace (WorldDrag / mass).ToTuple ();
             }
         }
 

--- a/service/SpaceCenter/test/test_flight.py
+++ b/service/SpaceCenter/test/test_flight.py
@@ -934,6 +934,25 @@ class TestFlightFAR(krpctest.TestCase):
             delta=0.15 * math.hypot(upright_lift, upright_side),
         )
 
+    def test_aerodynamic_torque_matches_far(self):
+        # The live torque is the one FAR applies about the center of mass, so it agrees with
+        # FAR's simulation of the same state.
+        flight = self.fly()
+        torque = vector(flight.aerodynamic_torque)
+        simulated = vector(
+            flight.simulate_aerodynamic_torque_at(
+                self.body,
+                self.vessel.position(self.ref),
+                self.vessel.velocity(self.ref),
+                self.vessel.rotation(self.ref),
+                (0.0, 0.0, 0.0),
+            )
+        )
+        # A capsule at an angle of attack has its center of pressure off its center of
+        # mass, so there is a real torque to compare.
+        self.assertGreater(norm(simulated), 10)
+        self.assertLess(norm(torque - simulated), 1 + 0.25 * norm(simulated))
+
     def test_flight_parameters(self):
         # The flight parameters FAR computes, read while flying a known state: the pod is
         # placed at a set airspeed and angle of attack with no sideslip, and the pressures

--- a/service/SpaceCenter/test/test_flight.py
+++ b/service/SpaceCenter/test/test_flight.py
@@ -324,29 +324,6 @@ class TestFlightAtLaunchpad(krpctest.TestCase):
         up = body.msl_normal(flight.latitude, flight.longitude, frame)
         self.assertAlmostEqual(1, dot(up, normal), places=5)
 
-    def test_ferram_aerospace_research(self):
-        if self.far:
-            flight = self.vessel.flight()
-
-            self.assertAlmostEqual(1.188, flight.atmosphere_density, places=3)
-            self.assertAlmostEqual(0, flight.drag, delta=0.5)
-            self.assertAlmostEqual(0, flight.dynamic_pressure)
-
-            self.assertAlmostEqual(0, flight.angle_of_attack, delta=2.5)
-            self.assertAlmostEqual(-27, flight.sideslip_angle, delta=2)
-            self.assertAlmostEqual(0, flight.stall_fraction)
-
-            self.assertAlmostEqual(0, flight.mach_number)
-            self.assertAlmostEqual(193, flight.terminal_velocity, delta=0.5)
-
-            self.assertAlmostEqual(0.103, flight.drag_coefficient, places=3)
-            self.assertAlmostEqual(0, flight.lift_coefficient, places=3)
-            self.assertAlmostEqual(0, flight.pitching_moment_coefficient, places=3)
-            self.assertAlmostEqual(2246.8, flight.ballistic_coefficient, delta=50)
-            self.assertAlmostEqual(0, flight.thrust_specific_fuel_consumption)
-
-            self.assertEqual("Nominal", flight.far_status)
-
     def test_simulate_aerodynamic_force_rotation(self):
         # The rotation argument sets the vessel attitude the force is computed
         # for (issue #913). A 300 m/s head-on wind (angle of attack 0 at the
@@ -699,6 +676,14 @@ class TestFlightAero(krpctest.TestCase):
         self.assertGreater(norm(vector(broadside[1]) - vector(head_on[1])), 1)
 
 
+class TestFlightAeroFAR(TestFlightAero):
+    """The aerodynamic simulation suite run against Ferram Aerospace Research instead of the
+    stock model. The simulation RPCs hand the whole state to FAR when it is installed, so the
+    same expectations hold; the base class skips the few checks that are stock-only."""
+
+    mods = ["FAR"]
+
+
 class TestFlightAirbrake(krpctest.TestCase):
     """Regression for issue #622: SimulateAerodynamicForceAt must account for
     the current physical deflection of ModuleAeroSurface airbrakes."""
@@ -786,6 +771,235 @@ class TestFlightAirbrake(krpctest.TestCase):
         finally:
             for cs in self._airbrakes():
                 cs.deployed = False
+
+
+class TestFlightFAR(krpctest.TestCase):
+    """The live aerodynamic readouts with Ferram Aerospace Research installed, which
+    replaces the stock aerodynamics model with its own (issue #498)."""
+
+    mods = ["FAR"]
+
+    ALTITUDE = 5000
+    SPEED = 200
+    # A nose-up attitude relative to the flight path, so the air stream pushes the pod
+    # sideways as well as backwards and there is a lift force to check.
+    ANGLE_OF_ATTACK = 20
+    # Time given to the flight readouts to catch up with a freshly placed vessel. A couple
+    # of physics frames: the pod is unstable at this angle of attack and starts pitching up
+    # as soon as physics resume, so every extra frame moves the state being measured.
+    SETTLE = 0.05
+
+    @classmethod
+    def setUpClass(cls):
+        cls.new_save()
+        cls.launch_vessel_from_vab("Basic")
+        cls.remove_other_vessels()
+        cls.space_center = cls.connect().space_center
+        cls.vessel = cls.space_center.active_vessel
+        cls.body = cls.vessel.orbit.body
+        cls.ref = cls.body.reference_frame
+
+    def fly(self, roll=0):
+        """Put the pod in level flight at a fixed angle of attack and the given roll, and
+        wait until FAR reports a force on it (it voxelizes the craft asynchronously, and
+        reports nothing until the vessel is unpacked and moving through the air)."""
+        self.set_flight(
+            altitude=self.ALTITUDE,
+            speed=self.SPEED,
+            pitch=self.ANGLE_OF_ATTACK,
+            angle_of_attack=self.ANGLE_OF_ATTACK,
+            roll=roll,
+        )
+        flight = self.vessel.flight(self.ref)
+        self.wait_until(
+            lambda: norm(vector(flight.aerodynamic_force)) > 1,
+            message="FAR to report an aerodynamic force on the vessel",
+        )
+        # The per-frame flight readouts lag the teleport by a frame or two, so let them
+        # catch up with the state the vessel was placed in before reading any of them.
+        self.wait(self.SETTLE)
+        return flight
+
+    def airstream_angles(self):
+        """The angle of attack and sideslip angle the vessel is currently flying at, in
+        degrees, worked out from the direction the air stream comes from in the vessel's own
+        axes: +x to its right, +y along its nose, +z out of its belly. Each is the angle
+        between the nose and the air stream in one plane, so the air stream is projected
+        onto the nose-belly plane for the angle of attack and the nose-right plane for the
+        sideslip angle."""
+        airstream = self.space_center.transform_direction(
+            self.vessel.flight(self.ref).velocity, self.ref, self.vessel.reference_frame
+        )
+        right, nose, belly = airstream
+        return (
+            rad2deg(math.atan2(belly, nose)),
+            rad2deg(math.atan2(right, nose)),
+        )
+
+    def test_aerodynamic_force_matches_far(self):
+        # The reported force is the one FAR applies to the vessel, so it agrees with FAR's
+        # own simulation of the same state in direction as well as magnitude. Building it
+        # from FAR's lift and drag coefficients instead, as kRPC used to, gets the
+        # direction wrong because those coefficients are scalars measured against the
+        # vessel's own axes.
+        flight = self.fly()
+        force = vector(flight.aerodynamic_force)
+        simulated = vector(
+            flight.simulate_aerodynamic_force_at(
+                self.body,
+                self.vessel.position(self.ref),
+                self.vessel.velocity(self.ref),
+                self.vessel.rotation(self.ref),
+            )
+        )
+        self.assertGreater(norm(simulated), 1)
+        # The live force and the state passed to the simulation are read a few physics
+        # frames apart while the pod pitches up, so allow for the state moving on between
+        # them. The force the old code built pointed somewhere else entirely.
+        self.assertLess(norm(force - simulated), 0.2 * norm(simulated))
+
+    def test_lift_and_drag_split_the_force(self):
+        # Drag, lift and side force are the components of the total force along the air
+        # stream, across it towards the top of the vessel, and across it out of its side.
+        # The three are mutually perpendicular and sum back to the total force, and each
+        # acceleration is its force over the mass.
+        flight = self.fly()
+        force = vector(flight.aerodynamic_force)
+        lift = vector(flight.lift)
+        drag = vector(flight.drag)
+        side_force = vector(flight.side_force)
+        airstream = normalize(vector(flight.velocity))
+        magnitude = norm(force)
+        self.assertGreater(magnitude, 1)
+        self.assertLess(norm(lift + side_force + drag - force), 1e-3 * magnitude)
+        # Drag opposes the motion through the air; the other two are across it.
+        self.assertLess(dot(drag, airstream), 0)
+        self.assertLess(abs(dot(lift, airstream)), 1e-3 * magnitude)
+        self.assertLess(abs(dot(side_force, airstream)), 1e-3 * magnitude)
+        self.assertLess(abs(dot(lift, side_force)), 1e-3 * magnitude * magnitude)
+        # The pod is placed with its nose in the plane of its flight path, so the air
+        # stream pushes it towards its top and hardly at all out of its side.
+        self.assertGreater(norm(lift), 10 * norm(side_force))
+        mass = self.vessel.mass
+        for force_attr, accel_attr in (
+            ("aerodynamic_force", "aerodynamic_acceleration"),
+            ("lift", "lift_acceleration"),
+            ("drag", "drag_acceleration"),
+        ):
+            expected = tuple(f / mass for f in getattr(flight, force_attr))
+            self.assertAlmostEqual(
+                expected, getattr(flight, accel_attr), delta=1e-3 * magnitude / mass
+            )
+
+    def test_aerodynamic_force_independent_of_roll(self):
+        # Issue #498: rolling a vessel of revolution about its own axis does not change the
+        # aerodynamic force acting on it. Compare the two quantities that describe the
+        # force relative to the air stream - how strong it is, and how far it is turned
+        # from the air stream - after flying at the same angle of attack, once upright and
+        # once rolled onto its side.
+        def measure(roll):
+            flight = self.fly(roll)
+            force = vector(flight.aerodynamic_force)
+            airstream = normalize(vector(flight.velocity))
+            return norm(force), rad2deg(math.acos(dot(normalize(force), airstream)))
+
+        upright_magnitude, upright_angle = measure(0)
+        rolled_magnitude, rolled_angle = measure(90)
+        self.assertGreater(upright_magnitude, 1)
+        # The pod is a body of revolution apart from its hatch and windows, so allow a
+        # little for those. Reconstructing the force from FAR's lift coefficient loses the
+        # whole across-stream component when rolled, which is far larger than this.
+        self.assertAlmostEqual(
+            upright_magnitude, rolled_magnitude, delta=0.1 * upright_magnitude
+        )
+        self.assertAlmostEqual(upright_angle, rolled_angle, delta=5)
+
+    def test_rolling_moves_lift_into_side_force(self):
+        # Lift and side force are named for the vessel, not for the world: they are the two
+        # halves of the across-stream force, one towards the vessel's top and one out of its
+        # side. Flying the same angle of attack rolled onto its side turns what was lift into
+        # side force, while the total force across the stream is unchanged.
+        def measure(roll):
+            flight = self.fly(roll)
+            return norm(vector(flight.lift)), norm(vector(flight.side_force))
+
+        upright_lift, upright_side = measure(0)
+        rolled_lift, rolled_side = measure(90)
+        self.assertGreater(upright_lift, 10 * upright_side)
+        self.assertGreater(rolled_side, 10 * rolled_lift)
+        # The air pushes the pod just as hard across the stream either way round.
+        self.assertAlmostEqual(
+            math.hypot(upright_lift, upright_side),
+            math.hypot(rolled_lift, rolled_side),
+            delta=0.15 * math.hypot(upright_lift, upright_side),
+        )
+
+    def test_flight_parameters(self):
+        # The flight parameters FAR computes, read while flying a known state: the pod is
+        # placed at a set airspeed and angle of attack with no sideslip, and the pressures
+        # and speeds follow from the atmosphere it is flying through.
+        flight = self.fly()
+        speed = flight.true_air_speed
+        density = flight.atmosphere_density
+        dynamic_pressure = flight.dynamic_pressure
+        mach = flight.mach
+        self.assertAlmostEqual(self.SPEED, speed, delta=15)
+        self.assertAlmostEqual(
+            0.5 * density * speed * speed,
+            dynamic_pressure,
+            delta=0.05 * dynamic_pressure,
+        )
+        # FAR derives the speed of sound from its own atmosphere model, so its Mach number
+        # is near, but not equal to, the airspeed over the speed of sound the game reports.
+        self.assertAlmostEqual(speed / flight.speed_of_sound, mach, delta=0.2 * mach)
+        # The angle of attack and sideslip angle are the two angles between the nose and the
+        # air stream, measured in the vessel's pitch and yaw planes. Check them against the
+        # air stream in the vessel's own axes, which moves with the pod as it pitches up
+        # out of the attitude it was placed in.
+        angle_of_attack, sideslip_angle = self.airstream_angles()
+        self.assertGreater(
+            angle_of_attack, 0
+        )  # placed nose-up, so the air comes from below
+        self.assertAlmostEqual(angle_of_attack, flight.angle_of_attack, delta=2)
+        self.assertAlmostEqual(sideslip_angle, flight.sideslip_angle, delta=2)
+        # Terminal velocity is an estimate for this vessel falling in this atmosphere. The
+        # pod carries no lifting surface, so there is nothing on it that can stall.
+        self.assertGreater(flight.terminal_velocity, 0)
+        self.assertEqual(0, flight.stall_fraction)
+        # A blunt capsule at 200 m/s in the lower atmosphere: a large Reynolds number, real
+        # drag, and lift towards its back as it is held nose-up.
+        self.assertGreater(flight.reynolds_number, 1e6)
+        self.assertGreater(flight.drag_coefficient, 0)
+        self.assertGreater(flight.lift_coefficient, 0)
+        self.assertGreater(flight.ballistic_coefficient, 0)
+        # The pod carries no engine, so nothing is burning fuel to make thrust.
+        self.assertEqual(0, flight.thrust_specific_fuel_consumption)
+
+    def test_lift_and_drag_coefficients_match_the_forces(self):
+        # Both coefficients are their force divided by the same dynamic pressure and
+        # reference area, so their ratio is the ratio of the forces they measure. FAR
+        # measures its lift against the vessel's own axes rather than the air stream, as the
+        # component of the whole across-stream force that points towards the top of the
+        # vessel, so take that force in the vessel frame, whose z-axis points out of its
+        # bottom.
+        self.fly()
+        flight = self.vessel.flight(self.vessel.reference_frame)
+        across_stream = vector(flight.lift) + vector(flight.side_force)
+        lift_over_drag = -across_stream[2] / norm(vector(flight.drag))
+        self.assertGreater(abs(lift_over_drag), 0.01)
+        self.assertAlmostEqual(
+            lift_over_drag,
+            flight.lift_coefficient / flight.drag_coefficient,
+            delta=0.1 * abs(lift_over_drag),
+        )
+
+    def test_stock_only_readouts_unavailable(self):
+        # The per-part stock aerodynamic readouts have no FAR counterpart, so they refuse
+        # rather than report a stale stock value.
+        self.assertTrue(self.space_center.far_available)
+        part = self.vessel.parts.root
+        self.assertRaises(RuntimeError, part.lift, part.reference_frame)
+        self.assertRaises(RuntimeError, part.drag, part.reference_frame)
 
 
 if __name__ == "__main__":

--- a/tools/krpctest/CHANGELOG.md
+++ b/tools/krpctest/CHANGELOG.md
@@ -1,4 +1,7 @@
 ## [v0.7.0] - unreleased
+- Add Ferram Aerospace Research to the managed third-party mods, requested with
+  `mods = ["FAR"]` or `krpc-install --mods=FAR`, so the tests can exercise the aerodynamic
+  readouts against it (#1032)
 - Add `--skip-mod-install` to `krpc-install` and `krpc-run-ksp`, and the
   `KRPC_SKIP_MOD_INSTALL` environment variable honored when the tests auto-launch KSP,
   to leave the managed third-party mods in GameData untouched so a locally built mod

--- a/tools/krpctest/krpctest/game.py
+++ b/tools/krpctest/krpctest/game.py
@@ -57,6 +57,14 @@ _MOD_MODULES = {
     "AGExt": "ModuleAGX",
 }
 
+# Some mods add nothing to the part catalog at all, but are reported by a flag on a service
+# that wraps them (Ferram Aerospace Research replaces the aerodynamics model, and the
+# SpaceCenter service reports whether it is installed and active). Detect these by reading
+# that flag, given as a (service, property) pair.
+_MOD_FLAGS = {
+    "FAR": ("space_center", "far_available"),
+}
+
 # The KSP process this test run launched, or None if KSP was started externally (a
 # manually-started game is never killed or reinstalled).
 _owned_ksp = None  # pylint: disable=invalid-name
@@ -134,11 +142,16 @@ def _installed_mods(conn):
         for name, module in _MOD_MODULES.items()
         if conn.testing_tools.part_module_available(module)
     }
+    installed |= {
+        name
+        for name, (service, flag) in _MOD_FLAGS.items()
+        if getattr(getattr(conn, service), flag)
+    }
     return installed
 
 
 def _validate_mods(required):
-    known = set(_MOD_SERVICES) | set(_MOD_PARTS) | set(_MOD_MODULES)
+    known = set(_MOD_SERVICES) | set(_MOD_PARTS) | set(_MOD_MODULES) | set(_MOD_FLAGS)
     unknown = set(required) - known
     if unknown:
         raise ValueError(

--- a/tools/krpctest/krpctest/install.py
+++ b/tools/krpctest/krpctest/install.py
@@ -29,7 +29,8 @@ from krpctest.version import __version__
 # Managed third-party mods: name accepted by --mods -> list of components it installs, each a
 # (Bazel target under //tools/mods, GameData subdir it installs as) pair. Most mods are a
 # single component; RealChute and AGExt also pull in the shared ClickThroughBlocker /
-# ToolbarControl / Harmony dependencies, whose assemblies their plugins hard-depend on.
+# ToolbarControl / Harmony dependencies, whose assemblies their plugins hard-depend on, and
+# FAR pulls in ModularFlightIntegrator and KSPBurst.
 MODS = {
     "RemoteTech": [("remotetech", "RemoteTech")],
     "InfernalRobotics": [("infernal_robotics", "MagicSmokeIndustries")],
@@ -47,6 +48,12 @@ MODS = {
         ("clickthroughblocker", "000_ClickThroughBlocker"),
         ("toolbarcontrol", "001_ToolbarControl"),
         ("spacetuxlibrary", "SpaceTuxLibrary"),
+    ],
+    "FAR": [
+        ("far", "FerramAerospaceResearch"),
+        ("modular_flight_integrator", "ModularFlightIntegrator"),
+        ("kspburst", "000_KSPBurst"),
+        ("harmony", "000_Harmony"),
     ],
 }
 

--- a/tools/mods/BUILD.bazel
+++ b/tools/mods/BUILD.bazel
@@ -18,6 +18,9 @@
 #                        + GameData/000_Harmony, GameData/000_ClickThroughBlocker,
 #                          GameData/001_ToolbarControl (deps, shared with RealChute),
 #                          GameData/SpaceTuxLibrary (dep)
+#   FAR               -> GameData/FerramAerospaceResearch
+#                        + GameData/ModularFlightIntegrator, GameData/000_KSPBurst (deps),
+#                          GameData/000_Harmony (dep, shared with RealChute and AGExt)
 # tools/krpctest mirrors this registry on the Python side.
 
 filegroup(
@@ -79,6 +82,30 @@ filegroup(
 filegroup(
     name = "agext",
     srcs = ["@agext//:gamedata"],
+    visibility = ["//visibility:public"],
+)
+
+# Ferram Aerospace Research. Installing it swaps the game's aerodynamics model, so it is only
+# ever requested by the tests that check the Flight class against FAR.
+filegroup(
+    name = "far",
+    srcs = ["@far//:gamedata"],
+    visibility = ["//visibility:public"],
+)
+
+# FAR's dependencies, installed alongside it and never requested on their own. KSP refuses to
+# load FAR's assembly without ModularFlightIntegrator, and FAR's own types fail to load
+# without the Unity job-system assemblies in KSPBurst (which in turn needs Harmony, shared
+# with RealChute and AGExt).
+filegroup(
+    name = "modular_flight_integrator",
+    srcs = ["@modular_flight_integrator//:gamedata"],
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "kspburst",
+    srcs = ["@kspburst//:gamedata"],
     visibility = ["//visibility:public"],
 )
 


### PR DESCRIPTION
**Root cause.** With Ferram Aerospace Research installed, `Flight.AerodynamicForce` was not read from FAR at all. It was rebuilt from FAR's lift and drag coefficients, which are scalars measured against the vessel's own axes, and paired with a direction guessed from the cross product of the vessel's right axis and its velocity. That guess turns with the vessel, so the reported force turned with the vessel's roll: rolling a craft of revolution onto its side halved the force and lost its across-stream part altogether.

**Fix.** Report the force FAR applies to the vessel, which already carries the direction its per-part forces act in, the same way the stock model has always summed the real per-part vectors. Decomposing that force against the air stream then exposes what was missing from the reconstruction. `Flight.Lift` keeps its meaning, the force across the air stream and towards the top of the vessel, but its direction is now normalized, so it no longer comes back scaled by the cosine squared of the sideslip angle. The part of the force that pushes a sideslipping vessel out of that plane was previously dropped and is now `Flight.SideForce`; lift, side force and drag are mutually perpendicular and sum to the total.

Three related FAR problems are fixed alongside it, each on its own commit: `Flight.AerodynamicTorque` refused under FAR although FAR does expose a live torque about the center of mass; the simulate RPCs returned `NaN` for a state with no relative airflow, which FAR cannot normalize; and `Flight.StallFraction` returned `NaN` for a vessel with no lifting surfaces.

**Testing.** FAR is now one of the mods the integration test framework installs, requested with `mods = ["FAR"]`, so these paths run against the real mod rather than being reasoned about. The new tests fly a pod at a fixed angle of attack under FAR and check the live force against FAR's own simulation of the same state, the three components against each other and the air stream, and the force for the roll independence this issue asks for: rolling the pod onto its side moves its across-stream force from lift to side force while the total is unchanged. The existing aerodynamic simulation suite now also runs against FAR, which the checks it already carried were written for but never exercised.

Fixes #498
