### PR TITLE
Read and write serial ports on their own threads

### DIFF
--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -1,4 +1,7 @@
 ## [v0.7.0] - unreleased
+- Fix the game freezing for as long as a serial connection takes to carry an RPC; serial ports are
+  now read and written on their own threads rather than on the thread that runs the game. Data
+  waiting to be sent is buffered up to 1 MB, beyond which the connection is dropped (#1035)
 - Fix one server stopping emptying the object store that every server shares, which invalidated
   the objects held by clients of the servers still running (#1020)
 - Support for nullable values across all types (#1017)

--- a/core/src/KRPC.Core.csproj
+++ b/core/src/KRPC.Core.csproj
@@ -67,12 +67,16 @@
     <Compile Include="Server\ProtocolBuffers\StreamServer.cs" />
     <Compile Include="Server\ProtocolBuffers\StreamStream.cs" />
     <Compile Include="Server\ProtocolBuffers\Utils.cs" />
+    <Compile Include="Server\SerialIO\BufferedPort.cs" />
+    <Compile Include="Server\SerialIO\ByteBuffer.cs" />
     <Compile Include="Server\SerialIO\ByteClient.cs" />
     <Compile Include="Server\SerialIO\ByteServer.cs" />
     <Compile Include="Server\SerialIO\ByteStream.cs" />
     <Compile Include="Server\SerialIO\RPCClient.cs" />
     <Compile Include="Server\SerialIO\RPCServer.cs" />
+    <Compile Include="Server\SerialIO\IPort.cs" />
     <Compile Include="Server\SerialIO\RPCStream.cs" />
+    <Compile Include="Server\SerialIO\SerialPortAdapter.cs" />
     <Compile Include="Server\SerialIO\StreamServer.cs" />
     <Compile Include="Server\Server.cs" />
     <Compile Include="Server\ServerEventArgs.cs" />

--- a/core/src/Server/SerialIO/BufferedPort.cs
+++ b/core/src/Server/SerialIO/BufferedPort.cs
@@ -1,0 +1,262 @@
+using System;
+using System.IO;
+using System.Threading;
+using KRPC.Utils;
+
+namespace KRPC.Server.SerialIO
+{
+    /// <summary>
+    /// A serial port that is read and written by background threads, presenting the data to the
+    /// caller through in-memory buffers. Received data is buffered until it is read, and written
+    /// data is buffered until the port has sent it, so neither Read nor Write waits on the port.
+    ///
+    /// A serial port carries one byte at a time at the configured baud rate, which at the default
+    /// 9600 baud is about a millisecond per byte, and a write does not finish until the port has
+    /// sent every byte of it. The server calls into this class from the thread that runs the game,
+    /// so waiting for the port there would hold up the game for the duration of the transfer.
+    /// </summary>
+    sealed class BufferedPort
+    {
+        // How often the read thread checks the port for received data. Reads are only issued for
+        // data the port already holds, so that they return promptly without engaging the port's
+        // timeout handling: a read left waiting for data that arrives just as the read gives up
+        // can lose that data, depending on the port implementation.
+        const int pollInterval = 10;
+        // How long a read is allowed to take before it fails with TimeoutException. Reads are only
+        // issued for data the port already holds, so this is a guard against a port that
+        // misreports how much it has, which would otherwise leave the read thread stuck in a read
+        // that never returns.
+        const int readTimeout = 100;
+        // How long Close waits for each background thread to finish before abandoning it.
+        const int shutdownTimeout = 500;
+        // Number of bytes transferred to or from the port at a time.
+        const int chunkSize = 4096;
+        // Amount of unread received data at which reading from the port pauses, so that a client
+        // sending faster than the game reads cannot grow the buffer without limit. The data stays
+        // in the port's own buffer until the game catches up.
+        const int receiveLimit = 1024 * 1024;
+        // Amount of unsent written data at which the port is failed. A caller that writes faster
+        // than the configured baud rate for long enough would otherwise grow the buffer without
+        // limit, while the data waiting in it grows ever staler. Unlike reading, which can pause
+        // and leave data with the port, written data has nowhere else to live, so the connection
+        // is dropped instead.
+        const int sendLimit = 1024 * 1024;
+
+        readonly IPort port;
+        readonly ByteBuffer received = new ByteBuffer ();
+        readonly ByteBuffer sending = new ByteBuffer ();
+        readonly object receivedLock = new object ();
+        readonly object sendingLock = new object ();
+        Thread readThread;
+        Thread writeThread;
+        bool opened;
+        volatile bool closing;
+        volatile bool failed;
+
+        public BufferedPort (IPort innerPort)
+        {
+            if (innerPort == null)
+                throw new ArgumentNullException (nameof (innerPort));
+            port = innerPort;
+        }
+
+        public string PortName {
+            get { return port.PortName; }
+        }
+
+        /// <summary>
+        /// Whether the port is open and usable. False once it has been closed, or once one of the
+        /// background threads has failed and left the port in an unusable state.
+        /// </summary>
+        public bool IsOpen {
+            get { return !failed && port.IsOpen; }
+        }
+
+        /// <summary>
+        /// Number of bytes that have been received from the port and not yet read.
+        /// </summary>
+        public int BytesAvailable {
+            get {
+                CheckFailed ();
+                lock (receivedLock)
+                    return received.Length;
+            }
+        }
+
+        /// <summary>
+        /// Open the port and start transferring data to and from it. A port can only be opened
+        /// once: a background thread that outlives a Close, because it was stuck in a transfer,
+        /// could otherwise fail the reopened port. Create a new instance to open the port again.
+        /// </summary>
+        public void Open ()
+        {
+            if (opened)
+                throw new InvalidOperationException (
+                    "The serial port " + port.PortName + " cannot be opened again");
+            opened = true;
+            port.ReadTimeout = readTimeout;
+            port.Open ();
+            // Discard stale data from the port
+            port.DiscardInBuffer ();
+            readThread = StartThread (ReadLoop, "read");
+            writeThread = StartThread (WriteLoop, "write");
+        }
+
+        /// <summary>
+        /// Stop transferring data and close the port. Data already given to Write is sent first,
+        /// unless the port takes too long about it.
+        /// </summary>
+        public void Close ()
+        {
+            closing = true;
+            lock (receivedLock)
+                Monitor.PulseAll (receivedLock);
+            lock (sendingLock)
+                Monitor.PulseAll (sendingLock);
+            // Wait for the write thread first, so that it gets the chance to send what is left in
+            // the send buffer. A thread that does not finish in time is left to the port being
+            // closed under it, which fails its transfer and ends it.
+            JoinThread (writeThread);
+            JoinThread (readThread);
+            writeThread = null;
+            readThread = null;
+            lock (receivedLock)
+                received.Clear ();
+            lock (sendingLock)
+                sending.Clear ();
+            port.Close ();
+        }
+
+        /// <summary>
+        /// Read up to size bytes of received data into buffer, starting at offset. Returns the
+        /// number of bytes read, which is zero when nothing has been received.
+        /// </summary>
+        public int Read (byte[] buffer, int offset, int size)
+        {
+            CheckFailed ();
+            lock (receivedLock) {
+                var read = received.Take (buffer, offset, size);
+                // Reading may have taken the buffer back below the limit at which the read thread
+                // pauses, so let it know there is room again.
+                if (read > 0)
+                    Monitor.PulseAll (receivedLock);
+                return read;
+            }
+        }
+
+        /// <summary>
+        /// Queue size bytes from buffer, starting at offset, to be sent over the port. Fails the
+        /// port when the amount of queued data reaches the send limit, which means data is being
+        /// written faster than the port can carry it.
+        /// </summary>
+        public void Write (byte[] buffer, int offset, int size)
+        {
+            CheckFailed ();
+            lock (sendingLock) {
+                if (sending.Length + size > sendLimit) {
+                    var exn = new IOException (
+                        "Data is being written to the serial port " + port.PortName +
+                        " faster than the port can send it");
+                    Fail (exn);
+                    throw exn;
+                }
+                sending.Append (buffer, offset, size);
+                Monitor.PulseAll (sendingLock);
+            }
+        }
+
+        Thread StartThread (ThreadStart body, string role)
+        {
+            var thread = new Thread (body);
+            thread.Name = "kRPC SerialIO " + role + " " + port.PortName;
+            // The threads only move data for a server that the game owns, so they must never be
+            // what keeps the process alive.
+            thread.IsBackground = true;
+            thread.Start ();
+            return thread;
+        }
+
+        static void JoinThread (Thread thread)
+        {
+            if (thread != null)
+                thread.Join (shutdownTimeout);
+        }
+
+        void ReadLoop ()
+        {
+            var buffer = new byte [chunkSize];
+            while (!closing && !failed) {
+                lock (receivedLock) {
+                    while (!closing && !failed && received.Length >= receiveLimit)
+                        Monitor.Wait (receivedLock, readTimeout);
+                }
+                if (closing || failed)
+                    return;
+                int size;
+                try {
+                    if (port.BytesToRead == 0) {
+                        Thread.Sleep (pollInterval);
+                        continue;
+                    }
+                    size = port.Read (buffer, 0, buffer.Length);
+                } catch (TimeoutException) {
+                    // The port did not hand over the data it reported holding
+                    continue;
+                } catch (System.Exception exn) {
+                    Fail (exn);
+                    return;
+                }
+                if (size <= 0) {
+                    // The port reports itself readable but has nothing to give, which means the
+                    // other end has gone. Wait rather than ask again immediately.
+                    Thread.Sleep (readTimeout);
+                    continue;
+                }
+                lock (receivedLock)
+                    received.Append (buffer, 0, size);
+            }
+        }
+
+        void WriteLoop ()
+        {
+            var buffer = new byte [chunkSize];
+            while (!failed) {
+                int size;
+                lock (sendingLock) {
+                    while (sending.Length == 0) {
+                        if (closing || failed)
+                            return;
+                        Monitor.Wait (sendingLock);
+                    }
+                    size = sending.Take (buffer, 0, buffer.Length);
+                }
+                try {
+                    port.Write (buffer, 0, size);
+                } catch (System.Exception exn) {
+                    Fail (exn);
+                    return;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Record that the port can no longer be used, and wake anything waiting on it.
+        /// </summary>
+        void Fail (System.Exception exn)
+        {
+            failed = true;
+            Logger.WriteLine (
+                "SerialIO: transfer on " + port.PortName + " failed; " + exn, Logger.Severity.Error);
+            lock (receivedLock)
+                Monitor.PulseAll (receivedLock);
+            lock (sendingLock)
+                Monitor.PulseAll (sendingLock);
+        }
+
+        void CheckFailed ()
+        {
+            if (failed)
+                throw new IOException ("The serial port " + port.PortName + " is no longer usable");
+        }
+    }
+}

--- a/core/src/Server/SerialIO/ByteBuffer.cs
+++ b/core/src/Server/SerialIO/ByteBuffer.cs
@@ -1,0 +1,75 @@
+using System;
+
+namespace KRPC.Server.SerialIO
+{
+    /// <summary>
+    /// A first-in first-out queue of bytes. Data is appended at the back and taken from the front.
+    /// The backing array is compacted when the space behind the data runs out, and grown only when
+    /// the data itself no longer fits, so a buffer that is drained as fast as it is filled settles
+    /// on a fixed size and stops allocating.
+    /// </summary>
+    sealed class ByteBuffer
+    {
+        const int initialSize = 8 * 1024;
+
+        byte[] data = new byte [initialSize];
+        int start;
+        int end;
+
+        /// <summary>
+        /// Number of bytes held in the buffer.
+        /// </summary>
+        public int Length {
+            get { return end - start; }
+        }
+
+        /// <summary>
+        /// Append size bytes from buffer, starting at offset, to the back of the queue.
+        /// </summary>
+        public void Append (byte[] buffer, int offset, int size)
+        {
+            if (data.Length - end < size) {
+                var length = Length;
+                if (data.Length - length < size) {
+                    var newSize = data.Length;
+                    while (newSize - length < size)
+                        newSize *= 2;
+                    var newData = new byte [newSize];
+                    Array.Copy (data, start, newData, 0, length);
+                    data = newData;
+                } else {
+                    Array.Copy (data, start, data, 0, length);
+                }
+                start = 0;
+                end = length;
+            }
+            Array.Copy (buffer, offset, data, end, size);
+            end += size;
+        }
+
+        /// <summary>
+        /// Remove up to size bytes from the front of the queue, writing them to buffer starting at
+        /// offset. Returns the number of bytes taken, which is zero when the queue is empty.
+        /// </summary>
+        public int Take (byte[] buffer, int offset, int size)
+        {
+            size = Math.Min (size, Length);
+            Array.Copy (data, start, buffer, offset, size);
+            start += size;
+            if (start == end) {
+                start = 0;
+                end = 0;
+            }
+            return size;
+        }
+
+        /// <summary>
+        /// Discard the contents of the queue.
+        /// </summary>
+        public void Clear ()
+        {
+            start = 0;
+            end = 0;
+        }
+    }
+}

--- a/core/src/Server/SerialIO/ByteClient.cs
+++ b/core/src/Server/SerialIO/ByteClient.cs
@@ -1,24 +1,19 @@
 using System;
-#if NET
-using System.IO.Ports;
-#else
-using KRPC.IO.Ports;
-#endif
 
 namespace KRPC.Server.SerialIO
 {
     sealed class ByteClient : IClient<byte,byte>
     {
         readonly Guid guid;
-        SerialPort port;
+        BufferedPort port;
         ByteStream stream;
 
-        public ByteClient (SerialPort serialPort, byte[] buffer = null)
+        public ByteClient (BufferedPort bufferedPort, byte[] buffer = null)
         {
-            if (serialPort == null)
-                throw new ArgumentNullException (nameof (serialPort));
+            if (bufferedPort == null)
+                throw new ArgumentNullException (nameof (bufferedPort));
             guid = Guid.NewGuid ();
-            port = serialPort;
+            port = bufferedPort;
             Address = port.PortName;
             stream = new ByteStream (port, buffer);
         }

--- a/core/src/Server/SerialIO/ByteServer.cs
+++ b/core/src/Server/SerialIO/ByteServer.cs
@@ -46,7 +46,7 @@ namespace KRPC.Server.SerialIO
         /// </summary>
         public event EventHandler<ClientDisconnectedEventArgs<byte,byte>> OnClientDisconnected;
 
-        SerialPort port;
+        BufferedPort port;
         ByteClient client;
         ByteClient pendingClient;
         ulong closedClientsBytesRead;
@@ -79,12 +79,13 @@ namespace KRPC.Server.SerialIO
                 return;
             }
             Logger.WriteLine ("SerialIO.Server: starting " + Address, Logger.Severity.Debug);
-            port = new SerialPort (Address, (int)BaudRate, Parity, DataBits, StopBits);
+            var serialPort = new SerialPort (Address, (int)BaudRate, Parity, DataBits, StopBits);
             Logger.WriteLine ("SerialIO.Server: port name = " + Address, Logger.Severity.Debug);
-            Logger.WriteLine ("SerialIO.Server: baud rate = " + port.BaudRate, Logger.Severity.Debug);
-            Logger.WriteLine ("SerialIO.Server: data bits = " + port.DataBits, Logger.Severity.Debug);
-            Logger.WriteLine ("SerialIO.Server: parity = " + port.Parity, Logger.Severity.Debug);
-            Logger.WriteLine ("SerialIO.Server: stop bits = " + port.StopBits, Logger.Severity.Debug);
+            Logger.WriteLine ("SerialIO.Server: baud rate = " + serialPort.BaudRate, Logger.Severity.Debug);
+            Logger.WriteLine ("SerialIO.Server: data bits = " + serialPort.DataBits, Logger.Severity.Debug);
+            Logger.WriteLine ("SerialIO.Server: parity = " + serialPort.Parity, Logger.Severity.Debug);
+            Logger.WriteLine ("SerialIO.Server: stop bits = " + serialPort.StopBits, Logger.Severity.Debug);
+            port = new BufferedPort (new SerialPortAdapter (serialPort));
             try {
                 port.Open();
             } catch (Exception exn) {
@@ -92,8 +93,6 @@ namespace KRPC.Server.SerialIO
                 Logger.WriteLine("SerialIO.Server: failed to start server; " + exn, Logger.Severity.Error);
                 throw new ServerException(exn.GetType() + ": " + exn.Message, exn);
             }
-            // Discard stale data from the port
-            port.DiscardInBuffer();
             Logger.WriteLine ("SerialIO.Server: started successfully", Logger.Severity.Debug);
             EventHandlerExtensions.Invoke (OnStarted, this);
         }
@@ -149,8 +148,17 @@ namespace KRPC.Server.SerialIO
         /// </summary>
         public void Update ()
         {
+            // The server is updated whether or not it is running, and has no port when stopped.
+            if (port == null)
+                return;
             try {
-                if (client == null && pendingClient == null && port.IsOpen && port.BytesToRead > 0) {
+                // The port stops being open once transferring data over it has failed, which the
+                // server cannot recover from and so stops.
+                if (!port.IsOpen) {
+                    Stop ();
+                    return;
+                }
+                if (client == null && pendingClient == null && port.BytesAvailable > 0) {
                     Logger.WriteLine (
                         "SerialIO.Server[" + Address + "]: client requesting connection",
                         Logger.Severity.Debug);

--- a/core/src/Server/SerialIO/ByteStream.cs
+++ b/core/src/Server/SerialIO/ByteStream.cs
@@ -1,22 +1,17 @@
 using System;
 using System.IO;
-#if NET
-using System.IO.Ports;
-#else
-using KRPC.IO.Ports;
-#endif
 
 namespace KRPC.Server.SerialIO
 {
     sealed class ByteStream : IStream<byte,byte>
     {
-        SerialPort stream;
+        BufferedPort port;
         byte[] readBuffer;
         int readBufferOffset;
 
-        public ByteStream (SerialPort innerStream, byte[] buffer = null)
+        public ByteStream (BufferedPort innerPort, byte[] buffer = null)
         {
-            stream = innerStream;
+            port = innerPort;
             readBuffer = buffer;
         }
 
@@ -25,7 +20,7 @@ namespace KRPC.Server.SerialIO
                 try {
                     return
                         (readBuffer != null) ||
-                        (stream != null && stream.IsOpen && stream.BytesToRead > 0);
+                        (port != null && port.IsOpen && port.BytesAvailable > 0);
                 } catch (IOException) {
                     return false;
                 } catch (TimeoutException) {
@@ -57,10 +52,10 @@ namespace KRPC.Server.SerialIO
         {
             if (readBuffer != null)
                 return ReadBufferedData (buffer, offset, buffer.Length - offset);
-            if (stream == null)
+            if (port == null)
                 throw new ClientDisconnectedException ();
             try {
-                var size = stream.Read (buffer, offset, buffer.Length - offset);
+                var size = port.Read (buffer, offset, buffer.Length - offset);
                 BytesRead += (ulong)size;
                 return size;
             } catch (IOException e) {
@@ -76,10 +71,10 @@ namespace KRPC.Server.SerialIO
         {
             if (readBuffer != null)
                 return ReadBufferedData (buffer, offset, size);
-            if (stream == null)
+            if (port == null)
                 throw new ClientDisconnectedException ();
             try {
-                size = stream.Read (buffer, offset, size);
+                size = port.Read (buffer, offset, size);
                 BytesRead += (ulong)size;
                 return size;
             } catch (IOException e) {
@@ -103,10 +98,10 @@ namespace KRPC.Server.SerialIO
 
         public void Write (byte[] buffer, int offset, int size)
         {
-            if (stream == null)
+            if (port == null)
                 throw new ClientDisconnectedException ();
             try {
-                stream.Write (buffer, offset, size);
+                port.Write (buffer, offset, size);
                 BytesWritten += (ulong)size;
             } catch (IOException e) {
                 throw new ServerException (e.Message);
@@ -129,7 +124,7 @@ namespace KRPC.Server.SerialIO
 
         public void Close ()
         {
-            stream = null;
+            port = null;
         }
     }
 }

--- a/core/src/Server/SerialIO/IPort.cs
+++ b/core/src/Server/SerialIO/IPort.cs
@@ -1,0 +1,58 @@
+namespace KRPC.Server.SerialIO
+{
+    /// <summary>
+    /// The operations <see cref="BufferedPort"/> needs from the port it transfers data over.
+    /// Reading and writing are allowed to wait for the hardware, and are called only from the
+    /// threads that <see cref="BufferedPort"/> runs for that purpose.
+    /// </summary>
+    interface IPort
+    {
+        /// <summary>
+        /// Name identifying the port, such as the path of its device.
+        /// </summary>
+        string PortName { get; }
+
+        /// <summary>
+        /// Whether the port is open.
+        /// </summary>
+        bool IsOpen { get; }
+
+        /// <summary>
+        /// How long a read waits for data, in milliseconds, before it gives up and throws
+        /// TimeoutException.
+        /// </summary>
+        int ReadTimeout { get; set; }
+
+        /// <summary>
+        /// Number of bytes the port has received and not yet handed over to a read.
+        /// </summary>
+        int BytesToRead { get; }
+
+        /// <summary>
+        /// Open the port.
+        /// </summary>
+        void Open ();
+
+        /// <summary>
+        /// Close the port.
+        /// </summary>
+        void Close ();
+
+        /// <summary>
+        /// Discard data that the port has received but not yet handed over.
+        /// </summary>
+        void DiscardInBuffer ();
+
+        /// <summary>
+        /// Read up to count bytes into buffer, starting at offset, waiting up to the read timeout
+        /// for the first of them. Returns the number of bytes read, and throws TimeoutException if
+        /// none arrive in time.
+        /// </summary>
+        int Read (byte[] buffer, int offset, int count);
+
+        /// <summary>
+        /// Write count bytes from buffer, starting at offset, waiting until the port has sent them.
+        /// </summary>
+        void Write (byte[] buffer, int offset, int count);
+    }
+}

--- a/core/src/Server/SerialIO/SerialPortAdapter.cs
+++ b/core/src/Server/SerialIO/SerialPortAdapter.cs
@@ -1,0 +1,66 @@
+using System;
+#if NET
+using System.IO.Ports;
+#else
+using KRPC.IO.Ports;
+#endif
+
+namespace KRPC.Server.SerialIO
+{
+    /// <summary>
+    /// Presents a serial port as an <see cref="IPort"/>.
+    /// </summary>
+    sealed class SerialPortAdapter : IPort
+    {
+        readonly SerialPort port;
+
+        public SerialPortAdapter (SerialPort serialPort)
+        {
+            if (serialPort == null)
+                throw new ArgumentNullException (nameof (serialPort));
+            port = serialPort;
+        }
+
+        public string PortName {
+            get { return port.PortName; }
+        }
+
+        public bool IsOpen {
+            get { return port.IsOpen; }
+        }
+
+        public int ReadTimeout {
+            get { return port.ReadTimeout; }
+            set { port.ReadTimeout = value; }
+        }
+
+        public int BytesToRead {
+            get { return port.BytesToRead; }
+        }
+
+        public void Open ()
+        {
+            port.Open ();
+        }
+
+        public void Close ()
+        {
+            port.Close ();
+        }
+
+        public void DiscardInBuffer ()
+        {
+            port.DiscardInBuffer ();
+        }
+
+        public int Read (byte[] buffer, int offset, int count)
+        {
+            return port.Read (buffer, offset, count);
+        }
+
+        public void Write (byte[] buffer, int offset, int count)
+        {
+            port.Write (buffer, offset, count);
+        }
+    }
+}

--- a/core/test/KRPC.Core.Test.csproj
+++ b/core/test/KRPC.Core.Test.csproj
@@ -51,6 +51,8 @@
     <Compile Include="Server\ProtocolBuffers\StreamServerTest.cs" />
     <Compile Include="Server\ProtocolBuffers\StreamStreamTest.cs" />
     <Compile Include="Server\ProtocolBuffers\TestingTools.cs" />
+    <Compile Include="Server\SerialIO\BufferedPortTest.cs" />
+    <Compile Include="Server\SerialIO\ByteBufferTest.cs" />
     <Compile Include="Server\SerialIO\ByteClientTest.cs" />
     <Compile Include="Server\SerialIO\RPCServerTest.cs" />
     <Compile Include="Server\SerialIO\RPCStreamTest.cs" />

--- a/core/test/Server/SerialIO/BufferedPortTest.cs
+++ b/core/test/Server/SerialIO/BufferedPortTest.cs
@@ -1,0 +1,413 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading;
+using KRPC.Server.SerialIO;
+using NUnit.Framework;
+
+namespace KRPC.Test.Server.SerialIO
+{
+    /// <summary>
+    /// A port that stands in for serial hardware. Reads return data that the test has queued, and
+    /// writes take as long as the test asks them to, standing for the time a real port spends
+    /// sending a byte at a time at the configured baud rate.
+    /// </summary>
+    sealed class TestPort : IPort
+    {
+        readonly object dataLock = new object ();
+        readonly Queue<byte[]> toRead = new Queue<byte[]> ();
+        readonly List<byte> written = new List<byte> ();
+
+        public string PortName {
+            get { return "TestPort"; }
+        }
+
+        public bool IsOpen { get; private set; }
+
+        public int ReadTimeout { get; set; }
+
+        public int BytesToRead {
+            get {
+                lock (dataLock) {
+                    var total = 0;
+                    foreach (var data in toRead)
+                        total += data.Length;
+                    return total;
+                }
+            }
+        }
+
+        /// <summary>
+        /// How long each write takes.
+        /// </summary>
+        public int WriteDelay { get; set; }
+
+        /// <summary>
+        /// Set to fail the next read with this exception.
+        /// </summary>
+        public Exception ReadFailure { get; set; }
+
+        /// <summary>
+        /// Set to fail the next write with this exception.
+        /// </summary>
+        public Exception WriteFailure { get; set; }
+
+        public int Reads { get; private set; }
+
+        public int Writes { get; private set; }
+
+        public void Open ()
+        {
+            IsOpen = true;
+        }
+
+        public void Close ()
+        {
+            IsOpen = false;
+        }
+
+        public void DiscardInBuffer ()
+        {
+            lock (dataLock)
+                toRead.Clear ();
+        }
+
+        /// <summary>
+        /// Queue data for the port to hand over on a subsequent read.
+        /// </summary>
+        public void QueueRead (byte[] data)
+        {
+            lock (dataLock) {
+                toRead.Enqueue (data);
+                Monitor.PulseAll (dataLock);
+            }
+        }
+
+        /// <summary>
+        /// Everything that has been written to the port so far.
+        /// </summary>
+        public byte[] Written {
+            get {
+                lock (dataLock)
+                    return written.ToArray ();
+            }
+        }
+
+        public int Read (byte[] buffer, int offset, int count)
+        {
+            lock (dataLock) {
+                if (ReadFailure != null) {
+                    var failure = ReadFailure;
+                    ReadFailure = null;
+                    throw failure;
+                }
+                if (toRead.Count == 0) {
+                    // Stand in for the port waiting for data that does not arrive
+                    Monitor.Wait (dataLock, Math.Max (1, ReadTimeout));
+                    if (toRead.Count == 0)
+                        throw new TimeoutException ();
+                }
+                var data = toRead.Dequeue ();
+                var size = Math.Min (count, data.Length);
+                Array.Copy (data, 0, buffer, offset, size);
+                Reads++;
+                return size;
+            }
+        }
+
+        public void Write (byte[] buffer, int offset, int count)
+        {
+            if (WriteDelay > 0)
+                Thread.Sleep (WriteDelay);
+            lock (dataLock) {
+                if (WriteFailure != null) {
+                    var failure = WriteFailure;
+                    WriteFailure = null;
+                    throw failure;
+                }
+                for (int i = 0; i < count; i++)
+                    written.Add (buffer [offset + i]);
+                Writes++;
+            }
+        }
+    }
+
+    [TestFixture]
+    public class BufferedPortTest
+    {
+        const int timeout = 5000;
+
+        static void WaitFor (Func<bool> condition)
+        {
+            var timer = Stopwatch.StartNew ();
+            while (!condition ()) {
+                if (timer.ElapsedMilliseconds > timeout)
+                    Assert.Fail ("Timed out waiting for the port");
+                Thread.Sleep (1);
+            }
+        }
+
+        [Test]
+        public void NotOpen ()
+        {
+            var port = new BufferedPort (new TestPort ());
+            Assert.AreEqual ("TestPort", port.PortName);
+            Assert.IsFalse (port.IsOpen);
+        }
+
+        [Test]
+        public void OpenAndClose ()
+        {
+            var testPort = new TestPort ();
+            var port = new BufferedPort (testPort);
+            port.Open ();
+            Assert.IsTrue (port.IsOpen);
+            port.Close ();
+            Assert.IsFalse (port.IsOpen);
+            Assert.IsFalse (testPort.IsOpen);
+        }
+
+        [Test]
+        public void ReceivedDataIsBuffered ()
+        {
+            var testPort = new TestPort ();
+            var port = new BufferedPort (testPort);
+            port.Open ();
+            try {
+                testPort.QueueRead (new byte[] { 1, 2, 3 });
+                WaitFor (() => port.BytesAvailable == 3);
+                var buffer = new byte [8];
+                Assert.AreEqual (3, port.Read (buffer, 0, buffer.Length));
+                Assert.AreEqual (new byte[] { 1, 2, 3, 0, 0, 0, 0, 0 }, buffer);
+                Assert.AreEqual (0, port.BytesAvailable);
+            } finally {
+                port.Close ();
+            }
+        }
+
+        /// <summary>
+        /// Whatever the port received before the server opened it is left over from something
+        /// else, and must not be taken for the start of a client's first message.
+        /// </summary>
+        [Test]
+        public void OpeningDiscardsStaleData ()
+        {
+            var testPort = new TestPort ();
+            testPort.QueueRead (new byte[] { 1, 2, 3 });
+            var port = new BufferedPort (testPort);
+            port.Open ();
+            try {
+                Thread.Sleep (50);
+                Assert.AreEqual (0, port.BytesAvailable);
+            } finally {
+                port.Close ();
+            }
+        }
+
+        [Test]
+        public void ReadWithNothingReceived ()
+        {
+            var testPort = new TestPort ();
+            var port = new BufferedPort (testPort);
+            port.Open ();
+            try {
+                Assert.AreEqual (0, port.BytesAvailable);
+                Assert.AreEqual (0, port.Read (new byte [8], 0, 8));
+            } finally {
+                port.Close ();
+            }
+        }
+
+        /// <summary>
+        /// The reason the port is buffered at all: the caller runs the game loop, so a write must
+        /// return to it long before the port has finished sending the data.
+        /// </summary>
+        [Test]
+        public void WriteDoesNotWaitForThePort ()
+        {
+            var testPort = new TestPort ();
+            testPort.WriteDelay = 500;
+            var port = new BufferedPort (testPort);
+            port.Open ();
+            try {
+                var timer = Stopwatch.StartNew ();
+                for (int i = 0; i < 4; i++)
+                    port.Write (new byte[] { (byte)i }, 0, 1);
+                var elapsed = timer.ElapsedMilliseconds;
+                Assert.Less (elapsed, 250, "Writing waited for the port to send the data");
+                WaitFor (() => testPort.Written.Length == 4);
+            } finally {
+                port.Close ();
+            }
+        }
+
+        [Test]
+        public void WrittenDataArrivesInOrder ()
+        {
+            var testPort = new TestPort ();
+            var port = new BufferedPort (testPort);
+            port.Open ();
+            try {
+                for (int i = 0; i < 64; i++)
+                    port.Write (new byte[] { (byte)i }, 0, 1);
+                WaitFor (() => testPort.Written.Length == 64);
+                var written = testPort.Written;
+                for (int i = 0; i < 64; i++)
+                    Assert.AreEqual ((byte)i, written [i]);
+            } finally {
+                port.Close ();
+            }
+        }
+
+        [Test]
+        public void WritePartOfABuffer ()
+        {
+            var testPort = new TestPort ();
+            var port = new BufferedPort (testPort);
+            port.Open ();
+            try {
+                port.Write (new byte[] { 1, 2, 3, 4, 5 }, 1, 3);
+                WaitFor (() => testPort.Written.Length == 3);
+                Assert.AreEqual (new byte[] { 2, 3, 4 }, testPort.Written);
+            } finally {
+                port.Close ();
+            }
+        }
+
+        /// <summary>
+        /// Data handed to Write before the port is closed must still be sent, so that a response
+        /// the server has already produced is not lost when the server stops.
+        /// </summary>
+        [Test]
+        public void ClosingSendsWhatIsLeft ()
+        {
+            var testPort = new TestPort ();
+            testPort.WriteDelay = 20;
+            var port = new BufferedPort (testPort);
+            port.Open ();
+            for (int i = 0; i < 4; i++)
+                port.Write (new byte[] { (byte)i }, 0, 1);
+            port.Close ();
+            Assert.AreEqual (4, testPort.Written.Length);
+        }
+
+        /// <summary>
+        /// A port that never finishes sending must not hold up the caller indefinitely.
+        /// </summary>
+        [Test]
+        public void ClosingGivesUpOnAStuckPort ()
+        {
+            var testPort = new TestPort ();
+            testPort.WriteDelay = 30000;
+            var port = new BufferedPort (testPort);
+            port.Open ();
+            port.Write (new byte[] { 1 }, 0, 1);
+            var timer = Stopwatch.StartNew ();
+            port.Close ();
+            Assert.Less (timer.ElapsedMilliseconds, timeout, "Closing waited for the stuck port");
+            Assert.IsFalse (port.IsOpen);
+        }
+
+        /// <summary>
+        /// A caller writing faster than the port can send, for long enough, must not grow the
+        /// send buffer without limit. The port cannot pace the caller, so it fails instead.
+        /// </summary>
+        [Test]
+        public void OverfillingTheSendBufferFailsThePort ()
+        {
+            var testPort = new TestPort ();
+            testPort.WriteDelay = 30000;
+            var port = new BufferedPort (testPort);
+            port.Open ();
+            try {
+                var chunk = new byte [64 * 1024];
+                Assert.Throws<System.IO.IOException> (() => {
+                    for (int i = 0; i < 32; i++)
+                        port.Write (chunk, 0, chunk.Length);
+                });
+                Assert.IsFalse (port.IsOpen);
+            } finally {
+                port.Close ();
+            }
+        }
+
+        [Test]
+        public void CannotBeOpenedTwice ()
+        {
+            var port = new BufferedPort (new TestPort ());
+            port.Open ();
+            port.Close ();
+            Assert.Throws<InvalidOperationException> (() => port.Open ());
+        }
+
+        [Test]
+        public void FailedReadClosesThePort ()
+        {
+            var testPort = new TestPort ();
+            testPort.ReadFailure = new System.IO.IOException ("read failed");
+            var port = new BufferedPort (testPort);
+            port.Open ();
+            try {
+                // Reads are only issued for data the port holds, so give it some to provoke the
+                // failing read
+                testPort.QueueRead (new byte[] { 1 });
+                WaitFor (() => !port.IsOpen);
+                Assert.Throws<System.IO.IOException> (() => port.Read (new byte [8], 0, 8));
+                Assert.Throws<System.IO.IOException> (() => port.Write (new byte[] { 1 }, 0, 1));
+            } finally {
+                port.Close ();
+            }
+        }
+
+        [Test]
+        public void FailedWriteClosesThePort ()
+        {
+            var testPort = new TestPort ();
+            var port = new BufferedPort (testPort);
+            port.Open ();
+            try {
+                testPort.WriteFailure = new System.IO.IOException ("write failed");
+                port.Write (new byte[] { 1 }, 0, 1);
+                WaitFor (() => !port.IsOpen);
+            } finally {
+                port.Close ();
+            }
+        }
+
+        /// <summary>
+        /// Reading from and writing to the port at the same time, from the thread that would be
+        /// running the game, must lose nothing in either direction.
+        /// </summary>
+        [Test]
+        public void ReadAndWriteTogether ()
+        {
+            var testPort = new TestPort ();
+            var port = new BufferedPort (testPort);
+            port.Open ();
+            try {
+                var received = new List<byte> ();
+                var buffer = new byte [256];
+                for (int i = 0; i < 200; i++) {
+                    testPort.QueueRead (new byte[] { (byte)i });
+                    port.Write (new byte[] { (byte)i }, 0, 1);
+                    var read = port.Read (buffer, 0, buffer.Length);
+                    for (int j = 0; j < read; j++)
+                        received.Add (buffer [j]);
+                }
+                WaitFor (() => testPort.Written.Length == 200);
+                WaitFor (() => {
+                    var read = port.Read (buffer, 0, buffer.Length);
+                    for (int j = 0; j < read; j++)
+                        received.Add (buffer [j]);
+                    return received.Count == 200;
+                });
+                for (int i = 0; i < 200; i++) {
+                    Assert.AreEqual ((byte)i, received [i]);
+                    Assert.AreEqual ((byte)i, testPort.Written [i]);
+                }
+            } finally {
+                port.Close ();
+            }
+        }
+    }
+}

--- a/core/test/Server/SerialIO/ByteBufferTest.cs
+++ b/core/test/Server/SerialIO/ByteBufferTest.cs
@@ -1,0 +1,185 @@
+using System;
+using KRPC.Server.SerialIO;
+using NUnit.Framework;
+
+namespace KRPC.Test.Server.SerialIO
+{
+    [TestFixture]
+    public class ByteBufferTest
+    {
+        static byte[] Sequence (int start, int length)
+        {
+            var data = new byte [length];
+            for (int i = 0; i < length; i++)
+                data [i] = (byte)((start + i) % 256);
+            return data;
+        }
+
+        [Test]
+        public void Empty ()
+        {
+            var buffer = new ByteBuffer ();
+            Assert.AreEqual (0, buffer.Length);
+            Assert.AreEqual (0, buffer.Take (new byte [16], 0, 16));
+        }
+
+        [Test]
+        public void AppendAndTake ()
+        {
+            var buffer = new ByteBuffer ();
+            buffer.Append (new byte[] { 1, 2, 3, 4 }, 0, 4);
+            Assert.AreEqual (4, buffer.Length);
+            var result = new byte [4];
+            Assert.AreEqual (4, buffer.Take (result, 0, 4));
+            Assert.AreEqual (new byte[] { 1, 2, 3, 4 }, result);
+            Assert.AreEqual (0, buffer.Length);
+        }
+
+        [Test]
+        public void AppendPartOfABuffer ()
+        {
+            var buffer = new ByteBuffer ();
+            buffer.Append (new byte[] { 1, 2, 3, 4, 5 }, 1, 3);
+            var result = new byte [3];
+            Assert.AreEqual (3, buffer.Take (result, 0, 3));
+            Assert.AreEqual (new byte[] { 2, 3, 4 }, result);
+        }
+
+        [Test]
+        public void TakeIntoPartOfABuffer ()
+        {
+            var buffer = new ByteBuffer ();
+            buffer.Append (new byte[] { 1, 2 }, 0, 2);
+            var result = new byte [4];
+            Assert.AreEqual (2, buffer.Take (result, 1, 3));
+            Assert.AreEqual (new byte[] { 0, 1, 2, 0 }, result);
+        }
+
+        [Test]
+        public void TakeMoreThanIsHeld ()
+        {
+            var buffer = new ByteBuffer ();
+            buffer.Append (new byte[] { 1, 2, 3 }, 0, 3);
+            var result = new byte [8];
+            Assert.AreEqual (3, buffer.Take (result, 0, 8));
+            Assert.AreEqual (new byte[] { 1, 2, 3, 0, 0, 0, 0, 0 }, result);
+            Assert.AreEqual (0, buffer.Length);
+        }
+
+        [Test]
+        public void TakeLessThanIsHeld ()
+        {
+            var buffer = new ByteBuffer ();
+            buffer.Append (new byte[] { 1, 2, 3, 4, 5 }, 0, 5);
+            var result = new byte [2];
+            Assert.AreEqual (2, buffer.Take (result, 0, 2));
+            Assert.AreEqual (new byte[] { 1, 2 }, result);
+            Assert.AreEqual (3, buffer.Length);
+            result = new byte [3];
+            Assert.AreEqual (3, buffer.Take (result, 0, 3));
+            Assert.AreEqual (new byte[] { 3, 4, 5 }, result);
+            Assert.AreEqual (0, buffer.Length);
+        }
+
+        [Test]
+        public void OrderIsPreservedAcrossAppends ()
+        {
+            var buffer = new ByteBuffer ();
+            buffer.Append (new byte[] { 1, 2 }, 0, 2);
+            buffer.Append (new byte[] { 3 }, 0, 1);
+            buffer.Append (new byte[] { 4, 5, 6 }, 0, 3);
+            var result = new byte [6];
+            Assert.AreEqual (6, buffer.Take (result, 0, 6));
+            Assert.AreEqual (new byte[] { 1, 2, 3, 4, 5, 6 }, result);
+        }
+
+        [Test]
+        public void Clear ()
+        {
+            var buffer = new ByteBuffer ();
+            buffer.Append (new byte[] { 1, 2, 3 }, 0, 3);
+            buffer.Clear ();
+            Assert.AreEqual (0, buffer.Length);
+            buffer.Append (new byte[] { 4 }, 0, 1);
+            var result = new byte [1];
+            Assert.AreEqual (1, buffer.Take (result, 0, 1));
+            Assert.AreEqual (new byte[] { 4 }, result);
+        }
+
+        /// <summary>
+        /// Data larger than the buffer starts out at must be held in full.
+        /// </summary>
+        [Test]
+        public void GrowsForDataLargerThanItself ()
+        {
+            var buffer = new ByteBuffer ();
+            var data = Sequence (0, 100 * 1024);
+            buffer.Append (data, 0, data.Length);
+            Assert.AreEqual (data.Length, buffer.Length);
+            var result = new byte [data.Length];
+            Assert.AreEqual (data.Length, buffer.Take (result, 0, result.Length));
+            Assert.AreEqual (data, result);
+        }
+
+        /// <summary>
+        /// Filling and draining repeatedly moves the data through the backing array many times
+        /// over, which must compact rather than grow it or run off the end.
+        /// </summary>
+        [Test]
+        public void RepeatedFillAndDrain ()
+        {
+            var buffer = new ByteBuffer ();
+            var chunk = new byte [1000];
+            var result = new byte [1000];
+            for (int i = 0; i < 1000; i++) {
+                Array.Copy (Sequence (i, chunk.Length), chunk, chunk.Length);
+                buffer.Append (chunk, 0, chunk.Length);
+                Assert.AreEqual (chunk.Length, buffer.Take (result, 0, result.Length));
+                Assert.AreEqual (chunk, result);
+                Assert.AreEqual (0, buffer.Length);
+            }
+        }
+
+        /// <summary>
+        /// Data appended while earlier data is still held must not disturb it, whether the append
+        /// fits behind it or forces the buffer to be compacted or grown.
+        /// </summary>
+        [Test]
+        public void AppendWhileDataIsStillHeld ()
+        {
+            var buffer = new ByteBuffer ();
+            var chunk = Sequence (0, 3 * 1024);
+            for (int i = 0; i < 10; i++)
+                buffer.Append (chunk, 0, chunk.Length);
+            Assert.AreEqual (10 * chunk.Length, buffer.Length);
+            var result = new byte [chunk.Length];
+            for (int i = 0; i < 10; i++) {
+                Assert.AreEqual (chunk.Length, buffer.Take (result, 0, result.Length));
+                Assert.AreEqual (chunk, result);
+            }
+            Assert.AreEqual (0, buffer.Length);
+        }
+
+        /// <summary>
+        /// Taking part of the held data leaves the rest at an offset into the backing array, which
+        /// a following append has to account for.
+        /// </summary>
+        [Test]
+        public void AppendAfterAPartialTake ()
+        {
+            var buffer = new ByteBuffer ();
+            buffer.Append (Sequence (0, 6 * 1024), 0, 6 * 1024);
+            var taken = new byte [5 * 1024];
+            Assert.AreEqual (taken.Length, buffer.Take (taken, 0, taken.Length));
+            Assert.AreEqual (Sequence (0, taken.Length), taken);
+            buffer.Append (Sequence (100, 6 * 1024), 0, 6 * 1024);
+            Assert.AreEqual (1024 + 6 * 1024, buffer.Length);
+            var result = new byte [1024];
+            Assert.AreEqual (result.Length, buffer.Take (result, 0, result.Length));
+            Assert.AreEqual (Sequence (5 * 1024, 1024), result);
+            result = new byte [6 * 1024];
+            Assert.AreEqual (result.Length, buffer.Take (result, 0, result.Length));
+            Assert.AreEqual (Sequence (100, 6 * 1024), result);
+        }
+    }
+}

--- a/core/test/Server/SerialIO/ByteClientTest.cs
+++ b/core/test/Server/SerialIO/ByteClientTest.cs
@@ -14,9 +14,9 @@ namespace KRPC.Test.Server.SerialIO
         [Test]
         public void Equality ()
         {
-            var clientA = new ByteClient (new SerialPort ());
+            var clientA = new ByteClient (new BufferedPort (new SerialPortAdapter (new SerialPort ())));
             ByteClient clientA2 = clientA;
-            var clientB = new ByteClient (new SerialPort ());
+            var clientB = new ByteClient (new BufferedPort (new SerialPortAdapter (new SerialPort ())));
             Assert.IsTrue (clientA.Equals (clientA));
             Assert.IsFalse (clientA.Equals (clientB));
             Assert.IsTrue (clientA == clientA2);
@@ -28,7 +28,7 @@ namespace KRPC.Test.Server.SerialIO
         [Test]
         public void NotConnected ()
         {
-            var client = new ByteClient (new SerialPort ());
+            var client = new ByteClient (new BufferedPort (new SerialPortAdapter (new SerialPort ())));
             Assert.IsFalse (client.Connected);
             Assert.AreEqual (client.Guid.ToString (), client.Name);
             Assert.AreEqual (new SerialPort ().PortName, client.Address);

--- a/doc/src/cnano/client.rst
+++ b/doc/src/cnano/client.rst
@@ -144,6 +144,13 @@ configured to use the serial port protocol (instead of the default TCP/IP protoc
 done from the in-game server configuration window, which also allows settings such as
 the port name, baud rate and parity settings.
 
+.. note:: A serial port carries data far more slowly than the game produces it, and the server
+          drops a connection that produces more data than the port can carry for a sustained
+          period. See :ref:`communication-protocol-serialio-buffering` for the limits and how to
+          stay within them. The client blocks while waiting for data from the server, with no
+          timeout, so a call that is never answered, for example because the connection was
+          dropped, never returns.
+
 Linking
 ^^^^^^^
 

--- a/doc/src/communication-protocols/serialio.rst
+++ b/doc/src/communication-protocols/serialio.rst
@@ -98,6 +98,10 @@ connection, a client must do the following:
    If the ``status`` field is set to ``ConnectionResponse.OK`` then the connection was successful.
    If not, the ``message`` field contains a description of what went wrong.
 
+   The server waits up to 3 seconds for the complete connection request message to arrive after
+   its first bytes are received. If it does not arrive in time, the server responds with the
+   ``TIMEOUT`` status.
+
 Receiving Stream Updates
 ------------------------
 
@@ -115,6 +119,28 @@ See :doc:`messages`.
 To send a procedure call, wrap the ``Request`` message in a ``MultiplexedRequest`` and set its
 ``request`` field. Receive the result as a ``MultiplexedResponse`` and read the ``Response`` from
 its ``response`` field.
+
+.. _communication-protocol-serialio-buffering:
+
+Buffering and Data Rates
+------------------------
+
+A serial port carries data far more slowly than the game produces it. At the default 9600 baud it
+carries roughly a thousand bytes per second. The server therefore buffers up to a megabyte of data
+in each direction, and the two directions behave differently when their buffer fills:
+
+* Data received from the port is buffered until the game reads it. When the buffer fills, the
+  server stops reading from the port until the game catches up. Nothing is lost, but the client
+  sees the port carry its data more slowly.
+
+* Data written by the game is buffered until the port has sent it. When this buffer fills, which
+  means the game has been producing data faster than the port can send for a sustained period,
+  the server drops the connection and stops. It can be started again from the in-game
+  configuration window. The easiest way to hit this limit is to request streams whose updates add
+  up to more than the port's data rate, as an update to a stream is sent every game update.
+
+To stay within the port's capacity, keep the number and size of streams small relative to the baud
+rate, or configure a higher baud rate.
 
 Examples
 --------

--- a/tools/build/client_test.bzl
+++ b/tools/build/client_test.bzl
@@ -47,7 +47,10 @@ def _impl(ctx):
             'echo "Server port = $SERVER_PORT"',
             'echo "Client port = $CLIENT_PORT"',
         ])
-        server_args = '--type=serialio --port="$SERVER_PORT"'
+
+        # Serial transfers run on background threads whose failures are only visible in the
+        # server's log, so capture the detail needed to diagnose them
+        server_args = '--type=serialio --debug --port="$SERVER_PORT"'
         get_server_settings = [
             # The virtual serial link (server PTY <-> socat <-> client PTY) is not always ready the
             # instant the server reports started, so wait briefly for it to settle before the client
@@ -59,6 +62,11 @@ def _impl(ctx):
 
     sub_commands.extend([
         'echo "" > %s' % stdout,
+        # The server's output goes to a file that never reaches the test log, which leaves a
+        # server-side failure invisible: the client just hangs until the test times out and is
+        # killed. Dump the file when the test fails, and from a trap for the timeout case, since
+        # the harness delivers SIGTERM when it times the test out.
+        'trap \'echo "=== server output ==="; cat %s\' TERM' % stdout,
         # Run the server directly from this test's runfiles tree; its
         # launcher finds the dotnet runtime and assemblies via RUNFILES_DIR,
         # and the dotnet host's relative probing paths resolve the
@@ -71,6 +79,7 @@ def _impl(ctx):
         "(cd test-executable.runfiles/_main/%s.runfiles/_main; %s ../../%s)" % (ctx.executable.test_executable.short_path, test_env, ctx.executable.test_executable.basename),
         "RESULT=$?",
         "kill $SERVER_PID",
+        'if [ $RESULT -ne 0 ]; then echo "=== server output ==="; cat %s; fi' % stdout,
         "exit $RESULT",
     ])
     ctx.actions.write(


### PR DESCRIPTION
**Problem.** An RPC over a serial connection freezes the game for as long as the transfer takes. A serial port carries one byte at a time at the configured baud rate, and the server ran transfers from the thread that runs the game. On Windows a write waits for the whole overlapped operation to complete, so the freeze is the full transfer; on POSIX a write returns once the data reaches the terminal, which is why the wait showed up on one platform and not the other.

**Fix.** Serial ports are now owned by a `BufferedPort` that runs a thread for each direction, moving data between the port and in-memory buffers. Reads and writes from the game thread only touch the buffers and return straight away. Both directions bound their buffering at 1 MB: reading pauses and leaves data with the port until the game catches up, while writing faster than the port can send for long enough fails the port and drops the connection, since queued writes have nowhere else to live. A failure on either background thread marks the port unusable and the server stops cleanly on its next update.

Fixes #458
