### PR TITLE
Control Kerbals on EVA through the vessel controls

### DIFF
--- a/doc/order.txt
+++ b/doc/order.txt
@@ -496,6 +496,11 @@ SpaceCenter.Control.GetActionGroupActions
 SpaceCenter.Control.AddNode
 SpaceCenter.Control.Nodes
 SpaceCenter.Control.RemoveNodes
+SpaceCenter.Control.Airlock
+SpaceCenter.Control.Board
+SpaceCenter.Control.Ladder
+SpaceCenter.Control.GrabLadder
+SpaceCenter.Control.ReleaseLadder
 SpaceCenter.ActionGroupAction
 SpaceCenter.ActionGroupAction.Part
 SpaceCenter.ActionGroupAction.Module
@@ -562,6 +567,7 @@ SpaceCenter.CrewMember.Trait
 SpaceCenter.CrewMember.Gender
 SpaceCenter.CrewMember.RosterStatus
 SpaceCenter.CrewMember.Part
+SpaceCenter.CrewMember.EVA
 SpaceCenter.CrewMember.SuitType
 SpaceCenter.CrewMember.CareerLogFlights
 SpaceCenter.CrewMember.CareerLogTypes

--- a/doc/src/dictionary.txt
+++ b/doc/src/dictionary.txt
@@ -84,6 +84,7 @@ integration
 internet
 intra
 javac
+jetpack
 jitter
 kOS
 kN

--- a/service/SpaceCenter/CHANGELOG.md
+++ b/service/SpaceCenter/CHANGELOG.md
@@ -9,6 +9,8 @@
     raises an exception without launching (#1017)
 
 - Vessels and crew
+  - Add `CrewMember.EVA`, which sends a Kerbal outside through the hatch of the part it is
+    in and returns the vessel it becomes (#319)
   - Add `Vessel.Terminate`, which removes a vessel and its parts from the game without
     recovering anything, as terminating it from the tracking station does. Its crew are
     reported missing. The active vessel cannot be terminated (#1034)
@@ -65,6 +67,10 @@
     and the rotation inputs turn its jetpack, at a rate proportional to the input.
     `Control.RCS` deploys and stows the jetpack, and `Control.Lights` switches the helmet
     lamp (#319)
+  - Add `Control.Board`, which climbs a Kerbal on EVA into the part whose hatch it is
+    standing at, and `Control.Airlock`, which reports that part. Add `Control.GrabLadder`
+    and `Control.ReleaseLadder` for the ladder it is alongside, and `Control.Ladder`, which
+    reports the ladder it is holding (#319)
   - Setting `Control.StageLock` now leaves the in-game Alt+L shortcut in step with it, so the
     next press of Alt+L locks or unlocks staging rather than being absorbed (#1022)
 

--- a/service/SpaceCenter/CHANGELOG.md
+++ b/service/SpaceCenter/CHANGELOG.md
@@ -59,6 +59,12 @@
     has nothing that can stall; it now reports no stall (#1032)
 
 - Control
+  - A Kerbal on EVA can now be driven through `Vessel.Control`. `Control.Forward` and
+    `Control.Right` walk it about, relative to the direction it is facing, and all three
+    translation inputs fly its jetpack once deployed. `Control.Yaw` steers it as it walks,
+    and the rotation inputs turn its jetpack, at a rate proportional to the input.
+    `Control.RCS` deploys and stows the jetpack, and `Control.Lights` switches the helmet
+    lamp (#319)
   - Setting `Control.StageLock` now leaves the in-game Alt+L shortcut in step with it, so the
     next press of Alt+L locks or unlocks staging rather than being absorbed (#1022)
 

--- a/service/SpaceCenter/src/EVAAddon.cs
+++ b/service/SpaceCenter/src/EVAAddon.cs
@@ -1,0 +1,352 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using UnityEngine;
+
+namespace KRPC.SpaceCenter
+{
+    /// <summary>
+    /// Addon that walks a kerbal on EVA, and flies its jetpack, from the control inputs
+    /// set through <see cref="Services.Control"/>. The translation inputs move the kerbal
+    /// and the rotation inputs turn it, so the same inputs that fly a craft also drive a
+    /// kerbal.
+    /// </summary>
+    /// <remarks>
+    /// A kerbal is moved by its <c>KerbalEVA</c> module, which takes no control input from
+    /// the vessel's flight control state. Its <c>FixedUpdate</c> zeroes a set of movement
+    /// command fields, fills them from the keyboard and joystick, and then runs the state
+    /// machine that consumes them and does the moving - all in one call. A command written
+    /// from any other <c>FixedUpdate</c> is therefore either zeroed before the state
+    /// machine reads it or written after it has already run.
+    ///
+    /// The commands are instead applied from inside that window, by prepending a callback
+    /// to the <c>OnFixedUpdate</c> of every state of the kerbal's state machine.
+    /// <c>KerbalFSM</c> runs the current state's <c>OnFixedUpdate</c> before checking that
+    /// state's transitions, so the callback runs after the module has taken keyboard input
+    /// and before anything has read the result. The command fields are protected, so they
+    /// are read and written by reflection.
+    ///
+    /// The commands are only written while kRPC has a non-zero input, so that a kerbal
+    /// being flown from the keyboard is left alone.
+    /// </remarks>
+    [KSPAddon (KSPAddon.Startup.Flight, false)]
+    public sealed class EVAAddon : MonoBehaviour
+    {
+        /// <summary>
+        /// The movement commands a <c>KerbalEVA</c> fills in for its state machine. They are
+        /// protected, so they are accessed by reflection.
+        /// </summary>
+        static class Commands
+        {
+            /// <summary>Direction to move in, in world space. Magnitude is ignored.</summary>
+            public static readonly FieldInfo Move = Find ("tgtRpos");
+            /// <summary>Direction the kerbal is holding, in world space.</summary>
+            public static readonly FieldInfo Facing = Find ("tgtFwd");
+            /// <summary>Up axis the kerbal is holding, in world space.</summary>
+            public static readonly FieldInfo FacingUp = Find ("tgtUp");
+            /// <summary>Climbing direction while on a ladder, in world space.</summary>
+            public static readonly FieldInfo Climb = Find ("ladderTgtRPos");
+            /// <summary>Jetpack translation demand, in world space.</summary>
+            public static readonly FieldInfo Translation = Find ("packTgtRPos");
+            /// <summary>Jetpack rotation demand, in world space, applied as torque.</summary>
+            public static readonly FieldInfo Torque = Find ("cmdRot");
+            /// <summary>
+            /// Whether rotation is being commanded directly. Holds off the attitude
+            /// controller that would otherwise fly the kerbal back to the orientation it
+            /// is holding, and which owns the rotation demand when it runs.
+            /// </summary>
+            public static readonly FieldInfo RotatingManually = Find ("manualAxisControl");
+            /// <summary>Parachute steering demand; x leans forward, y leans right.</summary>
+            public static readonly FieldInfo ParachuteSteering = Find ("parachuteInput");
+
+            /// <summary>The states of a kerbal's state machine.</summary>
+            public static readonly FieldInfo States =
+                typeof (KerbalFSM).GetField ("States", BindingFlags.NonPublic | BindingFlags.Instance);
+
+            static FieldInfo Find (string name)
+            {
+                return typeof (KerbalEVA).GetField (name, BindingFlags.NonPublic | BindingFlags.Instance);
+            }
+
+            /// <summary>
+            /// Whether every field was found, and so whether a kerbal can be driven at all.
+            /// </summary>
+            public static bool Available {
+                get {
+                    return Move != null && Facing != null && FacingUp != null &&
+                        Climb != null && Translation != null && Torque != null &&
+                        RotatingManually != null && ParachuteSteering != null && States != null;
+                }
+            }
+        }
+
+        /// <summary>
+        /// The kerbals whose state machines have had the callback installed, keyed by
+        /// vessel id. The module is held so that a kerbal rebuilt in place - which gets a
+        /// new state machine, and so loses the callback - is detected and hooked again.
+        /// </summary>
+        static readonly IDictionary<Guid, KerbalEVA> hooked = new Dictionary<Guid, KerbalEVA> ();
+
+        /// <summary>
+        /// The kerbals whose rotation kRPC is driving, by vessel id. Held so that the
+        /// attitude controller is only taken from, and handed back to, kerbals kRPC has
+        /// actually turned, leaving one being flown from the keyboard alone.
+        /// </summary>
+        static readonly HashSet<Guid> rotating = new HashSet<Guid> ();
+
+        /// <summary>
+        /// The movement mode each kerbal kRPC is walking was in beforehand, by vessel id.
+        /// Walking needs the game's first-person mode, and the player may have chosen the
+        /// other one, so the mode is put back when the walk ends.
+        /// </summary>
+        static readonly IDictionary<Guid, bool> walkedMovementMode = new Dictionary<Guid, bool> ();
+
+        /// <summary>
+        /// The rate below which a kerbal counts as having stopped rotating, in radians per
+        /// second.
+        /// </summary>
+        const float stoppedRotationRate = 0.05f;
+
+        static bool loggedUnavailable;
+
+        /// <summary>
+        /// Wake the addon.
+        /// </summary>
+        public void Awake ()
+        {
+            Clear ();
+            GameEvents.onVesselDestroy.Add (OnVesselDestroy);
+        }
+
+        /// <summary>
+        /// Destroy the addon.
+        /// </summary>
+        public void OnDestroy ()
+        {
+            GameEvents.onVesselDestroy.Remove (OnVesselDestroy);
+            Clear ();
+        }
+
+        static void Clear ()
+        {
+            hooked.Clear ();
+            rotating.Clear ();
+            walkedMovementMode.Clear ();
+        }
+
+        void OnVesselDestroy (Vessel vessel)
+        {
+            hooked.Remove (vessel.id);
+            rotating.Remove (vessel.id);
+            walkedMovementMode.Remove (vessel.id);
+        }
+
+        /// <summary>
+        /// Install the callback on every kerbal on EVA. A kerbal's state machine is built
+        /// when its module starts, so this cannot be done once at scene load.
+        /// </summary>
+        public void FixedUpdate ()
+        {
+            if (!FlightGlobals.ready)
+                return;
+            foreach (var vessel in FlightGlobals.VesselsLoaded) {
+                var eva = vessel.evaController;
+                if (eva == null || eva.fsm == null)
+                    continue;
+                KerbalEVA existing;
+                if (hooked.TryGetValue (vessel.id, out existing) && ReferenceEquals (existing, eva))
+                    continue;
+                if (Hook (eva))
+                    hooked [vessel.id] = eva;
+            }
+        }
+
+        /// <summary>
+        /// Prepend the callback to every state of a kerbal's state machine, so that it runs
+        /// whichever state the kerbal is in and before that state acts on the commands.
+        /// </summary>
+        static bool Hook (KerbalEVA eva)
+        {
+            if (!Commands.Available) {
+                LogUnavailableOnce ();
+                return false;
+            }
+            var states = Commands.States.GetValue (eva.fsm) as List<KFSMState>;
+            if (states == null || states.Count == 0)
+                return false;
+            KFSMCallback callback = () => Apply (eva);
+            foreach (var state in states)
+                state.OnFixedUpdate = (KFSMCallback)Delegate.Combine (callback, state.OnFixedUpdate);
+            return true;
+        }
+
+        static void LogUnavailableOnce ()
+        {
+            if (loggedUnavailable)
+                return;
+            loggedUnavailable = true;
+            KRPC.Utils.Logger.WriteLine (
+                "EVAAddon: failed to find the KerbalEVA movement command fields; " +
+                "kerbals on EVA cannot be controlled",
+                KRPC.Utils.Logger.Severity.Warning);
+        }
+
+        /// <summary>
+        /// Apply the vessel's control inputs to a kerbal, as the commands its state machine
+        /// is about to act on.
+        /// </summary>
+        static void Apply (KerbalEVA eva)
+        {
+            var vessel = eva.vessel;
+            if (vessel == null || vessel.packed)
+                return;
+            var inputs = PilotAddon.Get (vessel);
+            var transform = eva.transform;
+
+            // On foot the kerbal walks; off it, the jetpack flies it. The two are driven by
+            // the same inputs, and which one has any effect is left to the game: it walks
+            // the kerbal only while it is on a surface, and thrusts only while the jetpack
+            // is deployed.
+            var onFoot = vessel.LandedOrSplashed;
+            var walking = onFoot && (inputs.Forward != 0f || inputs.Right != 0f);
+
+            // Translation in the kerbal's own frame, matching the game's own EVA
+            // translation axes.
+            var translate = transform.forward * inputs.Forward + transform.right * inputs.Right +
+                            transform.up * inputs.Up;
+            if (translate != Vector3.zero)
+                Set (Commands.Translation, eva, Get (Commands.Translation, eva) + translate);
+
+            // On foot a kerbal can only turn, and only while it is walking, and on a
+            // ladder it is held by its hands and cannot turn at all, so the rotation
+            // inputs are the free-flying jetpack's alone. On a ladder it also cannot be
+            // stopped, so trying would leave the torque command latched on against
+            // whatever motion the ladder imposes.
+            if (onFoot || eva.OnALadder)
+                ReleaseRotation (eva);
+            else
+                Rotate (eva, transform.up * inputs.Yaw + transform.forward * inputs.Roll -
+                             transform.right * inputs.Pitch);
+
+            if (walking)
+                Walk (eva, inputs.Forward, inputs.Right, inputs.Yaw);
+            else
+                ReleaseWalk (eva);
+
+            if (inputs.Forward != 0f || inputs.Right != 0f) {
+                Set (Commands.Climb, eva, Get (Commands.Climb, eva) +
+                     transform.up * inputs.Forward + transform.right * inputs.Right);
+                Steer (eva, inputs.Forward, inputs.Right);
+            }
+        }
+
+        /// <summary>
+        /// Turn the kerbal with its jetpack, at a rate proportional to the input and up to
+        /// its turn rate for a full one.
+        /// </summary>
+        /// <remarks>
+        /// The kerbal's own attitude controller owns the jetpack's rotation demand and holds
+        /// the kerbal at a fixed orientation, so it has to be held off for as long as the
+        /// kerbal is being turned. Its demand is a torque, and a kerbal has so little
+        /// inertia that a steady torque would wind it up to an absurd rate within a second,
+        /// so the demand is closed around the kerbal's own rotation rate here rather than
+        /// passed straight through. When the input stops, the kerbal is brought to a halt
+        /// the same way before its attitude controller is handed the orientation it ended up
+        /// at, to hold.
+        /// </remarks>
+        static void Rotate (KerbalEVA eva, Vector3 rotate)
+        {
+            var id = eva.vessel.id;
+            if (rotate == Vector3.zero && !rotating.Contains (id))
+                return;
+            var rigidbody = eva.part.Rigidbody;
+            if (rigidbody == null)
+                return;
+            var error = rotate * eva.turnRate - rigidbody.angularVelocity;
+            if (rotate == Vector3.zero && error.magnitude < stoppedRotationRate) {
+                ReleaseRotation (eva);
+                return;
+            }
+            Set (Commands.Torque, eva, Vector3.ClampMagnitude (error, 1f));
+            Commands.RotatingManually.SetValue (eva, true);
+            rotating.Add (id);
+        }
+
+        /// <summary>
+        /// Give the kerbal's attitude controller its orientation back, to hold from here on.
+        /// </summary>
+        static void ReleaseRotation (KerbalEVA eva)
+        {
+            if (!rotating.Remove (eva.vessel.id))
+                return;
+            Commands.RotatingManually.SetValue (eva, false);
+            Set (Commands.Facing, eva, eva.transform.forward);
+            Set (Commands.FacingUp, eva, eva.transform.up);
+        }
+
+        /// <summary>
+        /// Walk the kerbal in the horizontal plane, relative to the direction it is facing,
+        /// and steer it as it goes.
+        /// </summary>
+        /// <remarks>
+        /// The direction is taken from the heading the kerbal is holding rather than from
+        /// which way it happens to be pointing at this instant, so that walking sideways is
+        /// a straight line rather than a curve that feeds its own turn. The kerbal is put
+        /// into the game's first-person movement mode for as long as it is being walked,
+        /// because the other mode moves it along its nose and relative to the camera, which
+        /// makes both sideways movement and a repeatable heading impossible. The mode it
+        /// was in is put back by <see cref="ReleaseWalk"/> when the walk ends.
+        /// </remarks>
+        static void Walk (KerbalEVA eva, float forward, float right, float yaw)
+        {
+            var up = eva.fUp;
+            var heading = Vector3.ProjectOnPlane (Get (Commands.Facing, eva), up);
+            if (heading.sqrMagnitude < 1e-6f)
+                heading = Vector3.ProjectOnPlane (eva.transform.forward, up);
+            heading = Quaternion.AngleAxis (
+                yaw * eva.turnRate * Mathf.Rad2Deg * Time.fixedDeltaTime, up) * heading.normalized;
+            // The walking direction is normalized and carries no speed, so the size of the
+            // input picks the direction and nothing else.
+            var direction = heading * forward + Vector3.Cross (up, heading) * right;
+            Set (Commands.Move, eva, (Get (Commands.Move, eva) + direction).normalized);
+            Set (Commands.Facing, eva, heading);
+            Set (Commands.FacingUp, eva, up);
+            if (!walkedMovementMode.ContainsKey (eva.vessel.id))
+                walkedMovementMode [eva.vessel.id] = eva.CharacterFrameMode;
+            eva.CharacterFrameMode = true;
+        }
+
+        /// <summary>
+        /// Put the kerbal back into the movement mode it was in before kRPC walked it.
+        /// </summary>
+        static void ReleaseWalk (KerbalEVA eva)
+        {
+            bool mode;
+            if (!walkedMovementMode.TryGetValue (eva.vessel.id, out mode))
+                return;
+            walkedMovementMode.Remove (eva.vessel.id);
+            eva.CharacterFrameMode = mode;
+        }
+
+        /// <summary>
+        /// Lean the kerbal under a deployed EVA parachute, as the same two inputs do when
+        /// they are thrusting the jetpack.
+        /// </summary>
+        static void Steer (KerbalEVA eva, float forward, float right)
+        {
+            var steering = Get (Commands.ParachuteSteering, eva) + new Vector3 (forward, right, 0f);
+            Set (Commands.ParachuteSteering, eva, new Vector3 (
+                Mathf.Clamp (steering.x, -1f, 1f), Mathf.Clamp (steering.y, -1f, 1f), 0f));
+        }
+
+        static Vector3 Get (FieldInfo command, KerbalEVA eva)
+        {
+            return (Vector3)command.GetValue (eva);
+        }
+
+        static void Set (FieldInfo command, KerbalEVA eva, Vector3 value)
+        {
+            command.SetValue (eva, value);
+        }
+    }
+}

--- a/service/SpaceCenter/src/ExtensionMethods/KerbalEVAExtensions.cs
+++ b/service/SpaceCenter/src/ExtensionMethods/KerbalEVAExtensions.cs
@@ -1,0 +1,40 @@
+using System.Collections.Generic;
+using System.Reflection;
+using UnityEngine;
+
+namespace KRPC.SpaceCenter.ExtensionMethods
+{
+    /// <summary>
+    /// What a kerbal on EVA has within reach. The module keeps track of the hatch it is
+    /// standing at and the ladders it is alongside, from the trigger volumes it is inside,
+    /// but keeps both to itself, so they are read by reflection.
+    /// </summary>
+    static class KerbalEVAExtensions
+    {
+        static readonly FieldInfo airlockPart = typeof (KerbalEVA).GetField (
+            "currentAirlockPart", BindingFlags.NonPublic | BindingFlags.Instance);
+        static readonly FieldInfo ladderTriggers = typeof (KerbalEVA).GetField (
+            "currentLadderTriggers", BindingFlags.NonPublic | BindingFlags.Instance);
+
+        /// <summary>
+        /// The part whose hatch the kerbal is standing at, or <c>null</c> if it is not at one.
+        /// </summary>
+        public static global::Part CurrentAirlock (this KerbalEVA eva)
+        {
+            var part = airlockPart == null ? null : airlockPart.GetValue (eva) as global::Part;
+            // A destroyed part is still a reference, and only compares equal to null through
+            // Unity's operator, so return it through one.
+            return part == null ? null : part;
+        }
+
+        /// <summary>
+        /// Whether the kerbal is alongside a ladder it could take hold of.
+        /// </summary>
+        public static bool LadderInReach (this KerbalEVA eva)
+        {
+            var triggers = ladderTriggers == null
+                ? null : ladderTriggers.GetValue (eva) as List<Collider>;
+            return triggers != null && triggers.Count > 0;
+        }
+    }
+}

--- a/service/SpaceCenter/src/KRPC.SpaceCenter.csproj
+++ b/service/SpaceCenter/src/KRPC.SpaceCenter.csproj
@@ -62,6 +62,7 @@
     <Compile Include="ExtensionMethods\HopTypeExtensions.cs" />
     <Compile Include="ExtensionMethods\InternalCameraExtensions.cs" />
     <Compile Include="ExtensionMethods\ITorqueProviderExtensions.cs" />
+    <Compile Include="ExtensionMethods\KerbalEVAExtensions.cs" />
     <Compile Include="ExtensionMethods\KerbalTypeExtensions.cs" />
     <Compile Include="ExtensionMethods\ModuleWheelDeploymentExtensions.cs" />
     <Compile Include="ExtensionMethods\MotorStateExtensions.cs" />

--- a/service/SpaceCenter/src/KRPC.SpaceCenter.csproj
+++ b/service/SpaceCenter/src/KRPC.SpaceCenter.csproj
@@ -80,6 +80,7 @@
     <Compile Include="ExtensionMethods\VesselTypeExtensions.cs" />
     <Compile Include="ActuatorControlAddon.cs" />
     <Compile Include="CameraAddon.cs" />
+    <Compile Include="EVAAddon.cs" />
     <Compile Include="ExternalAPIAddon.cs" />
     <Compile Include="ExternalAPI\AGExt.cs" />
     <Compile Include="ExternalAPI\FAR.cs" />

--- a/service/SpaceCenter/src/Services/Control.cs
+++ b/service/SpaceCenter/src/Services/Control.cs
@@ -21,6 +21,17 @@ namespace KRPC.SpaceCenter.Services
     /// and the custom axes) are zeroed when all clients that have set one or more of
     /// these inputs are no longer connected. The throttle is an exception: it keeps
     /// its value when clients disconnect.
+    ///
+    /// A kerbal on EVA is a vessel, and is driven by these same controls. The
+    /// translation inputs move it: <see cref="Forward"/> and <see cref="Right"/> walk
+    /// it about, relative to the direction it is facing, and all three translate its
+    /// jetpack once that is deployed. Walking is not throttled by the size of the
+    /// input, only started by it. The rotation inputs turn it, at a rate proportional
+    /// to the input: <see cref="Yaw"/> steers it as it walks, and all three turn its
+    /// jetpack. Turning the jetpack releases the kerbal from the orientation it was
+    /// holding; it stops and holds its new orientation once the input returns to zero.
+    /// <see cref="RCS"/> deploys and stows the jetpack and <see cref="Lights"/>
+    /// switches the helmet lamp. The remaining controls do nothing for a kerbal.
     /// </remarks>
     [KRPCClass (Service = "SpaceCenter", GameScene = GameScene.Flight)]
     public class Control : Equatable<Control>
@@ -117,10 +128,29 @@ namespace KRPC.SpaceCenter.Services
         /// <summary>
         /// The state of RCS.
         /// </summary>
+        /// <remarks>
+        /// For a kerbal on EVA this is whether its jetpack is deployed. Deploying it
+        /// requires the kerbal to have one and to be the active vessel; otherwise
+        /// setting this does nothing.
+        /// </remarks>
         [KRPCProperty]
         public bool RCS {
-            get { return InternalVessel.ActionGroups.groups [BaseAction.GetGroupIndex (KSPActionGroup.RCS)]; }
-            set { InternalVessel.ActionGroups.SetGroup (KSPActionGroup.RCS, value); }
+            get {
+                var eva = InternalVessel.evaController;
+                if (eva != null)
+                    return eva.JetpackDeployed;
+                return InternalVessel.ActionGroups.groups [BaseAction.GetGroupIndex (KSPActionGroup.RCS)];
+            }
+            set {
+                var vessel = InternalVessel;
+                var eva = vessel.evaController;
+                if (eva != null) {
+                    if (eva.JetpackDeployed != value)
+                        eva.ToggleJetpack ();
+                    return;
+                }
+                vessel.ActionGroups.SetGroup (KSPActionGroup.RCS, value);
+            }
         }
 
         /// <summary>
@@ -243,10 +273,28 @@ namespace KRPC.SpaceCenter.Services
         /// <summary>
         /// The state of the lights.
         /// </summary>
+        /// <remarks>
+        /// For a kerbal on EVA this is its helmet lamp. Switching it requires the
+        /// kerbal to be the active vessel; otherwise setting this does nothing.
+        /// </remarks>
         [KRPCProperty]
         public bool Lights {
-            get { return InternalVessel.ActionGroups.groups [BaseAction.GetGroupIndex (KSPActionGroup.Light)]; }
-            set { InternalVessel.ActionGroups.SetGroup (KSPActionGroup.Light, value); }
+            get {
+                var eva = InternalVessel.evaController;
+                if (eva != null)
+                    return eva.lampOn;
+                return InternalVessel.ActionGroups.groups [BaseAction.GetGroupIndex (KSPActionGroup.Light)];
+            }
+            set {
+                var vessel = InternalVessel;
+                var eva = vessel.evaController;
+                if (eva != null) {
+                    if (eva.lampOn != value)
+                        eva.ToggleLamp ();
+                    return;
+                }
+                vessel.ActionGroups.SetGroup (KSPActionGroup.Light, value);
+            }
         }
 
         /// <summary>

--- a/service/SpaceCenter/src/Services/Control.cs
+++ b/service/SpaceCenter/src/Services/Control.cs
@@ -32,6 +32,10 @@ namespace KRPC.SpaceCenter.Services
     /// holding; it stops and holds its new orientation once the input returns to zero.
     /// <see cref="RCS"/> deploys and stows the jetpack and <see cref="Lights"/>
     /// switches the helmet lamp. The remaining controls do nothing for a kerbal.
+    /// A kerbal is also sent out and brought back in from here: with
+    /// <see cref="CrewMember.EVA"/> and <see cref="Board"/>, and
+    /// <see cref="GrabLadder"/> and <see cref="ReleaseLadder"/> for the ladders it
+    /// passes on the way.
     /// </remarks>
     [KRPCClass (Service = "SpaceCenter", GameScene = GameScene.Flight)]
     public class Control : Equatable<Control>
@@ -917,6 +921,158 @@ namespace KRPC.SpaceCenter.Services
             foreach (var node in InternalVessel.patchedConicSolver.maneuverNodes.ToArray ())
                 node.RemoveSelf ();
             // TODO: delete the Node objects
+        }
+
+        /// <summary>
+        /// The ladder the kerbal is holding on to, or <c>null</c> if it is not holding one
+        /// or the vessel is not a kerbal on EVA.
+        /// </summary>
+        [KRPCProperty (Nullable = true)]
+        public Parts.Part Ladder {
+            get {
+                var eva = InternalVessel.evaController;
+                if (eva == null || !eva.OnALadder)
+                    return null;
+                var part = eva.LadderPart;
+                return part == null ? null : new Parts.Part (part);
+            }
+        }
+
+        /// <summary>
+        /// The part whose hatch the kerbal is standing at, and so the one
+        /// <see cref="Board"/> would put it in. <c>null</c> if it is not at a hatch or the
+        /// vessel is not a kerbal on EVA.
+        /// </summary>
+        [KRPCProperty (Nullable = true)]
+        public Parts.Part Airlock {
+            get {
+                var eva = InternalVessel.evaController;
+                if (eva == null)
+                    return null;
+                var part = eva.CurrentAirlock ();
+                return part == null ? null : new Parts.Part (part);
+            }
+        }
+
+        /// <summary>
+        /// Take hold of the ladder the kerbal is standing at, as pressing the grab key
+        /// in-game does. A kerbal can only take hold of a ladder it is already alongside;
+        /// it does not walk to one. <see cref="Ladder"/> reports the one it ends up
+        /// holding. Does nothing if the kerbal is already holding a ladder.
+        /// </summary>
+        /// <remarks>
+        /// Throws an exception if the vessel is not a kerbal on EVA, if there is no ladder
+        /// within reach, or if the kerbal is doing something it cannot grab a ladder from.
+        /// </remarks>
+        [KRPCMethod]
+        public void GrabLadder ()
+        {
+            var eva = CheckEVA ();
+            if (eva.OnALadder)
+                return;
+            if (!eva.LadderInReach ())
+                throw new InvalidOperationException ("The kerbal is not alongside a ladder");
+            if (!eva.fsm.Started || !eva.fsm.CurrentState.IsValid (eva.On_ladderGrabStart))
+                throw new InvalidOperationException (
+                    "The kerbal must be standing still to take hold of a ladder");
+            eva.fsm.RunEvent (eva.On_ladderGrabStart);
+        }
+
+        /// <summary>
+        /// Let go of the ladder the kerbal is holding, as pressing the jump key in-game
+        /// does. Does nothing if it is not holding one.
+        /// </summary>
+        /// <remarks>
+        /// Throws an exception if the vessel is not a kerbal on EVA.
+        /// </remarks>
+        [KRPCMethod]
+        public void ReleaseLadder ()
+        {
+            var eva = CheckEVA ();
+            if (!eva.OnALadder)
+                return;
+            ReleaseLadderWhenAble (eva, 0);
+        }
+
+        static void ReleaseLadderWhenAble (KerbalEVA eva, int tick)
+        {
+            if (eva == null || eva.vessel == null || !eva.OnALadder)
+                return;
+            // A kerbal that has just taken hold of a ladder is still swinging onto it, and
+            // cannot let go again until it is on, so wait for it rather than refuse.
+            if (!eva.fsm.Started || !eva.fsm.CurrentState.IsValid (eva.On_ladderLetGo)) {
+                if (tick > 200)
+                    throw new InvalidOperationException (
+                        "The kerbal cannot let go of the ladder from what it is currently doing");
+                throw new YieldException<Action> (() => ReleaseLadderWhenAble (eva, tick + 1));
+            }
+            eva.fsm.RunEvent (eva.On_ladderLetGo);
+        }
+
+        /// <summary>
+        /// Climb into the part whose hatch the kerbal is standing at, ending the EVA. The
+        /// kerbal takes a seat in that part and its own vessel ceases to exist. If the
+        /// kerbal was the active vessel, the game switches to the vessel it boarded.
+        /// </summary>
+        /// <remarks>
+        /// A kerbal can only board through a hatch it is already at, which
+        /// <see cref="Airlock"/> reports; it does not walk to one. Throws an exception if
+        /// the vessel is not a kerbal on EVA, if the kerbal is not at a hatch, if boarding
+        /// is disabled for the game, if the part has no free seat, or if the kerbal is
+        /// carrying science data that the part cannot store, as the game asks what to do
+        /// with it in that case.
+        /// </remarks>
+        [KRPCMethod]
+        public void Board ()
+        {
+            var eva = CheckEVA ();
+            if (!HighLogic.CurrentGame.Parameters.Flight.CanBoard)
+                throw new InvalidOperationException ("Boarding is disabled for this game");
+            var part = eva.CurrentAirlock ();
+            if (part == null)
+                throw new InvalidOperationException ("The kerbal is not at a hatch it can board through");
+            if (part.protoModuleCrew.Count >= part.CrewCapacity)
+                throw new InvalidOperationException ("The part has no free seat for the kerbal");
+            if (CarryingScienceData (eva.vessel) &&
+                part.FindModuleImplementing<ModuleScienceContainer> () == null)
+                throw new InvalidOperationException (
+                    "The kerbal is carrying science data and the part cannot store it. " +
+                    "Transfer or discard the data before boarding.");
+            var crewMember = eva.vessel.GetVesselCrew () [0];
+            eva.BoardPart (part);
+            throw new YieldException<Action> (() => WaitForBoard (crewMember, part, 0));
+        }
+
+        static bool CarryingScienceData (global::Vessel vessel)
+        {
+            foreach (var part in vessel.parts)
+                foreach (PartModule module in part.Modules) {
+                    var container = module as IScienceDataContainer;
+                    if (container != null && container.GetScienceCount () > 0)
+                        return true;
+                }
+            return false;
+        }
+
+        static void WaitForBoard (ProtoCrewMember crewMember, global::Part part, int tick)
+        {
+            // The kerbal is aboard once it appears in the part's crew; a vessel switch
+            // cannot signal it, as the game only switches when the kerbal was the active
+            // vessel. Waiting for the part's vessel to also be unpacked hands control
+            // back only once that vessel can be flown.
+            if (part != null && part.protoModuleCrew.Contains (crewMember) && !part.vessel.packed)
+                return;
+            if (tick > 200)
+                throw new InvalidOperationException ("The kerbal failed to board the vessel");
+            throw new YieldException<Action> (() => WaitForBoard (crewMember, part, tick + 1));
+        }
+
+        KerbalEVA CheckEVA ()
+        {
+            var eva = InternalVessel.evaController;
+            if (eva == null)
+                throw new InvalidOperationException ("The vessel is not a kerbal on EVA");
+            return eva;
         }
 
         void CheckActiveVessel ()

--- a/service/SpaceCenter/src/Services/CrewMember.cs
+++ b/service/SpaceCenter/src/Services/CrewMember.cs
@@ -149,6 +149,17 @@ namespace KRPC.SpaceCenter.Services
         [KRPCProperty (Nullable = true, GameScene = GameScene.Flight)]
         public Parts.Part Part {
             get {
+                var part = InternalPart;
+                return part == null ? null : new Parts.Part (part);
+            }
+        }
+
+        /// <summary>
+        /// The KSP part the crew member is occupying, or <c>null</c> if it is not in one or
+        /// the vessel containing it is not loaded.
+        /// </summary>
+        global::Part InternalPart {
+            get {
                 var crewMember = InternalCrewMember;
                 if (crewMember == null)
                     return null;
@@ -161,8 +172,52 @@ namespace KRPC.SpaceCenter.Services
                         .SelectMany (vessel => vessel.parts)
                         .FirstOrDefault (candidate => candidate.protoModuleCrew.Contains (crewMember));
                 }
-                return part == null ? null : new Parts.Part (part);
+                return part;
             }
+        }
+
+        /// <summary>
+        /// Send the crew member outside on EVA, through the hatch of the part it is in, and
+        /// return the vessel it becomes. The game switches to that vessel, which can then be
+        /// walked around and flown using its <see cref="Vessel.Control"/>, and brought back
+        /// in with <see cref="Control.Board"/>.
+        /// </summary>
+        /// <remarks>
+        /// Throws an exception if EVA is disabled for the game, if the crew member is not in
+        /// a loaded vessel, if it is already on EVA, or if every hatch out of the part it is
+        /// in is obstructed.
+        /// </remarks>
+        [KRPCMethod (GameScene = GameScene.Flight)]
+        public Vessel EVA ()
+        {
+            if (!HighLogic.CurrentGame.Parameters.Flight.CanEVA)
+                throw new InvalidOperationException ("EVA is disabled for this game");
+            var crewMember = InternalCrewMember;
+            var part = InternalPart;
+            if (part == null)
+                throw new InvalidOperationException ("The crew member is not in a loaded vessel");
+            if (part.vessel.isEVA)
+                throw new InvalidOperationException ("The crew member is already on EVA");
+            var eva = FlightEVA.fetch.spawnEVA (crewMember, part, part.airlock, true);
+            if (eva == null)
+                throw new InvalidOperationException (
+                    "Failed to send " + crewMember.name + " on EVA; every hatch out of " +
+                    part.partInfo.title + " may be obstructed");
+            return WaitForEVA (eva, 0);
+        }
+
+        static Vessel WaitForEVA (KerbalEVA eva, int tick)
+        {
+            // The game brings the kerbal into being over the following frames and then
+            // switches to it, so wait for it to be flyable rather than hand back a vessel
+            // that cannot yet be controlled.
+            if (eva == null || eva.vessel == null)
+                throw new InvalidOperationException ("The kerbal was destroyed while leaving the vessel");
+            if (FlightGlobals.ActiveVessel == eva.vessel && eva.vessel.loaded && !eva.vessel.packed)
+                return new Vessel (eva.vessel);
+            if (tick > 500)
+                throw new InvalidOperationException ("The kerbal failed to leave the vessel");
+            throw new YieldException<Func<Vessel>> (() => WaitForEVA (eva, tick + 1));
         }
 
         /// <summary>

--- a/service/SpaceCenter/test/test_eva.py
+++ b/service/SpaceCenter/test/test_eva.py
@@ -1,5 +1,33 @@
+import time
+
 import krpctest
 from krpctest.geometry import angle_between, norm
+
+
+def wait_for(predicate, message, timeout=30):
+    """Wait for predicate to hold. A module-level counterpart to TestCase.wait_until,
+    for the class-level setup that has no test instance to call it on."""
+    deadline = time.time() + timeout
+    while not predicate():
+        if time.time() > deadline:
+            raise AssertionError(
+                "Timed out after %gs waiting for %s" % (timeout, message)
+            )
+        time.sleep(0.1)
+
+
+def send_on_eva(space_center, let_go=True):
+    """Send the active vessel's first crew member outside and wait until it has finished
+    climbing out, which it signals by taking hold of the ladder by the hatch. Unless the
+    test is about the ladder, let go of it again: a kerbal moved while still jointed to
+    the ladder it is holding is torn apart."""
+    vessel = space_center.active_vessel.crew[0].eva()
+    control = vessel.control
+    wait_for(lambda: control.ladder is not None, "the kerbal to climb out")
+    if let_go:
+        control.release_ladder()
+        wait_for(lambda: control.ladder is None, "the kerbal to let go of the ladder")
+    return vessel
 
 
 class TestEVAOnFoot(krpctest.TestCase):
@@ -16,7 +44,7 @@ class TestEVAOnFoot(krpctest.TestCase):
     def setUpClass(cls):
         cls.new_save()
         cls.remove_other_vessels()
-        cls.connect().testing_tools.go_eva()
+        send_on_eva(cls.connect().space_center)
         cls.set_landed("Kerbin", cls.LATITUDE, cls.LONGITUDE)
         cls.space_center = cls.connect().space_center
         cls.vessel = cls.space_center.active_vessel
@@ -122,7 +150,7 @@ class TestEVAJetpack(krpctest.TestCase):
     def setUpClass(cls):
         cls.new_save()
         cls.remove_other_vessels()
-        cls.connect().testing_tools.go_eva()
+        send_on_eva(cls.connect().space_center)
         cls.set_circular_orbit("Kerbin", 100000)
         cls.space_center = cls.connect().space_center
         cls.vessel = cls.space_center.active_vessel
@@ -187,3 +215,87 @@ class TestEVAJetpack(krpctest.TestCase):
                 lambda: self.rotation_rate() < 0.1,
                 message="the kerbal to stop rotating",
             )
+
+
+class TestEVABoarding(krpctest.TestCase):
+    """Sending a kerbal out of a craft, on and off the ladder by the hatch, and back in."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.space_center = cls.connect().space_center
+
+    def setUp(self):
+        # Every test leaves the kerbal somewhere different, so start each from the
+        # craft sitting on the pad with its crew inside.
+        self.new_save(always_load=True)
+        self.remove_other_vessels()
+        self.craft = self.space_center.active_vessel
+        self.kerbal = self.craft.crew[0]
+
+    def test_eva_and_board(self):
+        self.assertIsNone(self.craft.control.airlock)
+        self.assertIsNone(self.craft.control.ladder)
+
+        vessel = send_on_eva(self.space_center, let_go=False)
+        self.assertEqual(self.space_center.VesselType.eva, vessel.type)
+        self.assertEqual(self.kerbal.name, vessel.name)
+        self.assertEqual(vessel, self.space_center.active_vessel)
+        self.assertEqual([], self.craft.crew)
+
+        # The kerbal climbs out at the hatch it came through, so it can go straight
+        # back in again.
+        self.assertEqual(self.kerbal.part.name, "kerbalEVA")
+        self.assertEqual("mk1pod.v2", vessel.control.airlock.name)
+        vessel.control.board()
+        self.assertEqual(self.craft, self.space_center.active_vessel)
+        self.assertEqual([self.kerbal.name], [crew.name for crew in self.craft.crew])
+
+    def test_ladder(self):
+        # A kerbal climbing out takes hold of the ladder by the hatch.
+        control = send_on_eva(self.space_center, let_go=False).control
+        self.assertEqual("mk1pod.v2", control.ladder.name)
+        control.release_ladder()
+        self.wait_until(lambda: control.ladder is None, message="the kerbal to let go")
+
+    def test_grab_ladder(self):
+        # A kerbal that lets go on the ground drops away from the ladder, so take hold
+        # of one again in orbit, where it stays alongside it.
+        self.set_circular_orbit("Kerbin", 100000)
+        control = send_on_eva(self.space_center, let_go=False).control
+        control.release_ladder()
+        self.wait_until(lambda: control.ladder is None, message="the kerbal to let go")
+
+        def take_hold():
+            # The kerbal counts as clear of the ladder for a moment after letting go,
+            # and cannot take hold of it again until it is alongside once more.
+            try:
+                control.grab_ladder()
+                return True
+            except RuntimeError:
+                return False
+
+        self.wait_until(take_hold, message="the kerbal to reach the ladder again")
+        self.wait_until(
+            lambda: control.ladder is not None, message="the kerbal to grab on again"
+        )
+        self.assertEqual("mk1pod.v2", control.ladder.name)
+
+    def test_out_of_reach(self):
+        control = send_on_eva(self.space_center).control
+        control.forward = 1
+        self.wait_until(
+            lambda: control.airlock is None,
+            message="the kerbal to walk clear of the hatch",
+        )
+        control.forward = 0
+        self.assertRaises(RuntimeError, control.board)
+        self.assertRaises(RuntimeError, control.grab_ladder)
+
+    def test_not_a_kerbal(self):
+        self.assertRaises(RuntimeError, self.craft.control.board)
+        self.assertRaises(RuntimeError, self.craft.control.grab_ladder)
+        self.assertRaises(RuntimeError, self.craft.control.release_ladder)
+
+    def test_already_on_eva(self):
+        send_on_eva(self.space_center)
+        self.assertRaises(RuntimeError, self.kerbal.eva)

--- a/service/SpaceCenter/test/test_eva.py
+++ b/service/SpaceCenter/test/test_eva.py
@@ -1,0 +1,189 @@
+import krpctest
+from krpctest.geometry import angle_between, norm
+
+
+class TestEVAOnFoot(krpctest.TestCase):
+    """A kerbal standing on open ground, driven by the translation and rotation
+    controls."""
+
+    # Flat, empty ground a few kilometers west of the KSC. The kerbal is moved here
+    # after climbing out, so that it has room to walk without bumping into the craft
+    # it came from or the launch pad structures.
+    LATITUDE = -0.05
+    LONGITUDE = -74.7
+
+    @classmethod
+    def setUpClass(cls):
+        cls.new_save()
+        cls.remove_other_vessels()
+        cls.connect().testing_tools.go_eva()
+        cls.set_landed("Kerbin", cls.LATITUDE, cls.LONGITUDE)
+        cls.space_center = cls.connect().space_center
+        cls.vessel = cls.space_center.active_vessel
+        cls.control = cls.vessel.control
+        # The rotating frame of the body the kerbal is standing on, so that standing
+        # still is zero speed and walking is not.
+        cls.reference_frame = cls.vessel.orbit.body.reference_frame
+
+    def setUp(self):
+        self.stop()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.control.forward = 0
+        cls.control.right = 0
+        cls.control.yaw = 0
+
+    def stop(self):
+        """Zero every input and wait for the kerbal to come to rest."""
+        self.control.forward = 0
+        self.control.right = 0
+        self.control.yaw = 0
+        self.wait_until(
+            lambda: self.speed() < 0.1, message="the kerbal to stop walking"
+        )
+
+    def speed(self):
+        return self.vessel.flight(self.reference_frame).speed
+
+    def walk(self, duration=3, **inputs):
+        """Hold the given inputs for duration seconds and return the velocity at the
+        end of it, before stopping again."""
+        for name, value in inputs.items():
+            setattr(self.control, name, value)
+        self.wait(duration)
+        velocity = self.vessel.velocity(self.reference_frame)
+        self.stop()
+        return velocity
+
+    def test_walk_forward_and_back(self):
+        forwards = self.walk(forward=1)
+        self.assertGreater(norm(forwards), 0.2)
+        backwards = self.walk(forward=-1)
+        self.assertGreater(norm(backwards), 0.2)
+        # Opposite inputs walk the kerbal in opposite directions.
+        self.assertGreater(angle_between(forwards, backwards), 150)
+
+    def test_walk_left_and_right(self):
+        right = self.walk(right=1)
+        self.assertGreater(norm(right), 0.2)
+        left = self.walk(right=-1)
+        self.assertGreater(norm(left), 0.2)
+        self.assertGreater(angle_between(right, left), 150)
+
+    def test_strafing_is_across_walking(self):
+        forwards = self.walk(forward=1)
+        right = self.walk(right=1)
+        # The kerbal keeps its heading while it strafes, so the two are across each
+        # other rather than along the same line.
+        angle = angle_between(forwards, right)
+        self.assertGreater(angle, 60)
+        self.assertLess(angle, 120)
+
+    def test_yaw_steers_while_walking(self):
+        self.control.forward = 1
+        self.wait(3)
+        before = self.vessel.velocity(self.reference_frame)
+        self.control.yaw = 0.3
+        self.wait(2)
+        self.control.yaw = 0
+        self.wait(1)
+        after = self.vessel.velocity(self.reference_frame)
+        self.stop()
+        self.assertGreater(angle_between(before, after), 30)
+
+    def test_stands_still_without_input(self):
+        self.wait(2)
+        self.assertLess(self.speed(), 0.1)
+
+    def test_jetpack_deploys_with_rcs(self):
+        self.assertFalse(self.control.rcs)
+        self.control.rcs = True
+        self.wait_until(lambda: self.control.rcs, message="the jetpack to deploy")
+        self.control.rcs = False
+        self.wait_until(lambda: not self.control.rcs, message="the jetpack to stow")
+
+    def test_lights(self):
+        self.assertFalse(self.control.lights)
+        self.control.lights = True
+        self.wait()
+        self.assertTrue(self.control.lights)
+        self.control.lights = False
+        self.wait()
+        self.assertFalse(self.control.lights)
+
+
+class TestEVAJetpack(krpctest.TestCase):
+    """A kerbal floating in orbit, flown by its jetpack. The kerbal climbs out on the
+    ground and is then put into orbit on its own: climbing out in orbit leaves it
+    holding the hatch ladder, which is a state it cannot use its jetpack from."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.new_save()
+        cls.remove_other_vessels()
+        cls.connect().testing_tools.go_eva()
+        cls.set_circular_orbit("Kerbin", 100000)
+        cls.space_center = cls.connect().space_center
+        cls.vessel = cls.space_center.active_vessel
+        cls.control = cls.vessel.control
+        cls.reference_frame = cls.vessel.orbit.body.non_rotating_reference_frame
+
+    def setUp(self):
+        self.control.rcs = True
+        self.wait_until(lambda: self.control.rcs, message="the jetpack to deploy")
+        self.wait_until(
+            lambda: self.rotation_rate() < 0.1, message="the kerbal to stop rotating"
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        for name in ["forward", "right", "up", "pitch", "yaw", "roll"]:
+            setattr(cls.control, name, 0)
+        cls.control.rcs = False
+
+    def rotation_rate(self):
+        return norm(self.vessel.angular_velocity(self.reference_frame))
+
+    def velocity_change(self, duration=2, **inputs):
+        """Hold the given inputs for duration seconds and return how much the kerbal's
+        velocity changed over them."""
+        for name, value in inputs.items():
+            setattr(self.control, name, value)
+        before = self.vessel.velocity(self.reference_frame)
+        self.wait(duration)
+        after = self.vessel.velocity(self.reference_frame)
+        for name in inputs:
+            setattr(self.control, name, 0)
+        return tuple(a - b for a, b in zip(after, before))
+
+    def thrust(self, **inputs):
+        """The velocity change from holding the given inputs, over and above the change
+        from falling around the body over the same interval."""
+        falling = self.velocity_change()
+        thrusting = self.velocity_change(**inputs)
+        return norm(tuple(a - b for a, b in zip(thrusting, falling)))
+
+    def test_translation_accelerates_the_kerbal(self):
+        for axis in ["forward", "right", "up"]:
+            self.assertGreater(self.thrust(**{axis: 1}), 2)
+
+    def test_stowed_jetpack_does_not_thrust(self):
+        self.control.rcs = False
+        self.wait_until(lambda: not self.control.rcs, message="the jetpack to stow")
+        self.assertLess(self.thrust(forward=1), 0.5)
+
+    def test_rotation_turns_the_kerbal(self):
+        for axis in ["pitch", "yaw", "roll"]:
+            setattr(self.control, axis, 0.5)
+            self.wait(2)
+            rate = self.rotation_rate()
+            setattr(self.control, axis, 0)
+            # Half input asks for half the kerbal's turn rate.
+            self.assertGreater(rate, 1)
+            # Releasing the input hands the kerbal back to its attitude controller,
+            # which stops it and holds the orientation it ended up at.
+            self.wait_until(
+                lambda: self.rotation_rate() < 0.1,
+                message="the kerbal to stop rotating",
+            )


### PR DESCRIPTION
**Sending and boarding.** `CrewMember.EVA` sends a Kerbal outside through the hatch of the part it is in and returns the vessel it becomes. `Control.Board` climbs it back in through the hatch it is standing at, which `Control.Airlock` reports. `Control.GrabLadder` and `Control.ReleaseLadder` take hold of and let go of a ladder within reach, and `Control.Ladder` reports the one being held.

**Driving.** A Kerbal on EVA is driven through the existing `Vessel.Control` inputs: the translation inputs walk it about and fly its jetpack once deployed, the rotation inputs steer it as it walks and turn the jetpack, `Control.RCS` deploys and stows the jetpack and `Control.Lights` switches the helmet lamp. The game's `KerbalEVA` module takes no input from the vessel's flight control state, so a new addon applies the kRPC inputs from inside the module's state machine, through a callback prepended to each state that writes the module's movement command fields by reflection. The commands are only written while kRPC has a non-zero input, so a Kerbal being flown from the keyboard is left alone.

**Testing.** `service/SpaceCenter/test/test_eva.py` adds 16 tests covering walking, jetpack flight, boarding and ladders.

Fixes #319