### PR TITLE
Add navball markers to the Drawing service

### DIFF
--- a/doc/api/drawing.tmpl
+++ b/doc/api/drawing.tmpl
@@ -10,5 +10,6 @@ Drawing API
 
    drawing/drawing
    drawing/line
+   drawing/navball-marker
    drawing/polygon
    drawing/text

--- a/doc/api/drawing/navball-marker.tmpl
+++ b/doc/api/drawing/navball-marker.tmpl
@@ -1,0 +1,9 @@
+.. default-domain:: {{ domain.sphinxname }}
+.. highlight:: {{ domain.highlight }}
+{{ domain.currentmodule('Drawing') }}
+{% import domain.macros as macros with context %}
+
+NavballMarker
+=============
+
+{{ macros.class(services['Drawing'].classes['NavballMarker']) }}

--- a/doc/order.txt
+++ b/doc/order.txt
@@ -1511,6 +1511,7 @@ Drawing.AddDirection
 Drawing.AddDirectionFromCom
 Drawing.AddPolygon
 Drawing.AddText
+Drawing.AddNavballMarker
 Drawing.Clear
 Drawing.Line
 Drawing.Line.Start
@@ -1521,6 +1522,15 @@ Drawing.Line.Color
 Drawing.Line.Material
 Drawing.Line.Thickness
 Drawing.Line.Remove
+Drawing.NavballMarker
+Drawing.NavballMarker.Direction
+Drawing.NavballMarker.ReferenceFrame
+Drawing.NavballMarker.Visible
+Drawing.NavballMarker.Color
+Drawing.NavballMarker.Icon
+Drawing.NavballMarker.AvailableIcons
+Drawing.NavballMarker.Size
+Drawing.NavballMarker.Remove
 Drawing.Polygon
 Drawing.Polygon.Vertices
 Drawing.Polygon.ReferenceFrame

--- a/service/Drawing/CHANGELOG.md
+++ b/service/Drawing/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [v0.7.0] - unreleased
+- Add `Drawing.AddNavballMarker`, which draws a marker on the navball pointing in a given
+  direction, for example to show a script's target attitude while the player flies the vessel.
+  The marker's icon, color and size can be changed, and it hides and fades as the navball's own
+  markers do (#1037)
+
 ## [v0.5.0]
 - Add `Drawing.AddDirectionFromCoM`
 - Change `Drawing.AddDirection` to start the line at the origin of the reference frame (#518)

--- a/service/Drawing/src/Drawing.cs
+++ b/service/Drawing/src/Drawing.cs
@@ -92,6 +92,18 @@ namespace KRPC.Drawing
         }
 
         /// <summary>
+        /// Draw a marker on the navball, pointing in the given direction.
+        /// </summary>
+        /// <param name="direction">Direction that the marker points in.</param>
+        /// <param name="referenceFrame">Reference frame that the direction is in.</param>
+        /// <param name="visible">Whether the marker is visible.</param>
+        [KRPCProcedure]
+        public static NavballMarker AddNavballMarker (Tuple3 direction, ReferenceFrame referenceFrame, bool visible = true)
+        {
+            return new NavballMarker (direction.ToVector (), referenceFrame, visible);
+        }
+
+        /// <summary>
         /// Remove all objects being drawn.
         /// </summary>
         /// <param name="clientOnly">If true, only remove objects created by the calling client.</param>

--- a/service/Drawing/src/KRPC.Drawing.csproj
+++ b/service/Drawing/src/KRPC.Drawing.csproj
@@ -47,6 +47,7 @@
     <Compile Include="Drawable.cs" />
     <Compile Include="Drawing.cs" />
     <Compile Include="Line.cs" />
+    <Compile Include="NavballMarker.cs" />
     <Compile Include="Polygon.cs" />
     <Compile Include="Text.cs" />
     <Compile Include="IDrawable.cs" />

--- a/service/Drawing/src/NavballMarker.cs
+++ b/service/Drawing/src/NavballMarker.cs
@@ -1,0 +1,198 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using KRPC.Service.Attributes;
+using KRPC.SpaceCenter.ExtensionMethods;
+using KRPC.SpaceCenter.Services;
+using UnityEngine;
+using Tuple3 = System.Tuple<double, double, double>;
+
+namespace KRPC.Drawing
+{
+    /// <summary>
+    /// A marker drawn on the navball. Created using <see cref="Drawing.AddNavballMarker" />.
+    /// </summary>
+    [KRPCClass (Service = "Drawing")]
+    public class NavballMarker : IDrawable
+    {
+        // Where the icons that a marker can be drawn with live in the game database.
+        const string iconDirectory = "Squad/Contracts/Icons/";
+
+        // The game object for one of the navball's own markers, which is cloned to make a new one.
+        const string stockMarkerName = "ProgradeVector";
+
+        // The rotation at which a marker's mesh faces the navball camera.
+        static readonly Quaternion stockRotation = Quaternion.Euler (90f, 180f, 0f);
+
+        static IList<string> availableIcons;
+
+        readonly KSP.UI.Screens.Flight.NavBall navBall;
+        readonly UnityEngine.Material material;
+        // The scale at which the game draws the navball's own markers, which a size of 1 matches.
+        readonly Vector3 stockScale;
+        Vector3d direction;
+        Tuple3 color;
+        string icon;
+        float size;
+
+        internal NavballMarker (Vector3d markerDirection, ReferenceFrame referenceFrame, bool visible)
+        {
+            navBall = UnityEngine.Object.FindObjectOfType<KSP.UI.Screens.Flight.NavBall> ();
+            if (navBall == null)
+                throw new InvalidOperationException ("Navball not found");
+            var stockMarker = FindStockMarker (navBall);
+            stockScale = stockMarker.transform.localScale;
+
+            // Cloning one of the navball's own markers gives a marker with the game's mesh,
+            // shader and render layer, drawn by the navball camera along with the rest.
+            GameObject = UnityEngine.Object.Instantiate (stockMarker);
+            GameObject.name = "KRPC.Drawing.NavballMarker";
+            GameObject.transform.SetParent (stockMarker.transform.parent, false);
+            var renderer = GameObject.GetComponent<Renderer> ();
+            // Give the clone a material of its own, so that changing it leaves the navball's
+            // own markers alone.
+            material = new UnityEngine.Material (renderer.sharedMaterial);
+            renderer.material = material;
+            // The navball's own markers share a texture atlas, each sampling a sub-rect of it.
+            // A marker's icon is a texture in its own right, so it uses the whole of one.
+            material.SetTextureOffset ("_MainTexture", Vector2.zero);
+            material.SetTextureScale ("_MainTexture", Vector2.one);
+
+            direction = markerDirection;
+            ReferenceFrame = referenceFrame;
+            Visible = visible;
+            Color = new Tuple3 (1, 1, 1);
+            Icon = "default";
+            Size = 1f;
+            Addon.AddObject (this);
+        }
+
+        // The navball's own markers are siblings, under the parent of the navball itself.
+        static GameObject FindStockMarker (KSP.UI.Screens.Flight.NavBall navBall)
+        {
+            foreach (var child in navBall.transform.parent.GetComponentsInChildren<Transform> (true)) {
+                if (child.gameObject.name == stockMarkerName)
+                    return child.gameObject;
+            }
+            throw new InvalidOperationException ("Navball marker not found");
+        }
+
+        /// <summary>
+        /// Update the marker.
+        /// </summary>
+        public void Update ()
+        {
+            Vector3 worldDirection = ReferenceFrame.DirectionToWorldSpace (direction).normalized;
+            var position = navBall.attitudeGymbal * (worldDirection * navBall.VectorUnitScale);
+            GameObject.transform.localPosition = position;
+            // The marker faces the navball camera wherever on the ball it sits, so its
+            // rotation is fixed in world space rather than relative to the ball.
+            GameObject.transform.rotation = stockRotation;
+            // A marker on the far side of the ball is hidden, and one near the edge fades out,
+            // as the navball's own markers do.
+            GameObject.SetActive (Visible && position.z > navBall.VectorUnitCutoff);
+            material.SetFloat ("_Opacity", Mathf.Clamp01 (Vector3.Dot (position.normalized, Vector3.forward)));
+        }
+
+        /// <summary>
+        /// Destroy the marker.
+        /// </summary>
+        public void Destroy ()
+        {
+            UnityEngine.Object.Destroy (material);
+            UnityEngine.Object.Destroy (GameObject);
+        }
+
+        /// <summary>
+        /// The game object for the marker.
+        /// </summary>
+        public GameObject GameObject { get; private set; }
+
+        /// <summary>
+        /// Remove the marker.
+        /// </summary>
+        [KRPCMethod]
+        public void Remove ()
+        {
+            Addon.RemoveObject (this);
+        }
+
+        /// <summary>
+        /// Reference frame that the direction of the marker is in.
+        /// </summary>
+        [KRPCProperty]
+        public ReferenceFrame ReferenceFrame { get; set; }
+
+        /// <summary>
+        /// Whether the marker is visible.
+        /// </summary>
+        /// <remarks>
+        /// A visible marker is still hidden while it is on the far side of the navball.
+        /// </remarks>
+        [KRPCProperty]
+        public bool Visible { get; set; }
+
+        /// <summary>
+        /// Direction that the marker is drawn at.
+        /// </summary>
+        [KRPCProperty]
+        public Tuple3 Direction {
+            get { return direction.ToTuple (); }
+            set { direction = value.ToVector (); }
+        }
+
+        /// <summary>
+        /// Set the color
+        /// </summary>
+        [KRPCProperty]
+        public Tuple3 Color {
+            get { return color; }
+            set {
+                color = value;
+                material.SetColor ("_TintColor", color.ToColor ());
+            }
+        }
+
+        /// <summary>
+        /// The icon that the marker is drawn with.
+        /// See <see cref="AvailableIcons"/> for the icons that can be used.
+        /// </summary>
+        [KRPCProperty]
+        public string Icon {
+            get { return icon; }
+            set {
+                if (!AvailableIcons ().Contains (value))
+                    throw new ArgumentException ("Icon does not exist");
+                icon = value;
+                material.SetTexture ("_MainTexture", GameDatabase.Instance.GetTexture (iconDirectory + icon, false));
+            }
+        }
+
+        /// <summary>
+        /// Size of the marker, relative to the size of the navball's own markers.
+        /// </summary>
+        [KRPCProperty]
+        public float Size {
+            get { return size; }
+            set {
+                size = value;
+                GameObject.transform.localScale = stockScale * size;
+            }
+        }
+
+        /// <summary>
+        /// A list of all available icons, taken from "GameData/Squad/Contracts/Icons/".
+        /// </summary>
+        [KRPCMethod]
+        public static IList<string> AvailableIcons ()
+        {
+            if (availableIcons == null) {
+                availableIcons = GameDatabase.Instance.databaseTexture
+                    .Where (texture => texture.name.StartsWith (iconDirectory, StringComparison.Ordinal))
+                    .Select (texture => texture.name.Substring (iconDirectory.Length))
+                    .ToList ();
+            }
+            return availableIcons;
+        }
+    }
+}

--- a/service/Drawing/test/test_navball_marker.py
+++ b/service/Drawing/test/test_navball_marker.py
@@ -1,0 +1,73 @@
+import unittest
+import krpctest
+
+
+class TestNavballMarker(krpctest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.new_save()
+        cls.drawing = cls.connect().drawing
+        cls.vessel = cls.connect().space_center.active_vessel
+        cls.ref = cls.vessel.reference_frame
+
+    def add_marker(self):
+        return self.drawing.add_navball_marker((0, 1, 0), self.ref, False)
+
+    def test_navball_marker(self):
+        marker = self.drawing.add_navball_marker((1, 2, 3), self.ref)
+        self.assertEqual((1, 2, 3), marker.direction)
+        self.assertEqual(self.ref, marker.reference_frame)
+        self.assertTrue(marker.visible)
+        self.assertEqual((1, 1, 1), marker.color)
+        self.assertEqual("default", marker.icon)
+        self.assertAlmostEqual(1, marker.size)
+        marker.remove()
+        self.assertRaises(ValueError, marker.remove)
+
+    def test_direction(self):
+        marker = self.add_marker()
+        self.assertFalse(marker.visible)
+        marker.direction = (0, 0, 1)
+        marker.visible = True
+        self.assertTrue(marker.visible)
+        self.assertEqual((0, 0, 1), marker.direction)
+        marker.remove()
+
+    def test_color(self):
+        marker = self.add_marker()
+        marker.color = (1, 0, 0)
+        self.assertEqual((1, 0, 0), marker.color)
+        marker.remove()
+
+    def test_size(self):
+        marker = self.add_marker()
+        marker.size = 2.5
+        self.assertAlmostEqual(2.5, marker.size)
+        marker.remove()
+
+    def test_icon(self):
+        marker = self.add_marker()
+        icons = marker.available_icons()
+        self.assertIn("default", icons)
+        self.assertIn("marker", icons)
+        for icon in icons:
+            marker.icon = icon
+            self.assertEqual(icon, marker.icon)
+        marker.remove()
+
+    def test_unknown_icon(self):
+        marker = self.add_marker()
+        with self.assertRaises(ValueError):
+            marker.icon = "not-an-icon"
+        self.assertEqual("default", marker.icon)
+        marker.remove()
+
+    def test_clear(self):
+        marker = self.add_marker()
+        self.drawing.clear()
+        self.assertRaises(ValueError, marker.remove)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
`Drawing.AddNavballMarker` draws a marker at a direction on the navball, so a script can compute a guidance solution and show the player where to point rather than flying the vessel itself. The marker's direction, reference frame, icon, color and size can all be changed. It hides while it is on the far side of the ball and fades as it nears the edge, as the navball's own markers do.

A marker is a clone of one of the game's own navball markers, so it draws with the game's mesh, shader and render layer, and its size is relative to the size the game draws them at. Its icon comes from the contract icons that `SpaceCenter.WaypointManager.Icons` also exposes.

**Testing.** In-game tests in `service/Drawing/test/test_navball_marker.py` cover the properties and removal.

Fixes #167