### PR TITLE
Stop the server and release client state while no game is loaded

### DIFF
--- a/server/CHANGELOG.md
+++ b/server/CHANGELOG.md
@@ -1,4 +1,9 @@
 ## [v0.7.0] - unreleased
+- The server is stopped whenever no game is loaded, so a client is disconnected when the player
+  quits to the main menu rather than being left waiting on a call that never returns. It starts
+  again with the next game if it is set to start automatically. State held for clients is released
+  at the same time, so user interface elements no longer stay on the screen for the whole of the
+  main menu (#1041)
 - Fix setting `KRPC.GameScene` from one editor straight to the other leaving the flight camera
   unable to follow a vessel for the rest of the session. The switch also keeps the vessel that is
   being constructed now, as the game's own switch editor button does (#1038)

--- a/server/src/Addon.cs
+++ b/server/src/Addon.cs
@@ -68,8 +68,10 @@ namespace KRPC
         }
 
         /// <summary>
-        /// Called whenever a scene change occurs. Ensures the server has been initialized,
-        /// (re)creates the UI, and shuts down the server in the main menu.
+        /// Called whenever a scene change occurs. Ensures the server has been initialized
+        /// and (re)creates the UI. The addon is declared for the scenes a game is loaded
+        /// in, so it is only ever entered with a game to serve; shutting kRPC down while
+        /// there is none is <see cref="NoGameAddon" />'s to do.
         /// </summary>
         public void Awake ()
         {
@@ -82,12 +84,6 @@ namespace KRPC
             var gameScene = GameScenesExtensions.CurrentGameScene();
             Service.CallContext.GameScene = gameScene;
             Utils.Logger.WriteLine ("Game scene switched to " + gameScene);
-
-            // If a game is not loaded, ensure the server is stopped and then exit
-            if (gameScene == Service.GameScene.None) {
-                core.StopAll ();
-                return;
-            }
 
             // Auto-start the server, if required
             if (config.Configuration.AutoStartServers) {

--- a/server/src/KRPC.csproj
+++ b/server/src/KRPC.csproj
@@ -51,6 +51,7 @@
     <Compile Include="Utils\ClientConnections.cs" />
     <Compile Include="Utils\ClientOwnedObjects.cs" />
     <Compile Include="Utils\ClientOwnedOverrides.cs" />
+    <Compile Include="Utils\ClientOwnedState.cs" />
     <Compile Include="Utils\Compatibility.cs" />
     <Compile Include="Utils\IClientOwnedCollection.cs" />
     <Compile Include="Utils\ConfigurationStorage.cs" />

--- a/server/src/KRPC.csproj
+++ b/server/src/KRPC.csproj
@@ -34,6 +34,7 @@
     <Compile Include="Addon.cs" />
     <Compile Include="ConfigurationFile.cs" />
     <Compile Include="Properties\AssemblyKSPVersion.cs" />
+    <Compile Include="NoGameAddon.cs" />
     <Compile Include="ServicesChecker.cs" />
     <Compile Include="UI\ClientConnectingDialog.cs" />
     <Compile Include="UI\ClientDisconnectDialog.cs" />

--- a/server/src/NoGameAddon.cs
+++ b/server/src/NoGameAddon.cs
@@ -1,0 +1,69 @@
+using KRPC.Utils;
+using UnityEngine;
+
+namespace KRPC
+{
+    /// <summary>
+    /// Shuts kRPC down for as long as no game is loaded: stops the servers, so that a
+    /// client is disconnected rather than left waiting on a server nothing is driving,
+    /// and releases the state kRPC holds on behalf of clients.
+    /// </summary>
+    /// <remarks>
+    /// Every other addon is declared for the scenes a game is loaded in, so none of them
+    /// exists in the main menu and nothing there drives the servers or sweeps up after a
+    /// client. The servers were left listening, and the state of the game just left was
+    /// held until a game was loaded again: anything the game keeps across a scene change,
+    /// such as a user interface element on the stock canvas, stayed on the screen for the
+    /// whole of the main menu.
+    ///
+    /// Declared for the main menu rather than for every scene. The game starts the addons
+    /// of a scene as that scene finishes loading, and it loads a scene of its own between
+    /// two game scenes, which is not a scene a game is loaded in either: an addon declared
+    /// for every scene would be started there and would take a switch from one game scene
+    /// to another for the game being unloaded. The main menu is the only way out of a
+    /// game other than quitting, which stops the servers on its way out.
+    /// </remarks>
+    [KSPAddon (KSPAddon.Startup.MainMenu, false)]
+    public sealed class NoGameAddon : MonoBehaviour
+    {
+        /// <summary>
+        /// Whether the state kRPC holds is still waiting to be released.
+        /// </summary>
+        bool releasePending;
+
+        /// <summary>
+        /// Stop the servers, as soon as the main menu is being entered.
+        /// </summary>
+        public void Awake ()
+        {
+            if (!ServicesChecker.OK)
+                return;
+            Utils.Logger.WriteLine ("No game is loaded");
+            Service.CallContext.GameScene = Service.GameScene.None;
+            var core = Core.Instance;
+            if (core.AnyRunning) {
+                Utils.Logger.WriteLine ("Stopping the server, as no game is loaded");
+                core.StopAll ();
+            }
+            releasePending = true;
+        }
+
+        /// <summary>
+        /// Release the state kRPC holds on behalf of clients.
+        /// </summary>
+        /// <remarks>
+        /// Not done in Awake, which runs while the scene is still loading: a destroy asked
+        /// for then does not take effect during that load, and the object it was asked for
+        /// lives on through the whole of the scene being entered. Asking once the scene is
+        /// running takes effect on the next frame.
+        /// </remarks>
+        public void Update ()
+        {
+            if (!releasePending)
+                return;
+            releasePending = false;
+            Utils.Logger.WriteLine ("Releasing the state held for clients");
+            ClientOwnedState.ReleaseAll ();
+        }
+    }
+}

--- a/server/src/Utils/ClientOwnedObjects.cs
+++ b/server/src/Utils/ClientOwnedObjects.cs
@@ -27,11 +27,14 @@ namespace KRPC.Utils
         /// Create a collection. The release action, if any, is invoked on each object
         /// released by <see cref="Sweep" /> and <see cref="Clear()" /> (but not on
         /// objects removed with <see cref="Remove" />, whose callers do their own
-        /// teardown).
+        /// teardown). The collection adds itself to <see cref="ClientOwnedState" />, so
+        /// that its state is released along with everything else when there is no game
+        /// left to hold it.
         /// </summary>
         public ClientOwnedObjects (Action<T> release = null)
         {
             this.release = release;
+            ClientOwnedState.Register (this);
         }
 
         /// <summary>

--- a/server/src/Utils/ClientOwnedOverrides.cs
+++ b/server/src/Utils/ClientOwnedOverrides.cs
@@ -116,6 +116,16 @@ namespace KRPC.Utils
         }
 
         /// <summary>
+        /// Release all overrides, whoever owns them.
+        /// </summary>
+        public void Clear ()
+        {
+            foreach (var entry in entries)
+                release (entry.Key, entry.Value);
+            entries.Clear ();
+        }
+
+        /// <summary>
         /// Take every override out of the collection, to be released by a later call to
         /// <see cref="ReleaseDetached" />.
         /// </summary>

--- a/server/src/Utils/ClientOwnedOverrides.cs
+++ b/server/src/Utils/ClientOwnedOverrides.cs
@@ -40,12 +40,15 @@ namespace KRPC.Utils
         /// <summary>
         /// Create a set of overrides, installed and released by the given delegates.
         /// The release delegate should restore any state saved by the install
-        /// delegate, and must handle its key having been destroyed.
+        /// delegate, and must handle its key having been destroyed. The set adds itself
+        /// to <see cref="ClientOwnedState" />, so that its overrides are released along
+        /// with everything else when there is no game left to hold them.
         /// </summary>
         public ClientOwnedOverrides (Func<TKey, TEntry> install, Action<TKey, TEntry> release)
         {
             this.install = install;
             this.release = release;
+            ClientOwnedState.Register (this);
         }
 
         /// <summary>

--- a/server/src/Utils/ClientOwnedState.cs
+++ b/server/src/Utils/ClientOwnedState.cs
@@ -1,0 +1,42 @@
+using System.Collections.Generic;
+
+namespace KRPC.Utils
+{
+    /// <summary>
+    /// Every collection of client-owned state in the mod, so that all of it can be
+    /// released at once when there is no game left to hold it.
+    /// </summary>
+    /// <remarks>
+    /// A collection is a static field of the addon that owns it, and an addon only exists
+    /// in the scenes it is declared for, so an addon cannot be asked to give its state up
+    /// once it is gone. Collections therefore add themselves here as they are created, and
+    /// releasing goes through the collections rather than through the addons.
+    /// </remarks>
+    public static class ClientOwnedState
+    {
+        static readonly List<IClientOwnedCollection> collections =
+            new List<IClientOwnedCollection> ();
+
+        /// <summary>
+        /// Add a collection, which is done by the collection itself as it is created.
+        /// </summary>
+        public static void Register (IClientOwnedCollection collection)
+        {
+            collections.Add (collection);
+        }
+
+        /// <summary>
+        /// Release every collection's state, whoever owns it, including state that has
+        /// been taken out of a collection but not yet released: a scene left before its
+        /// first sweep leaves the previous scene's state waiting for a sweep that will
+        /// not come.
+        /// </summary>
+        public static void ReleaseAll ()
+        {
+            foreach (var collection in collections) {
+                collection.Clear ();
+                collection.ReleaseDetached ();
+            }
+        }
+    }
+}

--- a/server/src/Utils/ClientOwnedState.cs
+++ b/server/src/Utils/ClientOwnedState.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 
 namespace KRPC.Utils
@@ -31,11 +32,30 @@ namespace KRPC.Utils
         /// first sweep leaves the previous scene's state waiting for a sweep that will
         /// not come.
         /// </summary>
+        /// <remarks>
+        /// One collection failing to release must not leave the rest holding their state,
+        /// so each is released on its own and a failure is logged and stepped over. The
+        /// collections belong to different services, and the order they are released in
+        /// is the order they happened to be created in, so without this the state a
+        /// failure strands would be whatever came after it.
+        /// </remarks>
         public static void ReleaseAll ()
         {
             foreach (var collection in collections) {
-                collection.Clear ();
-                collection.ReleaseDetached ();
+                Release (collection.Clear);
+                Release (collection.ReleaseDetached);
+            }
+        }
+
+        static void Release (Action release)
+        {
+            try {
+                release ();
+            } catch (Exception exn) {
+                // Anything at all, as the release actions are supplied by the services and
+                // run here against state whose subject the game may already have destroyed.
+                Logger.WriteLine (
+                    "Failed to release client-owned state; " + exn, Logger.Severity.Error);
             }
         }
     }

--- a/server/src/Utils/IClientOwnedCollection.cs
+++ b/server/src/Utils/IClientOwnedCollection.cs
@@ -12,6 +12,11 @@ namespace KRPC.Utils
         void Sweep ();
 
         /// <summary>
+        /// Release all entries, whoever owns them.
+        /// </summary>
+        void Clear ();
+
+        /// <summary>
         /// Take every entry out of the collection, holding them to be released by a later
         /// call to <see cref="ReleaseDetached" />. The collection is empty afterwards, so
         /// an entry added in the meantime is not caught up in the release.


### PR DESCRIPTION
**Problem.** Every kRPC addon is declared for the scenes a game is loaded in, so none of them exists in the main menu. Quitting to the main menu therefore left the servers listening with nothing driving them: a connected client waited on a call that never came back instead of being disconnected, and the state held on behalf of clients from the game just left was kept until a game was loaded again. Anything the game keeps across a scene change, such as a user interface element on the stock canvas, stayed on the screen for the whole of the main menu.

**Fix.** An addon declared for the main menu stops the servers and releases the state held for clients, which covers leaving a game for any reason other than quitting; quitting stops the servers on its way out. Releasing all of that state at once needs the collections of client-owned state to be reachable from outside the addons that own them, so each collection registers itself as it is created and gained a way to release every entry it holds.

**Robustness.** Release actions come from the services and run against state whose subject the game may already have destroyed, so each collection is released on its own and a failure is logged and stepped over rather than stranding the collections behind it.
