### PR TITLE
Compute reaction wheel available torque from the module's torque fields

### DIFF
--- a/service/SpaceCenter/CHANGELOG.md
+++ b/service/SpaceCenter/CHANGELOG.md
@@ -117,6 +117,9 @@
     engine needs tank pressure and whether it has it. On a tank it manages
     (`Part.HasRealFuelsTank`), `Part.HighlyPressurized` and `Part.BoiloffRate` give the tank's
     pressurization and how fast its cryogenic contents are boiling off (#1039)
+  - Fix `ReactionWheel.AvailableTorque`, and the vessel level torque properties that include
+    it, being scaled by the square of the wheel's authority limiter when KSPCommunityFixes is
+    installed (#1042)
 
 - Resources
   - Add `ResourceTransfer.Cancel` to stop a transfer before it finishes; no more of the

--- a/service/SpaceCenter/src/Services/Parts/ReactionWheel.cs
+++ b/service/SpaceCenter/src/Services/Parts/ReactionWheel.cs
@@ -111,14 +111,15 @@ namespace KRPC.SpaceCenter.Services.Parts
 
         internal TupleV3 AvailableTorqueVectors {
             get {
-                if (!Active || Broken)
+                // Computed from the wheel's torque fields rather than ModuleReactionWheel's
+                // ITorqueProvider implementation, whose handling of the authority limiter
+                // varies between the stock module and modded replacements of it. The
+                // conditions under which the wheel produces no torque match the stock ones:
+                // the module must be enabled and active, and actuator mode 2 disables it.
+                if (!reactionWheel.moduleIsEnabled || !Active || reactionWheel.actuatorModeCycle == 2)
                     return ITorqueProviderExtensions.zero;
-                // Note: GetPotentialTorque returns the base torque without applying the
-                // wheel's authority limiter
-                var torque = reactionWheel.GetPotentialTorque ();
-                var scale = reactionWheel.authorityLimiter / 100.0;
-                // Note: GetPotentialTorque returns negative torques with incorrect sign
-                return new TupleV3 (torque.Item1 * scale, -torque.Item2 * scale);
+                var torque = MaxTorqueVectors.Item1 * (reactionWheel.authorityLimiter / 100.0);
+                return new TupleV3 (torque, -torque);
             }
         }
 


### PR DESCRIPTION
**Root cause.** `ReactionWheel.AvailableTorque` called `ModuleReactionWheel.GetPotentialTorque` and applied the wheel's authority limiter to the result itself, because the stock module returns its base torque unscaled. KSPCommunityFixes' `ReactionWheelsPotentialTorque` patch moves that scaling inside `GetPotentialTorque`, so with the mod installed the limiter was applied twice and the reported torque came back scaled by the square of the authority. Anything downstream of the per-wheel value was wrong too: `Vessel.AvailableTorque`, the angular acceleration properties, and the autopilot's gain auto-tuner.

**Fix.** Derive the available torque from the module's `PitchTorque`, `RollTorque` and `YawTorque` fields, the same source `MaxTorque` already uses, and apply the authority limiter once. No patch of `GetPotentialTorque` can affect the result. The replacement guard reproduces the conditions under which the stock implementation reports no torque, so the value is unchanged without KSPCommunityFixes installed.

**Testing.** `service/SpaceCenter/test/test_parts_reaction_wheel.py` passes in game both on a stock install and with KSPCommunityFixes installed, whose `ReactionWheelsPotentialTorque` patch is enabled by default. `test_authority_limiter` covers the case the fix is about.
