### PR TITLE
Handle vessels that have no control point

### DIFF
--- a/service/SpaceCenter/CHANGELOG.md
+++ b/service/SpaceCenter/CHANGELOG.md
@@ -7,6 +7,29 @@
     assignments, launches with no crew; and a populated list seats exactly the named Kerbals,
     in the order given. An unknown or unavailable Kerbal name, or a craft with too few seats,
     raises an exception without launching (#1017)
+  - **Breaking:** `SpaceCenter.Parts.Controlling` returns `null` when the vessel has no
+    control point, rather than its root part. A vessel separated from another one is given a
+    control point only when one of its parts is a command module with crew aboard, so a
+    vessel that the game merely orients by its root part is now distinguishable from one that
+    is deliberately controlled from it (#1043)
+  - `SpaceCenter.Control.State`, `SpaceCenter.Control.Source` and the members of
+    `SpaceCenter.Comms` no longer throw for a vessel that has no node in the communication
+    network, such as the debris a decoupler leaves behind. They report no control and no
+    communications instead. `Comms.Power` is zero for a vessel whose antennas supply no
+    power, including one that carries none (#1043)
+  - `SpaceCenter.Control.Source` is `None` whenever `SpaceCenter.Control.State` is `None`.
+    A vessel whose only command module is a command pod with no crew aboard reported that
+    it was controlled by a kerbal, because KSP reports the kind of command module the
+    vessel carries separately from whether it is giving any control (#1043)
+  - `SpaceCenter.Control.State` and `SpaceCenter.Control.Source` are taken from the control
+    level that KSP gates a vessel's control on, rather than from the vessel's node in the
+    communication network. The network describes a vessel only while CommNet is enabled, so
+    with CommNet switched off both properties described a game rule that was not in use
+    (#1043)
+  - `SpaceCenter.Decoupler.Decouple` returns the separated vessel when it fires an
+    omni-decoupler such as a stack separator. Such a decoupler detaches at every node at
+    once, leaving itself on a vessel of its own as well as the vessel it separated, and the
+    two vessels this produced raised an exception (#1043)
 
 - Editor
   - Add `SpaceCenter.Editor`, available in the vehicle assembly building and the space

--- a/service/SpaceCenter/src/ExtensionMethods/VesselControlStateExtensions.cs
+++ b/service/SpaceCenter/src/ExtensionMethods/VesselControlStateExtensions.cs
@@ -6,6 +6,12 @@ namespace KRPC.SpaceCenter.ExtensionMethods
     {
         public static ControlSource ToControlSource (this CommNet.VesselControlState state)
         {
+            // KSP sets the kerbal and probe bits from the kind of command module the vessel
+            // carries, whether or not it is currently giving any control: a command pod with
+            // no crew aboard reports KerbalNone. A vessel that is not being controlled has no
+            // control source, so the level decides before the kind does.
+            if (state.ToControlState () == ControlState.None)
+                return ControlSource.None;
             if ((state & CommNet.VesselControlState.Kerbal) != 0)
                 return ControlSource.Kerbal;
             if ((state & CommNet.VesselControlState.Probe) != 0)

--- a/service/SpaceCenter/src/ExtensionMethods/VesselControlStateExtensions.cs
+++ b/service/SpaceCenter/src/ExtensionMethods/VesselControlStateExtensions.cs
@@ -1,31 +1,53 @@
+using System.Linq;
 using KRPC.SpaceCenter.Services;
 
 namespace KRPC.SpaceCenter.ExtensionMethods
 {
     static class VesselControlStateExtensions
     {
-        public static ControlSource ToControlSource (this CommNet.VesselControlState state)
+        /// <summary>
+        /// The control state a vessel is in, from the control level KSP gates its control on.
+        ///
+        /// This is deliberately taken from the vessel rather than from its communication
+        /// network node: KSP consults the network only when CommNet is enabled, and works
+        /// from the vessel's own parts otherwise, so the network's view of a vessel is not
+        /// the whole answer.
+        /// </summary>
+        public static ControlState ToControlState (this global::Vessel.ControlLevel level)
         {
-            // KSP sets the kerbal and probe bits from the kind of command module the vessel
-            // carries, whether or not it is currently giving any control: a command pod with
-            // no crew aboard reports KerbalNone. A vessel that is not being controlled has no
-            // control source, so the level decides before the kind does.
-            if (state.ToControlState () == ControlState.None)
-                return ControlSource.None;
-            if ((state & CommNet.VesselControlState.Kerbal) != 0)
-                return ControlSource.Kerbal;
-            if ((state & CommNet.VesselControlState.Probe) != 0)
-                return ControlSource.Probe;
-            return ControlSource.None;
+            switch (level) {
+            case global::Vessel.ControlLevel.FULL:
+                return ControlState.Full;
+            case global::Vessel.ControlLevel.PARTIAL_MANNED:
+            case global::Vessel.ControlLevel.PARTIAL_UNMANNED:
+                return ControlState.Partial;
+            default:
+                return ControlState.None;
+            }
         }
 
-        public static ControlState ToControlState (this CommNet.VesselControlState state)
+        /// <summary>
+        /// What is controlling a vessel, from its control level and, where the level does not
+        /// say, its parts. KSP records whether partial control comes from a kerbal or a probe,
+        /// but not for full control, so that case is decided by whether any part that is a
+        /// control source has crew aboard — a kerbal takes precedence over a probe core, as it
+        /// does in KSP's own control state.
+        /// </summary>
+        public static ControlSource ToControlSource (
+            this global::Vessel.ControlLevel level, global::Vessel vessel)
         {
-            if ((state & CommNet.VesselControlState.Full) != 0)
-                return ControlState.Full;
-            if ((state & CommNet.VesselControlState.Partial) != 0)
-                return ControlState.Partial;
-            return ControlState.None;
+            switch (level) {
+            case global::Vessel.ControlLevel.FULL:
+                return vessel.parts.Any (
+                    part => part.isControlSource > global::Vessel.ControlLevel.NONE &&
+                    part.protoModuleCrew.Count > 0) ? ControlSource.Kerbal : ControlSource.Probe;
+            case global::Vessel.ControlLevel.PARTIAL_MANNED:
+                return ControlSource.Kerbal;
+            case global::Vessel.ControlLevel.PARTIAL_UNMANNED:
+                return ControlSource.Probe;
+            default:
+                return ControlSource.None;
+            }
         }
     }
 }

--- a/service/SpaceCenter/src/Services/Comms.cs
+++ b/service/SpaceCenter/src/Services/Comms.cs
@@ -62,9 +62,21 @@ namespace KRPC.SpaceCenter.Services
 
         /// <summary>
         /// The KSP vessel communication object.
+        /// Null for a vessel that is not part of the network, see <see cref="InNetwork"/>.
         /// </summary>
         public CommNet.CommNetVessel InternalComms {
             get { return InternalVessel.Connection; }
+        }
+
+        /// <summary>
+        /// Whether the vessel is part of the communication network at all, and so has anything
+        /// to report about its communications. KSP gives no network node to a vessel whose type
+        /// is debris, a space object, unknown, a flag or a deployed science part. Debris is the
+        /// type it gives a vessel that is left with no command module, by a decoupler firing for
+        /// example.
+        /// </summary>
+        bool InNetwork {
+            get { return InternalComms != null; }
         }
 
         /// <summary>
@@ -72,7 +84,7 @@ namespace KRPC.SpaceCenter.Services
         /// </summary>
         [KRPCProperty]
         public bool CanCommunicate {
-            get { return InternalComms.CanComm; }
+            get { return InNetwork && InternalComms.CanComm; }
         }
 
         /// <summary>
@@ -80,7 +92,7 @@ namespace KRPC.SpaceCenter.Services
         /// </summary>
         [KRPCProperty]
         public bool CanTransmitScience {
-            get { return InternalComms.CanScience; }
+            get { return InNetwork && InternalComms.CanScience; }
         }
 
         /// <summary>
@@ -88,7 +100,7 @@ namespace KRPC.SpaceCenter.Services
         /// </summary>
         [KRPCProperty]
         public double SignalStrength {
-            get { return InternalComms.SignalStrength; }
+            get { return InNetwork ? InternalComms.SignalStrength : 0; }
         }
 
         /// <summary>
@@ -96,7 +108,7 @@ namespace KRPC.SpaceCenter.Services
         /// </summary>
         [KRPCProperty]
         public double SignalDelay {
-            get { return InternalComms.SignalDelay; }
+            get { return InNetwork ? InternalComms.SignalDelay : 0; }
         }
 
         /// <summary>
@@ -106,9 +118,14 @@ namespace KRPC.SpaceCenter.Services
         public double Power {
             get {
                 var antennas = new Vessel (VesselId).Parts.Antennas;
-                var powers = antennas.Select (x => x.Power);
-                var maxPower = powers.Max ();
+                var powers = antennas.Select (x => x.Power).ToList ();
                 var totalPower = powers.Sum ();
+                // The combination below divides by the total power, and by the largest of the
+                // powers, so both have to be above zero. The total is zero for a vessel that
+                // carries no antennae, and for one whose antennae all supply no power.
+                if (totalPower <= 0)
+                    return 0;
+                var maxPower = powers.Max ();
                 var averageWeightedExponent = antennas.Select (x => x.Power * x.CombinableExponent).Sum () / totalPower;
                 return maxPower * Math.Pow (totalPower / maxPower, averageWeightedExponent);
             }
@@ -119,7 +136,11 @@ namespace KRPC.SpaceCenter.Services
         /// </summary>
         [KRPCProperty]
         public IList<CommLink> ControlPath {
-            get { return InternalComms.ControlPath.Select (x => new CommLink (x)).ToList (); }
+            get {
+                if (!InNetwork)
+                    return new List<CommLink> ();
+                return InternalComms.ControlPath.Select (x => new CommLink (x)).ToList ();
+            }
         }
     }
 }

--- a/service/SpaceCenter/src/Services/Control.cs
+++ b/service/SpaceCenter/src/Services/Control.cs
@@ -77,11 +77,7 @@ namespace KRPC.SpaceCenter.Services
         /// </summary>
         [KRPCProperty]
         public ControlState State {
-            get {
-                var connection = InternalVessel.Connection;
-                return connection == null
-                    ? ControlState.None : connection.ControlState.ToControlState ();
-            }
+            get { return InternalVessel.CurrentControlLevel.ToControlState (); }
         }
 
         /// <summary>
@@ -90,9 +86,8 @@ namespace KRPC.SpaceCenter.Services
         [KRPCProperty]
         public ControlSource Source {
             get {
-                var connection = InternalVessel.Connection;
-                return connection == null
-                    ? ControlSource.None : connection.ControlState.ToControlSource ();
+                var vessel = InternalVessel;
+                return vessel.CurrentControlLevel.ToControlSource (vessel);
             }
         }
 

--- a/service/SpaceCenter/src/Services/Control.cs
+++ b/service/SpaceCenter/src/Services/Control.cs
@@ -77,7 +77,11 @@ namespace KRPC.SpaceCenter.Services
         /// </summary>
         [KRPCProperty]
         public ControlState State {
-            get { return InternalVessel.Connection.ControlState.ToControlState (); }
+            get {
+                var connection = InternalVessel.Connection;
+                return connection == null
+                    ? ControlState.None : connection.ControlState.ToControlState ();
+            }
         }
 
         /// <summary>
@@ -85,7 +89,11 @@ namespace KRPC.SpaceCenter.Services
         /// </summary>
         [KRPCProperty]
         public ControlSource Source {
-            get { return InternalVessel.Connection.ControlState.ToControlSource (); }
+            get {
+                var connection = InternalVessel.Connection;
+                return connection == null
+                    ? ControlSource.None : connection.ControlState.ToControlSource ();
+            }
         }
 
         /// <summary>

--- a/service/SpaceCenter/src/Services/Parts/Decoupler.cs
+++ b/service/SpaceCenter/src/Services/Parts/Decoupler.cs
@@ -76,7 +76,7 @@ namespace KRPC.SpaceCenter.Services.Parts
             // Fire the decoupler
             decoupler.Decouple();
 
-            return PartSeparation.NewVessel (preVesselIds, () => Decoupled);
+            return PartSeparation.NewVessel (Part, preVesselIds, () => Decoupled);
         }
 
         /// <summary>

--- a/service/SpaceCenter/src/Services/Parts/DockingPort.cs
+++ b/service/SpaceCenter/src/Services/Parts/DockingPort.cs
@@ -136,7 +136,7 @@ namespace KRPC.SpaceCenter.Services.Parts
             // that docked in flight; a given port only ever offers one of them.
             if (port.InvokeEvent ("Decouple") || port.InvokeEvent ("Undock") ||
                 (dockedPort != null && (dockedPort.InvokeEvent ("Decouple") || dockedPort.InvokeEvent ("Undock")))) {
-                return PartSeparation.NewVessel (preVesselIds, () => State != DockingPortState.Docked);
+                return PartSeparation.NewVessel (Part, preVesselIds, () => State != DockingPortState.Docked);
             }
 
             // Failed to undock

--- a/service/SpaceCenter/src/Services/Parts/PartSeparation.cs
+++ b/service/SpaceCenter/src/Services/Parts/PartSeparation.cs
@@ -24,15 +24,31 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// Yields until the separation has completed (<paramref name="separated"/> returns true) and
         /// the settle margin has elapsed, then returns the vessel that <c>FlightGlobals.Vessels</c>
         /// gained relative to <paramref name="preVesselIds"/> — the snapshot of vessel ids taken
-        /// before the separation was triggered. A single separation produces exactly one new vessel.
+        /// before the separation was triggered.
+        ///
+        /// A separation usually produces one new vessel, but an omni-decoupler detaches at every
+        /// node at once: it separates the vessel beyond it and is itself left on a vessel of its
+        /// own, so two appear. The one to return is the vessel that was separated, which is the one
+        /// <paramref name="part"/> — the decoupler or docking port that was fired — did not end up
+        /// on. It is looked up once the wait is over, and by identifier, so that it resolves to
+        /// the right object however the separation rearranged the parts in the meantime.
         /// </summary>
-        internal static Vessel NewVessel (IList<Guid> preVesselIds, Func<bool> separated, int wait = 0)
+        internal static Vessel NewVessel (Part part, IList<Guid> preVesselIds, Func<bool> separated, int wait = 0)
         {
             if (wait < SettleFrames || !separated ())
                 throw new YieldException<Func<Vessel>> (
-                    () => NewVessel (preVesselIds, separated, wait + 1));
-            return new Vessel (
-                FlightGlobals.Vessels.Select (v => v.id).Except (preVesselIds).Single ());
+                    () => NewVessel (part, preVesselIds, separated, wait + 1));
+            var newVessels = FlightGlobals.Vessels
+                .Where (vessel => !preVesselIds.Contains (vessel.id)).ToList ();
+            if (newVessels.Count == 1)
+                return new Vessel (newVessels [0].id);
+            var partVessel = part.InternalPart.vessel;
+            var separatedVessels = newVessels.Where (vessel => vessel != partVessel).ToList ();
+            if (separatedVessels.Count != 1)
+                throw new InvalidOperationException (
+                    "The separation produced " + newVessels.Count + " new vessels, and which of " +
+                    "them was separated is ambiguous");
+            return new Vessel (separatedVessels [0].id);
         }
     }
 }

--- a/service/SpaceCenter/src/Services/Parts/Parts.cs
+++ b/service/SpaceCenter/src/Services/Parts/Parts.cs
@@ -111,14 +111,24 @@ namespace KRPC.SpaceCenter.Services.Parts
 
         /// <summary>
         /// The part from which the vessel is controlled.
+        /// Returns <c>null</c> if the vessel has no control point, in which case it is
+        /// oriented by its root part.
         /// </summary>
-        [KRPCProperty (GameScene = GameScene.Flight)]
+        /// <remarks>
+        /// A vessel gets no control point when it is created by a decoupler or an undocking
+        /// and none of its parts is a command module with crew aboard. A probe core does not
+        /// give it one either. Assign this property to choose the control point, which is
+        /// equivalent to "Control From Here" in game.
+        /// </remarks>
+        [KRPCProperty (Nullable = true, GameScene = GameScene.Flight)]
         public Part Controlling {
             get {
-                var vessel = InternalVessel;
-                return new Part (vessel.GetReferenceTransformPart () ?? vessel.rootPart);
+                var part = InternalVessel.GetReferenceTransformPart ();
+                return part == null ? null : new Part (part);
             }
             set {
+                if (ReferenceEquals (value, null))
+                    throw new ArgumentNullException (nameof (Controlling));
                 var part = value.InternalPart;
                 if (part.HasModule <ModuleCommand> ()) {
                     part.Module<ModuleCommand> ().MakeReference ();

--- a/service/SpaceCenter/test/craft/CrewlessCommandPod.craft
+++ b/service/SpaceCenter/test/craft/CrewlessCommandPod.craft
@@ -1,0 +1,1123 @@
+ship = CrewlessCommandPod
+version = 1.12.5
+description = 
+type = VAB
+size = 2.44576693,5.84194183,2.44576669
+steamPublishedFileId = 0
+persistentId = 4252780976
+rot = 0,0,0,0
+missionFlag = Squad/Flags/default
+vesselType = Debris
+OverrideDefault = False,False,False,False
+OverrideActionControl = 0,0,0,0
+OverrideAxisControl = 0,0,0,0
+OverrideGroupNames = ,,,
+PART
+{
+	part = mk1-3pod_4294571308
+	partName = Part
+	persistentId = 3521331972
+	pos = -0.321516573,14.8773642,1.19169664
+	attPos = 0,0,0
+	attPos0 = -0.321516573,14.8773642,1.19169664
+	rot = 0,0,0,1
+	attRot = 0,0,0,1
+	attRot0 = 0,0,0,1
+	mir = 1,1,1
+	symMethod = Radial
+	autostrutMode = Off
+	rigidAttachment = False
+	istg = -1
+	resPri = 0
+	dstg = 0
+	sidx = -1
+	sqor = -1
+	sepI = -1
+	attm = 0
+	sameVesselCollision = False
+	modCost = 0
+	modMass = 0
+	modSize = 0,0,0
+	link = trussPiece1x_4294469162
+	attN = bottom,trussPiece1x_4294469162_0|-0.47924|0_0|-1|0_0|-0.47924|0_0|-1|0
+	attN = top,Null_0_0|1.19318998|0_0|1|0_0|1.19318998|0_0|1|0
+	EVENTS
+	{
+	}
+	ACTIONS
+	{
+		ToggleSameVesselInteraction
+		{
+			actionGroup = None
+			wasActiveBeforePartWasAdjusted = False
+		}
+		SetSameVesselInteraction
+		{
+			actionGroup = None
+			wasActiveBeforePartWasAdjusted = False
+		}
+		RemoveSameVesselInteraction
+		{
+			actionGroup = None
+			wasActiveBeforePartWasAdjusted = False
+		}
+	}
+	PARTDATA
+	{
+	}
+	MODULE
+	{
+		name = ModuleCommand
+		isEnabled = True
+		hibernation = False
+		hibernateOnWarp = False
+		activeControlPointName = _default
+		stagingEnabled = True
+		EVENTS
+		{
+		}
+		ACTIONS
+		{
+			MakeReferenceToggle
+			{
+				actionGroup = None
+				wasActiveBeforePartWasAdjusted = False
+			}
+			HibernateToggle
+			{
+				actionGroup = None
+				active = False
+				wasActiveBeforePartWasAdjusted = False
+			}
+		}
+		UPGRADESAPPLIED
+		{
+		}
+	}
+	MODULE
+	{
+		name = ModuleReactionWheel
+		isEnabled = True
+		actuatorModeCycle = 0
+		authorityLimiter = 100
+		stateString = Active
+		stagingEnabled = True
+		WheelState = Active
+		EVENTS
+		{
+		}
+		ACTIONS
+		{
+			CycleAction
+			{
+				actionGroup = None
+				wasActiveBeforePartWasAdjusted = False
+			}
+			Activate
+			{
+				actionGroup = None
+				wasActiveBeforePartWasAdjusted = False
+			}
+			Deactivate
+			{
+				actionGroup = None
+				wasActiveBeforePartWasAdjusted = False
+			}
+			Toggle
+			{
+				actionGroup = None
+				wasActiveBeforePartWasAdjusted = False
+			}
+		}
+		UPGRADESAPPLIED
+		{
+		}
+	}
+	MODULE
+	{
+		name = ModuleColorChanger
+		isEnabled = True
+		animState = False
+		stagingEnabled = True
+		EVENTS
+		{
+		}
+		ACTIONS
+		{
+			ToggleAction
+			{
+				actionGroup = Light
+				wasActiveBeforePartWasAdjusted = False
+			}
+		}
+		UPGRADESAPPLIED
+		{
+		}
+	}
+	MODULE
+	{
+		name = ModuleScienceExperiment
+		isEnabled = True
+		Deployed = False
+		Inoperable = False
+		cooldownToGo = 0
+		stagingEnabled = True
+		EVENTS
+		{
+		}
+		ACTIONS
+		{
+			DeployAction
+			{
+				actionGroup = None
+				wasActiveBeforePartWasAdjusted = False
+			}
+			ResetAction
+			{
+				actionGroup = None
+				wasActiveBeforePartWasAdjusted = False
+			}
+		}
+		UPGRADESAPPLIED
+		{
+		}
+	}
+	MODULE
+	{
+		name = ModuleScienceContainer
+		isEnabled = True
+		stagingEnabled = True
+		EVENTS
+		{
+		}
+		ACTIONS
+		{
+			CollectAllAction
+			{
+				actionGroup = None
+				wasActiveBeforePartWasAdjusted = False
+			}
+		}
+		UPGRADESAPPLIED
+		{
+		}
+	}
+	MODULE
+	{
+		name = FlagDecal
+		isEnabled = True
+		flagDisplayed = True
+		isMirrored = False
+		stagingEnabled = True
+		EVENTS
+		{
+		}
+		ACTIONS
+		{
+		}
+		UPGRADESAPPLIED
+		{
+		}
+	}
+	MODULE
+	{
+		name = ModuleConductionMultiplier
+		isEnabled = True
+		stagingEnabled = True
+		EVENTS
+		{
+		}
+		ACTIONS
+		{
+		}
+		UPGRADESAPPLIED
+		{
+		}
+	}
+	MODULE
+	{
+		name = ModuleDataTransmitter
+		isEnabled = True
+		xmitIncomplete = False
+		stagingEnabled = True
+		EVENTS
+		{
+		}
+		ACTIONS
+		{
+			StartTransmissionAction
+			{
+				actionGroup = None
+				active = False
+				wasActiveBeforePartWasAdjusted = False
+			}
+		}
+		UPGRADESAPPLIED
+		{
+		}
+	}
+	MODULE
+	{
+		name = ModuleProbeControlPoint
+		isEnabled = True
+		stagingEnabled = True
+		EVENTS
+		{
+		}
+		ACTIONS
+		{
+		}
+		UPGRADESAPPLIED
+		{
+		}
+	}
+	MODULE
+	{
+		name = ModuleLiftingSurface
+		isEnabled = True
+		stagingEnabled = True
+		EVENTS
+		{
+		}
+		ACTIONS
+		{
+		}
+		UPGRADESAPPLIED
+		{
+		}
+	}
+	MODULE
+	{
+		name = ModuleRCSFX
+		isEnabled = True
+		rcsEnabled = True
+		thrustPercentage = 100
+		currentShowToggles = False
+		enableYaw = True
+		enablePitch = True
+		enableRoll = True
+		enableX = True
+		enableY = True
+		enableZ = True
+		useThrottle = False
+		fullThrust = False
+		stagingEnabled = False
+		EVENTS
+		{
+		}
+		ACTIONS
+		{
+			ToggleAction
+			{
+				actionGroup = None
+				wasActiveBeforePartWasAdjusted = False
+			}
+		}
+		UPGRADESAPPLIED
+		{
+		}
+	}
+	MODULE
+	{
+		name = ModuleInventoryPart
+		isEnabled = True
+		stagingEnabled = True
+		EVENTS
+		{
+		}
+		ACTIONS
+		{
+		}
+		STOREDPARTS
+		{
+		}
+		UPGRADESAPPLIED
+		{
+		}
+	}
+	MODULE
+	{
+		name = KOSNameTag
+		isEnabled = True
+		nameTag = 
+		stagingEnabled = True
+		EVENTS
+		{
+		}
+		ACTIONS
+		{
+		}
+		UPGRADESAPPLIED
+		{
+		}
+	}
+	MODULE
+	{
+		name = ModuleTripLogger
+		isEnabled = True
+		stagingEnabled = True
+		EVENTS
+		{
+		}
+		ACTIONS
+		{
+		}
+		Log
+		{
+			flight = 0
+		}
+		UPGRADESAPPLIED
+		{
+		}
+	}
+	RESOURCE
+	{
+		name = ElectricCharge
+		amount = 150
+		maxAmount = 150
+		flowState = True
+		isTweakable = True
+		hideFlow = False
+		isVisible = True
+		flowMode = Both
+	}
+	RESOURCE
+	{
+		name = MonoPropellant
+		amount = 30
+		maxAmount = 30
+		flowState = True
+		isTweakable = True
+		hideFlow = False
+		isVisible = True
+		flowMode = Both
+	}
+}
+PART
+{
+	part = trussPiece1x_4294469162
+	partName = Part
+	persistentId = 927049603
+	pos = -0.321516573,13.838851,1.19169664
+	attPos = 0,0,0
+	attPos0 = 0,-1.03851318,0
+	rot = 0,0,0,1
+	attRot = 0,0,0,1
+	attRot0 = 0,0,0,1
+	mir = 1,1,1
+	symMethod = Radial
+	autostrutMode = Off
+	rigidAttachment = False
+	istg = -1
+	resPri = 0
+	dstg = 0
+	sidx = -1
+	sqor = -1
+	sepI = -1
+	attm = 0
+	sameVesselCollision = False
+	modCost = 0
+	modMass = 0
+	modSize = 0,0,0
+	link = Separator.1_4294467932
+	attN = bottom,Separator.1_4294467932_0|-0.559272826|0_0|-1|0_0|-0.559272826|0_0|-1|0
+	attN = top,mk1-3pod_4294571308_0|0.559272826|0_0|1|0_0|0.559272826|0_0|1|0
+	EVENTS
+	{
+	}
+	ACTIONS
+	{
+		ToggleSameVesselInteraction
+		{
+			actionGroup = None
+			wasActiveBeforePartWasAdjusted = False
+		}
+		SetSameVesselInteraction
+		{
+			actionGroup = None
+			wasActiveBeforePartWasAdjusted = False
+		}
+		RemoveSameVesselInteraction
+		{
+			actionGroup = None
+			wasActiveBeforePartWasAdjusted = False
+		}
+	}
+	PARTDATA
+	{
+	}
+	MODULE
+	{
+		name = ModuleCargoPart
+		isEnabled = True
+		beingAttached = False
+		beingSettled = False
+		reinitResourcesOnStoreInVessel = False
+		stagingEnabled = True
+		EVENTS
+		{
+		}
+		ACTIONS
+		{
+		}
+		UPGRADESAPPLIED
+		{
+		}
+	}
+	MODULE
+	{
+		name = KOSNameTag
+		isEnabled = True
+		nameTag = 
+		stagingEnabled = True
+		EVENTS
+		{
+		}
+		ACTIONS
+		{
+		}
+		UPGRADESAPPLIED
+		{
+		}
+	}
+}
+PART
+{
+	part = Separator.1_4294467932
+	partName = Part
+	persistentId = 3015920256
+	pos = -0.321516573,13.229578,1.19169664
+	attPos = 0,0,0
+	attPos0 = 0,-0.609272957,0
+	rot = 0,0,0,1
+	attRot = 0,0,0,1
+	attRot0 = 0,0,0,1
+	mir = 1,1,1
+	symMethod = Radial
+	autostrutMode = Off
+	rigidAttachment = False
+	istg = 0
+	resPri = 0
+	dstg = 1
+	sidx = 0
+	sqor = 0
+	sepI = 0
+	attm = 0
+	sameVesselCollision = False
+	modCost = 0
+	modMass = 0
+	modSize = 0,0,0
+	link = trussPiece1x_4294183856
+	attN = top,trussPiece1x_4294469162_0|0.0500000007|0_0|1|0_0|0.0500000007|0_0|1|0
+	attN = bottom,trussPiece1x_4294183856_0|-0.0500000007|0_0|-1|0_0|-0.0500000007|0_0|-1|0
+	EVENTS
+	{
+	}
+	ACTIONS
+	{
+		ToggleSameVesselInteraction
+		{
+			actionGroup = None
+			wasActiveBeforePartWasAdjusted = False
+		}
+		SetSameVesselInteraction
+		{
+			actionGroup = None
+			wasActiveBeforePartWasAdjusted = False
+		}
+		RemoveSameVesselInteraction
+		{
+			actionGroup = None
+			wasActiveBeforePartWasAdjusted = False
+		}
+	}
+	PARTDATA
+	{
+	}
+	MODULE
+	{
+		name = ModuleDecouple
+		isEnabled = True
+		ejectionForcePercent = 100
+		isDecoupled = False
+		stagingEnabled = True
+		EVENTS
+		{
+		}
+		ACTIONS
+		{
+			DecoupleAction
+			{
+				actionGroup = None
+				wasActiveBeforePartWasAdjusted = False
+			}
+		}
+		UPGRADESAPPLIED
+		{
+		}
+	}
+	MODULE
+	{
+		name = ModuleToggleCrossfeed
+		isEnabled = True
+		crossfeedStatus = False
+		stagingEnabled = True
+		EVENTS
+		{
+		}
+		ACTIONS
+		{
+			ToggleAction
+			{
+				actionGroup = None
+				wasActiveBeforePartWasAdjusted = False
+			}
+			EnableAction
+			{
+				actionGroup = None
+				wasActiveBeforePartWasAdjusted = False
+			}
+			DisableAction
+			{
+				actionGroup = None
+				wasActiveBeforePartWasAdjusted = False
+			}
+		}
+		UPGRADESAPPLIED
+		{
+		}
+	}
+	MODULE
+	{
+		name = ModuleTestSubject
+		isEnabled = True
+		stagingEnabled = True
+		EVENTS
+		{
+		}
+		ACTIONS
+		{
+		}
+		UPGRADESAPPLIED
+		{
+		}
+	}
+	MODULE
+	{
+		name = ModulePartVariants
+		isEnabled = True
+		useVariantMass = True
+		stagingEnabled = True
+		EVENTS
+		{
+		}
+		ACTIONS
+		{
+		}
+		UPGRADESAPPLIED
+		{
+		}
+	}
+	MODULE
+	{
+		name = ModuleCargoPart
+		isEnabled = True
+		beingAttached = False
+		beingSettled = False
+		reinitResourcesOnStoreInVessel = False
+		stagingEnabled = True
+		EVENTS
+		{
+		}
+		ACTIONS
+		{
+		}
+		UPGRADESAPPLIED
+		{
+		}
+	}
+	MODULE
+	{
+		name = KOSNameTag
+		isEnabled = True
+		nameTag = 
+		stagingEnabled = True
+		EVENTS
+		{
+		}
+		ACTIONS
+		{
+		}
+		UPGRADESAPPLIED
+		{
+		}
+	}
+}
+PART
+{
+	part = trussPiece1x_4294183856
+	partName = Part
+	persistentId = 225170597
+	pos = -0.321516573,12.6203051,1.19169664
+	attPos = 0,0,0
+	attPos0 = 0,-0.609272957,0
+	rot = 0,0,-1,0
+	attRot = 0,0,-0.99999994,0
+	attRot0 = 0,0,-1,0
+	mir = 1,1,1
+	symMethod = Radial
+	autostrutMode = Off
+	rigidAttachment = False
+	istg = 0
+	resPri = 0
+	dstg = 2
+	sidx = -1
+	sqor = -1
+	sepI = 0
+	attm = 0
+	sameVesselCollision = False
+	modCost = 0
+	modMass = 0
+	modSize = 0,0,0
+	link = mk1-3pod_4294281452
+	attN = bottom,Separator.1_4294467932_0|-0.559272826|0_0|-1|0_0|-0.559272826|0_0|-1|0
+	attN = top,mk1-3pod_4294281452_0|0.559272826|0_0|1|0_0|0.559272826|0_0|1|0
+	EVENTS
+	{
+	}
+	ACTIONS
+	{
+		ToggleSameVesselInteraction
+		{
+			actionGroup = None
+			wasActiveBeforePartWasAdjusted = False
+		}
+		SetSameVesselInteraction
+		{
+			actionGroup = None
+			wasActiveBeforePartWasAdjusted = False
+		}
+		RemoveSameVesselInteraction
+		{
+			actionGroup = None
+			wasActiveBeforePartWasAdjusted = False
+		}
+	}
+	PARTDATA
+	{
+	}
+	MODULE
+	{
+		name = ModuleCargoPart
+		isEnabled = True
+		beingAttached = False
+		beingSettled = False
+		reinitResourcesOnStoreInVessel = False
+		stagingEnabled = True
+		EVENTS
+		{
+		}
+		ACTIONS
+		{
+		}
+		UPGRADESAPPLIED
+		{
+		}
+	}
+	MODULE
+	{
+		name = KOSNameTag
+		isEnabled = True
+		nameTag = 
+		stagingEnabled = True
+		EVENTS
+		{
+		}
+		ACTIONS
+		{
+		}
+		UPGRADESAPPLIED
+		{
+		}
+	}
+}
+PART
+{
+	part = mk1-3pod_4294281452
+	partName = Part
+	persistentId = 2353277458
+	pos = -0.321516573,11.5817919,1.19169664
+	attPos = 0,0,0
+	attPos0 = 0,1.03851318,0
+	rot = 0,0,-1,0
+	attRot = 0,0,0,1
+	attRot0 = 0,0,0,1
+	mir = 1,1,1
+	symMethod = Radial
+	autostrutMode = Off
+	rigidAttachment = False
+	istg = 0
+	resPri = 0
+	dstg = 2
+	sidx = -1
+	sqor = -1
+	sepI = 0
+	attm = 0
+	sameVesselCollision = False
+	modCost = 0
+	modMass = 0
+	modSize = 0,0,0
+	attN = bottom,trussPiece1x_4294183856_0|-0.47924|0_0|-1|0_0|-0.47924|0_0|-1|0
+	attN = top,Null_0_0|1.19318998|0_0|1|0_0|1.19318998|0_0|1|0
+	EVENTS
+	{
+	}
+	ACTIONS
+	{
+		ToggleSameVesselInteraction
+		{
+			actionGroup = None
+			wasActiveBeforePartWasAdjusted = False
+		}
+		SetSameVesselInteraction
+		{
+			actionGroup = None
+			wasActiveBeforePartWasAdjusted = False
+		}
+		RemoveSameVesselInteraction
+		{
+			actionGroup = None
+			wasActiveBeforePartWasAdjusted = False
+		}
+	}
+	PARTDATA
+	{
+	}
+	MODULE
+	{
+		name = ModuleCommand
+		isEnabled = True
+		hibernation = False
+		hibernateOnWarp = False
+		activeControlPointName = _default
+		stagingEnabled = True
+		EVENTS
+		{
+		}
+		ACTIONS
+		{
+			MakeReferenceToggle
+			{
+				actionGroup = None
+				wasActiveBeforePartWasAdjusted = False
+			}
+			HibernateToggle
+			{
+				actionGroup = None
+				active = False
+				wasActiveBeforePartWasAdjusted = False
+			}
+		}
+		UPGRADESAPPLIED
+		{
+		}
+	}
+	MODULE
+	{
+		name = ModuleReactionWheel
+		isEnabled = True
+		actuatorModeCycle = 0
+		authorityLimiter = 100
+		stateString = Active
+		stagingEnabled = True
+		WheelState = Active
+		EVENTS
+		{
+		}
+		ACTIONS
+		{
+			CycleAction
+			{
+				actionGroup = None
+				wasActiveBeforePartWasAdjusted = False
+			}
+			Activate
+			{
+				actionGroup = None
+				wasActiveBeforePartWasAdjusted = False
+			}
+			Deactivate
+			{
+				actionGroup = None
+				wasActiveBeforePartWasAdjusted = False
+			}
+			Toggle
+			{
+				actionGroup = None
+				wasActiveBeforePartWasAdjusted = False
+			}
+		}
+		UPGRADESAPPLIED
+		{
+		}
+	}
+	MODULE
+	{
+		name = ModuleColorChanger
+		isEnabled = True
+		animState = False
+		stagingEnabled = True
+		EVENTS
+		{
+		}
+		ACTIONS
+		{
+			ToggleAction
+			{
+				actionGroup = Light
+				wasActiveBeforePartWasAdjusted = False
+			}
+		}
+		UPGRADESAPPLIED
+		{
+		}
+	}
+	MODULE
+	{
+		name = ModuleScienceExperiment
+		isEnabled = True
+		Deployed = False
+		Inoperable = False
+		cooldownToGo = 0
+		stagingEnabled = True
+		EVENTS
+		{
+		}
+		ACTIONS
+		{
+			DeployAction
+			{
+				actionGroup = None
+				wasActiveBeforePartWasAdjusted = False
+			}
+			ResetAction
+			{
+				actionGroup = None
+				wasActiveBeforePartWasAdjusted = False
+			}
+		}
+		UPGRADESAPPLIED
+		{
+		}
+	}
+	MODULE
+	{
+		name = ModuleScienceContainer
+		isEnabled = True
+		stagingEnabled = True
+		EVENTS
+		{
+		}
+		ACTIONS
+		{
+			CollectAllAction
+			{
+				actionGroup = None
+				wasActiveBeforePartWasAdjusted = False
+			}
+		}
+		UPGRADESAPPLIED
+		{
+		}
+	}
+	MODULE
+	{
+		name = FlagDecal
+		isEnabled = True
+		flagDisplayed = True
+		isMirrored = False
+		stagingEnabled = True
+		EVENTS
+		{
+		}
+		ACTIONS
+		{
+		}
+		UPGRADESAPPLIED
+		{
+		}
+	}
+	MODULE
+	{
+		name = ModuleConductionMultiplier
+		isEnabled = True
+		stagingEnabled = True
+		EVENTS
+		{
+		}
+		ACTIONS
+		{
+		}
+		UPGRADESAPPLIED
+		{
+		}
+	}
+	MODULE
+	{
+		name = ModuleDataTransmitter
+		isEnabled = True
+		xmitIncomplete = False
+		stagingEnabled = True
+		EVENTS
+		{
+		}
+		ACTIONS
+		{
+			StartTransmissionAction
+			{
+				actionGroup = None
+				active = False
+				wasActiveBeforePartWasAdjusted = False
+			}
+		}
+		UPGRADESAPPLIED
+		{
+		}
+	}
+	MODULE
+	{
+		name = ModuleProbeControlPoint
+		isEnabled = True
+		stagingEnabled = True
+		EVENTS
+		{
+		}
+		ACTIONS
+		{
+		}
+		UPGRADESAPPLIED
+		{
+		}
+	}
+	MODULE
+	{
+		name = ModuleLiftingSurface
+		isEnabled = True
+		stagingEnabled = True
+		EVENTS
+		{
+		}
+		ACTIONS
+		{
+		}
+		UPGRADESAPPLIED
+		{
+		}
+	}
+	MODULE
+	{
+		name = ModuleRCSFX
+		isEnabled = True
+		rcsEnabled = True
+		thrustPercentage = 100
+		currentShowToggles = False
+		enableYaw = True
+		enablePitch = True
+		enableRoll = True
+		enableX = True
+		enableY = True
+		enableZ = True
+		useThrottle = False
+		fullThrust = False
+		stagingEnabled = False
+		EVENTS
+		{
+		}
+		ACTIONS
+		{
+			ToggleAction
+			{
+				actionGroup = None
+				wasActiveBeforePartWasAdjusted = False
+			}
+		}
+		UPGRADESAPPLIED
+		{
+		}
+	}
+	MODULE
+	{
+		name = ModuleInventoryPart
+		isEnabled = True
+		stagingEnabled = True
+		EVENTS
+		{
+		}
+		ACTIONS
+		{
+		}
+		STOREDPARTS
+		{
+		}
+		UPGRADESAPPLIED
+		{
+		}
+	}
+	MODULE
+	{
+		name = KOSNameTag
+		isEnabled = True
+		nameTag = 
+		stagingEnabled = True
+		EVENTS
+		{
+		}
+		ACTIONS
+		{
+		}
+		UPGRADESAPPLIED
+		{
+		}
+	}
+	MODULE
+	{
+		name = ModuleTripLogger
+		isEnabled = True
+		stagingEnabled = True
+		EVENTS
+		{
+		}
+		ACTIONS
+		{
+		}
+		Log
+		{
+			flight = 0
+		}
+		UPGRADESAPPLIED
+		{
+		}
+	}
+	RESOURCE
+	{
+		name = ElectricCharge
+		amount = 150
+		maxAmount = 150
+		flowState = True
+		isTweakable = True
+		hideFlow = False
+		isVisible = True
+		flowMode = Both
+	}
+	RESOURCE
+	{
+		name = MonoPropellant
+		amount = 30
+		maxAmount = 30
+		flowState = True
+		isTweakable = True
+		hideFlow = False
+		isVisible = True
+		flowMode = Both
+	}
+}

--- a/service/SpaceCenter/test/test_parts_decoupler.py
+++ b/service/SpaceCenter/test/test_parts_decoupler.py
@@ -54,5 +54,47 @@ class TestPartsDecoupler(krpctest.TestCase):
         self.assertFalse(self.disabled_decoupler.staged)
 
 
+class TestPartsOmniDecoupler(krpctest.TestCase):
+    """An omni-decoupler detaches at every node at once, so firing it produces two new
+    vessels: the stack it separated, and the decoupler left on its own. Decouple returns
+    the vessel that was separated. This needs a class of its own because firing the
+    separator takes the rest of the craft with it."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.new_save()
+        cls.launch_vessel_from_vab("PartsDecoupler")
+        cls.remove_other_vessels()
+        cls.set_circular_orbit("Kerbin", 250000)
+        cls.vessel = cls.connect().space_center.active_vessel
+        cls.separator = cls.vessel.parts.with_name("Separator.1")[0].decoupler
+
+    def test_decouple_returns_the_separated_vessel(self):
+        self.assertTrue(self.separator.is_omni_decoupler)
+        new_vessel = self.separator.decouple()
+        self.assertTrue(self.separator.decoupled)
+
+        # The separator is left on a vessel of its own, which is not the one returned.
+        self.assertNotEqual(new_vessel, self.separator.part.vessel)
+        self.assertEqual(
+            ["Separator.1"],
+            [part.name for part in self.separator.part.vessel.parts.all],
+        )
+
+        # The vessel returned is the stack that was separated, below the separator.
+        self.assertNotEqual(self.vessel, new_vessel)
+        self.assertCountEqual(
+            [
+                "fuelTank",
+                "radialDecoupler2",
+                "fuelTank",
+                "fuelTank",
+                "Decoupler.1",
+                "fuelTank",
+            ],
+            [part.name for part in new_vessel.parts.all],
+        )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/service/SpaceCenter/test/test_vessel_without_control_point.py
+++ b/service/SpaceCenter/test/test_vessel_without_control_point.py
@@ -56,5 +56,55 @@ class TestVesselWithoutControlPoint(krpctest.TestCase):
         self.assertEqual([], comms.control_path)
 
 
+class TestVesselWithCrewlessCommandPod(krpctest.TestCase):
+    """CrewlessCommandPod is a command pod, a stack separator and a second command pod
+    mounted upside down. Launched with a single crew member, who is seated in the first
+    pod, separating leaves a vessel whose only command module has no crew aboard. That
+    vessel is in the communication network, unlike one with no command module at all, but
+    it has no control point and no control."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.new_save()
+        cls.space_center = cls.connect().space_center
+        if cls.space_center.get_kerbal("Solo Kerman") is None:
+            cls.space_center.create_kerbal("Solo Kerman", "Pilot", True)
+        cls._stage_craft("CrewlessCommandPod", "VAB", None)
+        cls.space_center.launch_vessel(
+            "VAB", "CrewlessCommandPod", "LaunchPad", ["Solo Kerman"]
+        )
+        cls.remove_other_vessels()
+        cls.set_circular_orbit("Kerbin", 250000)
+        cls.vessel = cls.space_center.active_vessel
+        # The TS-12 is an omni-decoupler, detaching at both ends, so staging it leaves the
+        # separator on its own as well as the stack below it. The stack below is the one
+        # with the crewless pod on it.
+        new_vessels = cls.vessel.control.activate_next_stage()
+        cls.wait(1)
+        cls.lower = next(v for v in new_vessels if v.crew_capacity > 0)
+
+    def test_crew_is_in_the_upper_vessel(self):
+        self.assertEqual(1, self.vessel.crew_count)
+        self.assertEqual(0, self.lower.crew_count)
+        self.assertEqual(3, self.lower.crew_capacity)
+
+    def test_no_control_point(self):
+        self.assertIsNone(self.lower.parts.controlling)
+        self.assertEqual("trussPiece1x", self.lower.parts.root.name)
+
+    def test_control_state(self):
+        # The empty pod makes this vessel part of the network, so the control state comes
+        # from CommNet rather than from the absence of a connection.
+        self.assertEqual(self.space_center.ControlState.none, self.lower.control.state)
+        self.assertEqual(
+            self.space_center.ControlSource.none, self.lower.control.source
+        )
+        # The vessel that kept the crew is unaffected.
+        self.assertEqual(self.space_center.ControlState.full, self.vessel.control.state)
+        self.assertEqual(
+            self.space_center.ControlSource.kerbal, self.vessel.control.source
+        )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/service/SpaceCenter/test/test_vessel_without_control_point.py
+++ b/service/SpaceCenter/test/test_vessel_without_control_point.py
@@ -7,7 +7,7 @@ class TestVesselWithoutControlPoint(krpctest.TestCase):
     """A vessel separated from another one gets a control point only if one of its parts
     is a command module with crew aboard. The lower stage of PartsDecoupler has neither,
     so the vessel the decoupler leaves behind has no control point at all: KSP orients it
-    by its root part, and gives it no node in the communication network."""
+    by its root part, and gives it no presence in the communication network."""
 
     @classmethod
     def setUpClass(cls):
@@ -20,6 +20,25 @@ class TestVesselWithoutControlPoint(krpctest.TestCase):
         decoupler = cls.vessel.parts.with_name("Decoupler.1")[0].decoupler
         cls.debris = decoupler.decouple()
         cls.wait(1)
+
+    def test_controlling_is_none(self):
+        self.assertIsNone(self.debris.parts.controlling)
+        # The vessel that kept the crewed pod still has one.
+        self.assertEqual(self.vessel.parts.root, self.vessel.parts.controlling)
+
+    def test_oriented_by_root_part(self):
+        ref = self.debris.orbit.body.non_rotating_reference_frame
+        self.assertAlmostEqual(
+            self.debris.parts.root.direction(ref), self.debris.direction(ref), places=3
+        )
+
+    def test_setting_a_control_point(self):
+        root = self.debris.parts.root
+        self.debris.parts.controlling = root
+        self.assertEqual(root, self.debris.parts.controlling)
+
+    def test_setting_a_control_point_to_none_fails(self):
+        self.assertRaises(ValueError, setattr, self.debris.parts, "controlling", None)
 
     def test_control_state(self):
         self.assertEqual(self.space_center.ControlState.none, self.debris.control.state)

--- a/service/SpaceCenter/test/test_vessel_without_control_point.py
+++ b/service/SpaceCenter/test/test_vessel_without_control_point.py
@@ -1,0 +1,41 @@
+import unittest
+
+import krpctest
+
+
+class TestVesselWithoutControlPoint(krpctest.TestCase):
+    """A vessel separated from another one gets a control point only if one of its parts
+    is a command module with crew aboard. The lower stage of PartsDecoupler has neither,
+    so the vessel the decoupler leaves behind has no control point at all: KSP orients it
+    by its root part, and gives it no node in the communication network."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.new_save()
+        cls.launch_vessel_from_vab("PartsDecoupler")
+        cls.remove_other_vessels()
+        cls.set_circular_orbit("Kerbin", 250000)
+        cls.space_center = cls.connect().space_center
+        cls.vessel = cls.space_center.active_vessel
+        decoupler = cls.vessel.parts.with_name("Decoupler.1")[0].decoupler
+        cls.debris = decoupler.decouple()
+        cls.wait(1)
+
+    def test_control_state(self):
+        self.assertEqual(self.space_center.ControlState.none, self.debris.control.state)
+        self.assertEqual(
+            self.space_center.ControlSource.none, self.debris.control.source
+        )
+
+    def test_comms(self):
+        comms = self.debris.comms
+        self.assertFalse(comms.can_communicate)
+        self.assertFalse(comms.can_transmit_science)
+        self.assertEqual(0, comms.signal_strength)
+        self.assertEqual(0, comms.signal_delay)
+        self.assertEqual(0, comms.power)
+        self.assertEqual([], comms.control_path)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**Problem.** KSP gives a vessel a control point only when one of its parts is a command module with crew aboard, and gives no communication network node at all to a vessel left with no command module, such as the debris a decoupler leaves behind. kRPC assumed neither case could happen. `Control.State`, `Control.Source` and every member of `Comms` dereferenced the missing network node and threw a `NullReferenceException`, `Comms.Power` threw for a vessel carrying no antennae, and `Parts.Controlling` quietly fell back to the root part, reporting the same answer for a vessel that has no control point as for one deliberately controlled from its root. Separately, firing an omni-decoupler such as a stack separator threw, because it detaches at every node at once and so produces two vessels where `Decoupler.Decouple` assumed one.

**Control point.** `Parts.Controlling` returns `null` when the vessel has no control point, so a script can detect the state and correct it by assigning the property. This is a breaking change for callers that relied on the root part coming back.

**Control state.** `Control.State` and `Control.Source` are taken from `Vessel.CurrentControlLevel`, the level KSP gates control on, rather than from the vessel's network node. The node describes a vessel only while CommNet is enabled, so with CommNet switched off both properties described a rule that was not in use. Reading the level also fixes a vessel whose only command module is a crewless command pod reporting that a kerbal controlled it while `State` said there was no control: KSP records the kind of command module a vessel carries separately from whether that module is giving any control.

**Communications.** The members of `Comms` report the state a vessel with no network node is in, rather than throwing: no communications, and an empty control path. `Comms.Power` is zero for a vessel whose antennae supply no power, including one that carries none.

**Omni-decouplers.** `Decoupler.Decouple` returns the vessel that was separated, which is the one the fired part did not end up on. A separation producing neither a single new vessel nor one that can be told apart this way now reports that it is ambiguous.

**Testing.** New in-game tests in `service/SpaceCenter/test/test_vessel_without_control_point.py` cover both vessels that have no control point: one with no command module, and one whose only command module is a crewless pod, from the new `CrewlessCommandPod` craft. `test_parts_decoupler.py` covers firing the omni-decoupler. Those files, along with `test_comms.py`, `test_control.py`, `test_parts.py` and `test_parts_docking_port.py`, pass in game.
