### PR TITLE
Order service definitions before registering them

### DIFF
--- a/client/cnano/test/test_client.cpp
+++ b/client/cnano/test/test_client.cpp
@@ -262,6 +262,19 @@ TEST_F(test_client, test_enums) {
   ASSERT_EQ(value, KRPC_TESTSERVICE_TESTENUM_VALUEB);
   ASSERT_EQ(KRPC_OK, krpc_TestService_EnumEcho(conn, &value, KRPC_TESTSERVICE_TESTENUM_VALUEC));
   ASSERT_EQ(value, KRPC_TESTSERVICE_TESTENUM_VALUEC);
+
+  krpc_list_enum_t list = KRPC_NULL_LIST;
+  list.size = 2;
+  list.items = new krpc_enum_t[2];
+  list.items[0] = KRPC_TESTSERVICE_TESTENUM_VALUEA;
+  list.items[1] = KRPC_TESTSERVICE_TESTENUM_VALUEB;
+  krpc_list_enum_t result = KRPC_NULL_LIST;
+  ASSERT_EQ(KRPC_OK, krpc_TestService_EnumListDefault(conn, &result, &list));
+  ASSERT_EQ(2u, result.size);
+  ASSERT_EQ(KRPC_TESTSERVICE_TESTENUM_VALUEA, result.items[0]);
+  ASSERT_EQ(KRPC_TESTSERVICE_TESTENUM_VALUEB, result.items[1]);
+  delete[] list.items;
+  KRPC_FREE_LIST(result);
 }
 
 TEST_F(test_client, test_test_service_enum_members) {

--- a/client/cpp/CHANGELOG.md
+++ b/client/cpp/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## [v0.7.0] - unreleased
 - **Breaking:** Support null for any nullable type; nullable non-class values use
   `std::optional`, changing generated signatures (#1017)
+- Fix a service with a collection of enumerations in a procedure signature failing to
+  compile (#1044)
 
 ## [v0.6.0]
 - Update to protobuf v35.1 (#850)

--- a/client/cpp/test/test_client.cpp
+++ b/client/cpp/test/test_client.cpp
@@ -243,6 +243,13 @@ TEST_F(test_client, test_enums) {
   ASSERT_EQ(krpc::services::TestService::TestEnum::value_c, test_service.enum_default_arg());
   ASSERT_EQ(krpc::services::TestService::TestEnum::value_b,
             test_service.enum_default_arg(krpc::services::TestService::TestEnum::value_b));
+  std::vector<krpc::services::TestService::TestEnum> enums = {
+      krpc::services::TestService::TestEnum::value_b,
+      krpc::services::TestService::TestEnum::value_c};
+  ASSERT_EQ(enums, test_service.enum_list_default());
+  enums = {krpc::services::TestService::TestEnum::value_a,
+           krpc::services::TestService::TestEnum::value_b};
+  ASSERT_EQ(enums, test_service.enum_list_default(enums));
 }
 
 TEST_F(test_client, test_collections) {

--- a/client/csharp/test/ConnectionTest.cs
+++ b/client/csharp/test/ConnectionTest.cs
@@ -259,6 +259,12 @@ namespace KRPC.Client.Test
             Assert.AreEqual (TestEnum.ValueA, Connection.TestService ().EnumDefaultArg (TestEnum.ValueA));
             Assert.AreEqual (TestEnum.ValueC, Connection.TestService ().EnumDefaultArg ());
             Assert.AreEqual (TestEnum.ValueB, Connection.TestService ().EnumDefaultArg (TestEnum.ValueB));
+            CollectionAssert.AreEqual (
+                new [] { TestEnum.ValueB, TestEnum.ValueC },
+                Connection.TestService ().EnumListDefault ());
+            CollectionAssert.AreEqual (
+                new [] { TestEnum.ValueA, TestEnum.ValueB },
+                Connection.TestService ().EnumListDefault (new [] { TestEnum.ValueA, TestEnum.ValueB }));
         }
 
         [TestCase (new int[] { }, new int[] { })]

--- a/client/java/test/krpc/client/ConnectionTest.java
+++ b/client/java/test/krpc/client/ConnectionTest.java
@@ -209,6 +209,9 @@ public class ConnectionTest {
     assertEquals(TestService.TestEnum.VALUE_A, testService.enumEcho(TestService.TestEnum.VALUE_A));
     assertEquals(TestService.TestEnum.VALUE_B, testService.enumEcho(TestService.TestEnum.VALUE_B));
     assertEquals(TestService.TestEnum.VALUE_C, testService.enumEcho(TestService.TestEnum.VALUE_C));
+    List<TestService.TestEnum> enums =
+        Arrays.asList(TestService.TestEnum.VALUE_A, TestService.TestEnum.VALUE_B);
+    assertEquals(enums, testService.enumListDefault(enums));
   }
 
   @Test

--- a/client/lua/CHANGELOG.md
+++ b/client/lua/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [v0.7.0] - unreleased
 - **Breaking:** Support `Types.none` for any nullable type (#1017)
+- Fix a service failing to load when one of its procedures defaults to a member of an
+  enumeration defined by a service that had not been loaded yet (#1044)
 
 ## [v0.6.0]
 - Fix `attributes` module to always return boolean for `is_a_class_member` and `is_a_class_property_accessor` (#850)

--- a/client/lua/krpc/client.lua
+++ b/client/lua/krpc/client.lua
@@ -9,6 +9,7 @@ local decoder = require 'krpc.decoder'
 local service = require 'krpc.service'
 local to_snake_case = service.to_snake_case
 local create_service = service.create_service
+local register_definitions = service.register_definitions
 
 local Client = class()
 
@@ -18,6 +19,13 @@ function Client:_init(rpc_connection)
 
   -- Set up the main KRPC service
   local services = self:_invoke('KRPC', 'GetServices', nil, nil, nil, self._types:services_type()).services
+
+  -- Register the types of every service before creating any of them: a service's procedures
+  -- are built from types that any service may define, and a default value cannot be decoded
+  -- before the values of the enumeration it belongs to are known
+  for _, service in ipairs(services) do
+    register_definitions(self._types, service)
+  end
 
   -- Set up services
   for _, service in ipairs(services) do

--- a/client/lua/krpc/service.lua
+++ b/client/lua/krpc/service.lua
@@ -104,22 +104,32 @@ function ServiceBase:_parse_procedure(procedure)
   return param_names, param_types, param_required, param_default, return_type
 end
 
+--- Register the types that a service defines in the given type registry
+function service.register_definitions(types, svc)
+  for _,cls in ipairs(svc.classes) do
+    types:class_type(svc.name, cls.name)
+  end
+  for _,enum in ipairs(svc.enumerations) do
+    local values = {}
+    for _,value in ipairs(enum.values) do
+      values[service.to_snake_case(value.name)] = value.value
+    end
+    types:enumeration_type(svc.name, enum.name):set_values(values)
+  end
+end
+
+-- The types a service defines are registered from its definitions, before any service is
+-- created, so the following two take the types they were registered as and make them members
+-- of the service
+
 --- Add a class type
 function ServiceBase:_add_service_class(cls)
-  local class_type = self._client._types:class_type(self._name, cls.name)
-  self[cls.name] = class_type.lua_type
+  self[cls.name] = self._client._types:class_type(self._name, cls.name).lua_type
 end
 
 --- Add an enumeration type
 function ServiceBase:_add_service_enumeration(enum)
-  local name = enum.name
-  local enum_type = self._client._types:enumeration_type(self._name, name)
-  local values = {}
-  for _,x in ipairs(enum.values) do
-    values[service.to_snake_case(x.name)] = x.value
-  end
-  enum_type:set_values(values)
-  self[name] = enum_type.lua_type
+  self[enum.name] = self._client._types:enumeration_type(self._name, enum.name).lua_type
 end
 
 --- Add a procedure

--- a/client/lua/krpc/test/init.lua
+++ b/client/lua/krpc/test/init.lua
@@ -8,6 +8,7 @@ TestEncoder = require 'krpc.test.test_encoder'
 TestObjects = require 'krpc.test.test_objects'
 TestPerformance = require 'krpc.test.test_performance'
 TestPlatform = require 'krpc.test.test_platform'
+TestServiceDefinitions = require 'krpc.test.test_service_definitions'
 TestSnakeCase = require 'krpc.test.test_snake_case'
 TestTypes = require 'krpc.test.test_types'
 

--- a/client/lua/krpc/test/test_client.lua
+++ b/client/lua/krpc/test/test_client.lua
@@ -214,6 +214,10 @@ function TestClient:test_enumerations()
   luaunit.assertEquals(enum.value_a, self.conn.test_service.enum_default_arg(enum.value_a))
   luaunit.assertEquals(enum.value_c, self.conn.test_service.enum_default_arg())
   luaunit.assertEquals(enum.value_b, self.conn.test_service.enum_default_arg(enum.value_b))
+
+  luaunit.assertEquals(List{enum.value_b, enum.value_c}, self.conn.test_service.enum_list_default())
+  luaunit.assertEquals(List{enum.value_a, enum.value_b},
+                       self.conn.test_service.enum_list_default(List{enum.value_a, enum.value_b}))
 end
 
 function TestClient:test_invalid_enum()
@@ -377,6 +381,7 @@ function TestClient:test_test_service_service_members()
      'empty_list_default',
      'enum_default_arg',
      'enum_echo',
+     'enum_list_default',
      'enum_return',
      'float_to_string',
      'get_deprecated_property',

--- a/client/lua/krpc/test/test_service_definitions.lua
+++ b/client/lua/krpc/test/test_service_definitions.lua
@@ -1,0 +1,116 @@
+local luaunit = require 'luaunit'
+local class = require 'pl.class'
+local List = require 'pl.List'
+local schema = require 'krpc.schema.KRPC'
+local Types = require 'krpc.types'
+local encoder = require 'krpc.encoder'
+local service = require 'krpc.service'
+
+local TestServiceDefinitions = class()
+
+--- As much of a client as creating a service needs, without a connection to a server
+local FakeClient = class()
+
+function FakeClient:_init()
+  self._types = Types()
+end
+
+function FakeClient:_invoke()
+  error('not connected to a server')
+end
+
+--- A service defining an enumeration and nothing else
+local function enum_service(name)
+  local svc = schema.Service()
+  svc.name = name
+  local enum = svc.enumerations:add()
+  enum.name = 'Mode'
+  for _,case in ipairs({{'Slow', 1}, {'Fast', 2}}) do
+    local value = enum.values:add()
+    value.name = case[1]
+    value.value = case[2]
+  end
+  return svc
+end
+
+--- A service with a procedure whose parameter defaults to a member of another service's
+--- enumeration, either directly or through a list
+local function default_service(name, enum_service_name, in_a_list)
+  local types = Types()
+  local svc = schema.Service()
+  svc.name = name
+  local procedure = svc.procedures:add()
+  procedure.name = 'Frob'
+  local parameter = procedure.parameters:add()
+  parameter.name = 'mode'
+  local encoded = encoder.encode(2, types:sint32_type())
+  if in_a_list then
+    parameter.type.code = Types.LIST
+    local value_type = parameter.type.types:add()
+    value_type.code = Types.ENUMERATION
+    value_type.service = enum_service_name
+    value_type.name = 'Mode'
+    local items = schema.List()
+    items.items:append(encoded)
+    encoded = items:SerializeToString()
+  else
+    parameter.type.code = Types.ENUMERATION
+    parameter.type.service = enum_service_name
+    parameter.type.name = 'Mode'
+  end
+  parameter.has_default_value = true
+  parameter.default_value = encoded
+  return svc
+end
+
+local function create_services(svcs)
+  local client = FakeClient()
+  for _,svc in ipairs(svcs) do
+    service.register_definitions(client._types, svc)
+  end
+  local created = {}
+  for _,svc in ipairs(svcs) do
+    created[svc.name] = service.create_service(client, svc)
+  end
+  return client, created
+end
+
+--- Create the given services, and return the client along with the default value that
+--- ServiceA decoded for the parameter of its procedure
+local function create_services_and_default(svcs)
+  local client, created = create_services(svcs)
+  luaunit.assertNotNil(created['ServiceA'].frob)
+  local procedure
+  for _,svc in ipairs(svcs) do
+    if svc.name == 'ServiceA' then
+      procedure = svc.procedures[1]
+    end
+  end
+  local _,_,_,param_default = created['ServiceA']:_parse_procedure(procedure)
+  return client, param_default[1]
+end
+
+function TestServiceDefinitions:check_services(svcs, in_a_list)
+  local client, default = create_services_and_default(svcs)
+  local fast = client._types:enumeration_type('ServiceB', 'Mode').lua_type.fast
+  luaunit.assertEquals(2, fast.value)
+  if in_a_list then
+    luaunit.assertEquals(List{fast}, default)
+  else
+    luaunit.assertEquals(fast, default)
+  end
+end
+
+function TestServiceDefinitions:test_defined_before_it_is_used()
+  self:check_services({enum_service('ServiceB'), default_service('ServiceA', 'ServiceB')})
+end
+
+function TestServiceDefinitions:test_defined_after_it_is_used()
+  self:check_services({default_service('ServiceA', 'ServiceB'), enum_service('ServiceB')})
+end
+
+function TestServiceDefinitions:test_used_inside_a_collection()
+  self:check_services({default_service('ServiceA', 'ServiceB', true), enum_service('ServiceB')}, true)
+end
+
+return TestServiceDefinitions

--- a/client/python/CHANGELOG.md
+++ b/client/python/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [v0.7.0] - unreleased
 - **Breaking:** Support `None` for any nullable type (#1017)
+- Fix a service failing to load when one of its procedures defaults to a member of an
+  enumeration defined by a service that had not been loaded yet (#1044)
 
 ## [v0.6.0]
 - **Breaking:** Requires Python 3.10+ (#837)

--- a/client/python/krpc/client.py
+++ b/client/python/krpc/client.py
@@ -5,10 +5,11 @@ from contextlib import contextmanager
 import sys
 import threading
 from krpc.connection import Connection
+from krpc.definitions import CLASS, ENUMERATION, Definition, register_all
 from krpc.error import StreamError
 from krpc.event import Event
 from krpc.types import Types, TypeBase, DefaultArgument, EXCEPTION_TYPES
-from krpc.service import create_service
+from krpc.service import create_service, service_definitions
 from krpc.streammanager import StreamManager
 from krpc.stream import Stream
 from krpc.encoder import Encoder
@@ -18,6 +19,41 @@ from krpc.error import RPCError
 import krpc.streammanager
 import krpc.schema.KRPC_pb2 as KRPC
 import krpc.services
+
+
+def _stub_definitions(name: str, service: object) -> Iterator[Definition]:
+    """The types of a service whose stubs were generated ahead of time, as records that can be
+    registered in a type registry. The stubs already provide the python types, so registering
+    them is what lets a dynamically created service use them."""
+
+    def register_class(class_name: str, python_type: type) -> Callable[[Types], None]:
+        def register(types: Types) -> None:
+            types.register_class_type(name, class_name, python_type)
+
+        return register
+
+    def register_enumeration(
+        enum_name: str, python_type: type
+    ) -> Callable[[Types], None]:
+        def register(types: Types) -> None:
+            types.register_enum_type(name, enum_name, python_type)
+
+        return register
+
+    classes = service._classes  # type: ignore[attr-defined]
+    for class_name, python_type in classes.items():
+        yield Definition(
+            CLASS, name, class_name, [], register_class(class_name, python_type)
+        )
+    enumerations = service._enumerations  # type: ignore[attr-defined]
+    for enum_name, python_type in enumerations.items():
+        yield Definition(
+            ENUMERATION,
+            name,
+            enum_name,
+            [],
+            register_enumeration(enum_name, python_type),
+        )
 
 
 class Client(krpc.services.Client):
@@ -47,23 +83,24 @@ class Client(krpc.services.Client):
         ).services
 
         # Load services
+        definitions = []
         dynamic_services = []
-        # Load services with pre-generated stubs first
-        # so that class/enum types are loaded if a dynamic service needs them
         for service_info in services:
             service = None
             if use_pregenerated_stubs:
                 service = self._services.get(service_info.name)
             if service is not None:
-                for name, typ in service._classes.items():  # type: ignore[attr-defined]
-                    self._types.register_class_type(service_info.name, name, typ)
-                for name, typ in service._enumerations.items():  # type: ignore[attr-defined]
-                    self._types.register_enum_type(service_info.name, name, typ)
+                definitions.extend(_stub_definitions(service_info.name, service))
             else:
                 dynamic_services.append(service_info)
-        # Then dynamically load services for those without pre-generated stubs
+                definitions.extend(service_definitions(service_info))
+        # Register the types of every service, whether its stubs were pre-generated or not,
+        # before creating any of them: a service's procedures are built from types that any
+        # service may define, and a default value cannot be decoded before the definition of
+        # the enumeration it belongs to has been registered
+        register_all(self._types, definitions)
+        # Then dynamically create services for those without pre-generated stubs
         for service_info in dynamic_services:
-            # Dynamically create
             setattr(
                 self, snake_case(service_info.name), create_service(self, service_info)
             )

--- a/client/python/krpc/definitions.py
+++ b/client/python/krpc/definitions.py
@@ -1,0 +1,184 @@
+from __future__ import annotations
+from collections.abc import Hashable
+from typing import (
+    Callable,
+    Dict,
+    Iterable,
+    Iterator,
+    List,
+    Optional,
+    Set,
+    Tuple,
+    TypeVar,
+    TYPE_CHECKING,
+)
+from krpc.decoder import Decoder
+from krpc.types import (
+    DictionaryType,
+    EnumerationType,
+    ListType,
+    SetType,
+    TupleType,
+    TypeBase,
+    Types,
+)
+import krpc.schema.KRPC_pb2 as KRPC
+
+if TYPE_CHECKING:
+    from krpc.client import Client
+
+
+CLASS = "class"
+ENUMERATION = "enumeration"
+EXCEPTION = "exception"
+
+# The kind of definition that each named protocol buffer type refers to
+_KIND_FROM_CODE = {
+    KRPC.Type.CLASS: CLASS,
+    KRPC.Type.ENUMERATION: ENUMERATION,
+}
+
+# What identifies a definition, and therefore what a reference to one resolves against
+Key = Tuple[str, str, str]
+
+Node = TypeVar("Node")
+NodeKey = TypeVar("NodeKey", bound=Hashable)
+
+
+class Definition:
+    """Something a service defines - a class, an enumeration or an exception - together with
+    the types it refers to and how to register it in a type registry.
+
+    Whatever a set of definitions was read from builds these, and register_all registers them
+    in an order in which a definition is only registered once everything it refers to is.
+    """
+
+    def __init__(
+        self,
+        kind: str,
+        service: str,
+        name: str,
+        references: Iterable[KRPC.Type],
+        register: Callable[[Types], None],
+    ) -> None:
+        self.kind = kind
+        self.service = service
+        self.name = name
+        self.references = list(references)
+        self.register = register
+
+    @property
+    def key(self) -> Key:
+        return (self.kind, self.service, self.name)
+
+    def __str__(self) -> str:
+        return "%s %s.%s" % (self.kind, self.service, self.name)
+
+
+def register_all(types: Types, definitions: Iterable[Definition]) -> None:
+    """Register the given definitions in the given type registry, each one after everything it
+    refers to, so that every type in the registry can be used without regard to the order the
+    definitions arrived in.
+
+    Raises a RuntimeError if a definition refers to something none of the given definitions
+    define, or if they refer to each other in a cycle."""
+    index: Dict[Key, Definition] = {}
+    for definition in definitions:
+        if definition.key in index:
+            raise RuntimeError("%s is defined more than once" % definition)
+        index[definition.key] = definition
+
+    def dependencies(definition: Definition) -> Iterator[Definition]:
+        for kind, service, name in _referenced_keys(definition.references):
+            referenced = index.get((kind, service, name))
+            if referenced is None:
+                raise RuntimeError(
+                    "%s refers to the %s %s.%s, which none of the given service "
+                    "definitions define" % (definition, kind, service, name)
+                )
+            yield referenced
+
+    for definition in topological_order(index.values(), lambda x: x.key, dependencies):
+        definition.register(types)
+
+
+def topological_order(
+    nodes: Iterable[Node],
+    key: Callable[[Node], NodeKey],
+    dependencies: Callable[[Node], Iterable[Node]],
+) -> List[Node]:
+    """Return the given nodes, and the nodes they depend on, ordered so that every node follows
+    everything it depends on. Nodes that depend on nothing keep the order they were given in.
+
+    Raises a RuntimeError if the dependencies contain a cycle."""
+    ordered: List[Node] = []
+    ordered_keys: Set[NodeKey] = set()
+    path: List[Node] = []
+    path_keys: Set[NodeKey] = set()
+
+    def visit(node: Node) -> None:
+        node_key = key(node)
+        if node_key in ordered_keys:
+            return
+        if node_key in path_keys:
+            start = next(i for i, x in enumerate(path) if key(x) == node_key)
+            cycle = " -> ".join(str(x) for x in path[start:] + [node])
+            raise RuntimeError("Cyclic dependency: " + cycle)
+        path.append(node)
+        path_keys.add(node_key)
+        for dependency in dependencies(node):
+            visit(dependency)
+        path.pop()
+        path_keys.remove(node_key)
+        ordered.append(node)
+        ordered_keys.add(node_key)
+
+    for node in nodes:
+        visit(node)
+    return ordered
+
+
+def decode_default_value(
+    client: Optional[Client], value: bytes, typ: TypeBase, location: str
+) -> object:
+    """Decode the default value of a parameter from the encoded form a definition carries it in.
+
+    location names the parameter the value belongs to, for example
+    'TestService.EnumDefaultArg parameter x', and is included in the error raised when the value
+    cannot be decoded."""
+    _check_registered(typ, location)
+    try:
+        return Decoder.decode(client, value, typ)
+    except ValueError as exn:
+        raise RuntimeError("%s: %s" % (location, exn)) from exn
+
+
+def _check_registered(typ: TypeBase, location: str) -> None:
+    """Raise a RuntimeError if the given type, or a type it contains, is an enumeration whose
+    definition was never registered and whose values are therefore unknown."""
+    if isinstance(typ, EnumerationType):
+        if not typ.has_values:
+            service = typ.protobuf_type.service
+            raise RuntimeError(
+                "%s has the enumeration %s.%s in its type, but the definitions for service "
+                "%s were not provided"
+                % (location, service, typ.protobuf_type.name, service)
+            )
+    elif isinstance(typ, TupleType):
+        for value_type in typ.value_types:
+            _check_registered(value_type, location)
+    elif isinstance(typ, (ListType, SetType)):
+        _check_registered(typ.value_type, location)
+    elif isinstance(typ, DictionaryType):
+        _check_registered(typ.key_type, location)
+        _check_registered(typ.value_type, location)
+
+
+def _referenced_keys(protobuf_types: Iterable[KRPC.Type]) -> Iterator[Key]:
+    """The definitions that the given types refer to, including those they refer to through a
+    collection type."""
+    for protobuf_type in protobuf_types:
+        kind = _KIND_FROM_CODE.get(protobuf_type.code)
+        if kind is not None:
+            yield (kind, protobuf_type.service, protobuf_type.name)
+        yield from _referenced_keys(protobuf_type.types)

--- a/client/python/krpc/service.py
+++ b/client/python/krpc/service.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 from typing import (
     cast,
+    Any,
     Callable,
     DefaultDict,
     Iterable,
+    Iterator,
     List,
     Optional,
     Tuple,
@@ -13,8 +15,14 @@ import keyword
 import warnings
 from collections import defaultdict
 from xml.etree import ElementTree
+from krpc.definitions import (
+    CLASS,
+    ENUMERATION,
+    EXCEPTION,
+    Definition,
+    decode_default_value,
+)
 from krpc.types import Types, TypeBase, DynamicType, DynamicClassBase, DefaultArgument
-from krpc.decoder import Decoder
 from krpc.utils import snake_case
 from krpc.attributes import Attributes
 import krpc.schema.KRPC_pb2 as KRPC
@@ -242,6 +250,64 @@ def _parse_documentation(xml: str) -> str:
     return "\n\n".join(x for x in (summary, params_str, returns, note) if x != "")
 
 
+def _documentation(member: Any, service_name: str) -> str:
+    """The documentation of a service member, including a notice when it is deprecated"""
+    doc = _parse_documentation(member.documentation)
+    if member.deprecated:
+        doc = _deprecated_doc(doc, member.deprecated_reason, service_name)
+    return doc
+
+
+def service_definitions(service: KRPC.Service) -> Iterator[Definition]:
+    """The types a service defines, as records that can be registered in a type registry.
+
+    A service's procedures are built from types that this or any other service defines, so
+    every service's definitions are registered before any service is created."""
+    name = service.name
+
+    def register_class(cls: KRPC.Class) -> Callable[[Types], None]:
+        doc = _documentation(cls, name)
+
+        def register(types: Types) -> None:
+            types.class_type(name, cls.name, doc)
+
+        return register
+
+    def register_enumeration(enumeration: KRPC.Enumeration) -> Callable[[Types], None]:
+        doc = _documentation(enumeration, name)
+        values = dict(
+            (
+                str(snake_case(value.name)),
+                {"value": value.value, "doc": _documentation(value, name)},
+            )
+            for value in enumeration.values
+        )
+
+        def register(types: Types) -> None:
+            types.enumeration_type(name, enumeration.name, doc).set_values(values)
+
+        return register
+
+    def register_exception(exception: KRPC.Exception) -> Callable[[Types], None]:
+        doc = _documentation(exception, name)
+
+        def register(types: Types) -> None:
+            types.exception_type(name, exception.name, doc)
+
+        return register
+
+    for cls in service.classes:
+        yield Definition(CLASS, name, cls.name, [], register_class(cls))
+    for enumeration in service.enumerations:
+        yield Definition(
+            ENUMERATION, name, enumeration.name, [], register_enumeration(enumeration)
+        )
+    for exception in service.exceptions:
+        yield Definition(
+            EXCEPTION, name, exception.name, [], register_exception(exception)
+        )
+
+
 def create_service(client: Client, service: KRPC.Service) -> object:
     """Create a new service type"""
     doc = _parse_documentation(service.documentation)
@@ -333,51 +399,29 @@ class ServiceBase(DynamicType):
     _client: Client
     _name: str
 
+    # The types a service defines are registered from its definitions, before any service is
+    # created, so the following take the types they were registered as and make them members of
+    # the service
+
     @classmethod
     def _add_service_class(cls, remote_cls: KRPC.Class) -> None:
         """Add a class type"""
-        name = remote_cls.name
-        doc = _parse_documentation(remote_cls.documentation)
-        if remote_cls.deprecated:
-            doc = _deprecated_doc(doc, remote_cls.deprecated_reason, cls._name)
-        class_type = cls._client._types.class_type(cls._name, name, doc)
-        setattr(cls, name, class_type.python_type)
+        class_type = cls._client._types.class_type(cls._name, remote_cls.name)
+        setattr(cls, remote_cls.name, class_type.python_type)
 
     @classmethod
     def _add_service_enumeration(cls, enumeration: KRPC.Enumeration) -> None:
         """Add an enum type"""
-        name = enumeration.name
-        doc = _parse_documentation(enumeration.documentation)
-        if enumeration.deprecated:
-            doc = _deprecated_doc(doc, enumeration.deprecated_reason, cls._name)
-        enumeration_type = cls._client._types.enumeration_type(cls._name, name, doc)
-
-        def value_doc(value: KRPC.EnumerationValue) -> str:
-            vdoc = _parse_documentation(value.documentation)
-            if value.deprecated:
-                vdoc = _deprecated_doc(vdoc, value.deprecated_reason, cls._name)
-            return vdoc
-
-        enumeration_type.set_values(
-            dict(
-                (
-                    str(snake_case(x.name)),
-                    {"value": x.value, "doc": value_doc(x)},
-                )
-                for x in enumeration.values
-            )
+        enumeration_type = cls._client._types.enumeration_type(
+            cls._name, enumeration.name
         )
-        setattr(cls, name, enumeration_type.python_type)
+        setattr(cls, enumeration.name, enumeration_type.python_type)
 
     @classmethod
     def _add_service_exception(cls, exception: KRPC.Exception) -> None:
         """Add an exception type"""
-        name = exception.name
-        doc = _parse_documentation(exception.documentation)
-        if exception.deprecated:
-            doc = _deprecated_doc(doc, exception.deprecated_reason, cls._name)
-        exception_type = cls._client._types.exception_type(cls._name, name, doc)
-        setattr(cls, name, exception_type)
+        exception_type = cls._client._types.exception_type(cls._name, exception.name)
+        setattr(cls, exception.name, exception_type)
 
     @classmethod
     def _parse_procedure(cls, procedure: KRPC.Procedure) -> Tuple[
@@ -395,8 +439,15 @@ class ServiceBase(DynamicType):
         param_default: List[Optional[object]] = []
         for param, typ in zip(procedure.parameters, param_types):
             if param.has_default_value and not param.default_value_is_null:
+                location = "%s.%s parameter %s" % (
+                    cls._name,
+                    procedure.name,
+                    snake_case(param.name),
+                )
                 param_default.append(
-                    Decoder.decode(cls._client, param.default_value, typ)
+                    decode_default_value(
+                        cls._client, param.default_value, typ, location
+                    )
                 )
             else:
                 param_default.append(None)

--- a/client/python/krpc/test/test_client.py
+++ b/client/python/krpc/test/test_client.py
@@ -369,6 +369,14 @@ class TestClient(ServerTestCase, unittest.TestCase):
             enum.value_b, self.conn.test_service.enum_default_arg(enum.value_b)
         )
 
+        self.assertEqual(
+            [enum.value_b, enum.value_c], self.conn.test_service.enum_list_default()
+        )
+        self.assertEqual(
+            [enum.value_a, enum.value_b],
+            self.conn.test_service.enum_list_default([enum.value_a, enum.value_b]),
+        )
+
     def test_invalid_enum(self) -> None:
         self.assertRaises(ValueError, self.conn.test_service.TestEnum, 9999)
 
@@ -551,6 +559,7 @@ class TestClient(ServerTestCase, unittest.TestCase):
                     "enum_return",
                     "enum_echo",
                     "enum_default_arg",
+                    "enum_list_default",
                     "blocking_procedure",
                     "increment_list",
                     "increment_dictionary",

--- a/client/python/krpc/test/test_definitions.py
+++ b/client/python/krpc/test/test_definitions.py
@@ -1,0 +1,226 @@
+import unittest
+from typing import Dict, Iterable, List
+from krpc.definitions import (
+    ENUMERATION,
+    Definition,
+    decode_default_value,
+    register_all,
+    topological_order,
+)
+from krpc.encoder import Encoder
+from krpc.types import EnumerationType, Types
+from krpc.schema.KRPC_pb2 import Type
+
+
+def enumeration_type(service: str, name: str) -> Type:
+    protobuf_type = Type()
+    protobuf_type.code = Type.ENUMERATION
+    protobuf_type.service = service
+    protobuf_type.name = name
+    return protobuf_type
+
+
+def class_type(service: str, name: str) -> Type:
+    protobuf_type = Type()
+    protobuf_type.code = Type.CLASS
+    protobuf_type.service = service
+    protobuf_type.name = name
+    return protobuf_type
+
+
+def list_type(value_type: Type) -> Type:
+    protobuf_type = Type()
+    protobuf_type.code = Type.LIST
+    protobuf_type.types.extend([value_type])
+    return protobuf_type
+
+
+class TestRegisterAll(unittest.TestCase):
+    def setUp(self) -> None:
+        self.registered: List[str] = []
+        self.types = Types()
+
+    def definition(
+        self,
+        name: str,
+        references: Iterable[Type] = (),
+        kind: str = ENUMERATION,
+        service: str = "ServiceA",
+    ) -> Definition:
+        """A definition that records the order in which it is registered"""
+
+        def register(types: Types) -> None:  # pylint: disable=unused-argument
+            self.registered.append(name)
+
+        return Definition(kind, service, name, references, register)
+
+    def test_registers_every_definition(self) -> None:
+        register_all(
+            self.types,
+            [self.definition("A"), self.definition("B"), self.definition("C")],
+        )
+        self.assertEqual(["A", "B", "C"], self.registered)
+
+    def test_registered_after_what_it_refers_to(self) -> None:
+        # C refers to B, which refers to A, so the only valid order is A, B, C
+        definitions = {
+            "A": self.definition("A"),
+            "B": self.definition("B", [enumeration_type("ServiceA", "A")]),
+            "C": self.definition("C", [enumeration_type("ServiceA", "B")]),
+        }
+        for order in (["A", "B", "C"], ["C", "B", "A"], ["B", "C", "A"]):
+            self.registered = []
+            register_all(self.types, [definitions[name] for name in order])
+            self.assertEqual(["A", "B", "C"], self.registered)
+
+    def test_refers_to_a_type_inside_a_collection(self) -> None:
+        register_all(
+            self.types,
+            [
+                self.definition("B", [list_type(enumeration_type("ServiceA", "A"))]),
+                self.definition("A"),
+            ],
+        )
+        self.assertEqual(["A", "B"], self.registered)
+
+    def test_refers_to_another_service(self) -> None:
+        register_all(
+            self.types,
+            [
+                self.definition("B", [enumeration_type("ServiceB", "A")]),
+                self.definition("A", service="ServiceB"),
+            ],
+        )
+        self.assertEqual(["A", "B"], self.registered)
+
+    def test_registered_once_when_referred_to_repeatedly(self) -> None:
+        reference = enumeration_type("ServiceA", "A")
+        register_all(
+            self.types,
+            [
+                self.definition("B", [reference]),
+                self.definition("C", [reference, enumeration_type("ServiceA", "B")]),
+                self.definition("A"),
+            ],
+        )
+        self.assertEqual(["A", "B", "C"], self.registered)
+
+    def test_a_reference_names_a_kind_as_well_as_a_name(self) -> None:
+        # The reference is to a class, so the enumeration of the same name does not satisfy it
+        with self.assertRaises(RuntimeError) as cm:
+            register_all(
+                self.types,
+                [
+                    self.definition("B", [class_type("ServiceA", "A")]),
+                    self.definition("A", kind=ENUMERATION),
+                ],
+            )
+        self.assertIn("class ServiceA.A", str(cm.exception))
+
+    def test_reference_that_nothing_defines(self) -> None:
+        with self.assertRaises(RuntimeError) as cm:
+            register_all(
+                self.types,
+                [self.definition("B", [enumeration_type("ServiceB", "Mode")])],
+            )
+        self.assertIn("enumeration ServiceA.B", str(cm.exception))
+        self.assertIn("enumeration ServiceB.Mode", str(cm.exception))
+        self.assertEqual([], self.registered)
+
+    def test_cycle(self) -> None:
+        with self.assertRaises(RuntimeError) as cm:
+            register_all(
+                self.types,
+                [
+                    self.definition("A", [enumeration_type("ServiceA", "B")]),
+                    self.definition("B", [enumeration_type("ServiceA", "A")]),
+                ],
+            )
+        self.assertEqual(
+            "Cyclic dependency: enumeration ServiceA.A -> enumeration ServiceA.B "
+            "-> enumeration ServiceA.A",
+            str(cm.exception),
+        )
+
+    def test_defined_twice(self) -> None:
+        with self.assertRaises(RuntimeError) as cm:
+            register_all(self.types, [self.definition("A"), self.definition("A")])
+        self.assertIn(
+            "enumeration ServiceA.A is defined more than once", str(cm.exception)
+        )
+
+
+class TestTopologicalOrder(unittest.TestCase):
+    @staticmethod
+    def order(graph: Dict[str, List[str]], nodes: Iterable[str]) -> List[str]:
+        def key(node: str) -> str:
+            return node
+
+        def dependencies(node: str) -> List[str]:
+            return graph[node]
+
+        return topological_order(nodes, key, dependencies)
+
+    def test_each_node_is_returned_once(self) -> None:
+        graph = {"a": ["b", "c"], "b": ["c"], "c": []}
+        self.assertEqual(["c", "b", "a"], self.order(graph, ["a", "b", "c"]))
+
+    def test_dependencies_that_were_not_given_are_included(self) -> None:
+        self.assertEqual(["b", "a"], self.order({"a": ["b"], "b": []}, ["a"]))
+
+    def test_cycle(self) -> None:
+        graph = {"a": ["b"], "b": ["c"], "c": ["b"]}
+        with self.assertRaises(RuntimeError) as cm:
+            self.order(graph, ["a"])
+        self.assertEqual("Cyclic dependency: b -> c -> b", str(cm.exception))
+
+
+class TestDecodeDefaultValue(unittest.TestCase):
+    location = "ServiceA.Frob parameter mode"
+
+    def setUp(self) -> None:
+        self.types = Types()
+
+    def encode(self, value: int) -> bytes:
+        return Encoder.encode(value, self.types.sint32_type)
+
+    def enumeration(self, registered: bool = True) -> EnumerationType:
+        typ = self.types.enumeration_type("ServiceA", "Mode")
+        if registered:
+            typ.set_values(
+                {"slow": {"value": 1, "doc": ""}, "fast": {"value": 2, "doc": ""}}
+            )
+        return typ
+
+    def test_decodes_an_enumeration_value(self) -> None:
+        typ = self.enumeration()
+        value = decode_default_value(None, self.encode(2), typ, self.location)
+        self.assertEqual(getattr(typ.python_type, "fast"), value)
+
+    def test_enumeration_that_was_never_registered(self) -> None:
+        with self.assertRaises(RuntimeError) as cm:
+            decode_default_value(
+                None, self.encode(2), self.enumeration(registered=False), self.location
+            )
+        self.assertIn(self.location, str(cm.exception))
+        self.assertIn("ServiceA.Mode", str(cm.exception))
+
+    def test_enumeration_inside_a_collection(self) -> None:
+        typ = self.types.list_type(self.enumeration(registered=False))
+        # The value is never reached, as the type it would be decoded through is incomplete
+        with self.assertRaises(RuntimeError) as cm:
+            decode_default_value(None, b"", typ, self.location)
+        self.assertIn(self.location, str(cm.exception))
+        self.assertIn("ServiceA.Mode", str(cm.exception))
+
+    def test_value_the_enumeration_does_not_declare(self) -> None:
+        with self.assertRaises(RuntimeError) as cm:
+            decode_default_value(
+                None, self.encode(7), self.enumeration(), self.location
+            )
+        self.assertIn(self.location, str(cm.exception))
+        self.assertIn("7 is not a valid Mode", str(cm.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/client/python/krpc/test/test_service_definitions.py
+++ b/client/python/krpc/test/test_service_definitions.py
@@ -1,0 +1,118 @@
+import unittest
+from inspect import signature
+from typing import List
+from krpc.definitions import register_all
+from krpc.encoder import Encoder
+from krpc.service import create_service, service_definitions
+from krpc.types import Types
+import krpc.schema.KRPC_pb2 as KRPC
+
+
+class FakeClient:
+    """As much of a client as creating a service needs, without a connection to a server"""
+
+    def __init__(self) -> None:
+        self._types = Types()
+
+    def _invoke(self, *args: object, **kwargs: object) -> object:
+        raise NotImplementedError
+
+    def _build_call(self, *args: object, **kwargs: object) -> object:
+        raise NotImplementedError
+
+
+def enum_service(name: str) -> KRPC.Service:
+    """A service defining an enumeration and nothing else"""
+    service = KRPC.Service()
+    service.name = name
+    enumeration = service.enumerations.add()
+    enumeration.name = "Mode"
+    for value_name, value in (("Slow", 1), ("Fast", 2)):
+        enumeration_value = enumeration.values.add()
+        enumeration_value.name = value_name
+        enumeration_value.value = value
+    return service
+
+
+def default_service(
+    name: str, enum_service_name: str, in_a_list: bool = False
+) -> KRPC.Service:
+    """A service with a procedure whose parameter defaults to a member of another service's
+    enumeration, either directly or through a list"""
+    types = Types()
+    enumeration_type = types.enumeration_type(enum_service_name, "Mode")
+    encoded = Encoder.encode(2, types.sint32_type)
+    if in_a_list:
+        items = KRPC.List()
+        items.items.extend([encoded])
+        encoded = items.SerializeToString()
+
+    service = KRPC.Service()
+    service.name = name
+    procedure = service.procedures.add()
+    procedure.name = "Frob"
+    parameter = procedure.parameters.add()
+    parameter.name = "mode"
+    if in_a_list:
+        parameter.type.CopyFrom(types.list_type(enumeration_type).protobuf_type)
+    else:
+        parameter.type.CopyFrom(enumeration_type.protobuf_type)
+    parameter.has_default_value = True
+    parameter.default_value = encoded
+    return service
+
+
+class TestServiceDefinitions(unittest.TestCase):
+    @staticmethod
+    def create_services(services: List[KRPC.Service]) -> FakeClient:
+        client = FakeClient()
+        definitions = [
+            definition
+            for service in services
+            for definition in service_definitions(service)
+        ]
+        register_all(client._types, definitions)
+        for service in services:
+            setattr(client, service.name, create_service(client, service))  # type: ignore[arg-type]
+        return client
+
+    def check_default(self, client: FakeClient, expected: str) -> None:
+        service = getattr(client, "ServiceA")
+        default = signature(service.frob).parameters["mode"].default
+        self.assertEqual(expected, str(default))
+
+    def test_defined_before_it_is_used(self) -> None:
+        client = self.create_services(
+            [enum_service("ServiceB"), default_service("ServiceA", "ServiceB")]
+        )
+        self.check_default(client, "Mode.fast")
+
+    def test_defined_after_it_is_used(self) -> None:
+        client = self.create_services(
+            [default_service("ServiceA", "ServiceB"), enum_service("ServiceB")]
+        )
+        self.check_default(client, "Mode.fast")
+
+    def test_used_inside_a_collection(self) -> None:
+        client = self.create_services(
+            [
+                default_service("ServiceA", "ServiceB", in_a_list=True),
+                enum_service("ServiceB"),
+            ]
+        )
+        self.check_default(client, "[<Mode.fast: 2>]")
+
+    def test_defined_by_the_service_that_uses_it(self) -> None:
+        service = default_service("ServiceA", "ServiceA")
+        service.enumerations.extend(enum_service("ServiceA").enumerations)
+        self.check_default(self.create_services([service]), "Mode.fast")
+
+    def test_defined_by_no_service(self) -> None:
+        with self.assertRaises(RuntimeError) as cm:
+            self.create_services([default_service("ServiceA", "ServiceB")])
+        self.assertIn("ServiceA.Frob parameter mode", str(cm.exception))
+        self.assertIn("ServiceB.Mode", str(cm.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/client/python/krpc/types.py
+++ b/client/python/krpc/types.py
@@ -403,6 +403,12 @@ class EnumerationType(TypeBase):
         # be called to set the python_type
         super().__init__(protobuf_type, cast(type, typ), string)
 
+    @property
+    def has_values(self) -> bool:
+        """Whether the values of the enumeration are known, which they are
+        only once its definition has been registered by calling set_values"""
+        return self._python_type is not None
+
     def set_values(self, values: Mapping[str, Mapping[str, object]]) -> None:
         """Set the python type. Creates an Enum class
         using the given values."""

--- a/tools/TestServer/src/TestService.cs
+++ b/tools/TestServer/src/TestService.cs
@@ -394,6 +394,21 @@ namespace TestServer
             return x;
         }
 
+        public static class CreateEnumListDefault
+        {
+            public static object Create ()
+            {
+                return new List<TestEnum> { TestEnum.ValueB, TestEnum.ValueC };
+            }
+        }
+
+        [KRPCProcedure]
+        public static IList<TestEnum> EnumListDefault (
+            [KRPCDefaultValue (typeof(CreateEnumListDefault))] IList<TestEnum> x)
+        {
+            return x;
+        }
+
         public static class CreateEmptyListDefault
         {
             public static object Create ()

--- a/tools/krpctools/CHANGELOG.md
+++ b/tools/krpctools/CHANGELOG.md
@@ -1,5 +1,20 @@
 ## [v0.7.0] - unreleased
+- **Breaking:** A generator module given to `krpc-clientgen` by path is constructed with
+  the definitions of every service that was loaded, rather than with those of the single
+  service it generates (#1044)
 - Support for nullable values across all types (#1017)
+- Generate an enumeration default value as the member it names, instead of a cast of its
+  integer value (#1044)
+- Fix generating a default value whose type contains an enumeration, such as a list of
+  them, failing (#1044)
+- Fix Lua documentation writing default values in Python's syntax rather than Lua's
+  (#1044)
+- Fix C++ documentation writing a collection default value as a constructor call rather
+  than a braced initializer list, so `std::vector<int32_t>(1, 2, 3)` named a constructor
+  that builds something else entirely (#1044)
+- A default value naming an undeclared enumeration value, or one whose enumeration no
+  supplied service defines, is now reported naming the service, procedure and parameter
+  it came from (#1044)
 
 ## [v0.6.0]
 - **Breaking:** Requires Python 3.10+

--- a/tools/krpctools/krpctools/clientgen/__init__.py
+++ b/tools/krpctools/krpctools/clientgen/__init__.py
@@ -10,6 +10,7 @@ from .cpp import CppGenerator
 from .java import JavaGenerator
 from .cnano import CnanoGenerator
 from .python import PythonGenerator
+from ..definitions import Definitions
 from ..version import __version__
 from ..servicedefs import servicedefs
 
@@ -125,8 +126,9 @@ def main():
             # Generator defined in a python module
             generator, macro_template = load_generator(args.language)
 
-        # Run the generator
-        g = generator(macro_template, args.service, defs[args.service])
+        # Run the generator, over all of the definitions that were loaded: the requested
+        # service is the one generated, but the types it refers to may be defined by any of them
+        g = generator(macro_template, args.service, Definitions(defs))
         if args.output:
             g.generate_file(args.output)
         else:

--- a/tools/krpctools/krpctools/clientgen/cnano.py
+++ b/tools/krpctools/krpctools/clientgen/cnano.py
@@ -272,25 +272,18 @@ class CnanoGenerator(Generator):
 
         context["properties"] = properties
 
-        context["collection_types"] = []
-
-        def build_collection_types(typ):
-            if isinstance(typ, TupleType):
-                for value_type in typ.value_types:
-                    build_collection_types(value_type)
-            elif isinstance(typ, (ListType, SetType)):
-                build_collection_types(typ.value_type)
-            elif isinstance(typ, DictionaryType):
-                build_collection_types(typ.key_type)
-                build_collection_types(typ.value_type)
-            else:
-                return
-            typ = self.parse_collection_type(typ)
-            if typ not in context["collection_types"]:
-                context["collection_types"].append(typ)
-
-        for typ in sorted(self._collection_types, key=self.parse_type_name):
-            build_collection_types(typ)
+        # C requires a struct to be declared before it is used, so a collection type has to
+        # follow the collection types it contains. Several kRPC types share one C type, as
+        # every class is a krpc_object_t and every enumeration a krpc_enum_t, so collections
+        # are deduplicated by what they become in C rather than by what they are here.
+        collection_types = []
+        for typ in self._definitions.collection_types(
+            sorted(self._collection_types, key=self.parse_type_name)
+        ):
+            ctype = self.parse_collection_type(typ)
+            if ctype not in collection_types:
+                collection_types.append(ctype)
+        context["collection_types"] = collection_types
 
         return context
 

--- a/tools/krpctools/krpctools/clientgen/cnano.py
+++ b/tools/krpctools/krpctools/clientgen/cnano.py
@@ -169,8 +169,8 @@ class CnanoGenerator(Generator):
             return typ.protobuf_type.code != Type.STRING
         return False
 
-    def generate_context_parameters(self, procedure):
-        parameters = super().generate_context_parameters(procedure)
+    def generate_context_parameters(self, name, procedure):
+        parameters = super().generate_context_parameters(name, procedure)
         for i, parameter in enumerate(parameters):
             if not parameter["nullable"]:
                 continue
@@ -232,7 +232,7 @@ class CnanoGenerator(Generator):
                 properties["set_" + name] = {
                     "remote_id": info["setter"]["remote_id"],
                     "parameters": self.generate_context_parameters(
-                        info["setter"]["procedure"]
+                        info["setter"]["remote_name"], info["setter"]["procedure"]
                     ),
                     "return_type": {"ctype": "void", "cvtype": None, "name": None},
                     "documentation": info["documentation"],
@@ -259,7 +259,8 @@ class CnanoGenerator(Generator):
                         "remote_id": info["setter"]["remote_id"],
                         "parameters": [
                             self.generate_context_parameters(
-                                info["setter"]["procedure"]
+                                info["setter"]["remote_name"],
+                                info["setter"]["procedure"],
                             )[1]
                         ],
                         "return_type": {"ctype": "void", "cvtype": None, "name": None},

--- a/tools/krpctools/krpctools/clientgen/cpp.py
+++ b/tools/krpctools/krpctools/clientgen/cpp.py
@@ -29,8 +29,8 @@ class CppGenerator(Generator):
     def _wrap_optional(type_str):
         return _cpp_template_fix("std::optional<%s>" % type_str)
 
-    def generate_context_parameters(self, procedure):
-        parameters = super().generate_context_parameters(procedure)
+    def generate_context_parameters(self, name, procedure):
+        parameters = super().generate_context_parameters(name, procedure)
         for i, parameter in enumerate(parameters):
             # A nullable class parameter keeps its class type (null is the id-0 object);
             # every other nullable parameter is wrapped in std::optional.
@@ -88,7 +88,7 @@ class CppGenerator(Generator):
                 properties["set_" + name] = {
                     "remote_name": info["setter"]["remote_name"],
                     "parameters": self.generate_context_parameters(
-                        info["setter"]["procedure"]
+                        info["setter"]["remote_name"], info["setter"]["procedure"]
                     ),
                     "return_type": "void",
                     "return_set_client": False,
@@ -125,7 +125,8 @@ class CppGenerator(Generator):
                         "remote_name": info["setter"]["remote_name"],
                         "parameters": [
                             self.generate_context_parameters(
-                                info["setter"]["procedure"]
+                                info["setter"]["remote_name"],
+                                info["setter"]["procedure"],
                             )[1]
                         ],
                         "return_type": "void",

--- a/tools/krpctools/krpctools/clientgen/cpp.tmpl
+++ b/tools/krpctools/krpctools/clientgen/cpp.tmpl
@@ -225,6 +225,36 @@ namespace decoder {
   {% endfor %}
 
 }  // namespace decoder
+
+// The encoder and decoder for a collection call encode and decode on the type it
+// contains without qualifying them, so the ones above, which are declared after those
+// templates, are only reachable through argument dependent lookup. That searches the
+// namespace enclosing the enumeration, which is this one, so the collection encoder and
+// decoder find an enumeration through these.
+namespace services {
+  {% for enum_name,enm in enumerations.items() %}
+
+  {% if enm.deprecated %}
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+  {% endif %}
+  inline std::string encode(const {{ service_name }}::{{ enum_name }}& value) {
+    return encoder::encode(value);
+  }
+
+  inline void decode({{ service_name }}::{{ enum_name }}& value, const std::string& data, Client* client) {
+    decoder::decode(value, data, client);
+  }
+  {% if enm.deprecated %}
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
+  {% endif %}
+  {% endfor %}
+
+}  // namespace services
 {% endif %}
 
 namespace services {

--- a/tools/krpctools/krpctools/clientgen/csharp.py
+++ b/tools/krpctools/krpctools/clientgen/csharp.py
@@ -32,8 +32,8 @@ class CsharpGenerator(Generator):
         content = content.replace("  <remarks", "<remarks")
         return content
 
-    def generate_context_parameters(self, procedure):
-        parameters = super().generate_context_parameters(procedure)
+    def generate_context_parameters(self, name, procedure):
+        parameters = super().generate_context_parameters(name, procedure)
         for i, parameter in enumerate(parameters):
             typ = as_type(self.types, procedure["parameters"][i]["type"])
             if parameter["nullable"] and self._is_nullable_value_type(typ):

--- a/tools/krpctools/krpctools/clientgen/generator.py
+++ b/tools/krpctools/krpctools/clientgen/generator.py
@@ -69,7 +69,7 @@ class Generator:
         language-specific names."""
         return flatten_deprecation_reason(reason, self.parse_plain_cref)
 
-    def generate_context_parameters(self, procedure):
+    def generate_context_parameters(self, name, procedure):
         parameters = []
         for parameter in procedure["parameters"]:
             typ = as_type(self.types, parameter["type"])
@@ -78,7 +78,12 @@ class Generator:
                 "type": self.parse_parameter_type(typ),
             }
             if "default_value" in parameter:
-                value = decode_default_value(parameter["default_value"], typ)
+                location = "%s.%s parameter %s" % (
+                    self._service,
+                    name,
+                    parameter["name"],
+                )
+                value = decode_default_value(parameter["default_value"], typ, location)
                 info["default_value"] = self.parse_default_value(value, typ)
             info["nullable"] = parameter.get("nullable", False)
             parameters.append(info)
@@ -149,7 +154,7 @@ class Generator:
                     "procedure": procedure,
                     "remote_name": name,
                     "remote_id": procedure["id"],
-                    "parameters": self.generate_context_parameters(procedure),
+                    "parameters": self.generate_context_parameters(name, procedure),
                     "return_type": self.parse_return_type(
                         self.get_return_type(procedure)
                     ),
@@ -185,7 +190,7 @@ class Generator:
 
             elif Attributes.is_a_property_setter(name):
                 property_name = self.parse_name(Attributes.get_property_name(name))
-                params = self.generate_context_parameters(procedure)
+                params = self.generate_context_parameters(name, procedure)
                 if property_name not in context["properties"]:
                     context["properties"][property_name] = {
                         "type": params[0]["type"],
@@ -208,7 +213,7 @@ class Generator:
             elif Attributes.is_a_class_method(name):
                 class_name = Attributes.get_class_name(name)
                 method_name = self.parse_name(Attributes.get_class_member_name(name))
-                params = self.generate_context_parameters(procedure)
+                params = self.generate_context_parameters(name, procedure)
                 context["classes"][class_name]["methods"][method_name] = {
                     "procedure": procedure,
                     "remote_name": name,
@@ -234,7 +239,7 @@ class Generator:
                     "procedure": procedure,
                     "remote_name": name,
                     "remote_id": procedure["id"],
-                    "parameters": self.generate_context_parameters(procedure),
+                    "parameters": self.generate_context_parameters(name, procedure),
                     "return_type": self.parse_return_type(
                         self.get_return_type(procedure)
                     ),
@@ -275,7 +280,7 @@ class Generator:
                 cls = context["classes"][class_name]
                 property_name = self.parse_name(Attributes.get_class_member_name(name))
                 if property_name not in cls["properties"]:
-                    params = self.generate_context_parameters(procedure)
+                    params = self.generate_context_parameters(name, procedure)
                     cls["properties"][property_name] = {
                         "type": params[1]["type"],
                         "getter": None,

--- a/tools/krpctools/krpctools/clientgen/generator.py
+++ b/tools/krpctools/krpctools/clientgen/generator.py
@@ -1,7 +1,6 @@
 import collections
 import jinja2
 from krpc.attributes import Attributes
-from krpc.types import Types
 from krpc.utils import snake_case
 from ..utils import lower_camel_case, indent, single_line, as_type, decode_default_value
 from .docparser import flatten_deprecation_reason
@@ -12,13 +11,15 @@ class Generator:
     def __init__(self, macro_template, service, definitions):
         self._macro_template = macro_template
         self._service = service
-        self._defs = definitions
+        self._definitions = definitions
+        self._defs = definitions.services[service]
+        # The registry every service in the definitions was registered in, so that a type
+        # another service defines resolves to what that service defines it as
+        self.types = definitions.types
 
     @property
     def service_name(self):
         return self._service
-
-    types = Types()
 
     def generate_file(self, path):
         content = self.generate()

--- a/tools/krpctools/krpctools/clientgen/java.py
+++ b/tools/krpctools/krpctools/clientgen/java.py
@@ -87,8 +87,8 @@ class JavaGenerator(Generator):
             Type.BYTES,
         )
 
-    def generate_context_parameters(self, procedure):
-        parameters = super().generate_context_parameters(procedure)
+    def generate_context_parameters(self, name, procedure):
+        parameters = super().generate_context_parameters(name, procedure)
         for i, parameter in enumerate(parameters):
             typ = as_type(self.types, procedure["parameters"][i]["type"])
             if parameter["nullable"] and self._needs_boxing(typ):
@@ -130,7 +130,7 @@ class JavaGenerator(Generator):
                     "procedure": info["setter"]["procedure"],
                     "remote_name": info["setter"]["remote_name"],
                     "parameters": self.generate_context_parameters(
-                        info["setter"]["procedure"]
+                        info["setter"]["remote_name"], info["setter"]["procedure"]
                     ),
                     "return_type": "void",
                     "documentation": info["documentation"],
@@ -159,7 +159,8 @@ class JavaGenerator(Generator):
                         "remote_name": info["setter"]["remote_name"],
                         "parameters": [
                             self.generate_context_parameters(
-                                info["setter"]["procedure"]
+                                info["setter"]["remote_name"],
+                                info["setter"]["procedure"],
                             )[1]
                         ],
                         "return_type": "void",

--- a/tools/krpctools/krpctools/clientgen/python.py
+++ b/tools/krpctools/krpctools/clientgen/python.py
@@ -18,11 +18,30 @@ from ..lang.python import PythonLanguage
 from ..utils import as_type
 
 
+class StubLanguage(PythonLanguage):
+    """How a generated stub module names the types it uses: another service's through the module
+    its stubs are imported from, and its own service's directly."""
+
+    def __init__(self, service):
+        super().__init__()
+        self.module = service
+
+    def parse_type(self, typ):
+        if isinstance(typ, (ClassType, EnumerationType)):
+            name = typ.protobuf_type.name
+            if typ.protobuf_type.service != self.module:
+                name = typ.protobuf_type.service.lower() + "." + name
+            return name
+        return super().parse_type(typ)
+
+
 class PythonGenerator(Generator):
 
-    language = PythonLanguage()
-
     parse_plain_cref_member = staticmethod(snake_case)
+
+    def __init__(self, macro_template, service, definitions):
+        super().__init__(macro_template, service, definitions)
+        self.language = StubLanguage(service)
 
     def parse_python_type(self, typ):
         if typ is None:
@@ -82,9 +101,7 @@ class PythonGenerator(Generator):
             else:
                 return "KRPC_pb2.%s" % typ.python_type.__name__
         elif isinstance(typ, (ClassType, EnumerationType)):
-            spec = typ.protobuf_type.name
-            if typ.protobuf_type.service != self.service_name:
-                spec = typ.protobuf_type.service.lower() + "." + spec
+            spec = self.language.parse_type(typ)
         elif isinstance(typ, TupleType):
             spec = "Tuple[%s]" % ",".join(
                 self.parse_type_specification(t) for t in typ.value_types
@@ -126,7 +143,7 @@ class PythonGenerator(Generator):
                     "procedure": info["setter"]["procedure"],
                     "remote_name": info["setter"]["remote_name"],
                     "parameters": self.generate_context_parameters(
-                        info["setter"]["procedure"]
+                        info["setter"]["remote_name"], info["setter"]["procedure"]
                     ),
                     "return_type": "None",
                     "documentation": info["documentation"],
@@ -157,7 +174,8 @@ class PythonGenerator(Generator):
                         "remote_name": info["setter"]["remote_name"],
                         "parameters": [
                             self.generate_context_parameters(
-                                info["setter"]["procedure"]
+                                info["setter"]["remote_name"],
+                                info["setter"]["procedure"],
                             )[1]
                         ],
                         "return_type": "None",
@@ -330,14 +348,6 @@ class PythonGenerator(Generator):
             info["documentation"] = '"""\n' + line + "\n\n" + body + '\n"""'
         else:
             info["documentation"] = '"""\n' + line + '\n"""'
-
-    def parse_default_value(self, value, typ):
-        result = super().parse_default_value(value, typ)
-        # Fix references to types within the same service
-        prefix = self.service_name + "."
-        if result.startswith(prefix):
-            result = result[len(prefix) :]
-        return result
 
     @staticmethod
     def parse_documentation(documentation):

--- a/tools/krpctools/krpctools/definitions.py
+++ b/tools/krpctools/krpctools/definitions.py
@@ -1,0 +1,118 @@
+from krpc.definitions import (
+    CLASS,
+    ENUMERATION,
+    EXCEPTION,
+    Definition,
+    register_all,
+    topological_order,
+)
+from krpc.types import Types, TupleType, ListType, SetType, DictionaryType
+from .utils import as_type
+
+
+class Definitions:
+    """The service definitions a single run of a generator was given, with a type registry in
+    which everything they define is registered.
+
+    The registry belongs to the run rather than to the process, so that generating from one set
+    of definitions does not see the types of another."""
+
+    def __init__(self, services_info):
+        self._services = services_info
+        self._types = Types()
+        register_all(self._types, _definitions(services_info))
+
+    @property
+    def types(self):
+        """The type registry the definitions were registered in"""
+        return self._types
+
+    @property
+    def services(self):
+        """The definitions themselves, keyed by service name"""
+        return self._services
+
+    def as_type(self, type_info):
+        """Convert a type parsed from a service definitions file into a type object"""
+        return as_type(self._types, type_info)
+
+    @staticmethod
+    def collection_types(types):
+        """The collection types among the given types, and the collection types they contain,
+        innermost first, so that a type always follows the types it is composed of."""
+        return topological_order(
+            [typ for typ in types if _is_collection(typ)],
+            lambda typ: typ.protobuf_type.SerializeToString(),
+            _contained_collection_types,
+        )
+
+
+def _definitions(services_info):
+    """A definition record for everything the given services define"""
+    for service_name, info in services_info.items():
+        for name in info.get("classes", {}):
+            yield Definition(
+                CLASS, service_name, name, [], _register_class(service_name, name)
+            )
+        for name, enumeration in info.get("enumerations", {}).items():
+            yield Definition(
+                ENUMERATION,
+                service_name,
+                name,
+                [],
+                _register_enumeration(service_name, name, enumeration),
+            )
+        for name in info.get("exceptions", {}):
+            yield Definition(
+                EXCEPTION,
+                service_name,
+                name,
+                [],
+                _register_exception(service_name, name),
+            )
+
+
+def _register_class(service, name):
+    def register(types):
+        types.class_type(service, name)
+
+    return register
+
+
+def _register_enumeration(service, name, enumeration):
+    # The values keep the names they are declared with, as each language names them its own way
+    values = dict(
+        (
+            value["name"],
+            {"value": value["value"], "doc": value["documentation"]},
+        )
+        for value in enumeration["values"]
+    )
+
+    def register(types):
+        types.enumeration_type(service, name).set_values(values)
+
+    return register
+
+
+def _register_exception(service, name):
+    def register(types):
+        types.exception_type(service, name)
+
+    return register
+
+
+def _is_collection(typ):
+    return isinstance(typ, (TupleType, ListType, SetType, DictionaryType))
+
+
+def _contained_collection_types(typ):
+    if isinstance(typ, TupleType):
+        contained = typ.value_types
+    elif isinstance(typ, (ListType, SetType)):
+        contained = [typ.value_type]
+    elif isinstance(typ, DictionaryType):
+        contained = [typ.key_type, typ.value_type]
+    else:
+        contained = []
+    return [x for x in contained if _is_collection(x)]

--- a/tools/krpctools/krpctools/docgen/__init__.py
+++ b/tools/krpctools/krpctools/docgen/__init__.py
@@ -6,8 +6,8 @@ from io import open
 import sys
 from importlib.resources import files
 import jinja2
-from krpc.types import Types
 from krpc.utils import snake_case
+from ..definitions import Definitions
 from ..utils import lower_camel_case, indent, single_line
 from .utils import lookup_cref
 from .cnano import CnanoDomain
@@ -107,8 +107,14 @@ def main():
         del info["id"]
         return info
 
+    # Register everything the services define before building any documentation node, as a node
+    # for a procedure's default value is built from the type the value decodes through
+    definitions = Definitions(services_info)
+
     services = {
-        name: Service(name, sort=sort, **parse_service_info(info))
+        name: Service(
+            name, sort=sort, types=definitions.types, **parse_service_info(info)
+        )
         for name, info in services_info.items()
     }
 

--- a/tools/krpctools/krpctools/docgen/cpp.py
+++ b/tools/krpctools/krpctools/docgen/cpp.py
@@ -107,35 +107,3 @@ class CppDomain(Domain):
     @staticmethod
     def paramref(name):
         return Domain.paramref(snake_case(name))
-
-    def default_value(self, value, typ):
-        if isinstance(typ, TupleType):
-            if value is None:
-                value = tuple()
-            values = (
-                self.default_value(x, typ.value_types[i]) for i, x in enumerate(value)
-            )
-            return "%s(%s)" % (self.language.parse_type(typ), ", ".join(values))
-        if isinstance(typ, ListType):
-            if value is None:
-                value = []
-            values = (self.default_value(x, typ.value_type) for x in value)
-            return "%s(%s)" % (self.language.parse_type(typ), ", ".join(values))
-        if isinstance(typ, SetType):
-            if value is None:
-                value = set()
-            values = (self.default_value(x, typ.value_type) for x in value)
-            return "%s(%s)" % (self.language.parse_type(typ), ", ".join(values))
-        if isinstance(typ, DictionaryType):
-            if value is None:
-                value = {}
-            entries = (
-                "{%s, %s}"
-                % (
-                    self.default_value(k, typ.key_type),
-                    self.default_value(v, typ.value_type),
-                )
-                for k, v in value.items()
-            )
-            return "%s(%s)" % (self.language.parse_type(typ), ", ".join(entries))
-        return self.language.parse_default_value(value, typ)

--- a/tools/krpctools/krpctools/docgen/csharp.py
+++ b/tools/krpctools/krpctools/docgen/csharp.py
@@ -62,7 +62,10 @@ class CsharpDomain(Domain):
 
     def default_value(self, value, typ):
         if isinstance(typ, EnumerationType):
-            return "%s" % value
+            return "%s.%s" % (
+                self.type(typ),
+                self.language.parse_enum_value_name(value.name),
+            )
         if isinstance(typ, TupleType):
             if value is None:
                 value = tuple()

--- a/tools/krpctools/krpctools/docgen/nodes.py
+++ b/tools/krpctools/krpctools/docgen/nodes.py
@@ -157,7 +157,14 @@ class Class(Appendable):
 class Parameter(Appendable):
     # pylint: disable=redefined-builtin
     def __init__(
-        self, name, type, documentation, types, default_value=None, nullable=False
+        self,
+        name,
+        type,
+        documentation,
+        types,
+        procedure,
+        default_value=None,
+        nullable=False,
     ):
         super().__init__()
         self.types = types
@@ -165,7 +172,8 @@ class Parameter(Appendable):
         self.type = as_type(self.types, type)
         self.has_default_value = default_value is not None
         if default_value is not None:
-            default_value = decode_default_value(default_value, self.type)
+            location = "%s parameter %s" % (procedure, name)
+            default_value = decode_default_value(default_value, self.type, location)
         self.default_value = default_value
         self.nullable = nullable
         self.documentation = documentation
@@ -198,7 +206,12 @@ class Procedure(Appendable):
             self.return_type = None
         self.return_is_nullable = return_is_nullable
         self.parameters = [
-            Parameter(documentation=documentation, types=types, **info)
+            Parameter(
+                documentation=documentation,
+                types=types,
+                procedure=self.fullname,
+                **info
+            )
             for info in parameters
         ]
         self.game_scenes = game_scenes
@@ -264,7 +277,12 @@ class ClassMethod(Appendable):
             self.return_type = None
         self.return_is_nullable = return_is_nullable
         self.parameters = [
-            Parameter(documentation=documentation, types=types, **info)
+            Parameter(
+                documentation=documentation,
+                types=types,
+                procedure=self.fullname,
+                **info
+            )
             for info in parameters
         ]
         self.game_scenes = game_scenes
@@ -305,7 +323,12 @@ class ClassStaticMethod(Appendable):
             self.return_type = None
         self.return_is_nullable = return_is_nullable
         self.parameters = [
-            Parameter(documentation=documentation, types=types, **info)
+            Parameter(
+                documentation=documentation,
+                types=types,
+                procedure=self.fullname,
+                **info
+            )
             for info in parameters
         ]
         self.game_scenes = game_scenes

--- a/tools/krpctools/krpctools/docgen/nodes.py
+++ b/tools/krpctools/krpctools/docgen/nodes.py
@@ -1,14 +1,11 @@
 from collections import OrderedDict, defaultdict
 from krpc.attributes import Attributes
-from krpc.types import Types
 from ..utils import as_type, decode_default_value
 
 
 class Appendable:
     def __init__(self):
         self._appended = []
-
-    types = Types()
 
     def append(self, value):
         self._appended.append(value)
@@ -28,10 +25,12 @@ class Service(Appendable):
         exceptions,
         documentation,
         sort,
+        types,
         deprecated=False,
         deprecated_reason="",
     ):
         super().__init__()
+        self.types = types
         self.name = name
         self.fullname = name
         self.documentation = documentation
@@ -54,14 +53,15 @@ class Service(Appendable):
                 info["game_scenes"] = "All"
 
             if Attributes.is_a_procedure(pname):
-                members.append(Procedure(name, pname, **info))
+                members.append(Procedure(name, pname, types=types, **info))
 
             elif Attributes.is_a_property_accessor(pname):
                 propname = Attributes.get_property_name(pname)
+                procedure = Procedure(name, pname, types=types, **info)
                 if Attributes.is_a_property_getter(pname):
-                    properties[propname]["getter"] = Procedure(name, pname, **info)
+                    properties[propname]["getter"] = procedure
                 else:
-                    properties[propname]["setter"] = Procedure(name, pname, **info)
+                    properties[propname]["setter"] = procedure
 
             elif Attributes.is_a_class_member(pname):
                 cname = Attributes.get_class_name(pname)
@@ -71,7 +71,9 @@ class Service(Appendable):
             members.append(Property(name, propname, **prop))
 
         self.classes = {
-            cname: Class(name, cname, cprocedures[cname], sort=sort, **cinfo)
+            cname: Class(
+                name, cname, cprocedures[cname], sort=sort, types=types, **cinfo
+            )
             for (cname, cinfo) in classes.items()
         }
         self.enumerations = {
@@ -105,10 +107,12 @@ class Class(Appendable):
         procedures,
         documentation,
         sort,
+        types,
         deprecated=False,
         deprecated_reason="",
     ):
         super().__init__()
+        self.types = types
         self.service_name = service_name
         self.name = name
         self.fullname = service_name + "." + name
@@ -125,14 +129,18 @@ class Class(Appendable):
                 del pinfo["id"]
 
             if Attributes.is_a_class_method(pname):
-                members.append(ClassMethod(service_name, name, pname, **pinfo))
+                members.append(
+                    ClassMethod(service_name, name, pname, types=types, **pinfo)
+                )
 
             elif Attributes.is_a_class_static_method(pname):
-                members.append(ClassStaticMethod(service_name, name, pname, **pinfo))
+                members.append(
+                    ClassStaticMethod(service_name, name, pname, types=types, **pinfo)
+                )
 
             elif Attributes.is_a_class_property_accessor(pname):
                 propname = Attributes.get_class_member_name(pname)
-                proc = Procedure(service_name, pname, **pinfo)
+                proc = Procedure(service_name, pname, types=types, **pinfo)
                 if Attributes.is_a_class_property_getter(pname):
                     properties[propname]["getter"] = proc
                 else:
@@ -148,8 +156,11 @@ class Class(Appendable):
 
 class Parameter(Appendable):
     # pylint: disable=redefined-builtin
-    def __init__(self, name, type, documentation, default_value=None, nullable=False):
+    def __init__(
+        self, name, type, documentation, types, default_value=None, nullable=False
+    ):
         super().__init__()
+        self.types = types
         self.name = name
         self.type = as_type(self.types, type)
         self.has_default_value = default_value is not None
@@ -169,6 +180,7 @@ class Procedure(Appendable):
         name,
         parameters,
         documentation,
+        types,
         return_type=None,
         return_is_nullable=False,
         game_scenes=None,
@@ -176,6 +188,7 @@ class Procedure(Appendable):
         deprecated_reason="",
     ):
         super().__init__()
+        self.types = types
         self.service_name = service_name
         self.name = name
         self.fullname = service_name + "." + name
@@ -185,7 +198,8 @@ class Procedure(Appendable):
             self.return_type = None
         self.return_is_nullable = return_is_nullable
         self.parameters = [
-            Parameter(documentation=documentation, **info) for info in parameters
+            Parameter(documentation=documentation, types=types, **info)
+            for info in parameters
         ]
         self.game_scenes = game_scenes
         self.documentation = documentation
@@ -220,6 +234,7 @@ class Property(Appendable):
 
 
 class ClassMethod(Appendable):
+    # pylint: disable=too-many-instance-attributes,too-many-arguments
     member_type = "class_method"
 
     def __init__(
@@ -229,6 +244,7 @@ class ClassMethod(Appendable):
         name,
         parameters,
         documentation,
+        types,
         return_type=None,
         return_is_nullable=False,
         game_scenes=None,
@@ -236,6 +252,7 @@ class ClassMethod(Appendable):
         deprecated_reason="",
     ):
         super().__init__()
+        self.types = types
         name = Attributes.get_class_member_name(name)
         self.service_name = service_name
         self.class_name = class_name
@@ -247,7 +264,8 @@ class ClassMethod(Appendable):
             self.return_type = None
         self.return_is_nullable = return_is_nullable
         self.parameters = [
-            Parameter(documentation=documentation, **info) for info in parameters
+            Parameter(documentation=documentation, types=types, **info)
+            for info in parameters
         ]
         self.game_scenes = game_scenes
         self.documentation = documentation
@@ -257,6 +275,7 @@ class ClassMethod(Appendable):
 
 
 class ClassStaticMethod(Appendable):
+    # pylint: disable=too-many-instance-attributes,too-many-arguments
     member_type = "class_static_method"
 
     def __init__(
@@ -266,6 +285,7 @@ class ClassStaticMethod(Appendable):
         name,
         parameters,
         documentation,
+        types,
         return_type=None,
         return_is_nullable=False,
         game_scenes=None,
@@ -273,6 +293,7 @@ class ClassStaticMethod(Appendable):
         deprecated_reason="",
     ):
         super().__init__()
+        self.types = types
         name = Attributes.get_class_member_name(name)
         self.service_name = service_name
         self.class_name = class_name
@@ -284,7 +305,8 @@ class ClassStaticMethod(Appendable):
             self.return_type = None
         self.return_is_nullable = return_is_nullable
         self.parameters = [
-            Parameter(documentation=documentation, **info) for info in parameters
+            Parameter(documentation=documentation, types=types, **info)
+            for info in parameters
         ]
         self.game_scenes = game_scenes
         self.documentation = documentation

--- a/tools/krpctools/krpctools/lang/cpp.py
+++ b/tools/krpctools/krpctools/lang/cpp.py
@@ -159,9 +159,15 @@ class CppLanguage(Language):
         if isinstance(typ, ClassType) and value is None:
             return self.parse_type(typ) + "()"
         if isinstance(typ, EnumerationType):
-            return "static_cast<%s>(%s)" % (self.parse_type(typ), value)
+            return "%s::%s" % (
+                self.parse_type(typ),
+                self.parse_enum_value_name(value.name),
+            )
         if value is None:
             return self.parse_type(typ) + "()"
+        # A collection is written as a braced initializer list. Parentheses would name a
+        # constructor instead, so std::vector<int32_t>(1, 2, 3) is not the vector of those
+        # three values it appears to be.
         if isinstance(typ, TupleType):
             values = (
                 self.parse_default_value(x, typ.value_types[i])

--- a/tools/krpctools/krpctools/lang/csharp.py
+++ b/tools/krpctools/krpctools/lang/csharp.py
@@ -167,10 +167,9 @@ class CsharpLanguage(Language):
         if isinstance(typ, ClassType) and value is None:
             return "null"
         if isinstance(typ, EnumerationType):
-            return "(global::KRPC.Client.Services.%s.%s)%s" % (
-                typ.protobuf_type.service,
-                typ.protobuf_type.name,
-                value,
+            return "%s.%s" % (
+                self.parse_type(typ),
+                self.parse_enum_value_name(value.name),
             )
         if value is None:
             return "null"

--- a/tools/krpctools/krpctools/lang/language.py
+++ b/tools/krpctools/krpctools/lang/language.py
@@ -7,6 +7,10 @@ class Language:
             return "%s_" % name
         return name
 
+    def parse_enum_value_name(self, name):
+        """The name of a value of an enumeration, as the enumeration declares it"""
+        return self.parse_name(name)
+
     def parse_type(self, typ):  # pylint: disable=unused-argument
         raise NotImplementedError
 

--- a/tools/krpctools/krpctools/lang/lua.py
+++ b/tools/krpctools/krpctools/lang/lua.py
@@ -10,6 +10,7 @@ from krpc.types import (
     SetType,
     DictionaryType,
 )
+from krpc.utils import snake_case
 from .language import Language
 
 
@@ -46,14 +47,36 @@ class LuaLanguage(Language):
             return "Tuple"
         raise RuntimeError("Unknown type '%s'" % str(typ))
 
+    def parse_enum_value_name(self, name):
+        return snake_case(name)
+
     def parse_default_value(self, value, typ):
         if isinstance(typ, ValueType) and typ.protobuf_type.code == Type.STRING:
             return "'%s'" % value
-        # python2 fix: convert set to string manually
-        if isinstance(typ, SetType):
-            return (
-                "{"
-                + ", ".join(self.parse_default_value(x, typ.value_type) for x in value)
-                + "}"
+        if isinstance(typ, ValueType) and typ.protobuf_type.code == Type.BOOL:
+            return "true" if value else "false"
+        if isinstance(typ, EnumerationType):
+            return "%s.%s" % (
+                self.parse_type(typ),
+                self.parse_enum_value_name(value.name),
             )
+        if isinstance(typ, TupleType):
+            values = (
+                self.parse_default_value(x, typ.value_types[i])
+                for i, x in enumerate(value)
+            )
+            return "{%s}" % ", ".join(values)
+        if isinstance(typ, (ListType, SetType)):
+            values = (self.parse_default_value(x, typ.value_type) for x in value)
+            return "{%s}" % ", ".join(values)
+        if isinstance(typ, DictionaryType):
+            entries = (
+                "[%s] = %s"
+                % (
+                    self.parse_default_value(k, typ.key_type),
+                    self.parse_default_value(v, typ.value_type),
+                )
+                for k, v in value.items()
+            )
+            return "{%s}" % ", ".join(entries)
         return str(value)

--- a/tools/krpctools/krpctools/lang/python.py
+++ b/tools/krpctools/krpctools/lang/python.py
@@ -59,7 +59,35 @@ class PythonLanguage(Language):
         if isinstance(typ, ValueType) and typ.protobuf_type.code == Type.STRING:
             return "'%s'" % value
         if isinstance(typ, EnumerationType):
-            return self.parse_type(typ) + "(%d)" % value
+            return "%s.%s" % (
+                self.parse_type(typ),
+                self.parse_enum_value_name(value.name),
+            )
+        if isinstance(typ, TupleType):
+            values = [
+                self.parse_default_value(x, typ.value_types[i])
+                for i, x in enumerate(value)
+            ]
+            # A tuple of one value needs the trailing comma to be a tuple at all
+            return "(%s%s)" % (", ".join(values), "," if len(values) == 1 else "")
+        if isinstance(typ, ListType):
+            values = (self.parse_default_value(x, typ.value_type) for x in value)
+            return "[%s]" % ", ".join(values)
+        if isinstance(typ, SetType):
+            if not value:
+                return "set()"
+            values = (self.parse_default_value(x, typ.value_type) for x in value)
+            return "{%s}" % ", ".join(values)
+        if isinstance(typ, DictionaryType):
+            entries = (
+                "%s: %s"
+                % (
+                    self.parse_default_value(k, typ.key_type),
+                    self.parse_default_value(v, typ.value_type),
+                )
+                for k, v in value.items()
+            )
+            return "{%s}" % ", ".join(entries)
         return str(value)
 
     def shorten_ref(self, name):

--- a/tools/krpctools/krpctools/test/Ordering.json
+++ b/tools/krpctools/krpctools/test/Ordering.json
@@ -1,0 +1,70 @@
+{
+  "ServiceA": {
+    "id": 1,
+    "documentation": "<doc>\n<summary>\nA service whose procedures use another service's enumeration.\n</summary>\n</doc>",
+    "procedures": {
+      "Frob": {
+        "id": 1,
+        "parameters": [
+          {
+            "name": "mode",
+            "type": {
+              "code": "ENUMERATION",
+              "service": "ServiceB",
+              "name": "Mode"
+            },
+            "default_value": "Ag=="
+          }
+        ],
+        "documentation": "<doc>\n<summary>\nDefaults to a member of another service's enumeration.\n</summary>\n</doc>"
+      },
+      "FrobAll": {
+        "id": 2,
+        "parameters": [
+          {
+            "name": "modes",
+            "type": {
+              "code": "LIST",
+              "types": [
+                {
+                  "code": "ENUMERATION",
+                  "service": "ServiceB",
+                  "name": "Mode"
+                }
+              ]
+            },
+            "default_value": "CgEC"
+          }
+        ],
+        "documentation": "<doc>\n<summary>\nDefaults to a collection containing a member of another service's enumeration.\n</summary>\n</doc>"
+      }
+    },
+    "classes": {},
+    "enumerations": {},
+    "exceptions": {}
+  },
+  "ServiceB": {
+    "id": 2,
+    "documentation": "<doc>\n<summary>\nA service defining an enumeration that another service uses.\n</summary>\n</doc>",
+    "procedures": {},
+    "classes": {},
+    "enumerations": {
+      "Mode": {
+        "documentation": "<doc>\n<summary>\nHow to frob.\n</summary>\n</doc>",
+        "values": [
+          {
+            "name": "Slow",
+            "value": 0,
+            "documentation": "<doc>\n<summary>\nFrob slowly.\n</summary>\n</doc>"
+          },
+          {
+            "name": "Fast",
+            "value": 1,
+            "documentation": "<doc>\n<summary>\nFrob quickly.\n</summary>\n</doc>"
+          }
+        ]
+      }
+    },
+    "exceptions": {}
+  }
+}

--- a/tools/krpctools/krpctools/test/UndeclaredEnumValue.json
+++ b/tools/krpctools/krpctools/test/UndeclaredEnumValue.json
@@ -1,0 +1,42 @@
+{
+  "BadService": {
+    "id": 1,
+    "documentation": "",
+    "procedures": {
+      "Frob": {
+        "id": 1,
+        "parameters": [
+          {
+            "name": "mode",
+            "type": {
+              "code": "ENUMERATION",
+              "service": "BadService",
+              "name": "Mode"
+            },
+            "default_value": "Dg=="
+          }
+        ],
+        "documentation": ""
+      }
+    },
+    "classes": {},
+    "enumerations": {
+      "Mode": {
+        "documentation": "",
+        "values": [
+          {
+            "name": "Slow",
+            "value": 0,
+            "documentation": ""
+          },
+          {
+            "name": "Fast",
+            "value": 1,
+            "documentation": ""
+          }
+        ]
+      }
+    },
+    "exceptions": {}
+  }
+}

--- a/tools/krpctools/krpctools/test/clientgen-Ordering-cnano.txt
+++ b/tools/krpctools/krpctools/test/clientgen-Ordering-cnano.txt
@@ -1,0 +1,155 @@
+#pragma once
+
+#include <krpc_cnano/decoder.h>
+#include <krpc_cnano/deprecated.h>
+#include <krpc_cnano/encoder.h>
+#include <krpc_cnano/error.h>
+#include <krpc_cnano/memory.h>
+#include <krpc_cnano/pb_decode.h>
+#include <krpc_cnano/pb_encode.h>
+#include <krpc_cnano/types.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifndef KRPC_TYPE_LIST_ENUM
+#define KRPC_TYPE_LIST_ENUM
+
+typedef struct krpc_list_enum_s krpc_list_enum_t;
+struct krpc_list_enum_s {
+  size_t size;
+  krpc_enum_t * items;
+};
+
+static inline krpc_error_t krpc_encode_list_enum(
+  pb_ostream_t * stream, const krpc_list_enum_t * value);
+static inline krpc_error_t krpc_encode_size_list_enum(
+  size_t * size, const krpc_list_enum_t * value);
+static inline bool krpc_encode_callback_list_enum(
+  pb_ostream_t * stream, const pb_field_t * field, void * const * arg);
+static inline krpc_error_t krpc_decode_list_enum(
+  pb_istream_t * stream, krpc_list_enum_t * value);
+
+#endif  // KRPC_TYPE_LIST_ENUM
+
+/**
+ * Defaults to a member of another service's enumeration.
+ */
+static inline krpc_error_t krpc_ServiceA_Frob(krpc_connection_t connection, krpc_ServiceB_Mode_t mode);
+
+/**
+ * Defaults to a collection containing a member of another service's enumeration.
+ */
+static inline krpc_error_t krpc_ServiceA_FrobAll(krpc_connection_t connection, const krpc_list_enum_t * modes);
+
+// Implementation
+
+#ifndef KRPC_IMPL_TYPE_LIST_ENUM
+#define KRPC_IMPL_TYPE_LIST_ENUM
+
+static inline bool krpc_encode_callback_items_list_enum(
+  pb_ostream_t * stream, const pb_field_t * field, void * const * arg) {
+  const krpc_list_enum_t * value = (const krpc_list_enum_t*)(*arg);
+  size_t i = 0;
+  for (; i < value->size; i++) {
+    if (!pb_encode_tag_for_field(stream, field))
+      KRPC_CALLBACK_RETURN_ERROR("encoding tag for list item");
+    size_t size;
+    KRPC_CALLBACK_RETURN_ON_ERROR(krpc_encode_size_enum(&size, value->items[i]));
+    if (!pb_encode_varint(stream, size))
+      KRPC_CALLBACK_RETURN_ERROR("encoding size for list item");
+    KRPC_CALLBACK_RETURN_ON_ERROR(krpc_encode_enum(stream, value->items[i]));
+  }
+  return true;
+}
+
+static inline krpc_error_t krpc_encode_list_enum(
+  pb_ostream_t * stream, const krpc_list_enum_t * value) {
+  krpc_schema_List message = krpc_schema_List_init_default;
+  message.items.funcs.encode = &krpc_encode_callback_items_list_enum;
+  message.items.arg = (krpc_list_enum_t*)value;
+  KRPC_RETURN_ON_ERROR(krpc_encode_message_List(stream, &message));
+  return KRPC_OK;
+}
+
+static inline krpc_error_t krpc_encode_size_list_enum(
+  size_t * size, const krpc_list_enum_t * value) {
+  pb_ostream_t stream = PB_OSTREAM_SIZING;
+  KRPC_RETURN_ON_ERROR(krpc_encode_list_enum(&stream, value));
+  *size = stream.bytes_written;
+  return KRPC_OK;
+}
+
+static inline bool krpc_encode_callback_list_enum(
+  pb_ostream_t * stream, const pb_field_t * field, void * const * arg) {
+  if (!pb_encode_tag_for_field(stream, field))
+    KRPC_CALLBACK_RETURN_ERROR("encoding tag for list_enum");
+  krpc_list_enum_t * value = (krpc_list_enum_t*)(*arg);
+  size_t size;
+  KRPC_CALLBACK_RETURN_ON_ERROR(krpc_encode_size_list_enum(&size, value));
+  if (!pb_encode_varint(stream, size))
+    KRPC_CALLBACK_RETURN_ERROR("encoding size for list_enum");
+  KRPC_CALLBACK_RETURN_ON_ERROR(krpc_encode_list_enum(stream, value));
+  return true;
+}
+
+static inline bool krpc_decode_callback_item_list_enum(
+  pb_istream_t * stream, const pb_field_t * field, void ** arg) {
+  typedef struct State { size_t capacity; krpc_list_enum_t * value; } State;
+  State * state = (State*)(*arg);
+  size_t i = state->value->size;
+  state->value->size++;
+  if (state->capacity > 0 && state->value->size > state->capacity) {
+    state->value->items = (krpc_enum_t*)krpc_recalloc(state->value->items, state->capacity, KRPC_ALLOC_BLOCK_SIZE, sizeof(krpc_enum_t));
+    state->capacity += KRPC_ALLOC_BLOCK_SIZE;
+  }
+  KRPC_CALLBACK_RETURN_ON_ERROR(krpc_decode_enum(stream, &state->value->items[i]));
+  return true;
+}
+
+static inline krpc_error_t krpc_decode_list_enum(
+  pb_istream_t * stream, krpc_list_enum_t * value) {
+  typedef struct State { size_t capacity; krpc_list_enum_t * value; } State;
+  State state = { 0, value };
+  value->size = 0;
+  if (value->items == NULL) {
+    value->items = (krpc_enum_t*)krpc_calloc(KRPC_ALLOC_BLOCK_SIZE, sizeof(krpc_enum_t));
+    state.capacity = KRPC_ALLOC_BLOCK_SIZE;
+  }
+  krpc_schema_List message = krpc_schema_List_init_default;
+  message.items.funcs.decode = &krpc_decode_callback_item_list_enum;
+  message.items.arg = &state;
+  KRPC_RETURN_ON_ERROR(krpc_decode_message_List(stream, &message));
+  return KRPC_OK;
+}
+
+#endif  // KRPC_IMPL_TYPE_LIST_ENUM
+
+static inline krpc_error_t krpc_ServiceA_Frob(krpc_connection_t connection, krpc_ServiceB_Mode_t mode) {
+  krpc_call_t _call;
+  krpc_argument_t _arguments[1];
+  KRPC_CHECK(krpc_call(&_call, 1, 1, 1, _arguments));
+  KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_enum, &mode));
+  krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
+  KRPC_CHECK(krpc_init_result(&_result));
+  KRPC_CHECK(krpc_invoke(connection, &_result.message, &_call.message));
+  KRPC_CHECK(krpc_free_result(&_result));
+  return KRPC_OK;
+}
+
+static inline krpc_error_t krpc_ServiceA_FrobAll(krpc_connection_t connection, const krpc_list_enum_t * modes) {
+  krpc_call_t _call;
+  krpc_argument_t _arguments[1];
+  KRPC_CHECK(krpc_call(&_call, 1, 2, 1, _arguments));
+  KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_list_enum, modes));
+  krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
+  KRPC_CHECK(krpc_init_result(&_result));
+  KRPC_CHECK(krpc_invoke(connection, &_result.message, &_call.message));
+  KRPC_CHECK(krpc_free_result(&_result));
+  return KRPC_OK;
+}
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif

--- a/tools/krpctools/krpctools/test/clientgen-Ordering-cpp.txt
+++ b/tools/krpctools/krpctools/test/clientgen-Ordering-cpp.txt
@@ -1,0 +1,72 @@
+#pragma once
+
+#include <map>
+#include <set>
+#include <string>
+#include <tuple>
+#include <vector>
+
+#include <krpc/decoder.hpp>
+#include <krpc/encoder.hpp>
+#include <krpc/error.hpp>
+#include <krpc/event.hpp>
+#include <krpc/object.hpp>
+#include <krpc/service.hpp>
+#include <krpc/stream.hpp>
+
+namespace krpc {
+namespace services {
+
+class ServiceA : public Service {
+ public:
+  explicit ServiceA(Client* client);
+
+  /**
+   * Defaults to a member of another service's enumeration.
+   */
+  void frob(ServiceB::Mode mode);
+
+  /**
+   * Defaults to a collection containing a member of another service's enumeration.
+   */
+  void frob_all(std::vector<ServiceB::Mode> modes);
+
+  ::krpc::schema::ProcedureCall frob_call(ServiceB::Mode mode);
+
+  ::krpc::schema::ProcedureCall frob_all_call(std::vector<ServiceB::Mode> modes);
+};
+
+}  // namespace services
+
+namespace services {
+
+inline ServiceA::ServiceA(Client* client):
+  Service(client) {
+}
+
+inline void ServiceA::frob(ServiceB::Mode mode = ServiceB::Mode::fast) {
+  std::vector<krpc::encoder::Value> _args;
+  _args.push_back(encoder::encode(mode));
+  this->_client->invoke("ServiceA", "Frob", _args);
+}
+
+inline void ServiceA::frob_all(std::vector<ServiceB::Mode> modes = std::vector<ServiceB::Mode>{ServiceB::Mode::fast}) {
+  std::vector<krpc::encoder::Value> _args;
+  _args.push_back(encoder::encode(modes));
+  this->_client->invoke("ServiceA", "FrobAll", _args);
+}
+
+inline ::krpc::schema::ProcedureCall ServiceA::frob_call(ServiceB::Mode mode = ServiceB::Mode::fast) {
+  std::vector<krpc::encoder::Value> _args;
+  _args.push_back(encoder::encode(mode));
+  return this->_client->build_call("ServiceA", "Frob", _args);
+}
+
+inline ::krpc::schema::ProcedureCall ServiceA::frob_all_call(std::vector<ServiceB::Mode> modes = std::vector<ServiceB::Mode>{ServiceB::Mode::fast}) {
+  std::vector<krpc::encoder::Value> _args;
+  _args.push_back(encoder::encode(modes));
+  return this->_client->build_call("ServiceA", "FrobAll", _args);
+}
+}  // namespace services
+
+}  // namespace krpc

--- a/tools/krpctools/krpctools/test/clientgen-Ordering-csharp.txt
+++ b/tools/krpctools/krpctools/test/clientgen-Ordering-csharp.txt
@@ -1,0 +1,70 @@
+using Google.Protobuf;
+using System;
+using System.Collections.Generic;
+using System.Runtime.Serialization;
+
+#if NET35
+using systemAlias = global::KRPC.Client.Compatibility;
+using genericCollectionsAlias = global::KRPC.Client.Compatibility;
+#else
+using systemAlias = global::System;
+using genericCollectionsAlias = global::System.Collections.Generic;
+#endif
+
+// Generated code references its own deprecated members (e.g. when registering
+// exception types), so suppress the deprecation warnings within this file.
+#pragma warning disable 612, 618
+
+namespace KRPC.Client.Services.ServiceA
+{
+    /// <summary>
+    /// Extension methods for ServiceA service.
+    /// </summary>
+    public static class ExtensionMethods
+    {
+        /// <summary>
+        /// Create an instance of the ServiceA service.
+        /// </summary>
+        public static global::KRPC.Client.Services.ServiceA.Service ServiceA (this global::KRPC.Client.IConnection connection)
+        {
+            return new global::KRPC.Client.Services.ServiceA.Service (connection);
+        }
+    }
+
+    /// <summary>
+    /// ServiceA service.
+    /// </summary>
+    public class Service
+    {
+        global::KRPC.Client.IConnection connection;
+
+        internal Service (global::KRPC.Client.IConnection serverConnection)
+        {
+            connection = serverConnection;
+        }
+
+        /// <summary>
+        /// Defaults to a member of another service's enumeration.
+        /// </summary>
+        [global::KRPC.Client.Attributes.RPCAttribute ("ServiceA", "Frob")]
+        public void Frob (global::KRPC.Client.Services.ServiceB.Mode mode = global::KRPC.Client.Services.ServiceB.Mode.Fast)
+        {
+            var _args = new ByteString[] {
+                global::KRPC.Client.Encoder.Encode (mode, typeof(global::KRPC.Client.Services.ServiceB.Mode))
+            };
+            connection.Invoke ("ServiceA", "Frob", _args);
+        }
+
+        /// <summary>
+        /// Defaults to a collection containing a member of another service's enumeration.
+        /// </summary>
+        [global::KRPC.Client.Attributes.RPCAttribute ("ServiceA", "FrobAll")]
+        public void FrobAll (global::System.Collections.Generic.IList<global::KRPC.Client.Services.ServiceB.Mode> modes = null)
+        {
+            var _args = new ByteString[] {
+                global::KRPC.Client.Encoder.Encode (modes ?? new global::System.Collections.Generic.List<global::KRPC.Client.Services.ServiceB.Mode> { global::KRPC.Client.Services.ServiceB.Mode.Fast }, typeof(global::System.Collections.Generic.IList<global::KRPC.Client.Services.ServiceB.Mode>))
+            };
+            connection.Invoke ("ServiceA", "FrobAll", _args);
+        }
+    }
+}

--- a/tools/krpctools/krpctools/test/clientgen-Ordering-java.txt
+++ b/tools/krpctools/krpctools/test/clientgen-Ordering-java.txt
@@ -1,0 +1,89 @@
+package krpc.client.services;
+
+import com.google.protobuf.ByteString;
+
+import krpc.client.Connection;
+import krpc.client.Encoder;
+import krpc.client.RemoteEnum;
+import krpc.client.RemoteObject;
+import krpc.client.RPCInfo;
+import krpc.client.RPCException;
+import krpc.client.Types;
+
+// Generated code references its own deprecated members (e.g. when registering
+// exception types), so suppress the deprecation warnings within this class.
+@SuppressWarnings("deprecation")
+public class ServiceA {
+
+    public static ServiceA newInstance(Connection connection) {
+        return new ServiceA(connection);
+    }
+
+    private Connection connection;
+
+    private ServiceA(Connection connection) {
+        this.connection = connection;
+    }
+
+    private void addExceptionTypes(Connection connection) {
+    }
+
+    /**
+     * Defaults to a member of another service's enumeration.
+     */
+    @SuppressWarnings({ "unchecked" })
+    @RPCInfo(service = "ServiceA", procedure = "Frob", types = _Types.class)
+    public void frob(krpc.client.services.ServiceB.Mode mode) throws RPCException {
+        ByteString[] _args = new ByteString[] {
+            Encoder.encode(mode, krpc.client.Types.createEnumeration("ServiceB", "Mode"))
+        };
+        this.connection.invoke("ServiceA", "Frob", _args);
+    }
+
+    /**
+     * Defaults to a collection containing a member of another service's enumeration.
+     */
+    @SuppressWarnings({ "unchecked" })
+    @RPCInfo(service = "ServiceA", procedure = "FrobAll", types = _Types.class)
+    public void frobAll(java.util.List<krpc.client.services.ServiceB.Mode> modes) throws RPCException {
+        ByteString[] _args = new ByteString[] {
+            Encoder.encode(modes, krpc.client.Types.createList(krpc.client.Types.createEnumeration("ServiceB", "Mode")))
+        };
+        this.connection.invoke("ServiceA", "FrobAll", _args);
+    }
+
+    public static class _Types {
+        // Procedure return and parameter types are held in lookup maps that are
+        // populated by chunked initializer methods. Emitting them this way keeps
+        // every generated method under the JVM's 64KB bytecode limit as a service
+        // accumulates procedures.
+        private static final java.util.Map<String, krpc.schema.KRPC.Type> RETURN_TYPES =
+            new java.util.HashMap<String, krpc.schema.KRPC.Type>();
+        private static final java.util.Map<String, krpc.schema.KRPC.Type[]> PARAMETER_TYPES =
+            new java.util.HashMap<String, krpc.schema.KRPC.Type[]>();
+
+        static {
+            initTypes0();
+        }
+
+        private static void initTypes0() {
+            RETURN_TYPES.put("Frob", null);
+            PARAMETER_TYPES.put("Frob", new krpc.schema.KRPC.Type[] { krpc.client.Types.createEnumeration("ServiceB", "Mode") });
+            RETURN_TYPES.put("FrobAll", null);
+            PARAMETER_TYPES.put("FrobAll", new krpc.schema.KRPC.Type[] { krpc.client.Types.createList(krpc.client.Types.createEnumeration("ServiceB", "Mode")) });
+        }
+
+        public static krpc.schema.KRPC.Type getReturnType(String procedure) {
+            if (!RETURN_TYPES.containsKey(procedure))
+                throw new IllegalArgumentException("Procedure '" + procedure +"' not found");
+            return RETURN_TYPES.get(procedure);
+        }
+
+        public static krpc.schema.KRPC.Type[] getParameterTypes(String procedure) {
+            krpc.schema.KRPC.Type[] parameterTypes = PARAMETER_TYPES.get(procedure);
+            if (parameterTypes == null)
+                throw new IllegalArgumentException("Procedure '" + procedure +"' not found");
+            return parameterTypes;
+        }
+    }
+}

--- a/tools/krpctools/krpctools/test/clientgen-Ordering-python.txt
+++ b/tools/krpctools/krpctools/test/clientgen-Ordering-python.txt
@@ -1,0 +1,108 @@
+# pylint: disable=line-too-long,invalid-name,redefined-builtin,too-many-lines
+from __future__ import annotations
+import warnings
+from typing import Tuple, Set, Dict, List, Optional, TYPE_CHECKING
+import krpc.schema
+from krpc.schema import KRPC_pb2
+from krpc.types import TypeBase, ClassBase, WrappedClass, DocEnum, StaticMethod
+from krpc.event import Event
+if TYPE_CHECKING:
+    from krpc.services import Client
+from krpc.services import serviceb
+
+
+class ServiceA:
+    """
+    A service whose procedures use another service's enumeration.
+    """
+
+    def __init__(self, client: Client) -> None:
+        self._client = client
+
+    def __getattribute__(self, name):
+        # Intercepts calls to obtain classes from the service,
+        # to inject the client instance so that it can be used
+        # for static method calls
+        classes = object.__getattribute__(self, "_classes")
+        if name in classes:
+            client = object.__getattribute__(self, "_client")
+            return WrappedClass(client, classes[name])
+
+        # Intercept calls to obtain enumeration types
+        enumerations = object.__getattribute__(self, "_enumerations")
+        if name in enumerations:
+           return enumerations[name]
+
+        # Intercept calls to obtain exception types
+        exceptions = object.__getattribute__(self, "_exceptions")
+        if name in exceptions:
+           return exceptions[name]
+
+        # Fall back to default behaviour
+        return object.__getattribute__(self, name)
+
+    def __dir__(self):
+        result = object.__dir__(self)
+        result.extend(object.__getattribute__(self, "_classes").keys())
+        result.extend(object.__getattribute__(self, "_enumerations").keys())
+        result.extend(object.__getattribute__(self, "_exceptions").keys())
+        return result
+
+    _classes = {
+    }
+    _enumerations = {
+    }
+    _exceptions = {
+    }
+
+    def frob(self, mode: serviceb.Mode = serviceb.Mode.fast) -> None:
+        """
+        Defaults to a member of another service's enumeration.
+        """
+        return self._client._invoke(
+            "ServiceA",
+            "Frob",
+            [mode],
+            ["mode"],
+            [self._client._types.enumeration_type("ServiceB", "Mode")],
+            None
+        )
+
+    def _return_type_frob(self) -> TypeBase:
+        return None
+
+    def _build_call_frob(self, mode: serviceb.Mode = serviceb.Mode.fast) -> KRPC_pb2.ProcedureCall:
+        return self._client._build_call(
+            "ServiceA",
+            "Frob",
+            [mode],
+            ["mode"],
+            [self._client._types.enumeration_type("ServiceB", "Mode")],
+            None
+        )
+
+    def frob_all(self, modes: List[serviceb.Mode] = [serviceb.Mode.fast]) -> None:
+        """
+        Defaults to a collection containing a member of another service's enumeration.
+        """
+        return self._client._invoke(
+            "ServiceA",
+            "FrobAll",
+            [modes],
+            ["modes"],
+            [self._client._types.list_type(self._client._types.enumeration_type("ServiceB", "Mode"))],
+            None
+        )
+
+    def _return_type_frob_all(self) -> TypeBase:
+        return None
+
+    def _build_call_frob_all(self, modes: List[serviceb.Mode] = [serviceb.Mode.fast]) -> KRPC_pb2.ProcedureCall:
+        return self._client._build_call(
+            "ServiceA",
+            "FrobAll",
+            [modes],
+            ["modes"],
+            [self._client._types.list_type(self._client._types.enumeration_type("ServiceB", "Mode"))],
+            None
+        )

--- a/tools/krpctools/krpctools/test/clientgen-TestService-cnano.txt
+++ b/tools/krpctools/krpctools/test/clientgen-TestService-cnano.txt
@@ -120,6 +120,26 @@ static inline krpc_error_t krpc_decode_dictionary_string_list_int32(
 
 #endif  // KRPC_TYPE_DICTIONARY_STRING_LIST_INT32
 
+#ifndef KRPC_TYPE_LIST_ENUM
+#define KRPC_TYPE_LIST_ENUM
+
+typedef struct krpc_list_enum_s krpc_list_enum_t;
+struct krpc_list_enum_s {
+  size_t size;
+  krpc_enum_t * items;
+};
+
+static inline krpc_error_t krpc_encode_list_enum(
+  pb_ostream_t * stream, const krpc_list_enum_t * value);
+static inline krpc_error_t krpc_encode_size_list_enum(
+  size_t * size, const krpc_list_enum_t * value);
+static inline bool krpc_encode_callback_list_enum(
+  pb_ostream_t * stream, const pb_field_t * field, void * const * arg);
+static inline krpc_error_t krpc_decode_list_enum(
+  pb_istream_t * stream, krpc_list_enum_t * value);
+
+#endif  // KRPC_TYPE_LIST_ENUM
+
 #ifndef KRPC_TYPE_LIST_OBJECT
 #define KRPC_TYPE_LIST_OBJECT
 
@@ -295,6 +315,8 @@ static inline krpc_error_t krpc_TestService_EmptyListDefault(krpc_connection_t c
 static inline krpc_error_t krpc_TestService_EnumDefaultArg(krpc_connection_t connection, krpc_TestService_TestEnum_t * returnValue, krpc_TestService_TestEnum_t x);
 
 static inline krpc_error_t krpc_TestService_EnumEcho(krpc_connection_t connection, krpc_TestService_TestEnum_t * returnValue, krpc_TestService_TestEnum_t x);
+
+static inline krpc_error_t krpc_TestService_EnumListDefault(krpc_connection_t connection, krpc_list_enum_t * returnValue, const krpc_list_enum_t * x);
 
 static inline krpc_error_t krpc_TestService_EnumReturn(krpc_connection_t connection, krpc_TestService_TestEnum_t * returnValue);
 
@@ -907,6 +929,87 @@ static inline krpc_error_t krpc_decode_dictionary_string_list_int32(
 
 #endif  // KRPC_IMPL_TYPE_DICTIONARY_STRING_LIST_INT32
 
+#ifndef KRPC_IMPL_TYPE_LIST_ENUM
+#define KRPC_IMPL_TYPE_LIST_ENUM
+
+static inline bool krpc_encode_callback_items_list_enum(
+  pb_ostream_t * stream, const pb_field_t * field, void * const * arg) {
+  const krpc_list_enum_t * value = (const krpc_list_enum_t*)(*arg);
+  size_t i = 0;
+  for (; i < value->size; i++) {
+    if (!pb_encode_tag_for_field(stream, field))
+      KRPC_CALLBACK_RETURN_ERROR("encoding tag for list item");
+    size_t size;
+    KRPC_CALLBACK_RETURN_ON_ERROR(krpc_encode_size_enum(&size, value->items[i]));
+    if (!pb_encode_varint(stream, size))
+      KRPC_CALLBACK_RETURN_ERROR("encoding size for list item");
+    KRPC_CALLBACK_RETURN_ON_ERROR(krpc_encode_enum(stream, value->items[i]));
+  }
+  return true;
+}
+
+static inline krpc_error_t krpc_encode_list_enum(
+  pb_ostream_t * stream, const krpc_list_enum_t * value) {
+  krpc_schema_List message = krpc_schema_List_init_default;
+  message.items.funcs.encode = &krpc_encode_callback_items_list_enum;
+  message.items.arg = (krpc_list_enum_t*)value;
+  KRPC_RETURN_ON_ERROR(krpc_encode_message_List(stream, &message));
+  return KRPC_OK;
+}
+
+static inline krpc_error_t krpc_encode_size_list_enum(
+  size_t * size, const krpc_list_enum_t * value) {
+  pb_ostream_t stream = PB_OSTREAM_SIZING;
+  KRPC_RETURN_ON_ERROR(krpc_encode_list_enum(&stream, value));
+  *size = stream.bytes_written;
+  return KRPC_OK;
+}
+
+static inline bool krpc_encode_callback_list_enum(
+  pb_ostream_t * stream, const pb_field_t * field, void * const * arg) {
+  if (!pb_encode_tag_for_field(stream, field))
+    KRPC_CALLBACK_RETURN_ERROR("encoding tag for list_enum");
+  krpc_list_enum_t * value = (krpc_list_enum_t*)(*arg);
+  size_t size;
+  KRPC_CALLBACK_RETURN_ON_ERROR(krpc_encode_size_list_enum(&size, value));
+  if (!pb_encode_varint(stream, size))
+    KRPC_CALLBACK_RETURN_ERROR("encoding size for list_enum");
+  KRPC_CALLBACK_RETURN_ON_ERROR(krpc_encode_list_enum(stream, value));
+  return true;
+}
+
+static inline bool krpc_decode_callback_item_list_enum(
+  pb_istream_t * stream, const pb_field_t * field, void ** arg) {
+  typedef struct State { size_t capacity; krpc_list_enum_t * value; } State;
+  State * state = (State*)(*arg);
+  size_t i = state->value->size;
+  state->value->size++;
+  if (state->capacity > 0 && state->value->size > state->capacity) {
+    state->value->items = (krpc_enum_t*)krpc_recalloc(state->value->items, state->capacity, KRPC_ALLOC_BLOCK_SIZE, sizeof(krpc_enum_t));
+    state->capacity += KRPC_ALLOC_BLOCK_SIZE;
+  }
+  KRPC_CALLBACK_RETURN_ON_ERROR(krpc_decode_enum(stream, &state->value->items[i]));
+  return true;
+}
+
+static inline krpc_error_t krpc_decode_list_enum(
+  pb_istream_t * stream, krpc_list_enum_t * value) {
+  typedef struct State { size_t capacity; krpc_list_enum_t * value; } State;
+  State state = { 0, value };
+  value->size = 0;
+  if (value->items == NULL) {
+    value->items = (krpc_enum_t*)krpc_calloc(KRPC_ALLOC_BLOCK_SIZE, sizeof(krpc_enum_t));
+    state.capacity = KRPC_ALLOC_BLOCK_SIZE;
+  }
+  krpc_schema_List message = krpc_schema_List_init_default;
+  message.items.funcs.decode = &krpc_decode_callback_item_list_enum;
+  message.items.arg = &state;
+  KRPC_RETURN_ON_ERROR(krpc_decode_message_List(stream, &message));
+  return KRPC_OK;
+}
+
+#endif  // KRPC_IMPL_TYPE_LIST_ENUM
+
 #ifndef KRPC_IMPL_TYPE_LIST_OBJECT
 #define KRPC_IMPL_TYPE_LIST_OBJECT
 
@@ -1350,7 +1453,7 @@ static inline krpc_error_t krpc_TestService_AddMultipleValues(krpc_connection_t 
 static inline krpc_error_t krpc_TestService_AddToObjectList(krpc_connection_t connection, krpc_list_object_t * returnValue, const krpc_list_object_t * l, const char * value) {
   krpc_call_t _call;
   krpc_argument_t _arguments[2];
-  KRPC_CHECK(krpc_call(&_call, 9999, 31, 2, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 32, 2, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_list_object, l));
   KRPC_CHECK(krpc_add_argument(&_call, 1, &krpc_encode_callback_string, &value));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
@@ -1420,7 +1523,7 @@ static inline krpc_error_t krpc_TestService_BytesToHexString(krpc_connection_t c
 static inline krpc_error_t krpc_TestService_Counter(krpc_connection_t connection, int32_t * returnValue, const char * id, int32_t divisor) {
   krpc_call_t _call;
   krpc_argument_t _arguments[2];
-  KRPC_CHECK(krpc_call(&_call, 9999, 32, 2, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 33, 2, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_string, &id));
   KRPC_CHECK(krpc_add_argument(&_call, 1, &krpc_encode_callback_int32, &divisor));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
@@ -1455,7 +1558,7 @@ static inline krpc_error_t krpc_TestService_CreateTestObject(krpc_connection_t c
 static inline krpc_error_t krpc_TestService_DeprecatedProcedure(krpc_connection_t connection, char * * returnValue, float value) {
   krpc_call_t _call;
   krpc_argument_t _arguments[1];
-  KRPC_CHECK(krpc_call(&_call, 9999, 44, 1, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 45, 1, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_float, &value));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
@@ -1472,7 +1575,7 @@ static inline krpc_error_t krpc_TestService_DeprecatedProcedure(krpc_connection_
 static inline krpc_error_t krpc_TestService_DeprecatedProcedureNoMessage(krpc_connection_t connection, char * * returnValue, float value) {
   krpc_call_t _call;
   krpc_argument_t _arguments[1];
-  KRPC_CHECK(krpc_call(&_call, 9999, 45, 1, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 46, 1, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_float, &value));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
@@ -1632,7 +1735,7 @@ static inline krpc_error_t krpc_TestService_EchoTestObject(krpc_connection_t con
 static inline krpc_error_t krpc_TestService_EmptyListDefault(krpc_connection_t connection, krpc_list_string_t * returnValue, const krpc_list_string_t * x) {
   krpc_call_t _call;
   krpc_argument_t _arguments[1];
-  KRPC_CHECK(krpc_call(&_call, 9999, 30, 1, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 31, 1, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_list_string, x));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
@@ -1675,6 +1778,23 @@ static inline krpc_error_t krpc_TestService_EnumEcho(krpc_connection_t connectio
     pb_istream_t _stream;
     KRPC_CHECK(krpc_get_return_value(&_result, &_stream));
     KRPC_CHECK(krpc_decode_enum(&_stream, (int*)returnValue));
+  }
+  KRPC_CHECK(krpc_free_result(&_result));
+  return KRPC_OK;
+}
+
+static inline krpc_error_t krpc_TestService_EnumListDefault(krpc_connection_t connection, krpc_list_enum_t * returnValue, const krpc_list_enum_t * x) {
+  krpc_call_t _call;
+  krpc_argument_t _arguments[1];
+  KRPC_CHECK(krpc_call(&_call, 9999, 30, 1, _arguments));
+  KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_list_enum, x));
+  krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
+  KRPC_CHECK(krpc_init_result(&_result));
+  KRPC_CHECK(krpc_invoke(connection, &_result.message, &_call.message));
+  if (returnValue) {
+    pb_istream_t _stream;
+    KRPC_CHECK(krpc_get_return_value(&_result, &_stream));
+    KRPC_CHECK(krpc_decode_list_enum(&_stream, returnValue));
   }
   KRPC_CHECK(krpc_free_result(&_result));
   return KRPC_OK;
@@ -1868,7 +1988,7 @@ static inline krpc_error_t krpc_TestService_NotNullableObject(krpc_connection_t 
 static inline krpc_error_t krpc_TestService_OnTimer(krpc_connection_t connection, krpc_schema_Event * returnValue, uint32_t milliseconds, uint32_t repeats) {
   krpc_call_t _call;
   krpc_argument_t _arguments[2];
-  KRPC_CHECK(krpc_call(&_call, 9999, 42, 2, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 43, 2, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_uint32, &milliseconds));
   KRPC_CHECK(krpc_add_argument(&_call, 1, &krpc_encode_callback_uint32, &repeats));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
@@ -1886,7 +2006,7 @@ static inline krpc_error_t krpc_TestService_OnTimer(krpc_connection_t connection
 static inline krpc_error_t krpc_TestService_OnTimerUsingLambda(krpc_connection_t connection, krpc_schema_Event * returnValue, uint32_t milliseconds) {
   krpc_call_t _call;
   krpc_argument_t _arguments[1];
-  KRPC_CHECK(krpc_call(&_call, 9999, 43, 1, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 44, 1, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_uint32, &milliseconds));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
@@ -1926,7 +2046,7 @@ static inline krpc_error_t krpc_TestService_OptionalArguments(krpc_connection_t 
 
 static inline krpc_error_t krpc_TestService_ResetCustomExceptionLater(krpc_connection_t connection) {
   krpc_call_t _call;
-  KRPC_CHECK(krpc_call(&_call, 9999, 40, 0, NULL));
+  KRPC_CHECK(krpc_call(&_call, 9999, 41, 0, NULL));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
   KRPC_CHECK(krpc_invoke(connection, &_result.message, &_call.message));
@@ -1936,7 +2056,7 @@ static inline krpc_error_t krpc_TestService_ResetCustomExceptionLater(krpc_conne
 
 static inline krpc_error_t krpc_TestService_ResetInvalidOperationExceptionLater(krpc_connection_t connection) {
   krpc_call_t _call;
-  KRPC_CHECK(krpc_call(&_call, 9999, 34, 0, NULL));
+  KRPC_CHECK(krpc_call(&_call, 9999, 35, 0, NULL));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
   KRPC_CHECK(krpc_invoke(connection, &_result.message, &_call.message));
@@ -1995,7 +2115,7 @@ static inline krpc_error_t krpc_TestService_StringToInt32(krpc_connection_t conn
 
 static inline krpc_error_t krpc_TestService_ThrowArgumentException(krpc_connection_t connection, int32_t * returnValue) {
   krpc_call_t _call;
-  KRPC_CHECK(krpc_call(&_call, 9999, 36, 0, NULL));
+  KRPC_CHECK(krpc_call(&_call, 9999, 37, 0, NULL));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
   KRPC_CHECK(krpc_invoke(connection, &_result.message, &_call.message));
@@ -2011,7 +2131,7 @@ static inline krpc_error_t krpc_TestService_ThrowArgumentException(krpc_connecti
 static inline krpc_error_t krpc_TestService_ThrowArgumentNullException(krpc_connection_t connection, int32_t * returnValue, const char * foo) {
   krpc_call_t _call;
   krpc_argument_t _arguments[1];
-  KRPC_CHECK(krpc_call(&_call, 9999, 37, 1, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 38, 1, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_string, &foo));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
@@ -2028,7 +2148,7 @@ static inline krpc_error_t krpc_TestService_ThrowArgumentNullException(krpc_conn
 static inline krpc_error_t krpc_TestService_ThrowArgumentOutOfRangeException(krpc_connection_t connection, int32_t * returnValue, int32_t foo) {
   krpc_call_t _call;
   krpc_argument_t _arguments[1];
-  KRPC_CHECK(krpc_call(&_call, 9999, 38, 1, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 39, 1, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_int32, &foo));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
@@ -2044,7 +2164,7 @@ static inline krpc_error_t krpc_TestService_ThrowArgumentOutOfRangeException(krp
 
 static inline krpc_error_t krpc_TestService_ThrowCustomException(krpc_connection_t connection, int32_t * returnValue) {
   krpc_call_t _call;
-  KRPC_CHECK(krpc_call(&_call, 9999, 39, 0, NULL));
+  KRPC_CHECK(krpc_call(&_call, 9999, 40, 0, NULL));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
   KRPC_CHECK(krpc_invoke(connection, &_result.message, &_call.message));
@@ -2059,7 +2179,7 @@ static inline krpc_error_t krpc_TestService_ThrowCustomException(krpc_connection
 
 static inline krpc_error_t krpc_TestService_ThrowCustomExceptionLater(krpc_connection_t connection, int32_t * returnValue) {
   krpc_call_t _call;
-  KRPC_CHECK(krpc_call(&_call, 9999, 41, 0, NULL));
+  KRPC_CHECK(krpc_call(&_call, 9999, 42, 0, NULL));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
   KRPC_CHECK(krpc_invoke(connection, &_result.message, &_call.message));
@@ -2074,7 +2194,7 @@ static inline krpc_error_t krpc_TestService_ThrowCustomExceptionLater(krpc_conne
 
 static inline krpc_error_t krpc_TestService_ThrowInvalidOperationException(krpc_connection_t connection, int32_t * returnValue) {
   krpc_call_t _call;
-  KRPC_CHECK(krpc_call(&_call, 9999, 33, 0, NULL));
+  KRPC_CHECK(krpc_call(&_call, 9999, 34, 0, NULL));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
   KRPC_CHECK(krpc_invoke(connection, &_result.message, &_call.message));
@@ -2089,7 +2209,7 @@ static inline krpc_error_t krpc_TestService_ThrowInvalidOperationException(krpc_
 
 static inline krpc_error_t krpc_TestService_ThrowInvalidOperationExceptionLater(krpc_connection_t connection, int32_t * returnValue) {
   krpc_call_t _call;
-  KRPC_CHECK(krpc_call(&_call, 9999, 35, 0, NULL));
+  KRPC_CHECK(krpc_call(&_call, 9999, 36, 0, NULL));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
   KRPC_CHECK(krpc_invoke(connection, &_result.message, &_call.message));
@@ -2121,7 +2241,7 @@ static inline krpc_error_t krpc_TestService_TupleDefault(krpc_connection_t conne
 
 static inline krpc_error_t krpc_TestService_DeprecatedProperty(krpc_connection_t connection, char * * returnValue) {
   krpc_call_t _call;
-  KRPC_CHECK(krpc_call(&_call, 9999, 54, 0, NULL));
+  KRPC_CHECK(krpc_call(&_call, 9999, 55, 0, NULL));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
   KRPC_CHECK(krpc_invoke(connection, &_result.message, &_call.message));
@@ -2137,7 +2257,7 @@ static inline krpc_error_t krpc_TestService_DeprecatedProperty(krpc_connection_t
 static inline krpc_error_t krpc_TestService_set_DeprecatedProperty(krpc_connection_t connection, const char * value) {
   krpc_call_t _call;
   krpc_argument_t _arguments[1];
-  KRPC_CHECK(krpc_call(&_call, 9999, 55, 1, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 56, 1, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_string, &value));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
@@ -2148,7 +2268,7 @@ static inline krpc_error_t krpc_TestService_set_DeprecatedProperty(krpc_connecti
 
 static inline krpc_error_t krpc_TestService_NullableObject(krpc_connection_t connection, krpc_TestService_TestClass_t * returnValue) {
   krpc_call_t _call;
-  KRPC_CHECK(krpc_call(&_call, 9999, 52, 0, NULL));
+  KRPC_CHECK(krpc_call(&_call, 9999, 53, 0, NULL));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
   KRPC_CHECK(krpc_invoke(connection, &_result.message, &_call.message));
@@ -2168,7 +2288,7 @@ static inline krpc_error_t krpc_TestService_NullableObject(krpc_connection_t con
 static inline krpc_error_t krpc_TestService_set_NullableObject(krpc_connection_t connection, krpc_TestService_TestClass_t value) {
   krpc_call_t _call;
   krpc_argument_t _arguments[1];
-  KRPC_CHECK(krpc_call(&_call, 9999, 53, 1, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 54, 1, _arguments));
   if (value == KRPC_NULL) {
     KRPC_CHECK(krpc_add_null_argument(&_call, 0));
   } else {
@@ -2183,7 +2303,7 @@ static inline krpc_error_t krpc_TestService_set_NullableObject(krpc_connection_t
 
 static inline krpc_error_t krpc_TestService_ObjectProperty(krpc_connection_t connection, krpc_TestService_TestClass_t * returnValue) {
   krpc_call_t _call;
-  KRPC_CHECK(krpc_call(&_call, 9999, 50, 0, NULL));
+  KRPC_CHECK(krpc_call(&_call, 9999, 51, 0, NULL));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
   KRPC_CHECK(krpc_invoke(connection, &_result.message, &_call.message));
@@ -2203,7 +2323,7 @@ static inline krpc_error_t krpc_TestService_ObjectProperty(krpc_connection_t con
 static inline krpc_error_t krpc_TestService_set_ObjectProperty(krpc_connection_t connection, krpc_TestService_TestClass_t value) {
   krpc_call_t _call;
   krpc_argument_t _arguments[1];
-  KRPC_CHECK(krpc_call(&_call, 9999, 51, 1, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 52, 1, _arguments));
   if (value == KRPC_NULL) {
     KRPC_CHECK(krpc_add_null_argument(&_call, 0));
   } else {
@@ -2218,7 +2338,7 @@ static inline krpc_error_t krpc_TestService_set_ObjectProperty(krpc_connection_t
 
 static inline krpc_error_t krpc_TestService_StringProperty(krpc_connection_t connection, char * * returnValue) {
   krpc_call_t _call;
-  KRPC_CHECK(krpc_call(&_call, 9999, 46, 0, NULL));
+  KRPC_CHECK(krpc_call(&_call, 9999, 47, 0, NULL));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
   KRPC_CHECK(krpc_invoke(connection, &_result.message, &_call.message));
@@ -2234,7 +2354,7 @@ static inline krpc_error_t krpc_TestService_StringProperty(krpc_connection_t con
 static inline krpc_error_t krpc_TestService_set_StringProperty(krpc_connection_t connection, const char * value) {
   krpc_call_t _call;
   krpc_argument_t _arguments[1];
-  KRPC_CHECK(krpc_call(&_call, 9999, 47, 1, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 48, 1, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_string, &value));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
@@ -2246,7 +2366,7 @@ static inline krpc_error_t krpc_TestService_set_StringProperty(krpc_connection_t
 static inline krpc_error_t krpc_TestService_set_StringPropertyPrivateGet(krpc_connection_t connection, const char * value) {
   krpc_call_t _call;
   krpc_argument_t _arguments[1];
-  KRPC_CHECK(krpc_call(&_call, 9999, 48, 1, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 49, 1, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_string, &value));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
@@ -2257,7 +2377,7 @@ static inline krpc_error_t krpc_TestService_set_StringPropertyPrivateGet(krpc_co
 
 static inline krpc_error_t krpc_TestService_StringPropertyPrivateSet(krpc_connection_t connection, char * * returnValue) {
   krpc_call_t _call;
-  KRPC_CHECK(krpc_call(&_call, 9999, 49, 0, NULL));
+  KRPC_CHECK(krpc_call(&_call, 9999, 50, 0, NULL));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
   KRPC_CHECK(krpc_invoke(connection, &_result.message, &_call.message));
@@ -2273,7 +2393,7 @@ static inline krpc_error_t krpc_TestService_StringPropertyPrivateSet(krpc_connec
 static inline krpc_error_t krpc_TestService_DeprecatedClass_DeprecatedMethod(krpc_connection_t connection, char * * returnValue, krpc_TestService_DeprecatedClass_t instance) {
   krpc_call_t _call;
   krpc_argument_t _arguments[1];
-  KRPC_CHECK(krpc_call(&_call, 9999, 69, 1, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 70, 1, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_uint64, &instance));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
@@ -2290,7 +2410,7 @@ static inline krpc_error_t krpc_TestService_DeprecatedClass_DeprecatedMethod(krp
 static inline krpc_error_t krpc_TestService_TestClass_EchoNullableObject(krpc_connection_t connection, krpc_TestService_TestClass_t * returnValue, krpc_TestService_TestClass_t instance, krpc_TestService_TestClass_t value) {
   krpc_call_t _call;
   krpc_argument_t _arguments[2];
-  KRPC_CHECK(krpc_call(&_call, 9999, 59, 2, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 60, 2, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_uint64, &instance));
   if (value == KRPC_NULL) {
     KRPC_CHECK(krpc_add_null_argument(&_call, 1));
@@ -2316,7 +2436,7 @@ static inline krpc_error_t krpc_TestService_TestClass_EchoNullableObject(krpc_co
 static inline krpc_error_t krpc_TestService_TestClass_FloatToString(krpc_connection_t connection, char * * returnValue, krpc_TestService_TestClass_t instance, float x) {
   krpc_call_t _call;
   krpc_argument_t _arguments[2];
-  KRPC_CHECK(krpc_call(&_call, 9999, 57, 2, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 58, 2, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_uint64, &instance));
   KRPC_CHECK(krpc_add_argument(&_call, 1, &krpc_encode_callback_float, &x));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
@@ -2334,7 +2454,7 @@ static inline krpc_error_t krpc_TestService_TestClass_FloatToString(krpc_connect
 static inline krpc_error_t krpc_TestService_TestClass_GetValue(krpc_connection_t connection, char * * returnValue, krpc_TestService_TestClass_t instance) {
   krpc_call_t _call;
   krpc_argument_t _arguments[1];
-  KRPC_CHECK(krpc_call(&_call, 9999, 56, 1, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 57, 1, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_uint64, &instance));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
@@ -2351,7 +2471,7 @@ static inline krpc_error_t krpc_TestService_TestClass_GetValue(krpc_connection_t
 static inline krpc_error_t krpc_TestService_TestClass_ObjectToString(krpc_connection_t connection, char * * returnValue, krpc_TestService_TestClass_t instance, krpc_TestService_TestClass_t other) {
   krpc_call_t _call;
   krpc_argument_t _arguments[2];
-  KRPC_CHECK(krpc_call(&_call, 9999, 58, 2, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 59, 2, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_uint64, &instance));
   if (other == KRPC_NULL) {
     KRPC_CHECK(krpc_add_null_argument(&_call, 1));
@@ -2373,7 +2493,7 @@ static inline krpc_error_t krpc_TestService_TestClass_ObjectToString(krpc_connec
 static inline krpc_error_t krpc_TestService_TestClass_OptionalArguments(krpc_connection_t connection, char * * returnValue, krpc_TestService_TestClass_t instance, const char * x, const char * y, const char * z, krpc_TestService_TestClass_t obj) {
   krpc_call_t _call;
   krpc_argument_t _arguments[5];
-  KRPC_CHECK(krpc_call(&_call, 9999, 60, 5, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 61, 5, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_uint64, &instance));
   KRPC_CHECK(krpc_add_argument(&_call, 1, &krpc_encode_callback_string, &x));
   KRPC_CHECK(krpc_add_argument(&_call, 2, &krpc_encode_callback_string, &y));
@@ -2398,7 +2518,7 @@ static inline krpc_error_t krpc_TestService_TestClass_OptionalArguments(krpc_con
 static inline krpc_error_t krpc_TestService_TestClass_IntProperty(krpc_connection_t connection, int32_t * returnValue, krpc_TestService_TestClass_t instance) {
   krpc_call_t _call;
   krpc_argument_t _arguments[1];
-  KRPC_CHECK(krpc_call(&_call, 9999, 63, 1, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 64, 1, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_uint64, &instance));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
@@ -2415,7 +2535,7 @@ static inline krpc_error_t krpc_TestService_TestClass_IntProperty(krpc_connectio
 static inline krpc_error_t krpc_TestService_TestClass_set_IntProperty(krpc_connection_t connection, krpc_TestService_TestClass_t instance, int32_t value) {
   krpc_call_t _call;
   krpc_argument_t _arguments[2];
-  KRPC_CHECK(krpc_call(&_call, 9999, 64, 2, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 65, 2, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_uint64, &instance));
   KRPC_CHECK(krpc_add_argument(&_call, 1, &krpc_encode_callback_int32, &value));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
@@ -2428,7 +2548,7 @@ static inline krpc_error_t krpc_TestService_TestClass_set_IntProperty(krpc_conne
 static inline krpc_error_t krpc_TestService_TestClass_ObjectProperty(krpc_connection_t connection, krpc_TestService_TestClass_t * returnValue, krpc_TestService_TestClass_t instance) {
   krpc_call_t _call;
   krpc_argument_t _arguments[1];
-  KRPC_CHECK(krpc_call(&_call, 9999, 65, 1, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 66, 1, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_uint64, &instance));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
@@ -2449,7 +2569,7 @@ static inline krpc_error_t krpc_TestService_TestClass_ObjectProperty(krpc_connec
 static inline krpc_error_t krpc_TestService_TestClass_set_ObjectProperty(krpc_connection_t connection, krpc_TestService_TestClass_t instance, krpc_TestService_TestClass_t value) {
   krpc_call_t _call;
   krpc_argument_t _arguments[2];
-  KRPC_CHECK(krpc_call(&_call, 9999, 66, 2, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 67, 2, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_uint64, &instance));
   if (value == KRPC_NULL) {
     KRPC_CHECK(krpc_add_null_argument(&_call, 1));
@@ -2466,7 +2586,7 @@ static inline krpc_error_t krpc_TestService_TestClass_set_ObjectProperty(krpc_co
 static inline krpc_error_t krpc_TestService_TestClass_set_StringPropertyPrivateGet(krpc_connection_t connection, krpc_TestService_TestClass_t instance, const char * value) {
   krpc_call_t _call;
   krpc_argument_t _arguments[2];
-  KRPC_CHECK(krpc_call(&_call, 9999, 67, 2, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 68, 2, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_uint64, &instance));
   KRPC_CHECK(krpc_add_argument(&_call, 1, &krpc_encode_callback_string, &value));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
@@ -2479,7 +2599,7 @@ static inline krpc_error_t krpc_TestService_TestClass_set_StringPropertyPrivateG
 static inline krpc_error_t krpc_TestService_TestClass_StringPropertyPrivateSet(krpc_connection_t connection, char * * returnValue, krpc_TestService_TestClass_t instance) {
   krpc_call_t _call;
   krpc_argument_t _arguments[1];
-  KRPC_CHECK(krpc_call(&_call, 9999, 68, 1, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 69, 1, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_uint64, &instance));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
@@ -2496,7 +2616,7 @@ static inline krpc_error_t krpc_TestService_TestClass_StringPropertyPrivateSet(k
 static inline krpc_error_t krpc_TestService_TestClass_StaticMethod(krpc_connection_t connection, char * * returnValue, const char * a, const char * b) {
   krpc_call_t _call;
   krpc_argument_t _arguments[2];
-  KRPC_CHECK(krpc_call(&_call, 9999, 61, 2, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 62, 2, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_string, &a));
   KRPC_CHECK(krpc_add_argument(&_call, 1, &krpc_encode_callback_string, &b));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
@@ -2514,7 +2634,7 @@ static inline krpc_error_t krpc_TestService_TestClass_StaticMethod(krpc_connecti
 static inline krpc_error_t krpc_TestService_TestClass_StaticNullableObject(krpc_connection_t connection, krpc_TestService_TestClass_t * returnValue, krpc_TestService_TestClass_t value) {
   krpc_call_t _call;
   krpc_argument_t _arguments[1];
-  KRPC_CHECK(krpc_call(&_call, 9999, 62, 1, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 63, 1, _arguments));
   if (value == KRPC_NULL) {
     KRPC_CHECK(krpc_add_null_argument(&_call, 0));
   } else {

--- a/tools/krpctools/krpctools/test/clientgen-TestService-cpp.txt
+++ b/tools/krpctools/krpctools/test/clientgen-TestService-cpp.txt
@@ -579,6 +579,38 @@ namespace decoder {
 
 }  // namespace decoder
 
+// The encoder and decoder for a collection call encode and decode on the type it
+// contains without qualifying them, so the ones above, which are declared after those
+// templates, are only reachable through argument dependent lookup. That searches the
+// namespace enclosing the enumeration, which is this one, so the collection encoder and
+// decoder find an enumeration through these.
+namespace services {
+
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+  inline std::string encode(const TestService::DeprecatedEnum& value) {
+    return encoder::encode(value);
+  }
+
+  inline void decode(TestService::DeprecatedEnum& value, const std::string& data, Client* client) {
+    decoder::decode(value, data, client);
+  }
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
+
+  inline std::string encode(const TestService::TestEnum& value) {
+    return encoder::encode(value);
+  }
+
+  inline void decode(TestService::TestEnum& value, const std::string& data, Client* client) {
+    decoder::decode(value, data, client);
+  }
+
+}  // namespace services
+
 namespace services {
 
 inline TestService::TestService(Client* client):

--- a/tools/krpctools/krpctools/test/clientgen-TestService-cpp.txt
+++ b/tools/krpctools/krpctools/test/clientgen-TestService-cpp.txt
@@ -122,6 +122,8 @@ class TestService : public Service {
 
   TestService::TestEnum enum_echo(TestService::TestEnum x);
 
+  std::vector<TestService::TestEnum> enum_list_default(std::vector<TestService::TestEnum> x);
+
   TestService::TestEnum enum_return();
 
   /**
@@ -253,6 +255,8 @@ class TestService : public Service {
 
   ::krpc::Stream<TestService::TestEnum> enum_echo_stream(TestService::TestEnum x);
 
+  ::krpc::Stream<std::vector<TestService::TestEnum>> enum_list_default_stream(std::vector<TestService::TestEnum> x);
+
   ::krpc::Stream<TestService::TestEnum> enum_return_stream();
 
   ::krpc::Stream<std::string> float_to_string_stream(float value);
@@ -348,6 +352,8 @@ class TestService : public Service {
   ::krpc::schema::ProcedureCall enum_default_arg_call(TestService::TestEnum x);
 
   ::krpc::schema::ProcedureCall enum_echo_call(TestService::TestEnum x);
+
+  ::krpc::schema::ProcedureCall enum_list_default_call(std::vector<TestService::TestEnum> x);
 
   ::krpc::schema::ProcedureCall enum_return_call();
 
@@ -815,6 +821,16 @@ inline TestService::TestEnum TestService::enum_echo(TestService::TestEnum x) {
   return _result;
 }
 
+inline std::vector<TestService::TestEnum> TestService::enum_list_default(std::vector<TestService::TestEnum> x = std::vector<TestService::TestEnum>{TestService::TestEnum::value_b, TestService::TestEnum::value_c}) {
+  std::vector<krpc::encoder::Value> _args;
+  _args.push_back(encoder::encode(x));
+  auto _data = this->_client->invoke("TestService", "EnumListDefault", _args);
+  std::vector<TestService::TestEnum> _result{};
+  if (!_data.is_null())
+    decoder::decode(_result, _data.value(), this->_client);
+  return _result;
+}
+
 inline TestService::TestEnum TestService::enum_return() {
   auto _data = this->_client->invoke("TestService", "EnumReturn");
   TestService::TestEnum _result{};
@@ -1246,6 +1262,12 @@ inline ::krpc::Stream<TestService::TestEnum> TestService::enum_echo_stream(TestS
   return ::krpc::Stream<TestService::TestEnum>(this->_client, this->_client->build_call("TestService", "EnumEcho", _args));
 }
 
+inline ::krpc::Stream<std::vector<TestService::TestEnum>> TestService::enum_list_default_stream(std::vector<TestService::TestEnum> x = std::vector<TestService::TestEnum>{TestService::TestEnum::value_b, TestService::TestEnum::value_c}) {
+  std::vector<krpc::encoder::Value> _args;
+  _args.push_back(encoder::encode(x));
+  return ::krpc::Stream<std::vector<TestService::TestEnum>>(this->_client, this->_client->build_call("TestService", "EnumListDefault", _args));
+}
+
 inline ::krpc::Stream<TestService::TestEnum> TestService::enum_return_stream() {
   return ::krpc::Stream<TestService::TestEnum>(this->_client, this->_client->build_call("TestService", "EnumReturn"));
 }
@@ -1517,6 +1539,12 @@ inline ::krpc::schema::ProcedureCall TestService::enum_echo_call(TestService::Te
   std::vector<krpc::encoder::Value> _args;
   _args.push_back(encoder::encode(x));
   return this->_client->build_call("TestService", "EnumEcho", _args);
+}
+
+inline ::krpc::schema::ProcedureCall TestService::enum_list_default_call(std::vector<TestService::TestEnum> x = std::vector<TestService::TestEnum>{TestService::TestEnum::value_b, TestService::TestEnum::value_c}) {
+  std::vector<krpc::encoder::Value> _args;
+  _args.push_back(encoder::encode(x));
+  return this->_client->build_call("TestService", "EnumListDefault", _args);
 }
 
 inline ::krpc::schema::ProcedureCall TestService::enum_return_call() {

--- a/tools/krpctools/krpctools/test/clientgen-TestService-cpp.txt
+++ b/tools/krpctools/krpctools/test/clientgen-TestService-cpp.txt
@@ -763,7 +763,7 @@ inline std::vector<std::string> TestService::empty_list_default(std::vector<std:
   return _result;
 }
 
-inline TestService::TestEnum TestService::enum_default_arg(TestService::TestEnum x = static_cast<TestService::TestEnum>(2)) {
+inline TestService::TestEnum TestService::enum_default_arg(TestService::TestEnum x = TestService::TestEnum::value_c) {
   std::vector<krpc::encoder::Value> _args;
   _args.push_back(encoder::encode(x));
   auto _data = this->_client->invoke("TestService", "EnumDefaultArg", _args);
@@ -1202,7 +1202,7 @@ inline ::krpc::Stream<std::vector<std::string>> TestService::empty_list_default_
   return ::krpc::Stream<std::vector<std::string>>(this->_client, this->_client->build_call("TestService", "EmptyListDefault", _args));
 }
 
-inline ::krpc::Stream<TestService::TestEnum> TestService::enum_default_arg_stream(TestService::TestEnum x = static_cast<TestService::TestEnum>(2)) {
+inline ::krpc::Stream<TestService::TestEnum> TestService::enum_default_arg_stream(TestService::TestEnum x = TestService::TestEnum::value_c) {
   std::vector<krpc::encoder::Value> _args;
   _args.push_back(encoder::encode(x));
   return ::krpc::Stream<TestService::TestEnum>(this->_client, this->_client->build_call("TestService", "EnumDefaultArg", _args));
@@ -1475,7 +1475,7 @@ inline ::krpc::schema::ProcedureCall TestService::empty_list_default_call(std::v
   return this->_client->build_call("TestService", "EmptyListDefault", _args);
 }
 
-inline ::krpc::schema::ProcedureCall TestService::enum_default_arg_call(TestService::TestEnum x = static_cast<TestService::TestEnum>(2)) {
+inline ::krpc::schema::ProcedureCall TestService::enum_default_arg_call(TestService::TestEnum x = TestService::TestEnum::value_c) {
   std::vector<krpc::encoder::Value> _args;
   _args.push_back(encoder::encode(x));
   return this->_client->build_call("TestService", "EnumDefaultArg", _args);

--- a/tools/krpctools/krpctools/test/clientgen-TestService-csharp.txt
+++ b/tools/krpctools/krpctools/test/clientgen-TestService-csharp.txt
@@ -251,6 +251,16 @@ namespace KRPC.Client.Services.TestService
             return (global::KRPC.Client.Services.TestService.TestEnum)global::KRPC.Client.Encoder.Decode (_result.Value, typeof(global::KRPC.Client.Services.TestService.TestEnum), connection);
         }
 
+        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "EnumListDefault")]
+        public global::System.Collections.Generic.IList<global::KRPC.Client.Services.TestService.TestEnum> EnumListDefault (global::System.Collections.Generic.IList<global::KRPC.Client.Services.TestService.TestEnum> x = null)
+        {
+            var _args = new ByteString[] {
+                global::KRPC.Client.Encoder.Encode (x ?? new global::System.Collections.Generic.List<global::KRPC.Client.Services.TestService.TestEnum> { global::KRPC.Client.Services.TestService.TestEnum.ValueB, global::KRPC.Client.Services.TestService.TestEnum.ValueC }, typeof(global::System.Collections.Generic.IList<global::KRPC.Client.Services.TestService.TestEnum>))
+            };
+            var _result = connection.Invoke ("TestService", "EnumListDefault", _args);
+            return (global::System.Collections.Generic.IList<global::KRPC.Client.Services.TestService.TestEnum>)global::KRPC.Client.Encoder.Decode (_result.Value, typeof(global::System.Collections.Generic.IList<global::KRPC.Client.Services.TestService.TestEnum>), connection);
+        }
+
         [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "EnumReturn")]
         public global::KRPC.Client.Services.TestService.TestEnum EnumReturn ()
         {

--- a/tools/krpctools/krpctools/test/clientgen-TestService-csharp.txt
+++ b/tools/krpctools/krpctools/test/clientgen-TestService-csharp.txt
@@ -232,7 +232,7 @@ namespace KRPC.Client.Services.TestService
         }
 
         [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "EnumDefaultArg")]
-        public global::KRPC.Client.Services.TestService.TestEnum EnumDefaultArg (global::KRPC.Client.Services.TestService.TestEnum x = (global::KRPC.Client.Services.TestService.TestEnum)2)
+        public global::KRPC.Client.Services.TestService.TestEnum EnumDefaultArg (global::KRPC.Client.Services.TestService.TestEnum x = global::KRPC.Client.Services.TestService.TestEnum.ValueC)
         {
             var _args = new ByteString[] {
                 global::KRPC.Client.Encoder.Encode (x, typeof(global::KRPC.Client.Services.TestService.TestEnum))

--- a/tools/krpctools/krpctools/test/clientgen-TestService-java.txt
+++ b/tools/krpctools/krpctools/test/clientgen-TestService-java.txt
@@ -269,6 +269,16 @@ public class TestService {
     }
 
     @SuppressWarnings({ "unchecked" })
+    @RPCInfo(service = "TestService", procedure = "EnumListDefault", types = _Types.class)
+    public java.util.List<krpc.client.services.TestService.TestEnum> enumListDefault(java.util.List<krpc.client.services.TestService.TestEnum> x) throws RPCException {
+        ByteString[] _args = new ByteString[] {
+            Encoder.encode(x, krpc.client.Types.createList(krpc.client.Types.createEnumeration("TestService", "TestEnum")))
+        };
+        krpc.schema.KRPC.ProcedureResult _data = this.connection.invoke("TestService", "EnumListDefault", _args);
+        return (java.util.List<krpc.client.services.TestService.TestEnum>) Encoder.decode(_data.getValue(), krpc.client.Types.createList(krpc.client.Types.createEnumeration("TestService", "TestEnum")), this.connection);
+    }
+
+    @SuppressWarnings({ "unchecked" })
     @RPCInfo(service = "TestService", procedure = "EnumReturn", types = _Types.class)
     public krpc.client.services.TestService.TestEnum enumReturn() throws RPCException {
         krpc.schema.KRPC.ProcedureResult _data = this.connection.invoke("TestService", "EnumReturn");
@@ -970,6 +980,8 @@ public class TestService {
             PARAMETER_TYPES.put("EnumDefaultArg", new krpc.schema.KRPC.Type[] { krpc.client.Types.createEnumeration("TestService", "TestEnum") });
             RETURN_TYPES.put("EnumEcho", krpc.client.Types.createEnumeration("TestService", "TestEnum"));
             PARAMETER_TYPES.put("EnumEcho", new krpc.schema.KRPC.Type[] { krpc.client.Types.createEnumeration("TestService", "TestEnum") });
+            RETURN_TYPES.put("EnumListDefault", krpc.client.Types.createList(krpc.client.Types.createEnumeration("TestService", "TestEnum")));
+            PARAMETER_TYPES.put("EnumListDefault", new krpc.schema.KRPC.Type[] { krpc.client.Types.createList(krpc.client.Types.createEnumeration("TestService", "TestEnum")) });
             RETURN_TYPES.put("EnumReturn", krpc.client.Types.createEnumeration("TestService", "TestEnum"));
             PARAMETER_TYPES.put("EnumReturn", new krpc.schema.KRPC.Type[] {  });
             RETURN_TYPES.put("FloatToString", krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.STRING));
@@ -1032,11 +1044,11 @@ public class TestService {
             PARAMETER_TYPES.put("get_NullableObject", new krpc.schema.KRPC.Type[] {  });
             RETURN_TYPES.put("set_NullableObject", null);
             PARAMETER_TYPES.put("set_NullableObject", new krpc.schema.KRPC.Type[] { krpc.client.Types.createClass("TestService", "TestClass") });
-            RETURN_TYPES.put("get_ObjectProperty", krpc.client.Types.createClass("TestService", "TestClass"));
-            PARAMETER_TYPES.put("get_ObjectProperty", new krpc.schema.KRPC.Type[] {  });
         }
 
         private static void initTypes1() {
+            RETURN_TYPES.put("get_ObjectProperty", krpc.client.Types.createClass("TestService", "TestClass"));
+            PARAMETER_TYPES.put("get_ObjectProperty", new krpc.schema.KRPC.Type[] {  });
             RETURN_TYPES.put("set_ObjectProperty", null);
             PARAMETER_TYPES.put("set_ObjectProperty", new krpc.schema.KRPC.Type[] { krpc.client.Types.createClass("TestService", "TestClass") });
             RETURN_TYPES.put("get_StringProperty", krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.STRING));

--- a/tools/krpctools/krpctools/test/clientgen-TestService-python.txt
+++ b/tools/krpctools/krpctools/test/clientgen-TestService-python.txt
@@ -1048,6 +1048,29 @@ class TestService:
             self._client._types.enumeration_type("TestService", "TestEnum")
         )
 
+    def enum_list_default(self, x: List[TestEnum] = [TestEnum.value_b, TestEnum.value_c]) -> List[TestEnum]:
+        return self._client._invoke(
+            "TestService",
+            "EnumListDefault",
+            [x],
+            ["x"],
+            [self._client._types.list_type(self._client._types.enumeration_type("TestService", "TestEnum"))],
+            self._client._types.list_type(self._client._types.enumeration_type("TestService", "TestEnum"))
+        )
+
+    def _return_type_enum_list_default(self) -> TypeBase:
+        return self._client._types.list_type(self._client._types.enumeration_type("TestService", "TestEnum"))
+
+    def _build_call_enum_list_default(self, x: List[TestEnum] = [TestEnum.value_b, TestEnum.value_c]) -> KRPC_pb2.ProcedureCall:
+        return self._client._build_call(
+            "TestService",
+            "EnumListDefault",
+            [x],
+            ["x"],
+            [self._client._types.list_type(self._client._types.enumeration_type("TestService", "TestEnum"))],
+            self._client._types.list_type(self._client._types.enumeration_type("TestService", "TestEnum"))
+        )
+
     def enum_return(self) -> TestEnum:
         return self._client._invoke(
             "TestService",

--- a/tools/krpctools/krpctools/test/clientgen-TestService-python.txt
+++ b/tools/krpctools/krpctools/test/clientgen-TestService-python.txt
@@ -1002,7 +1002,7 @@ class TestService:
             self._client._types.list_type(self._client._types.string_type)
         )
 
-    def enum_default_arg(self, x: TestEnum = TestEnum(2)) -> TestEnum:
+    def enum_default_arg(self, x: TestEnum = TestEnum.value_c) -> TestEnum:
         return self._client._invoke(
             "TestService",
             "EnumDefaultArg",
@@ -1015,7 +1015,7 @@ class TestService:
     def _return_type_enum_default_arg(self) -> TypeBase:
         return self._client._types.enumeration_type("TestService", "TestEnum")
 
-    def _build_call_enum_default_arg(self, x: TestEnum = TestEnum(2)) -> KRPC_pb2.ProcedureCall:
+    def _build_call_enum_default_arg(self, x: TestEnum = TestEnum.value_c) -> KRPC_pb2.ProcedureCall:
         return self._client._build_call(
             "TestService",
             "EnumDefaultArg",

--- a/tools/krpctools/krpctools/test/clientgentest.py
+++ b/tools/krpctools/krpctools/test/clientgentest.py
@@ -1,5 +1,6 @@
 import json
 from importlib.resources import files
+from ..definitions import Definitions
 
 
 class ClientGenTestCase:
@@ -12,7 +13,7 @@ class ClientGenTestCase:
         defs = json.loads(
             files("krpctools.test").joinpath(name + ".json").read_text(encoding="utf-8")
         )
-        g = self.generator(macro_template, service_name, defs[service_name])
+        g = self.generator(macro_template, service_name, Definitions(defs))
         actual = g.generate()
 
         # with open('/home/alex/workspaces/krpc/krpc/' +

--- a/tools/krpctools/krpctools/test/clientgentest.py
+++ b/tools/krpctools/krpctools/test/clientgentest.py
@@ -4,17 +4,24 @@ from ..definitions import Definitions
 
 
 class ClientGenTestCase:
-    def run_test(self, service_name, name):
+    def generate(self, service_name, defs):
         macro_template = (
             files("krpctools.clientgen")
             .joinpath(self.language + ".tmpl")
             .read_text(encoding="utf-8")
         )
-        defs = json.loads(
+        g = self.generator(macro_template, service_name, Definitions(defs))
+        return g.generate()
+
+    @staticmethod
+    def load(name):
+        return json.loads(
             files("krpctools.test").joinpath(name + ".json").read_text(encoding="utf-8")
         )
-        g = self.generator(macro_template, service_name, Definitions(defs))
-        actual = g.generate()
+
+    def run_test(self, service_name, name):
+        defs = self.load(name)
+        actual = self.generate(service_name, defs)
 
         # with open('/home/alex/workspaces/krpc/krpc/' +
         #           'tools/krpctools/krpctools/test/' +
@@ -28,8 +35,30 @@ class ClientGenTestCase:
         )
         self.assertEqual(expected, actual)
 
+        # A service may be defined after one that uses its types, so the definitions in the
+        # reverse order have to generate the same thing
+        reversed_defs = dict(reversed(list(defs.items())))
+        self.assertEqual(actual, self.generate(service_name, reversed_defs))
+
     def test_empty(self):
         self.run_test("EmptyService", "Empty")
 
     def test_test_service(self):
         self.run_test("TestService", "TestService")
+
+    def test_ordering(self):
+        self.run_test("ServiceA", "Ordering")
+
+    def test_service_that_is_not_defined(self):
+        defs = self.load("Ordering")
+        del defs["ServiceB"]
+        with self.assertRaises(RuntimeError) as cm:
+            self.generate("ServiceA", defs)
+        self.assertIn("ServiceA.Frob parameter mode", str(cm.exception))
+        self.assertIn("ServiceB", str(cm.exception))
+
+    def test_value_the_enumeration_does_not_declare(self):
+        with self.assertRaises(RuntimeError) as cm:
+            self.generate("BadService", self.load("UndeclaredEnumValue"))
+        self.assertIn("BadService.Frob parameter mode", str(cm.exception))
+        self.assertIn("7 is not a valid Mode", str(cm.exception))

--- a/tools/krpctools/krpctools/test/docgen-Ordering-cnano.rst
+++ b/tools/krpctools/krpctools/test/docgen-Ordering-cnano.rst
@@ -1,0 +1,27 @@
+.. default-domain:: c
+.. highlight:: c
+
+
+
+
+A service whose procedures use another service's enumeration.
+
+
+.. function:: krpc_error_t krpc_ServiceA_Frob(krpc_connection_t connection, krpc_ServiceB_Mode_t mode)
+
+   Defaults to a member of another service's enumeration.
+
+   :Parameters:
+
+
+
+   
+
+
+
+
+.. function:: krpc_error_t krpc_ServiceA_FrobAll(krpc_connection_t connection, const krpc_list_enum_t * modes)
+
+   Defaults to a collection containing a member of another service's enumeration.
+
+   :Parameters:

--- a/tools/krpctools/krpctools/test/docgen-Ordering-cpp.rst
+++ b/tools/krpctools/krpctools/test/docgen-Ordering-cpp.rst
@@ -1,0 +1,30 @@
+.. default-domain:: cpp
+.. highlight:: cpp
+
+.. namespace:: krpc::services::ServiceA
+
+
+.. namespace:: krpc::services
+.. class:: ServiceA : public krpc::Service
+
+   A service whose procedures use another service's enumeration.
+
+   .. function:: ServiceA(krpc::Client* client)
+
+      Construct an instance of this service.
+
+   .. function:: void frob(ServiceB::Mode mode = ServiceB::Mode::fast)
+
+      Defaults to a member of another service's enumeration.
+
+      :Parameters:
+
+
+
+   
+
+   .. function:: void frob_all(std::vector<ServiceB::Mode> modes = std::vector<ServiceB::Mode>{ServiceB::Mode::fast})
+
+      Defaults to a collection containing a member of another service's enumeration.
+
+      :Parameters:

--- a/tools/krpctools/krpctools/test/docgen-Ordering-csharp.rst
+++ b/tools/krpctools/krpctools/test/docgen-Ordering-csharp.rst
@@ -1,0 +1,29 @@
+.. default-domain:: csharp
+.. highlight:: csharp
+
+.. namespace:: KRPC.Client.Services.ServiceA
+
+
+.. class:: ServiceA
+
+   A service whose procedures use another service's enumeration.
+
+   .. method:: void Frob(ServiceB.Mode mode = ServiceB.Mode.Fast)
+
+      Defaults to a member of another service's enumeration.
+
+      :parameters:
+
+
+
+      :Game Scenes: All
+
+   .. method:: void FrobAll(System.Collections.Generic.IList<ServiceB.Mode> modes = { ServiceB.Mode.Fast })
+
+      Defaults to a collection containing a member of another service's enumeration.
+
+      :parameters:
+
+
+
+      :Game Scenes: All

--- a/tools/krpctools/krpctools/test/docgen-Ordering-java.rst
+++ b/tools/krpctools/krpctools/test/docgen-Ordering-java.rst
@@ -1,0 +1,22 @@
+.. default-domain:: java
+.. highlight:: java
+
+.. package:: krpc.client.services.ServiceA
+
+
+.. type:: public class ServiceA
+
+   A service whose procedures use another service's enumeration.
+
+   .. method:: void frob(ServiceB.Mode mode)
+
+      Defaults to a member of another service's enumeration.
+
+      :param ServiceB.Mode mode:
+   
+
+   .. method:: void frobAll(java.util.List<ServiceB.Mode> modes)
+
+      Defaults to a collection containing a member of another service's enumeration.
+
+      :param java.util.List<ServiceB.Mode> modes:

--- a/tools/krpctools/krpctools/test/docgen-Ordering-lua.rst
+++ b/tools/krpctools/krpctools/test/docgen-Ordering-lua.rst
@@ -1,0 +1,25 @@
+.. default-domain:: lua
+.. highlight:: lua
+
+.. currentmodule:: ServiceA
+
+
+.. module:: ServiceA
+
+A service whose procedures use another service's enumeration.
+
+
+.. staticmethod:: frob([mode = ServiceB.Mode.fast])
+
+   Defaults to a member of another service's enumeration.
+
+   :param ServiceB.Mode mode:
+
+
+
+
+.. staticmethod:: frob_all([modes = {ServiceB.Mode.fast}])
+
+   Defaults to a collection containing a member of another service's enumeration.
+
+   :param List modes:

--- a/tools/krpctools/krpctools/test/docgen-Ordering-python.rst
+++ b/tools/krpctools/krpctools/test/docgen-Ordering-python.rst
@@ -1,0 +1,26 @@
+.. default-domain:: py
+.. highlight:: py
+
+.. currentmodule:: ServiceA
+
+
+.. module:: ServiceA
+
+A service whose procedures use another service's enumeration.
+
+
+.. staticmethod:: frob([mode = ServiceB.Mode.fast])
+
+   Defaults to a member of another service's enumeration.
+
+   :param ServiceB.Mode mode:
+   
+
+
+
+
+.. staticmethod:: frob_all([modes = [ServiceB.Mode.fast]])
+
+   Defaults to a collection containing a member of another service's enumeration.
+
+   :param list modes:

--- a/tools/krpctools/krpctools/test/docgen-TestService-cnano.rst
+++ b/tools/krpctools/krpctools/test/docgen-TestService-cnano.rst
@@ -262,6 +262,19 @@ Service documentation string.
 
 
 
+.. function:: krpc_error_t krpc_TestService_EnumListDefault(krpc_connection_t connection, krpc_list_enum_t * result, const krpc_list_enum_t * x)
+
+
+
+   :Parameters:
+
+
+
+   
+
+
+
+
 .. function:: krpc_error_t krpc_TestService_EnumReturn(krpc_connection_t connection, krpc_TestService_TestEnum_t * result)
 
 

--- a/tools/krpctools/krpctools/test/docgen-TestService-cpp.rst
+++ b/tools/krpctools/krpctools/test/docgen-TestService-cpp.rst
@@ -211,6 +211,16 @@
 
    
 
+   .. function:: std::vector<TestEnum> enum_list_default(std::vector<TestEnum> x = std::vector<TestEnum>{TestEnum::value_b, TestEnum::value_c})
+
+
+
+      :Parameters:
+
+
+
+   
+
    .. function:: TestEnum enum_return()
 
 

--- a/tools/krpctools/krpctools/test/docgen-TestService-cpp.rst
+++ b/tools/krpctools/krpctools/test/docgen-TestService-cpp.rst
@@ -121,7 +121,7 @@
 
    
 
-   .. function:: std::map<int32_t, bool> dictionary_default(std::map<int32_t, bool> x = std::map<int32_t, bool>({1, false}, {2, true}))
+   .. function:: std::map<int32_t, bool> dictionary_default(std::map<int32_t, bool> x = std::map<int32_t, bool>{{1, false}, {2, true}})
 
 
 
@@ -181,7 +181,7 @@
 
    
 
-   .. function:: std::vector<std::string> empty_list_default(std::vector<std::string> x = std::vector<std::string>())
+   .. function:: std::vector<std::string> empty_list_default(std::vector<std::string> x = std::vector<std::string>{})
 
 
 
@@ -191,7 +191,7 @@
 
    
 
-   .. function:: TestEnum enum_default_arg(TestEnum x = static_cast<TestEnum>(2))
+   .. function:: TestEnum enum_default_arg(TestEnum x = TestEnum::value_c)
 
 
 
@@ -298,7 +298,7 @@
 
    
 
-   .. function:: std::vector<int32_t> list_default(std::vector<int32_t> x = std::vector<int32_t>(1, 2, 3))
+   .. function:: std::vector<int32_t> list_default(std::vector<int32_t> x = std::vector<int32_t>{1, 2, 3})
 
 
 
@@ -387,7 +387,7 @@
 
    
 
-   .. function:: std::set<int32_t> set_default(std::set<int32_t> x = std::set<int32_t>(1, 2, 3))
+   .. function:: std::set<int32_t> set_default(std::set<int32_t> x = std::set<int32_t>{1, 2, 3})
 
 
 
@@ -481,7 +481,7 @@
 
    
 
-   .. function:: std::tuple<int32_t, bool> tuple_default(std::tuple<int32_t, bool> x = std::tuple<int32_t, bool>(1, false))
+   .. function:: std::tuple<int32_t, bool> tuple_default(std::tuple<int32_t, bool> x = std::tuple<int32_t, bool>{1, false})
 
 
 

--- a/tools/krpctools/krpctools/test/docgen-TestService-csharp.rst
+++ b/tools/krpctools/krpctools/test/docgen-TestService-csharp.rst
@@ -185,7 +185,7 @@
 
       :Game Scenes: All
 
-   .. method:: TestEnum EnumDefaultArg(TestEnum x = 2)
+   .. method:: TestEnum EnumDefaultArg(TestEnum x = TestEnum.ValueC)
 
 
 

--- a/tools/krpctools/krpctools/test/docgen-TestService-csharp.rst
+++ b/tools/krpctools/krpctools/test/docgen-TestService-csharp.rst
@@ -205,6 +205,16 @@
 
       :Game Scenes: All
 
+   .. method:: System.Collections.Generic.IList<TestEnum> EnumListDefault(System.Collections.Generic.IList<TestEnum> x = { TestEnum.ValueB, TestEnum.ValueC })
+
+
+
+      :parameters:
+
+
+
+      :Game Scenes: All
+
    .. method:: TestEnum EnumReturn()
 
 

--- a/tools/krpctools/krpctools/test/docgen-TestService-java.rst
+++ b/tools/krpctools/krpctools/test/docgen-TestService-java.rst
@@ -153,6 +153,13 @@
       :param TestEnum x:
    
 
+   .. method:: java.util.List<TestEnum> enumListDefault(java.util.List<TestEnum> x)
+
+
+
+      :param java.util.List<TestEnum> x:
+   
+
    .. method:: TestEnum enumReturn()
 
 

--- a/tools/krpctools/krpctools/test/docgen-TestService-lua.rst
+++ b/tools/krpctools/krpctools/test/docgen-TestService-lua.rst
@@ -120,7 +120,7 @@ Service documentation string.
 
 
 
-.. staticmethod:: dictionary_default([x = {1: False, 2: True}])
+.. staticmethod:: dictionary_default([x = {[1] = false, [2] = true}])
 
 
 
@@ -180,7 +180,7 @@ Service documentation string.
 
 
 
-.. staticmethod:: empty_list_default([x = []])
+.. staticmethod:: empty_list_default([x = {}])
 
 
 
@@ -190,7 +190,7 @@ Service documentation string.
 
 
 
-.. staticmethod:: enum_default_arg([x = 2])
+.. staticmethod:: enum_default_arg([x = TestService.TestEnum.value_c])
 
 
 
@@ -299,7 +299,7 @@ Service documentation string.
 
 
 
-.. staticmethod:: list_default([x = [1, 2, 3]])
+.. staticmethod:: list_default([x = {1, 2, 3}])
 
 
 
@@ -513,7 +513,7 @@ Service documentation string.
 
 
 
-.. staticmethod:: tuple_default([x = (1, False)])
+.. staticmethod:: tuple_default([x = {1, false}])
 
 
 

--- a/tools/krpctools/krpctools/test/docgen-TestService-lua.rst
+++ b/tools/krpctools/krpctools/test/docgen-TestService-lua.rst
@@ -210,6 +210,16 @@ Service documentation string.
 
 
 
+.. staticmethod:: enum_list_default([x = {TestService.TestEnum.value_b, TestService.TestEnum.value_c}])
+
+
+
+   :param List x:
+   :rtype: List
+
+
+
+
 .. staticmethod:: enum_return()
 
 

--- a/tools/krpctools/krpctools/test/docgen-TestService-python.rst
+++ b/tools/krpctools/krpctools/test/docgen-TestService-python.rst
@@ -207,7 +207,7 @@ Service documentation string.
 
 
 
-.. staticmethod:: enum_default_arg([x = TestEnum(2)])
+.. staticmethod:: enum_default_arg([x = TestEnum.value_c])
 
 
 

--- a/tools/krpctools/krpctools/test/docgen-TestService-python.rst
+++ b/tools/krpctools/krpctools/test/docgen-TestService-python.rst
@@ -229,6 +229,17 @@ Service documentation string.
 
 
 
+.. staticmethod:: enum_list_default([x = [TestEnum.value_b, TestEnum.value_c]])
+
+
+
+   :param list x:
+   :rtype: list(:class:`TestEnum`)
+   
+
+
+
+
 .. staticmethod:: enum_return()
 
 

--- a/tools/krpctools/krpctools/test/docgentest.py
+++ b/tools/krpctools/krpctools/test/docgentest.py
@@ -7,11 +7,13 @@ from ..docgen import process_file
 
 
 class DocGenTestCase:
-    def run_test(self, service_name, name):
-        defs = json.loads(
+    @staticmethod
+    def load(name):
+        return json.loads(
             files("krpctools.test").joinpath(name + ".json").read_text(encoding="utf-8")
         )
 
+    def generate(self, service_name, defs):
         def sort(member):
             return member.fullname
 
@@ -73,7 +75,11 @@ class DocGenTestCase:
         macros = str(files("krpctools.docgen").joinpath("%s.tmpl" % self.language))
         domain = self.domain(macros)
 
-        actual, _ = process_file(domain, services, path)
+        content, _ = process_file(domain, services, path)
+        return content
+
+    def run_test(self, service_name, name):
+        actual = self.generate(service_name, self.load(name))
 
         # with open('/home/alex/workspaces/krpc/krpc/' +
         #           'tools/krpctools/krpctools/test/' +
@@ -87,8 +93,31 @@ class DocGenTestCase:
         )
         self.assertEqual(expected, actual)
 
+        # A service may be defined after one that uses its types, so the definitions in the
+        # reverse order have to generate the same thing
+        defs = self.load(name)
+        reversed_defs = dict(reversed(list(defs.items())))
+        self.assertEqual(actual, self.generate(service_name, reversed_defs))
+
     def test_empty(self):
         self.run_test("EmptyService", "Empty")
 
     def test_test_service(self):
         self.run_test("TestService", "TestService")
+
+    def test_ordering(self):
+        self.run_test("ServiceA", "Ordering")
+
+    def test_service_that_is_not_defined(self):
+        defs = self.load("Ordering")
+        del defs["ServiceB"]
+        with self.assertRaises(RuntimeError) as cm:
+            self.generate("ServiceA", defs)
+        self.assertIn("ServiceA.Frob parameter mode", str(cm.exception))
+        self.assertIn("ServiceB", str(cm.exception))
+
+    def test_value_the_enumeration_does_not_declare(self):
+        with self.assertRaises(RuntimeError) as cm:
+            self.generate("BadService", self.load("UndeclaredEnumValue"))
+        self.assertIn("BadService.Frob parameter mode", str(cm.exception))
+        self.assertIn("7 is not a valid Mode", str(cm.exception))

--- a/tools/krpctools/krpctools/test/docgentest.py
+++ b/tools/krpctools/krpctools/test/docgentest.py
@@ -1,6 +1,7 @@
 import json
 import tempfile
 from importlib.resources import files
+from ..definitions import Definitions
 from ..docgen.nodes import Service
 from ..docgen import process_file
 
@@ -32,8 +33,12 @@ class DocGenTestCase:
                     info[key] = value
             return info
 
+        definitions = Definitions(defs)
+
         services = {
-            name: Service(name, sort=sort, **parse_service_info(info))
+            name: Service(
+                name, sort=sort, types=definitions.types, **parse_service_info(info)
+            )
             for name, info in defs.items()
         }
 

--- a/tools/krpctools/krpctools/test/test_clientgen_cnano.py
+++ b/tools/krpctools/krpctools/test/test_clientgen_cnano.py
@@ -3,9 +3,48 @@ from krpctools.test.clientgentest import ClientGenTestCase
 from krpctools.clientgen.cnano import CnanoGenerator
 
 
+def _list_of_class(name, class_name):
+    return {
+        "name": name,
+        "type": {
+            "code": "LIST",
+            "types": [{"code": "CLASS", "service": "ServiceA", "name": class_name}],
+        },
+    }
+
+
 class TestClientGenCNano(ClientGenTestCase, unittest.TestCase):
     language = "cnano"
     generator = CnanoGenerator
+
+    def test_collections_of_different_classes_share_one_struct(self):
+        # Every class is a krpc_object_t in C, so a list of one class and a list of another
+        # are the same struct, which can only be declared once
+        defs = {
+            "ServiceA": {
+                "id": 1,
+                "documentation": "",
+                "procedures": {
+                    "Frob": {
+                        "id": 1,
+                        "parameters": [
+                            _list_of_class("things", "Thing"),
+                            _list_of_class("widgets", "Widget"),
+                        ],
+                        "documentation": "",
+                    }
+                },
+                "classes": {
+                    "Thing": {"documentation": ""},
+                    "Widget": {"documentation": ""},
+                },
+                "enumerations": {},
+                "exceptions": {},
+            }
+        }
+        self.assertEqual(
+            1, self.generate("ServiceA", defs).count("struct krpc_list_object_s {")
+        )
 
 
 if __name__ == "__main__":

--- a/tools/krpctools/krpctools/test/test_definitions.py
+++ b/tools/krpctools/krpctools/test/test_definitions.py
@@ -1,0 +1,84 @@
+import unittest
+from krpc.types import Types
+from ..definitions import Definitions
+
+
+def enumeration(*values):
+    return {
+        "documentation": "",
+        "values": [
+            {"name": name, "value": value, "documentation": ""}
+            for name, value in values
+        ],
+    }
+
+
+class TestDefinitions(unittest.TestCase):
+    def setUp(self):
+        self.definitions = Definitions(
+            {
+                "ServiceA": {
+                    "id": 1,
+                    "documentation": "",
+                    "classes": {"Thing": {"documentation": ""}},
+                    "enumerations": {"Mode": enumeration(("Slow", 0), ("Fast", 1))},
+                    "exceptions": {"Failure": {"documentation": ""}},
+                }
+            }
+        )
+
+    def test_enumeration_values_are_registered(self):
+        typ = self.definitions.types.enumeration_type("ServiceA", "Mode")
+        self.assertEqual(1, typ.python_type.Fast.value)
+
+    def test_class_is_registered(self):
+        self.assertEqual(
+            "Thing",
+            self.definitions.types.class_type("ServiceA", "Thing").python_type.__name__,
+        )
+
+    def test_as_type(self):
+        typ = self.definitions.as_type(
+            {"code": "ENUMERATION", "service": "ServiceA", "name": "Mode"}
+        )
+        self.assertEqual(
+            self.definitions.types.enumeration_type("ServiceA", "Mode"), typ
+        )
+
+    def test_a_run_has_a_registry_of_its_own(self):
+        # Registering the same enumeration twice in one registry raises, so generating from
+        # two sets of definitions in one process must not share one
+        other = Definitions(
+            {
+                "ServiceA": {
+                    "id": 1,
+                    "documentation": "",
+                    "enumerations": {"Mode": enumeration(("Slow", 0))},
+                }
+            }
+        )
+        self.assertNotEqual(self.definitions.types, other.types)
+        self.assertFalse(
+            hasattr(
+                other.types.enumeration_type("ServiceA", "Mode").python_type, "Fast"
+            )
+        )
+
+    def test_collection_types_are_innermost_first(self):
+        types = Types()
+        pair = types.tuple_type(types.sint32_type, types.string_type)
+        listing = types.list_type(pair)
+        mapping = types.dictionary_type(types.string_type, listing)
+        self.assertEqual(
+            [pair, listing, mapping],
+            Definitions.collection_types([mapping, types.sint32_type, listing]),
+        )
+
+    def test_collection_types_are_returned_once(self):
+        types = Types()
+        listing = types.list_type(types.sint32_type)
+        self.assertEqual([listing], Definitions.collection_types([listing, listing]))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/krpctools/krpctools/utils.py
+++ b/tools/krpctools/krpctools/utils.py
@@ -1,11 +1,10 @@
 import array
 import base64
 import re
-from krpc.decoder import Decoder
+from krpc import definitions
 
 # pylint: disable=no-name-in-module
 from krpc.schema.KRPC_pb2 import Type
-from krpc.types import Types, EnumerationType
 
 _CAMEL_CASE_REGEX = re.compile(r"([^A-Z]+|[A-Z][^A-Z]*)")
 
@@ -56,14 +55,12 @@ def _as_protobuf_type(types, type_info):
     return protobuf_type
 
 
-def decode_default_value(value, typ):
+def decode_default_value(value, typ, location):
+    """Decode a default value parsed from a JSON service definitions file. location names the
+    parameter it belongs to, and is reported when the value cannot be decoded."""
     if value is None:
         # A JSON null default value means the default is null
         return None
     value = base64.b64decode(value)
     value = array.array("B", value).tobytes()
-    # Note: following is a workaround for decoding EnumerationType,
-    # as set_values has not been called
-    if not isinstance(typ, EnumerationType):
-        return Decoder.decode(None, value, typ)
-    return Decoder.decode(None, value, Types().sint32_type)
+    return definitions.decode_default_value(None, value, typ, location)


### PR DESCRIPTION
**Problem.** A procedure's default value is decoded as a client creates the service that declares it, through the type the parameter is declared as. When that type is an enumeration, or contains one, the values it decodes through are only known once the service defining the enumeration has been registered. Definitions arrive in whatever order the server or a definitions file lists them, so a service created before the one defining the enumeration decoded its default against an empty type and failed. The generators sidestepped this by reading an enumeration default as a plain integer, so generated clients and documentation named a raw integer where the enumeration declares a member, and a default whose type merely contained an enumeration, such as a list of them, failed outright.

**Ordering.** `krpc/definitions.py` takes a `Definition` record per class, enumeration and exception, orders them so that every definition follows the ones it refers to, and registers them in that order. A reference nothing defines and a cycle among the definitions are both reported naming what failed. The Python and Lua clients now build a record for every service, whether its stubs were pre-generated or not, and register them all before creating any service. `krpctools/definitions.py` does the same for a generator run, in a registry of its own rather than the one shared by every generator in the process, and hands `clientgen` every service that was loaded so that a type another service defines resolves.

**Defaults.** With the definitions registered before anything reads them, a default decodes through the type its parameter is declared as, and each language writes the member it names: `TestEnum.value_c` in Python, `TestEnum::value_c` in C++, `TestEnum.ValueC` in C#, and the same in the documentation. Python and Lua collection defaults are written in that language's syntax rather than Python's repr of the decoded value, and C++ documentation writes a collection default as a braced initializer list rather than a constructor call. A default naming a value its enumeration does not declare, or one whose enumeration no supplied service defines, is reported naming the service, procedure and parameter it came from.

**C++ client.** The encoder and decoder for a collection call `encode` and `decode` on the type it contains unqualified, and the overloads a generated service header adds for its enumerations were only visible in `krpc::encoder` and `krpc::decoder`, where neither ordinary lookup nor argument dependent lookup could reach them. Any service with a collection of enumerations in a signature failed to compile. The generated header now also declares each enumeration's `encode` and `decode` in `krpc::services`.

**Testing.** `TestService.EnumListDefault` defaults to a list of enumeration members, which puts the case in front of every client suite and every golden file. New generator fixtures cover ordering across services and a default naming an undeclared enumeration value, and there are unit tests for the ordering itself in both `krpc` and `krpctools`.
