### PR TITLE
Take the closest approach velocities from the orbit's own motion

### DIFF
--- a/service/SpaceCenter/CHANGELOG.md
+++ b/service/SpaceCenter/CHANGELOG.md
@@ -86,6 +86,11 @@
   - Add `CelestialBody.SurfaceNormal`, `CelestialBody.BedrockNormal` and `CelestialBody.MSLNormal`
     to get the slope of the terrain at a given latitude and longitude, as a unit vector normal to
     the surface, to the sea-bed, or to the sphere at sea level (#1030)
+  - Fix `ClosestApproach.Velocity` and `ClosestApproach.TargetVelocity`, which were both
+    offset by the velocity of the frame the active vessel's reference body moves in, some
+    9284 m/s for a vessel in orbit around Kerbin. `ClosestApproach.RelativeVelocity` and
+    `ClosestApproach.RelativeSpeed` are the difference of the two and were unaffected
+    (#1047)
 
 - Flight and aerodynamics
   - Add `Flight.SurfaceNormal` to get the slope of the terrain under a vessel, as a unit vector

--- a/service/SpaceCenter/src/Services/ClosestApproach.cs
+++ b/service/SpaceCenter/src/Services/ClosestApproach.cs
@@ -60,12 +60,18 @@ namespace KRPC.SpaceCenter.Services
             return o.InternalOrbit.getPositionAtUT (ut);
         }
 
-        // The true world-space velocity of the given orbit at the closest approach,
-        // including the motion of its reference body, so relative velocity is correct
-        // even when the two orbits are around different bodies.
+        // The world-space velocity of the given orbit at the closest approach: the
+        // motion around its reference body then, plus the motion of that body now. The
+        // body is taken as it is now to match WorldPosition above, which places the
+        // orbit against the body's current position, and to match the velocity a
+        // reference frame moves at, which is also the body's current one. Both objects
+        // are treated the same way, so the relative quantities remain the difference of
+        // the absolute ones.
         Vector3d WorldVelocity (Orbit o)
         {
-            return o.InternalOrbit.GetFrameVelAtUT (ut).SwapYZ ();
+            var internalOrbit = o.InternalOrbit;
+            return internalOrbit.getOrbitalVelocityAtUT (ut).SwapYZ () +
+                   internalOrbit.referenceBody.GetWorldVelocity ();
         }
 
         ReferenceFrame DefaultedFrame (ReferenceFrame referenceFrame)

--- a/service/SpaceCenter/test/test_orbit.py
+++ b/service/SpaceCenter/test/test_orbit.py
@@ -334,6 +334,28 @@ class TestClosestApproach(krpctest.TestCase):
             delta=1,
         )
 
+    def test_absolute_velocities(self):
+        """The velocities are each object's own, not merely consistent with each
+        other.
+
+        Both orbits are circular, so the speed at the approach is the circular
+        speed at that radius, which is computed here from the gravitational
+        parameter alone and owes nothing to the reference frame machinery. The
+        relative quantities are differences and so cannot see an offset common to
+        both velocities, which is how these came to carry the velocity of the
+        frame the active vessel is in, some 9284 m/s around Kerbin."""
+        approach = self.orbit.next_closest_approach(self.target)
+        frame = self.orbit.body.non_rotating_reference_frame
+        mu = self.orbit.body.gravitational_parameter
+        for orbit, speed in (
+            (self.orbit, norm(approach.velocity(frame))),
+            (self.target, norm(approach.target_velocity(frame))),
+        ):
+            expected = math.sqrt(
+                mu * ((2 / orbit.radius_at(approach.ut)) - (1 / orbit.semi_major_axis))
+            )
+            self.assertAlmostEqual(expected, speed, delta=1)
+
     def test_closest_approaches(self):
         approaches = self.orbit.closest_approaches(self.target, 3)
         self.assertEqual(3, len(approaches))


### PR DESCRIPTION
**Root cause.** `ClosestApproach.Velocity` and `ClosestApproach.TargetVelocity` were built from `Orbit.GetFrameVelAtUT`, which measures against KSP's own absolute frame rather than the one the rest of the service uses. Both velocities came out offset by the velocity of the frame the active vessel's reference body moves in, some 9284 m/s for a vessel in orbit around Kerbin.

The offset was common to both, so `ClosestApproach.RelativeVelocity` and `ClosestApproach.RelativeSpeed`, being the difference of the two, were correct throughout. That is what kept this hidden.

**Testing.** Verified in game. The new `test_absolute_velocities` checks each velocity against the speed the vis-viva equation gives for that orbit at the time of the approach, computed from the body's gravitational parameter alone.
