### PR TITLE
Object Lifetime

### DIFF
--- a/client/python/krpc/test/test_client.py
+++ b/client/python/krpc/test/test_client.py
@@ -569,6 +569,7 @@ class TestClient(ServerTestCase, unittest.TestCase):
                     "ArgumentException",
                     "ArgumentNullException",
                     "ArgumentOutOfRangeException",
+                    "ObjectDestroyedException",
                 ]
             ),
             set(x for x in dir(self.conn.krpc) if not x.startswith("_")),

--- a/core/BUILD.bazel
+++ b/core/BUILD.bazel
@@ -62,6 +62,7 @@ csharp_library(
     srcs = srcs,
     internals_visible_to = [
         "KRPC.Core.Test",
+        "TestingTools",
         "DynamicProxyGenAssembly2",
     ],
     target_frameworks = ["net472"],
@@ -83,6 +84,7 @@ csharp_library(
     out = "KRPC.Core",
     internals_visible_to = [
         "KRPC.Core.Test",
+        "TestingTools",
         "DynamicProxyGenAssembly2",
     ],
     # CS1701: Google.Protobuf's net5.0 build references net5-era framework

--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -2,6 +2,11 @@
 - Fix the game freezing for as long as a serial connection takes to carry an RPC; serial ports are
   now read and written on their own threads rather than on the thread that runs the game. Data
   waiting to be sent is buffered up to 1 MB, beyond which the connection is dropped (#1035)
+- Add `KRPC.ObjectDestroyedException`, raised when the game object that an object refers to
+  no longer exists (#1051)
+- Objects whose game objects the game no longer has are removed from the object store when a
+  game state is loaded, and using an object that has been removed raises
+  `KRPC.ObjectDestroyedException` rather than an argument error (#1051)
 - Fix one server stopping emptying the object store that every server shares, which invalidated
   the objects held by clients of the servers still running (#1020)
 - Support for nullable values across all types (#1017)

--- a/core/InternalsVisibleTo.cs
+++ b/core/InternalsVisibleTo.cs
@@ -4,3 +4,4 @@ using System.Runtime.CompilerServices;
 // via rules_dotnet's internals_visible_to attr instead, so this file lives
 // outside src/ (which Bazel globs) to avoid a duplicate attribute.
 [assembly: InternalsVisibleTo("KRPC.Core.Test")]
+[assembly: InternalsVisibleTo("TestingTools")]

--- a/core/src/KRPC.Core.csproj
+++ b/core/src/KRPC.Core.csproj
@@ -124,6 +124,7 @@
     <Compile Include="Service\KRPC\GameScene.cs" />
     <Compile Include="Service\KRPC\InvalidOperationException.cs" />
     <Compile Include="Service\KRPC\KRPC.cs" />
+    <Compile Include="Service\KRPC\ObjectDestroyedException.cs" />
     <Compile Include="Service\KRPC\Type.cs" />
     <Compile Include="Service\Messages\Argument.cs" />
     <Compile Include="Service\Messages\Class.cs" />

--- a/core/src/KRPC.Core.csproj
+++ b/core/src/KRPC.Core.csproj
@@ -116,6 +116,7 @@
     <Compile Include="Service\Event.cs" />
     <Compile Include="Service\EventStream.cs" />
     <Compile Include="Service\GameScene.cs" />
+    <Compile Include="Service\GameState.cs" />
     <Compile Include="Service\IProcedureHandler.cs" />
     <Compile Include="Service\KRPC\ArgumentException.cs" />
     <Compile Include="Service\KRPC\ArgumentNullException.cs" />

--- a/core/src/KRPC.Core.csproj
+++ b/core/src/KRPC.Core.csproj
@@ -175,6 +175,8 @@
     <Compile Include="Utils\Equatable.cs" />
     <Compile Include="Utils\EventHandlerExtensions.cs" />
     <Compile Include="Utils\ExponentialMovingAverage.cs" />
+    <Compile Include="Utils\GameObjectState.cs" />
+    <Compile Include="Utils\IGameObjectState.cs" />
     <Compile Include="Utils\IScheduler.cs" />
     <Compile Include="Utils\Logger.cs" />
     <Compile Include="Utils\Reflection.cs" />

--- a/core/src/Service/GameState.cs
+++ b/core/src/Service/GameState.cs
@@ -19,7 +19,7 @@ namespace KRPC.Service
         public static uint Generation { get; private set; }
 
         /// <summary>
-        /// Whether the object store is waiting to be swept, following a change of game state.
+        /// Whether the object store is waiting to be swept.
         /// </summary>
         public static bool SweepPending { get; private set; }
 
@@ -51,6 +51,22 @@ namespace KRPC.Service
         {
             Generation++;
             settled = false;
+            RequestSweep ();
+        }
+
+        /// <summary>
+        /// Called when the game destroys something that service objects may stand for, such
+        /// as a part or a vessel. Asks for the object store to be swept without moving the
+        /// generation on: what was destroyed is gone, but nothing else has been rebuilt, so
+        /// there is nothing for anyone to look up again.
+        /// </summary>
+        /// <remarks>
+        /// Several things can be destroyed in the same moment, a vessel breaking up being
+        /// the obvious case, and this only records that a sweep is due; one sweep then
+        /// covers all of them.
+        /// </remarks>
+        public static void RequestSweep ()
+        {
             SweepPending = true;
         }
 

--- a/core/src/Service/GameState.cs
+++ b/core/src/Service/GameState.cs
@@ -1,0 +1,76 @@
+using KRPC.Utils;
+
+namespace KRPC.Service
+{
+    /// <summary>
+    /// The state of the game that service objects stand for - the vessels, parts and
+    /// everything else a loaded game consists of.
+    /// </summary>
+    public static class GameState
+    {
+        /// <summary>
+        /// The number of times the game has replaced its state since the server started.
+        /// </summary>
+        /// <remarks>
+        /// A service object that caches something it looked up in the game records the
+        /// generation it looked it up in, and looks it up again when the generation has
+        /// moved on, because the game may have rebuilt what the cached value refers to.
+        /// </remarks>
+        public static uint Generation { get; private set; }
+
+        /// <summary>
+        /// Whether the object store is waiting to be swept, following a change of game state.
+        /// </summary>
+        public static bool SweepPending { get; private set; }
+
+        static bool settled = true;
+
+        /// <summary>
+        /// Whether the game has finished building the state it moved to.
+        /// </summary>
+        /// <remarks>
+        /// False from the moment the game replaces its state until the sweep that follows
+        /// it, which is the window in which the game is still filling in the vessels, parts
+        /// and everything else that state consists of. Nothing follows from one of them
+        /// being absent while this is false: it may be one the game has not built yet. It
+        /// starts out true, as nothing has said the game is between states.
+        /// </remarks>
+        public static bool Settled {
+            get { return settled; }
+        }
+
+        /// <summary>
+        /// Called when the game replaces the state that service objects stand for: a
+        /// game is loaded, quickloaded or reverted, or the scene changes. Moves the
+        /// generation on, so that anything cached from the previous state is looked up
+        /// again, asks for the object store to be swept, and records that the state is
+        /// being built, so that nothing is declared gone for being absent from a state
+        /// that is not finished.
+        /// </summary>
+        public static void Changed ()
+        {
+            Generation++;
+            settled = false;
+            SweepPending = true;
+        }
+
+        /// <summary>
+        /// Remove objects the game no longer has from the object store.
+        /// </summary>
+        /// <remarks>
+        /// Called once the game has finished building the state it moved to, rather than
+        /// at the moment it started: while a state is still being built, the objects it
+        /// consists of do not exist yet and every object in the store would look gone.
+        /// Being called is therefore what says the state is finished, which is what
+        /// <see cref="Settled" /> reports.
+        /// </remarks>
+        public static void Sweep ()
+        {
+            SweepPending = false;
+            settled = true;
+            var removed = ObjectStore.Instance.Sweep ();
+            if (removed > 0)
+                Logger.WriteLine ("Removed " + removed + " destroyed object(s) from the object store");
+        }
+    }
+}

--- a/core/src/Service/KRPC/ObjectDestroyedException.cs
+++ b/core/src/Service/KRPC/ObjectDestroyedException.cs
@@ -1,0 +1,36 @@
+using KRPC.Service.Attributes;
+
+namespace KRPC.Service.KRPC
+{
+    /// <summary>
+    /// The game object that a service object refers to no longer exists,
+    /// so the object cannot be used. For example, the part it represents
+    /// was destroyed, or the vessel it belongs to was recovered.
+    /// </summary>
+    [KRPCException (Service = "KRPC")]
+    public sealed class ObjectDestroyedException : System.Exception
+    {
+        /// <summary>
+        /// Construct the exception.
+        /// </summary>
+        public ObjectDestroyedException ()
+        {
+        }
+
+        /// <summary>
+        /// Construct the exception.
+        /// </summary>
+        public ObjectDestroyedException (string message) :
+            base (message)
+        {
+        }
+
+        /// <summary>
+        /// Construct the exception.
+        /// </summary>
+        public ObjectDestroyedException (string message, System.Exception innerException) :
+            base (message, innerException)
+        {
+        }
+    }
+}

--- a/core/src/Service/ObjectStore.cs
+++ b/core/src/Service/ObjectStore.cs
@@ -63,6 +63,13 @@ namespace KRPC.Service
         }
 
         /// <summary>
+        /// The number of instances in the store.
+        /// </summary>
+        public int Count {
+            get { return instances.Count; }
+        }
+
+        /// <summary>
         /// Remove every instance whose game object no longer exists, and return how many
         /// were removed. Instances that do not implement <see cref="IGameObjectState"/>
         /// are kept, as are those reporting anything but

--- a/core/src/Service/ObjectStore.cs
+++ b/core/src/Service/ObjectStore.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using KRPC.Utils;
 
 namespace KRPC.Service
 {
@@ -59,6 +60,46 @@ namespace KRPC.Service
                 instances.Remove (obj);
                 objectIds.Remove (objectId);
             }
+        }
+
+        /// <summary>
+        /// Remove every instance whose game object no longer exists, and return how many
+        /// were removed. Instances that do not implement <see cref="IGameObjectState"/>
+        /// are kept, as are those reporting anything but
+        /// <see cref="GameObjectState.Destroyed"/>.
+        /// </summary>
+        public int Sweep ()
+        {
+            List<object> dead = null;
+            foreach (var entry in instances) {
+                var instance = entry.Key as IGameObjectState;
+                if (instance == null)
+                    continue;
+                GameObjectState state;
+                try {
+                    state = instance.GameObjectState;
+                } catch (Exception e) {
+                    // One pass covers the whole store, so an instance that breaks the
+                    // interface's promise not to throw must not stop the rest from being
+                    // checked. Keeping it is the safe answer, on the same grounds as
+                    // reporting anything uncertain as dormant: an instance wrongly kept
+                    // costs memory until the next sweep, where one wrongly removed is gone.
+                    Logger.WriteLine (
+                        "Failed to determine whether an instance in the object store still " +
+                        "exists, so it was kept: " + e.Message, Logger.Severity.Error);
+                    continue;
+                }
+                if (state != GameObjectState.Destroyed)
+                    continue;
+                if (dead == null)
+                    dead = new List<object> ();
+                dead.Add (entry.Key);
+            }
+            if (dead == null)
+                return 0;
+            foreach (var obj in dead)
+                RemoveInstance (obj);
+            return dead.Count;
         }
 
         /// <summary>

--- a/core/src/Service/ObjectStore.cs
+++ b/core/src/Service/ObjectStore.cs
@@ -69,9 +69,17 @@ namespace KRPC.Service
             if (id == 0ul)
                 return null;
             object result;
-            if (!objectIds.TryGetValue (id, out result))
-                throw new ArgumentException ("Instance not found");
-            return result;
+            if (objectIds.TryGetValue (id, out result))
+                return result;
+            // Identifiers are allocated in sequence and never reused, so an identifier
+            // below the next one to be allocated was issued and has since been removed.
+            // That means the object it referred to is gone, rather than the client
+            // having made the identifier up.
+            if (id < nextObjectId)
+                throw new global::KRPC.Service.KRPC.ObjectDestroyedException (
+                    "The object with id " + id + " no longer exists, " +
+                    "as the game object it referred to was destroyed");
+            throw new ArgumentException ("Instance not found");
         }
 
         /// <summary>

--- a/core/src/Utils/GameObjectState.cs
+++ b/core/src/Utils/GameObjectState.cs
@@ -1,0 +1,50 @@
+namespace KRPC.Utils
+{
+    /// <summary>
+    /// What the game holds for the thing that a service object stands for.
+    /// </summary>
+    /// <remarks>
+    /// The values are ordered from most to least alive, so that an object built on
+    /// several others can combine their states with <see cref="GameObjectStates" />.
+    /// </remarks>
+    public enum GameObjectState
+    {
+        /// <summary>
+        /// The game object exists and can be used.
+        /// </summary>
+        Live,
+        /// <summary>
+        /// The game object does not exist, but the game still holds what it needs to
+        /// build it again, so the thing the service object stands for is intact.
+        /// </summary>
+        Dormant,
+        /// <summary>
+        /// The game holds nothing for it. It can never be used again.
+        /// </summary>
+        Destroyed
+    }
+
+    /// <summary>
+    /// Combines the states of the things a service object is built on.
+    /// </summary>
+    public static class GameObjectStates
+    {
+        /// <summary>
+        /// The state of an object that needs both of the things it is built on, which is
+        /// the less alive of their two states.
+        /// </summary>
+        public static GameObjectState LeastAlive (this GameObjectState state, GameObjectState other)
+        {
+            return state > other ? state : other;
+        }
+
+        /// <summary>
+        /// The state of an object that either of the things it is built on is enough for,
+        /// which is the more alive of their two states.
+        /// </summary>
+        public static GameObjectState MostAlive (this GameObjectState state, GameObjectState other)
+        {
+            return state < other ? state : other;
+        }
+    }
+}

--- a/core/src/Utils/IGameObjectState.cs
+++ b/core/src/Utils/IGameObjectState.cs
@@ -1,0 +1,23 @@
+namespace KRPC.Utils
+{
+    /// <summary>
+    /// Implemented by an object that stands for something in the game, which the game
+    /// can destroy. The object store drops objects that report themselves destroyed; an
+    /// object that does not implement this interface is kept until the server stops.
+    /// </summary>
+    public interface IGameObjectState
+    {
+        /// <summary>
+        /// What the game holds for the thing this object stands for.
+        /// </summary>
+        /// <remarks>
+        /// <see cref="GameObjectState.Destroyed" /> means the thing is definitively gone
+        /// and the object can never work again. Anything less certain, including a thing
+        /// the game has unloaded but can build again, is dormant: an object wrongly
+        /// dropped cannot be recovered, whereas one wrongly kept only costs memory until
+        /// it is checked again. Implementations must not throw, as this is called while
+        /// sweeping the whole object store.
+        /// </remarks>
+        GameObjectState GameObjectState { get; }
+    }
+}

--- a/core/test/KRPC.Core.Test.csproj
+++ b/core/test/KRPC.Core.Test.csproj
@@ -76,6 +76,7 @@
     <Compile Include="Service\KRPC\ExpressionTest.cs" />
     <Compile Include="Service\KRPC\KRPCTest.cs" />
     <Compile Include="Service\MessageAssert.cs" />
+    <Compile Include="Service\MortalObject.cs" />
     <Compile Include="Service\ObjectStoreTest.cs" />
     <Compile Include="Service\ProcedureHandlerTest.cs" />
     <Compile Include="Service\ProcedureParameterTest.cs" />

--- a/core/test/KRPC.Core.Test.csproj
+++ b/core/test/KRPC.Core.Test.csproj
@@ -72,6 +72,7 @@
     <Compile Include="Service\ClassMethodHandlerTest.cs" />
     <Compile Include="Service\DocumentationUtilsTest.cs" />
     <Compile Include="Service\GameSceneTest.cs" />
+    <Compile Include="Service\GameStateTest.cs" />
     <Compile Include="Service\ITestService.cs" />
     <Compile Include="Service\KRPC\ExpressionTest.cs" />
     <Compile Include="Service\KRPC\KRPCTest.cs" />

--- a/core/test/Service/GameStateTest.cs
+++ b/core/test/Service/GameStateTest.cs
@@ -28,6 +28,17 @@ namespace KRPC.Test.Service
         }
 
         [Test]
+        public void ARequestedSweepLeavesTheGenerationAlone ()
+        {
+            var generation = GameState.Generation;
+            GameState.RequestSweep ();
+            Assert.IsTrue (GameState.SweepPending);
+            Assert.AreEqual (generation, GameState.Generation);
+            GameState.Sweep ();
+            Assert.IsFalse (GameState.SweepPending);
+        }
+
+        [Test]
         public void SweepsTheObjectStore ()
         {
             var store = ObjectStore.Instance;

--- a/core/test/Service/GameStateTest.cs
+++ b/core/test/Service/GameStateTest.cs
@@ -1,0 +1,47 @@
+using KRPC.Service;
+using KRPC.Utils;
+using NUnit.Framework;
+using ObjectDestroyedException = KRPC.Service.KRPC.ObjectDestroyedException;
+
+namespace KRPC.Test.Service
+{
+    [TestFixture]
+    public class GameStateTest
+    {
+        [Test]
+        public void GenerationMovesOn ()
+        {
+            var generation = GameState.Generation;
+            GameState.Changed ();
+            Assert.AreEqual (generation + 1, GameState.Generation);
+            GameState.Changed ();
+            Assert.AreEqual (generation + 2, GameState.Generation);
+        }
+
+        [Test]
+        public void AChangeLeavesASweepPending ()
+        {
+            GameState.Changed ();
+            Assert.IsTrue (GameState.SweepPending);
+            GameState.Sweep ();
+            Assert.IsFalse (GameState.SweepPending);
+        }
+
+        [Test]
+        public void SweepsTheObjectStore ()
+        {
+            var store = ObjectStore.Instance;
+            var alive = new MortalObject ();
+            var dead = new MortalObject ();
+            var aliveId = store.AddInstance (alive);
+            var deadId = store.AddInstance (dead);
+            dead.GameObjectState = GameObjectState.Destroyed;
+
+            GameState.Sweep ();
+
+            Assert.AreSame (alive, store.GetInstance (aliveId));
+            Assert.Throws<ObjectDestroyedException> (() => store.GetInstance (deadId));
+            store.RemoveInstance (alive);
+        }
+    }
+}

--- a/core/test/Service/KRPC/KRPCTest.cs
+++ b/core/test/Service/KRPC/KRPCTest.cs
@@ -144,10 +144,13 @@ namespace KRPC.Test.Service.KRPC
                 } else if (exception.Name == "ArgumentOutOfRangeException") {
                     MessageAssert.HasDocumentation (exception,
                         "<doc>\n<summary>\nThe value of an argument is outside the allowable range of values as defined by the invoked method.\n</summary>\n</doc>");
+                } else if (exception.Name == "ObjectDestroyedException") {
+                    MessageAssert.HasDocumentation (exception,
+                        "<doc>\n<summary>\nThe game object that a service object refers to no longer exists,\nso the object cannot be used. For example, the part it represents\nwas destroyed, or the vessel it belongs to was recovered.\n</summary>\n</doc>");
                 }
                 foundExceptions++;
             }
-            Assert.AreEqual (4, foundExceptions);
+            Assert.AreEqual (5, foundExceptions);
         }
 
         [Test]

--- a/core/test/Service/MortalObject.cs
+++ b/core/test/Service/MortalObject.cs
@@ -1,0 +1,28 @@
+using System;
+using KRPC.Utils;
+
+namespace KRPC.Test.Service
+{
+    /// <summary>
+    /// An object standing for a game object that the test can destroy.
+    /// </summary>
+    sealed class MortalObject : IGameObjectState
+    {
+        /// <summary>
+        /// Whether reading the state raises, which the interface forbids and the store
+        /// has to survive anyway.
+        /// </summary>
+        public bool StateThrows { get; set; }
+
+        GameObjectState state = GameObjectState.Live;
+
+        public GameObjectState GameObjectState {
+            get {
+                if (StateThrows)
+                    throw new InvalidOperationException ("the game object cannot be read");
+                return state;
+            }
+            set { state = value; }
+        }
+    }
+}

--- a/core/test/Service/ObjectStoreTest.cs
+++ b/core/test/Service/ObjectStoreTest.cs
@@ -1,5 +1,6 @@
 using System;
 using KRPC.Service;
+using KRPC.Utils;
 using NUnit.Framework;
 using ObjectDestroyedException = KRPC.Service.KRPC.ObjectDestroyedException;
 
@@ -62,6 +63,83 @@ namespace KRPC.Test.Service
             Assert.AreEqual (1, store.AddInstance (a));
             Assert.AreEqual (1, store.GetObjectId (a));
             Assert.AreSame (a, store.GetInstance (1));
+        }
+
+        [Test]
+        public void SweepRemovesDeadInstances ()
+        {
+            var store = new ObjectStore ();
+            var alive = new MortalObject ();
+            var dead = new MortalObject ();
+            var aliveId = store.AddInstance (alive);
+            var deadId = store.AddInstance (dead);
+            dead.GameObjectState = GameObjectState.Destroyed;
+
+            Assert.AreEqual (1, store.Sweep ());
+            Assert.AreSame (alive, store.GetInstance (aliveId));
+            Assert.AreEqual (aliveId, store.GetObjectId (alive));
+            Assert.Throws<ArgumentException> (() => store.GetObjectId (dead));
+            Assert.Throws<ObjectDestroyedException> (() => store.GetInstance (deadId));
+        }
+
+        [Test]
+        public void SweepKeepsDormantInstances ()
+        {
+            var store = new ObjectStore ();
+            var dormant = new MortalObject ();
+            var id = store.AddInstance (dormant);
+            dormant.GameObjectState = GameObjectState.Dormant;
+
+            Assert.AreEqual (0, store.Sweep ());
+            Assert.AreSame (dormant, store.GetInstance (id));
+        }
+
+        [Test]
+        public void SweepKeepsInstancesWithoutAGameObjectState ()
+        {
+            var store = new ObjectStore ();
+            var id = store.AddInstance (a);
+            Assert.AreEqual (0, store.Sweep ());
+            Assert.AreSame (a, store.GetInstance (id));
+        }
+
+        [Test]
+        public void SweepKeepsAnInstanceWhoseStateThrows ()
+        {
+            var store = new ObjectStore ();
+            var broken = new MortalObject { StateThrows = true };
+            var dead = new MortalObject ();
+            var brokenId = store.AddInstance (broken);
+            var deadId = store.AddInstance (dead);
+            dead.GameObjectState = GameObjectState.Destroyed;
+
+            // The rest of the store is still swept, and the instance that could not be
+            // asked is kept rather than dropped on the strength of an error.
+            Assert.AreEqual (1, store.Sweep ());
+            Assert.AreSame (broken, store.GetInstance (brokenId));
+            Assert.Throws<ObjectDestroyedException> (() => store.GetInstance (deadId));
+        }
+
+        [Test]
+        public void SweepRemovesAnInstanceOnlyOnce ()
+        {
+            var store = new ObjectStore ();
+            var dead = new MortalObject ();
+            store.AddInstance (dead);
+            dead.GameObjectState = GameObjectState.Destroyed;
+            Assert.AreEqual (1, store.Sweep ());
+            Assert.AreEqual (0, store.Sweep ());
+        }
+
+        [Test]
+        public void SweepDoesNotReuseObjectIds ()
+        {
+            var store = new ObjectStore ();
+            var dead = new MortalObject ();
+            var deadId = store.AddInstance (dead);
+            dead.GameObjectState = GameObjectState.Destroyed;
+            store.Sweep ();
+            Assert.AreNotEqual (deadId, store.AddInstance (new MortalObject ()));
         }
 
         [Test]

--- a/core/test/Service/ObjectStoreTest.cs
+++ b/core/test/Service/ObjectStoreTest.cs
@@ -1,6 +1,7 @@
 using System;
 using KRPC.Service;
 using NUnit.Framework;
+using ObjectDestroyedException = KRPC.Service.KRPC.ObjectDestroyedException;
 
 namespace KRPC.Test.Service
 {
@@ -25,11 +26,11 @@ namespace KRPC.Test.Service
             Assert.AreSame (b, store.GetInstance (2));
             Assert.AreSame (c, store.GetInstance (3));
             store.RemoveInstance (a);
-            Assert.Throws<ArgumentException> (() => store.GetInstance (1));
+            Assert.Throws<ObjectDestroyedException> (() => store.GetInstance (1));
             store.RemoveInstance (b);
-            Assert.Throws<ArgumentException> (() => store.GetInstance (2));
+            Assert.Throws<ObjectDestroyedException> (() => store.GetInstance (2));
             store.RemoveInstance (c);
-            Assert.Throws<ArgumentException> (() => store.GetInstance (3));
+            Assert.Throws<ObjectDestroyedException> (() => store.GetInstance (3));
         }
 
         [Test]
@@ -39,6 +40,16 @@ namespace KRPC.Test.Service
             Assert.Throws<ArgumentException> (() => store.GetObjectId (a));
             Assert.Throws<ArgumentException> (() => store.GetInstance (1));
             Assert.DoesNotThrow (() => store.RemoveInstance (a));
+        }
+
+        [Test]
+        public void RemovedAndUnissuedObjectIds ()
+        {
+            var store = new ObjectStore ();
+            var id = store.AddInstance (a);
+            store.RemoveInstance (a);
+            Assert.Throws<ObjectDestroyedException> (() => store.GetInstance (id));
+            Assert.Throws<ArgumentException> (() => store.GetInstance (id + 1));
         }
 
         [Test]

--- a/doc/api/krpc/krpc.tmpl
+++ b/doc/api/krpc/krpc.tmpl
@@ -23,3 +23,4 @@ KRPC
 {{ macros.exception(services['KRPC'].exceptions['ArgumentException']) }}
 {{ macros.exception(services['KRPC'].exceptions['ArgumentNullException']) }}
 {{ macros.exception(services['KRPC'].exceptions['ArgumentOutOfRangeException']) }}
+{{ macros.exception(services['KRPC'].exceptions['ObjectDestroyedException']) }}

--- a/doc/order.txt
+++ b/doc/order.txt
@@ -82,6 +82,7 @@ KRPC.InvalidOperationException
 KRPC.ArgumentException
 KRPC.ArgumentNullException
 KRPC.ArgumentOutOfRangeException
+KRPC.ObjectDestroyedException
 SpaceCenter
 SpaceCenter.GameMode
 SpaceCenter.Expansions

--- a/doc/src/cnano/client.rst
+++ b/doc/src/cnano/client.rst
@@ -204,6 +204,10 @@ The following example demonstrates how to invoke remote procedures using the Cna
 
 .. literalinclude:: /scripts/client/cnano/RemoteProcedures.c
 
+Many procedures return an object standing for something in the game, such as a vessel or
+a part. See :doc:`Object Lifetime </tutorials/object-lifetime>` for what those objects do
+when a game is loaded or the thing they stand for is destroyed.
+
 .. _cnano-client-streams:
 .. _cnano-client-events:
 

--- a/doc/src/cpp/client.rst
+++ b/doc/src/cpp/client.rst
@@ -116,6 +116,10 @@ its altitude:
 
 .. literalinclude:: /scripts/client/cpp/RemoteProcedures.cpp
 
+Many procedures return an object standing for something in the game, such as a vessel or
+a part. See :doc:`Object Lifetime </tutorials/object-lifetime>` for what those objects do
+when a game is loaded or the thing they stand for is destroyed.
+
 .. _cpp-client-streams:
 
 Streaming Data

--- a/doc/src/csharp/client.rst
+++ b/doc/src/csharp/client.rst
@@ -53,6 +53,10 @@ vessel and then prints out its altitude:
 
 .. literalinclude:: /scripts/client/csharp/RemoteProcedures.cs
 
+Many procedures return an object standing for something in the game, such as a vessel or
+a part. See :doc:`Object Lifetime </tutorials/object-lifetime>` for what those objects do
+when a game is loaded or the thing they stand for is destroyed.
+
 .. _csharp-client-streams:
 
 Streaming Data

--- a/doc/src/dictionary.txt
+++ b/doc/src/dictionary.txt
@@ -139,6 +139,7 @@ py
 quaternion
 quaternions
 quickload
+quickloading
 quicksave
 radians
 reactively

--- a/doc/src/dictionary.txt
+++ b/doc/src/dictionary.txt
@@ -18,6 +18,7 @@ Kerbin
 Konstructs
 Kosmo
 Landers
+LaserDist
 LaunchPad
 MoI
 ModuleEngines
@@ -25,6 +26,7 @@ MyGroup
 NUnit
 Olex
 PID
+RemoteTech
 Tron
 Wheesley
 accelerometers

--- a/doc/src/java/client.rst
+++ b/doc/src/java/client.rst
@@ -56,6 +56,10 @@ vessel and then prints out its altitude:
 
 .. literalinclude:: /scripts/client/java/RemoteProcedures.java
 
+Many procedures return an object standing for something in the game, such as a vessel or
+a part. See :doc:`Object Lifetime </tutorials/object-lifetime>` for what those objects do
+when a game is loaded or the thing they stand for is destroyed.
+
 .. _java-client-streams:
 
 Streaming Data

--- a/doc/src/lua/client.rst
+++ b/doc/src/lua/client.rst
@@ -56,6 +56,10 @@ InfernalRobotics service is accessible via ``conn.infernal_robotics``.
 Calling methods, getting or setting properties, etc. are mapped to remote
 procedure calls and passed to the server by the lua client.
 
+Many procedures return an object standing for something in the game, such as a vessel or
+a part. See :doc:`Object Lifetime </tutorials/object-lifetime>` for what those objects do
+when a game is loaded or the thing they stand for is destroyed.
+
 Streams and Events
 ------------------
 

--- a/doc/src/python/client.rst
+++ b/doc/src/python/client.rst
@@ -48,6 +48,10 @@ The following example demonstrates how to invoke remote procedures using the Pyt
 
 .. literalinclude:: /scripts/client/python/RemoteProcedures.py
 
+Many procedures return an object standing for something in the game, such as a vessel or
+a part. See :doc:`Object Lifetime </tutorials/object-lifetime>` for what those objects do
+when a game is loaded or the thing they stand for is destroyed.
+
 All of the functionality provided by the ``SpaceCenter`` service is accessible via
 ``conn.space_center``. To explore the functionality provided by a service, you can use the
 ``help()`` function from an interactive terminal. For example, running ``help(conn.space_center)``

--- a/doc/src/tutorials.rst
+++ b/doc/src/tutorials.rst
@@ -1,5 +1,5 @@
-Tutorials and Examples
-======================
+Tutorials
+=========
 
 This collection of tutorials and example scripts explain how to use the features
 of kRPC.
@@ -14,4 +14,5 @@ of kRPC.
    tutorials/parts
    tutorials/docking-guidance
    tutorials/user-interface
+   tutorials/object-lifetime
    tutorials/autopilot

--- a/doc/src/tutorials/object-lifetime.rst
+++ b/doc/src/tutorials/object-lifetime.rst
@@ -79,3 +79,29 @@ Anything the game cannot currently answer for reports itself the same way, rathe
 claiming to be gone. A maneuver node of a vessel the game is not computing a flight plan for
 is one case, and a call that arrives while the game is between states, part way through
 loading one, is another.
+
+Objects in the editor
+---------------------
+
+The vessel under construction in the VAB or the SPH follows the same rules, with one
+difference: nothing there has an unloaded form. The editor holds exactly one vessel, so a part
+that is no longer in it is gone for good rather than waiting to be loaded, and using it raises
+``KRPC.ObjectDestroyedException``.
+
+Loading a craft into the editor starts a new vessel, and the parts of the vessel it replaced
+are gone. That is so whether or not the craft loaded is the one the editor already had: a
+part in the editor is named by an identifier that is only unique within one vessel, and a
+craft file saved from another carries those identifiers over, so a part of the old vessel
+cannot be told apart from the part of the new one that answers to the same identifier. Rather
+than hand back a part of a vessel that was never asked for, both raise
+``KRPC.ObjectDestroyedException``.
+
+Undo and redo are not a new vessel. They rebuild the one the editor already has, and the
+parts they rebuild keep the identifiers they had, so objects for the parts an undo leaves
+alone go on working. An object for a part that an undo takes away raises
+``KRPC.ObjectDestroyedException``, as one for any part no longer in the vessel does. An
+object is not expected to survive an undo followed by a redo.
+
+Leaving the editor destroys the vessel it had open, and with it every object reached through
+``SpaceCenter.Editor``: its parts, their part modules, its stages and its resources. A script
+that returns to the editor has to obtain them again.

--- a/doc/src/tutorials/object-lifetime.rst
+++ b/doc/src/tutorials/object-lifetime.rst
@@ -105,3 +105,39 @@ object is not expected to survive an undo followed by a redo.
 Leaving the editor destroys the vessel it had open, and with it every object reached through
 ``SpaceCenter.Editor``: its parts, their part modules, its stages and its resources. A script
 that returns to the editor has to obtain them again.
+
+Objects in other services
+-------------------------
+
+The same rules hold for every service, not only ``SpaceCenter``.
+
+An object a client makes itself follows what the game does with it. A line or a marker from
+the ``Drawing`` service, a panel or a button from ``UI``, and a force from ``Part.AddForce``
+are all gone once they are removed, once the service's ``Clear`` is called, or once the scene
+changes, and using one then raises ``KRPC.ObjectDestroyedException``. The server also removes
+what a client made when that client disconnects. A force is applied to a part, so it also
+stops, and is gone, once that part is destroyed.
+
+An object that stands for something on a part or a vessel is exactly as alive as the part or
+the vessel. A RemoteTech antenna, an Infernal Robotics servo, a LaserDist laser and a docking
+camera all raise the exception once their part is destroyed, or once the part no longer
+carries the module that made it one of those things. An Infernal Robotics servo group is named
+by its vessel and the group's name, so renaming a group leaves every object for it standing
+for a group the vessel no longer has, exactly as renaming a kerbal does, and an object for the
+group has to be obtained again under the new name.
+
+An object that stands for a record the game keeps finds that record again on every call, so it
+goes on working when the game rebuilds it and raises the exception once the game no longer has
+it. An alarm, a contract and its parameters, and a Kerbal Alarm Clock alarm all keep working
+across a load; removing an alarm or a waypoint leaves the object for it gone. A waypoint a
+client creates is not written into the save, so it does not outlive the game state it was
+created in.
+
+A comm link is a hop in a vessel's control path, and reports that path as it is now rather
+than as it was when the object was obtained. A path that no longer takes the hop has lost
+contact rather than destroyed anything, so the link reports itself as not currently connected,
+which is the not-loaded case above, and works again if the path takes it again.
+
+Where a mod is not installed, or is not ready to be asked, its objects report themselves as
+unavailable rather than gone, for the same reason a part that is not loaded does: nothing that
+can be asked has said the thing is not there.

--- a/doc/src/tutorials/object-lifetime.rst
+++ b/doc/src/tutorials/object-lifetime.rst
@@ -1,0 +1,81 @@
+Object Lifetime
+===============
+
+Many remote procedures return an object: a vessel, a part, a part module, a maneuver node, a
+reference frame. Such an object is a *name* for something in the game, not a copy of it and
+not a pointer into the game's memory. Every call made through it looks the thing up in the
+game again, which is what lets an object outlive the game tearing down and rebuilding what it
+names, and what lets the server say clearly when the thing is gone.
+
+Objects follow the game
+-----------------------
+
+Loading a save, quickloading and reverting all replace the game's own objects, and the game
+also rebuilds a vessel's parts whenever it comes back into range. An object obtained before
+any of that keeps working afterwards, provided the thing it names still exists, and reads the
+state of the loaded game rather than the state it was obtained in.
+
+So a script can hold onto a vessel or a part across a quickload. In Python, for example:
+
+.. code-block:: python
+
+   vessel = conn.space_center.active_vessel
+   parachute = vessel.parts.with_name('parachuteSingle')[0].parachute
+   conn.space_center.quickload()
+   # after the load, this reads the parachute of the game that was loaded
+   print(parachute.state)
+
+Objects that are gone
+---------------------
+
+When the thing an object names no longer exists, every member of that object that reads the
+game raises ``KRPC.ObjectDestroyedException`` instead of returning a value. A part raises it
+once it has been destroyed, or its vessel destroyed or recovered; a vessel raises it once it
+has been recovered or destroyed; a maneuver node raises it once it has been removed from the
+vessel's flight plan, which includes every node the vessel had before a game was loaded; a
+science subject raises it once the game state it was read from has been replaced.
+
+An object can also become gone because of what a client itself does. A crew member is named
+by the kerbal's name, which is what the game keeps its roster under, so renaming a kerbal by
+setting ``CrewMember.Name`` leaves every object for that kerbal standing for a kerbal the
+roster no longer has, including the one the rename was made through. They all raise the
+exception from then on, and an object for the renamed kerbal has to be obtained again under
+the new name.
+
+A few members read nothing and so raise nothing: those that hand back what the object was
+built from, such as the part a part module belongs to, or the name of a field. They answer as
+they always did, and what they hand back raises the exception itself as soon as it is used.
+
+The exception is documented in the ``KRPC`` API reference for each client language, alongside
+the other exceptions the server can raise, and is caught like any other exception the client
+library defines. In Python:
+
+.. code-block:: python
+
+   try:
+       print(part.temperature)
+   except conn.krpc.ObjectDestroyedException:
+       print('that part is gone')
+
+The server also stops holding an object once the thing it names is gone, which it does when a
+game is loaded. Using such an object afterwards raises the same exception, so a client cannot
+tell whether the server still had the object or had already let go of it. That is deliberate:
+either way, the answer is that the thing is gone and a fresh object has to be obtained from
+the vessel, its parts, or wherever the first one came from.
+
+Objects that are not loaded
+---------------------------
+
+A vessel far enough from the active vessel is *unloaded*: the game keeps it as orbital data
+and a description of its parts, and instantiates the parts again when it comes back into
+range. The vessel itself is unaffected and can be read normally, but its parts do not exist to
+be read, so using one raises an error saying that the part is not loaded.
+
+That is not the same as the part being destroyed, and it is temporary. The part works again
+once the game loads the vessel, and the object stays valid throughout. ``Vessel.Loaded``
+reports whether a vessel's parts are there to be used.
+
+Anything the game cannot currently answer for reports itself the same way, rather than
+claiming to be gone. A maneuver node of a vessel the game is not computing a flight plan for
+is one case, and a call that arrives while the game is between states, part way through
+loading one, is another.

--- a/server/CHANGELOG.md
+++ b/server/CHANGELOG.md
@@ -9,6 +9,11 @@
 - Fix setting `KRPC.GameScene` from one editor straight to the other leaving the flight camera
   unable to follow a vessel for the rest of the session. The switch also keeps the vessel that is
   being constructed now, as the game's own switch editor button does (#1038)
+- Sweep objects whose game objects no longer exist out of the object store when the game
+  loads, quickloads or reverts a game state, or changes scene, when it destroys a part or a
+  vessel, and when a client removes something it owns such as a drawing, a user interface
+  element or a force, so an object that has become useless is let go of promptly rather than
+  at the next load (#1051)
 
 ## [v0.6.0]
 - Fix server version reported to clients (read from `KRPC.dll` not `KRPC.Core.dll`) (#848)

--- a/server/src/Addon.cs
+++ b/server/src/Addon.cs
@@ -85,6 +85,10 @@ namespace KRPC
             Service.CallContext.GameScene = gameScene;
             Utils.Logger.WriteLine ("Game scene switched to " + gameScene);
 
+            // The scene being left takes its game objects with it, so the service objects
+            // standing for them are due to be swept once the new scene is built.
+            Service.GameState.Changed ();
+
             // Auto-start the server, if required
             if (config.Configuration.AutoStartServers) {
                 Utils.Logger.WriteLine ("Auto-starting server");
@@ -199,6 +203,7 @@ namespace KRPC
 
             // KSP events
             IsPaused = false;
+            GameEvents.onGameStatePostLoad.Add(OnGameStatePostLoad);
             GameEvents.onGamePause.Add(OnGamePause);
             GameEvents.onGameUnpause.Add(OnGameUnpause);
             GameEvents.onEditorRestart.Add(OnEditorRestart);
@@ -236,6 +241,13 @@ namespace KRPC
                 Utils.Logger.WriteLine("Asking player to accept client connection (" + e.Client.Address + ")");
                 clientConnectingDialog.OnClientRequestingConnection(sender, e);
             }
+        }
+
+        void OnGameStatePostLoad(ConfigNode node)
+        {
+            // Fired when a game is loaded, quickloaded or reverted, which replaces every
+            // game object the service objects stand for.
+            Service.GameState.Changed();
         }
 
         void OnGamePause()
@@ -321,6 +333,7 @@ namespace KRPC
         /// </summary>
         public void OnDestroy ()
         {
+            GameEvents.onGameStatePostLoad.Remove(OnGameStatePostLoad);
             GameEvents.onGamePause.Remove(OnGamePause);
             GameEvents.onGameUnpause.Remove(OnGameUnpause);
             GameEvents.onEditorRestart.Remove(OnEditorRestart);
@@ -367,6 +380,34 @@ namespace KRPC
             GUILayoutExtensions.OnGUI ();
         }
 
+        // The number of vessels the game had on the previous update, used to tell whether
+        // it has finished listing them. -1 means nothing has been counted yet.
+        static int lastVesselCount = -1;
+
+        /// <summary>
+        /// Sweep the object store, once the game has finished building the state it loaded.
+        /// </summary>
+        /// <remarks>
+        /// A scene is not populated at the moment it is switched to: the game adds its
+        /// vessels over the following frames, and a sweep run before it has finished sees
+        /// objects that are about to exist as gone. There is no event for having finished,
+        /// so wait for the count to stop changing, which also covers a game that adds
+        /// vessels more slowly than usual. A game with no vessels at all says nothing
+        /// about what exists, so nothing is swept then.
+        /// </remarks>
+        static void SweepObjectStore ()
+        {
+            if (HighLogic.CurrentGame == null || FlightGlobals.Vessels == null) {
+                lastVesselCount = -1;
+                return;
+            }
+            var count = FlightGlobals.Vessels.Count;
+            var settled = count > 0 && count == lastVesselCount;
+            lastVesselCount = count;
+            if (settled)
+                Service.GameState.Sweep ();
+        }
+
         /// <summary>
         /// Trigger server update
         /// </summary>
@@ -374,6 +415,8 @@ namespace KRPC
         {
             if (!ServicesChecker.OK)
                 return;
+            if (Service.GameState.SweepPending)
+                SweepObjectStore ();
             if (core != null && core.AnyRunning)
                 core.Update ();
         }

--- a/server/src/Addon.cs
+++ b/server/src/Addon.cs
@@ -204,6 +204,8 @@ namespace KRPC
             // KSP events
             IsPaused = false;
             GameEvents.onGameStatePostLoad.Add(OnGameStatePostLoad);
+            GameEvents.onPartDie.Add(OnPartDie);
+            GameEvents.onVesselDestroy.Add(OnVesselDestroy);
             GameEvents.onGamePause.Add(OnGamePause);
             GameEvents.onGameUnpause.Add(OnGameUnpause);
             GameEvents.onEditorRestart.Add(OnEditorRestart);
@@ -248,6 +250,18 @@ namespace KRPC
             // Fired when a game is loaded, quickloaded or reverted, which replaces every
             // game object the service objects stand for.
             Service.GameState.Changed();
+        }
+
+        void OnPartDie(Part part)
+        {
+            // The part is gone, so the objects standing for it and for its modules can go
+            // too, without waiting for the next game to be loaded.
+            Service.GameState.RequestSweep();
+        }
+
+        void OnVesselDestroy(Vessel vessel)
+        {
+            Service.GameState.RequestSweep();
         }
 
         void OnGamePause()
@@ -334,6 +348,8 @@ namespace KRPC
         public void OnDestroy ()
         {
             GameEvents.onGameStatePostLoad.Remove(OnGameStatePostLoad);
+            GameEvents.onPartDie.Remove(OnPartDie);
+            GameEvents.onVesselDestroy.Remove(OnVesselDestroy);
             GameEvents.onGamePause.Remove(OnGamePause);
             GameEvents.onGameUnpause.Remove(OnGameUnpause);
             GameEvents.onEditorRestart.Remove(OnEditorRestart);

--- a/server/src/Addon.cs
+++ b/server/src/Addon.cs
@@ -87,7 +87,7 @@ namespace KRPC
 
             // The scene being left takes its game objects with it, so the service objects
             // standing for them are due to be swept once the new scene is built.
-            Service.GameState.Changed ();
+            GameStateChanged ();
 
             // Auto-start the server, if required
             if (config.Configuration.AutoStartServers) {
@@ -205,6 +205,7 @@ namespace KRPC
             IsPaused = false;
             GameEvents.onGameStatePostLoad.Add(OnGameStatePostLoad);
             GameEvents.onPartDie.Add(OnPartDie);
+            GameEvents.onEditorShipModified.Add(OnEditorShipModified);
             GameEvents.onVesselDestroy.Add(OnVesselDestroy);
             GameEvents.onGamePause.Add(OnGamePause);
             GameEvents.onGameUnpause.Add(OnGameUnpause);
@@ -249,13 +250,38 @@ namespace KRPC
         {
             // Fired when a game is loaded, quickloaded or reverted, which replaces every
             // game object the service objects stand for.
-            Service.GameState.Changed();
+            GameStateChanged();
+        }
+
+        /// <summary>
+        /// Record that the game has replaced the state its game objects belong to.
+        /// </summary>
+        /// <remarks>
+        /// The count that says whether the game has finished building a state starts
+        /// again, because what the state being replaced counted says nothing about the
+        /// one being built, and a count carried over from it can equal the first count of
+        /// the new one by coincidence and report a state that has not begun to settle as
+        /// settled.
+        /// </remarks>
+        static void GameStateChanged ()
+        {
+            Service.GameState.Changed ();
+            lastCount = -1;
         }
 
         void OnPartDie(Part part)
         {
             // The part is gone, so the objects standing for it and for its modules can go
             // too, without waiting for the next game to be loaded.
+            Service.GameState.RequestSweep();
+        }
+
+        void OnEditorShipModified(ShipConstruct ship)
+        {
+            // Anything no longer in the vessel under construction is gone, as the editor
+            // holds no other vessel it could be in. The game raises no part-died event in
+            // the editor, and fires this for every change to the vessel, a part deleted
+            // and a different craft loaded included.
             Service.GameState.RequestSweep();
         }
 
@@ -349,6 +375,7 @@ namespace KRPC
         {
             GameEvents.onGameStatePostLoad.Remove(OnGameStatePostLoad);
             GameEvents.onPartDie.Remove(OnPartDie);
+            GameEvents.onEditorShipModified.Remove(OnEditorShipModified);
             GameEvents.onVesselDestroy.Remove(OnVesselDestroy);
             GameEvents.onGamePause.Remove(OnGamePause);
             GameEvents.onGameUnpause.Remove(OnGameUnpause);
@@ -396,9 +423,10 @@ namespace KRPC
             GUILayoutExtensions.OnGUI ();
         }
 
-        // The number of vessels the game had on the previous update, used to tell whether
-        // it has finished listing them. -1 means nothing has been counted yet.
-        static int lastVesselCount = -1;
+        // What the game had on the previous update of the sweep that is pending now: the
+        // number of vessels, or in an editor the number of parts in the vessel it has open.
+        // -1 means nothing counted yet.
+        static int lastCount = -1;
 
         /// <summary>
         /// Sweep the object store, once the game has finished building the state it loaded.
@@ -408,20 +436,49 @@ namespace KRPC
         /// vessels over the following frames, and a sweep run before it has finished sees
         /// objects that are about to exist as gone. There is no event for having finished,
         /// so wait for the count to stop changing, which also covers a game that adds
-        /// vessels more slowly than usual. A game with no vessels at all says nothing
+        /// vessels more slowly than usual. A game with nothing in it at all says nothing
         /// about what exists, so nothing is swept then.
+        ///
+        /// In an editor the objects stand for the vessel it has open rather than for
+        /// anything in the vessel list, which is empty on a save with nothing in flight,
+        /// and that vessel is rebuilt a part at a time in the same way. Its part count is
+        /// what settles there, which is what keeps a sweep out of the middle of a craft
+        /// being loaded, where the parts of the craft being reloaded are briefly absent.
+        ///
+        /// Only counts taken since the sweep was asked for say anything about whether the
+        /// game has finished: one left over from an earlier sweep can equal the first count
+        /// of this one by coincidence, which would report a state that has not begun to
+        /// settle as settled. The count is therefore forgotten whenever no sweep is due.
         /// </remarks>
         static void SweepObjectStore ()
         {
-            if (HighLogic.CurrentGame == null || FlightGlobals.Vessels == null) {
-                lastVesselCount = -1;
+            if (HighLogic.CurrentGame == null) {
+                lastCount = -1;
                 return;
             }
-            var count = FlightGlobals.Vessels.Count;
-            var settled = count > 0 && count == lastVesselCount;
-            lastVesselCount = count;
+            var count = HighLogic.LoadedSceneIsEditor ? EditorPartCount : VesselCount;
+            if (count < 0) {
+                lastCount = -1;
+                return;
+            }
+            var settled = count > 0 && count == lastCount;
+            lastCount = count;
             if (settled)
                 Service.GameState.Sweep ();
+        }
+
+        // The number of vessels the game lists, or -1 if it is not listing them yet.
+        static int VesselCount {
+            get { return FlightGlobals.Vessels == null ? -1 : FlightGlobals.Vessels.Count; }
+        }
+
+        // The number of parts in the vessel the editor has open, or -1 if it has none.
+        static int EditorPartCount {
+            get {
+                var editor = EditorLogic.fetch;
+                var ship = editor == null ? null : editor.ship;
+                return ReferenceEquals (ship, null) || ship.parts == null ? -1 : ship.parts.Count;
+            }
         }
 
         /// <summary>
@@ -433,6 +490,8 @@ namespace KRPC
                 return;
             if (Service.GameState.SweepPending)
                 SweepObjectStore ();
+            else
+                lastCount = -1;
             if (core != null && core.AnyRunning)
                 core.Update ();
         }

--- a/server/src/Utils/ClientOwnedObjects.cs
+++ b/server/src/Utils/ClientOwnedObjects.cs
@@ -22,6 +22,7 @@ namespace KRPC.Utils
         readonly List<Entry> entries = new List<Entry> ();
         readonly List<Entry> detached = new List<Entry> ();
         readonly Action<T> release;
+        readonly bool givenToClients;
 
         /// <summary>
         /// Create a collection. The release action, if any, is invoked on each object
@@ -30,10 +31,15 @@ namespace KRPC.Utils
         /// teardown). The collection adds itself to <see cref="ClientOwnedState" />, so
         /// that its state is released along with everything else when there is no game
         /// left to hold it.
+        ///
+        /// An object a client is given holds an identifier in the object store, so the
+        /// collection letting go of one asks for the store to be swept. A collection whose
+        /// objects are never handed out passes false, having nothing there to sweep.
         /// </summary>
-        public ClientOwnedObjects (Action<T> release = null)
+        public ClientOwnedObjects (Action<T> release = null, bool givenToClients = true)
         {
             this.release = release;
+            this.givenToClients = givenToClients;
             ClientOwnedState.Register (this);
         }
 
@@ -66,6 +72,7 @@ namespace KRPC.Utils
             if (index < 0)
                 return false;
             entries.RemoveAt (index);
+            LetGo (1);
             return true;
         }
 
@@ -75,7 +82,43 @@ namespace KRPC.Utils
         /// </summary>
         public void RemoveAll (Predicate<T> predicate)
         {
-            entries.RemoveAll (x => predicate (x.Object));
+            LetGo (entries.RemoveAll (x => predicate (x.Object)));
+        }
+
+        /// <summary>
+        /// Remove the objects that stand for something the game has destroyed, without
+        /// invoking the release action: what they held is already gone, so there is
+        /// nothing left to tear down. An object that does not say what the game holds for
+        /// it is kept, as is one that is merely not loaded, which the game can bring back.
+        /// </summary>
+        /// <remarks>
+        /// An addon that acts on its objects every frame calls this first, so that a
+        /// destroyed object is dropped rather than reached into from the frame loop, where
+        /// there is no client call to report the failure to.
+        /// </remarks>
+        public void RemoveDestroyed ()
+        {
+            LetGo (entries.RemoveAll (x => {
+                var obj = x.Object as IGameObjectState;
+                return obj != null && obj.GameObjectState == GameObjectState.Destroyed;
+            }));
+        }
+
+        /// <summary>
+        /// Record that the collection has let go of the given number of objects, so that
+        /// the object store is swept.
+        /// </summary>
+        /// <remarks>
+        /// What the collection lets go of is either already gone from the game or torn
+        /// down by the release action, so the objects standing for it are due to leave the
+        /// object store as well. Nothing else says so: a client removing its own line,
+        /// panel or force destroys nothing the game raises an event for, so without this
+        /// the object would sit in the store until something unrelated was destroyed.
+        /// </remarks>
+        void LetGo (int count)
+        {
+            if (count > 0 && givenToClients)
+                GameState.RequestSweep ();
         }
 
         /// <summary>
@@ -91,14 +134,17 @@ namespace KRPC.Utils
         /// </summary>
         public void Sweep ()
         {
+            var released = 0;
             for (var i = entries.Count - 1; i >= 0; i--) {
                 var entry = entries [i];
                 if (ClientConnections.Disconnected (entry.Owner)) {
                     entries.RemoveAt (i);
+                    released++;
                     if (release != null)
                         release (entry.Object);
                 }
             }
+            LetGo (released);
         }
 
         /// <summary>
@@ -106,14 +152,17 @@ namespace KRPC.Utils
         /// </summary>
         public void Clear (IClient owner)
         {
+            var released = 0;
             for (var i = entries.Count - 1; i >= 0; i--) {
                 var entry = entries [i];
                 if (entry.Owner == owner) {
                     entries.RemoveAt (i);
+                    released++;
                     if (release != null)
                         release (entry.Object);
                 }
             }
+            LetGo (released);
         }
 
         /// <summary>
@@ -126,6 +175,7 @@ namespace KRPC.Utils
             if (release != null)
                 foreach (var entry in released)
                     release (entry.Object);
+            LetGo (released.Count);
         }
 
         /// <summary>
@@ -148,6 +198,7 @@ namespace KRPC.Utils
             if (release != null)
                 foreach (var entry in released)
                     release (entry.Object);
+            LetGo (released.Count);
         }
     }
 }

--- a/service/DockingCamera/CHANGELOG.md
+++ b/service/DockingCamera/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [v0.7.0] - unreleased
+
+- A `Camera` whose part the game has destroyed, or that is no longer a camera, raises
+  `KRPC.ObjectDestroyedException` rather than reaching into a part that is gone, and is
+  freed rather than kept for the rest of the session (#1051)
+
 ## [v0.6.0]
 - Fix `DockingCamera.Available` incorrectly reporting false in game scenes other than flight (#937)
 

--- a/service/DockingCamera/src/Camera.cs
+++ b/service/DockingCamera/src/Camera.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using KRPC.Service.Attributes;
 using KRPC.Utils;
 using UnityEngine;
+using ObjectDestroyedException = KRPC.Service.KRPC.ObjectDestroyedException;
 
 namespace KRPC.DockingCamera
 {
@@ -11,11 +12,46 @@ namespace KRPC.DockingCamera
     /// A Docking Camera.
     /// </summary>
     [KRPCClass(Service = "DockingCamera")]
-    public class Camera : Equatable<Camera>
+    public class Camera : Equatable<Camera>, IGameObjectState
     {
-        internal static bool Is(SpaceCenter.Services.Parts.Part innerPart)
+        // The module that makes a part a camera. The mod's API takes the part rather than the
+        // module, so the part is what identifies this and all it has to reach.
+        const string moduleName = "PartCameraModule";
+
+        internal static bool Is(SpaceCenter.Services.Parts.Part part)
         {
-            return innerPart.InternalPart.Modules.Contains("PartCameraModule");
+            return part.InternalPart.Modules.Contains(moduleName);
+        }
+
+        /// <summary>
+        /// What the game holds for the camera. It belongs to its part, so it is exactly as
+        /// live, dormant or destroyed as the part, and destroyed when a part that is there
+        /// to look at no longer carries the module.
+        /// </summary>
+        public GameObjectState GameObjectState
+        {
+            get
+            {
+                var state = Part.GameObjectState;
+                if (state != GameObjectState.Live)
+                    return state;
+                return Part.InternalPart.Modules.Contains(moduleName)
+                    ? GameObjectState.Live : GameObjectState.Destroyed;
+            }
+        }
+
+        // The part it is on, checked to still carry the module. Every member that reaches
+        // the mod goes through this.
+        global::Part InternalPart
+        {
+            get
+            {
+                var innerPart = Part.InternalPart;
+                if (!innerPart.Modules.Contains(moduleName))
+                    throw new ObjectDestroyedException(
+                        "The camera no longer exists, as its part no longer has one.");
+                return innerPart;
+            }
         }
 
         internal Camera(SpaceCenter.Services.Parts.Part part)
@@ -62,7 +98,7 @@ namespace KRPC.DockingCamera
                 {
                     try
                     {
-                        var image = API.GetImage(Part.InternalPart);
+                        var image = API.GetImage(InternalPart);
                         Debug.Log("CAMERA IMAGE: OK");
                         return image;
                     }

--- a/service/Drawing/CHANGELOG.md
+++ b/service/Drawing/CHANGELOG.md
@@ -1,4 +1,11 @@
 ## [v0.7.0] - unreleased
+
+- Line, polygon, text and navball marker objects raise `KRPC.ObjectDestroyedException` once
+  the object they draw is gone, which removing it, `Drawing.Clear`, the client that made it
+  disconnecting and leaving the flight scene all do. They previously failed on a destroyed
+  game object, and were kept for the rest of the session (#1051)
+- A drawing object whose reference frame is defined against something the game has destroyed
+  is not drawn, rather than failing on every frame (#1051)
 - Add `Drawing.AddNavballMarker`, which draws a marker on the navball pointing in a given
   direction, for example to show a script's target attitude while the player flies the vessel.
   The marker's icon, color and size can be changed, and it hides and fades as the navball's own

--- a/service/Drawing/src/Addon.cs
+++ b/service/Drawing/src/Addon.cs
@@ -45,12 +45,13 @@ namespace KRPC.Drawing
         }
 
         /// <summary>
-        /// Update the addon: destroy the objects of clients that have disconnected,
-        /// and update the rest.
+        /// Update the addon: destroy the objects of clients that have disconnected, drop
+        /// the ones the game no longer has, and update the rest.
         /// </summary>
         public void Update ()
         {
             Sweep ();
+            objects.RemoveDestroyed ();
             foreach (var obj in objects.Items)
                 obj.Update ();
         }

--- a/service/Drawing/src/Drawable.cs
+++ b/service/Drawing/src/Drawable.cs
@@ -1,7 +1,9 @@
 using System;
 using KRPC.Service.Attributes;
 using KRPC.SpaceCenter.Services;
+using KRPC.Utils;
 using UnityEngine;
+using ObjectDestroyedException = KRPC.Service.KRPC.ObjectDestroyedException;
 
 namespace KRPC.Drawing
 {
@@ -10,13 +12,19 @@ namespace KRPC.Drawing
     /// </summary>
     public abstract class Drawable<T> : IDrawable
     {
+        readonly Renderer renderer;
+        // Whether the drawable has been taken out of the scene. The game tears a game
+        // object down at the end of the frame, so this records that it is on its way out,
+        // and an object removed and read again in the same frame reports it gone.
+        bool removed;
+
         /// <summary>
         /// Create a drawable and register it with the draw addon.
         /// </summary>
         protected Drawable (Type rendererType)
         {
             GameObject = new GameObject ("KRPC.Drawing." + typeof(T).Name);
-            Renderer = (Renderer)GameObject.AddComponent (rendererType);
+            renderer = (Renderer)GameObject.AddComponent (rendererType);
             Material = "Legacy Shaders/Particles/Additive";
             Addon.AddObject (this);
         }
@@ -31,7 +39,8 @@ namespace KRPC.Drawing
         /// </summary>
         public virtual void Destroy ()
         {
-            UnityEngine.Object.Destroy (Renderer);
+            removed = true;
+            UnityEngine.Object.Destroy (renderer);
             UnityEngine.Object.Destroy (GameObject);
         }
 
@@ -41,9 +50,52 @@ namespace KRPC.Drawing
         public GameObject GameObject { get; private set; }
 
         /// <summary>
-        /// The renderer object for the drawable.
+        /// What the game holds for the drawable. The drawable is the game object it was
+        /// made with, so it is live while the game still has that object, and destroyed
+        /// once it does not, which is what removing it, clearing the drawing objects,
+        /// disconnecting the client that made it and leaving the scene all do. Nothing
+        /// builds a client's drawing again, so there is no dormant state.
         /// </summary>
-        protected Renderer Renderer { get; private set; }
+        public GameObjectState GameObjectState {
+            get {
+                return removed || GameObject == null
+                    ? GameObjectState.Destroyed : GameObjectState.Live;
+            }
+        }
+
+        /// <summary>
+        /// The renderer object for the drawable, checked to still exist. Every member that
+        /// reaches into the game goes through this, so that a drawable the game no longer
+        /// has says so rather than failing on a torn down object.
+        /// </summary>
+        protected Renderer Renderer {
+            get {
+                CheckExists ();
+                return renderer;
+            }
+        }
+
+        /// <summary>
+        /// Raise if the game no longer has the drawable.
+        /// </summary>
+        protected void CheckExists ()
+        {
+            if (GameObjectState == GameObjectState.Destroyed)
+                throw new ObjectDestroyedException (
+                    "The drawing object no longer exists, as it has been removed.");
+        }
+
+        /// <summary>
+        /// Whether the drawable can be drawn where it is asked to be. A reference frame is
+        /// defined against things the game can destroy, and a drawable is left where it is
+        /// rather than removed when that happens, as it can be given another frame.
+        /// </summary>
+        protected bool CanBeDrawn {
+            get {
+                return GameObjectState == GameObjectState.Live &&
+                ReferenceFrame.GameObjectState == GameObjectState.Live;
+            }
+        }
 
         /// <summary>
         /// Remove the object.
@@ -51,6 +103,7 @@ namespace KRPC.Drawing
         [KRPCMethod]
         public void Remove ()
         {
+            CheckExists ();
             Addon.RemoveObject (this);
         }
 

--- a/service/Drawing/src/IDrawable.cs
+++ b/service/Drawing/src/IDrawable.cs
@@ -1,3 +1,4 @@
+using KRPC.Utils;
 using UnityEngine;
 
 namespace KRPC.Drawing
@@ -5,7 +6,11 @@ namespace KRPC.Drawing
     /// <summary>
     /// Interface for objects that can be drawn.
     /// </summary>
-    public interface IDrawable
+    /// <remarks>
+    /// A drawable says what the game holds for it, so that the addon stops drawing one
+    /// whose game object has been destroyed rather than reaching into it every frame.
+    /// </remarks>
+    public interface IDrawable : IGameObjectState
     {
         /// <summary>
         /// Update the drawable.

--- a/service/Drawing/src/Line.cs
+++ b/service/Drawing/src/Line.cs
@@ -41,9 +41,21 @@ namespace KRPC.Drawing
         /// </summary>
         public override void Update ()
         {
+            if (!CanBeDrawn) {
+                renderer.enabled = false;
+                return;
+            }
             renderer.enabled = Visible;
             renderer.SetPosition (0, ReferenceFrame.PositionToWorldSpace (start));
             renderer.SetPosition (1, ReferenceFrame.PositionToWorldSpace (end));
+        }
+
+        // The line renderer, checked to still exist.
+        LineRenderer LineRenderer {
+            get {
+                CheckExists ();
+                return renderer;
+            }
         }
 
         /// <summary>
@@ -74,7 +86,7 @@ namespace KRPC.Drawing
                 color = value;
                 var rgbColor = color.ToColor ();
                 #pragma warning disable 618
-                renderer.SetColors (rgbColor, rgbColor);
+                LineRenderer.SetColors (rgbColor, rgbColor);
                 #pragma warning restore
             }
         }
@@ -88,7 +100,7 @@ namespace KRPC.Drawing
             set {
                 thickness = value;
                 #pragma warning disable 618
-                renderer.SetWidth (thickness, thickness);
+                LineRenderer.SetWidth (thickness, thickness);
                 #pragma warning restore
             }
         }

--- a/service/Drawing/src/NavballMarker.cs
+++ b/service/Drawing/src/NavballMarker.cs
@@ -4,7 +4,9 @@ using System.Linq;
 using KRPC.Service.Attributes;
 using KRPC.SpaceCenter.ExtensionMethods;
 using KRPC.SpaceCenter.Services;
+using KRPC.Utils;
 using UnityEngine;
+using ObjectDestroyedException = KRPC.Service.KRPC.ObjectDestroyedException;
 using Tuple3 = System.Tuple<double, double, double>;
 
 namespace KRPC.Drawing
@@ -30,6 +32,10 @@ namespace KRPC.Drawing
         readonly UnityEngine.Material material;
         // The scale at which the game draws the navball's own markers, which a size of 1 matches.
         readonly Vector3 stockScale;
+        // Whether the marker has been taken out of the scene. The game tears a game object
+        // down at the end of the frame, so this records that it is on its way out, and a
+        // marker removed and read again in the same frame reports it gone.
+        bool removed;
         Vector3d direction;
         Tuple3 color;
         string icon;
@@ -82,6 +88,14 @@ namespace KRPC.Drawing
         /// </summary>
         public void Update ()
         {
+            // A marker is left where it is, rather than removed, when the frame its
+            // direction is measured in is defined against something the game has
+            // destroyed: the client can point it at another frame.
+            if (GameObjectState != GameObjectState.Live ||
+                ReferenceFrame.GameObjectState != GameObjectState.Live) {
+                GameObject.SetActive (false);
+                return;
+            }
             Vector3 worldDirection = ReferenceFrame.DirectionToWorldSpace (direction).normalized;
             var position = navBall.attitudeGymbal * (worldDirection * navBall.VectorUnitScale);
             GameObject.transform.localPosition = position;
@@ -99,6 +113,7 @@ namespace KRPC.Drawing
         /// </summary>
         public void Destroy ()
         {
+            removed = true;
             UnityEngine.Object.Destroy (material);
             UnityEngine.Object.Destroy (GameObject);
         }
@@ -109,11 +124,41 @@ namespace KRPC.Drawing
         public GameObject GameObject { get; private set; }
 
         /// <summary>
+        /// What the game holds for the marker. The marker is the game object it was made
+        /// with, so it is live while the game still has that object, and destroyed once it
+        /// does not, which is what removing it, clearing the drawing objects, disconnecting
+        /// the client that made it and leaving the scene all do.
+        /// </summary>
+        public GameObjectState GameObjectState {
+            get {
+                return removed || GameObject == null
+                    ? GameObjectState.Destroyed : GameObjectState.Live;
+            }
+        }
+
+        // The marker's own material, checked to still exist. Every member that reaches into
+        // the game goes through this or through the checked game object.
+        UnityEngine.Material Material {
+            get {
+                CheckExists ();
+                return material;
+            }
+        }
+
+        void CheckExists ()
+        {
+            if (GameObjectState == GameObjectState.Destroyed)
+                throw new ObjectDestroyedException (
+                    "The navball marker no longer exists, as it has been removed.");
+        }
+
+        /// <summary>
         /// Remove the marker.
         /// </summary>
         [KRPCMethod]
         public void Remove ()
         {
+            CheckExists ();
             Addon.RemoveObject (this);
         }
 
@@ -149,7 +194,7 @@ namespace KRPC.Drawing
             get { return color; }
             set {
                 color = value;
-                material.SetColor ("_TintColor", color.ToColor ());
+                Material.SetColor ("_TintColor", color.ToColor ());
             }
         }
 
@@ -164,7 +209,7 @@ namespace KRPC.Drawing
                 if (!AvailableIcons ().Contains (value))
                     throw new ArgumentException ("Icon does not exist");
                 icon = value;
-                material.SetTexture ("_MainTexture", GameDatabase.Instance.GetTexture (iconDirectory + icon, false));
+                Material.SetTexture ("_MainTexture", GameDatabase.Instance.GetTexture (iconDirectory + icon, false));
             }
         }
 
@@ -176,6 +221,7 @@ namespace KRPC.Drawing
             get { return size; }
             set {
                 size = value;
+                CheckExists ();
                 GameObject.transform.localScale = stockScale * size;
             }
         }

--- a/service/Drawing/src/Polygon.cs
+++ b/service/Drawing/src/Polygon.cs
@@ -42,6 +42,10 @@ namespace KRPC.Drawing
         /// </summary>
         public override void Update ()
         {
+            if (!CanBeDrawn) {
+                renderer.enabled = false;
+                return;
+            }
             renderer.enabled = Visible;
             var numVertices = vertices.Count;
             for (int i = 0; i < numVertices; i++)
@@ -56,6 +60,14 @@ namespace KRPC.Drawing
         {
             vertices.Clear ();
             base.Destroy ();
+        }
+
+        // The line renderer, checked to still exist.
+        LineRenderer LineRenderer {
+            get {
+                CheckExists ();
+                return renderer;
+            }
         }
 
         /// <summary>
@@ -77,7 +89,7 @@ namespace KRPC.Drawing
                 color = value;
                 var rgbColor = color.ToColor ();
                 #pragma warning disable 618
-                renderer.SetColors (rgbColor, rgbColor);
+                LineRenderer.SetColors (rgbColor, rgbColor);
                 #pragma warning restore
             }
         }
@@ -91,7 +103,7 @@ namespace KRPC.Drawing
             set {
                 thickness = value;
                 #pragma warning disable 618
-                renderer.SetWidth (thickness, thickness);
+                LineRenderer.SetWidth (thickness, thickness);
                 #pragma warning restore
             }
         }

--- a/service/Drawing/src/Text.cs
+++ b/service/Drawing/src/Text.cs
@@ -42,6 +42,10 @@ namespace KRPC.Drawing
         /// </summary>
         public override void Update ()
         {
+            if (!CanBeDrawn) {
+                renderer.enabled = false;
+                return;
+            }
             renderer.enabled = Visible;
             renderer.transform.position = ReferenceFrame.PositionToWorldSpace (position);
             renderer.transform.rotation = ReferenceFrame.RotationToWorldSpace (rotation);
@@ -74,6 +78,14 @@ namespace KRPC.Drawing
             base.Destroy ();
         }
 
+        // The text mesh, checked to still exist.
+        TextMesh Mesh {
+            get {
+                CheckExists ();
+                return mesh;
+            }
+        }
+
         /// <summary>
         /// A list of all available fonts.
         /// </summary>
@@ -88,8 +100,8 @@ namespace KRPC.Drawing
         /// </summary>
         [KRPCProperty]
         public string Content {
-            get { return mesh.text; }
-            set { mesh.text = value; }
+            get { return Mesh.text; }
+            set { Mesh.text = value; }
         }
 
         /// <summary>
@@ -97,12 +109,13 @@ namespace KRPC.Drawing
         /// </summary>
         [KRPCProperty]
         public string Font {
-            get { return mesh.font.name; }
+            get { return Mesh.font.name; }
             set {
                 if (!AvailableFonts ().Contains (value))
                     throw new ArgumentException ("Font does not exist");
-                mesh.font = UnityEngine.Font.CreateDynamicFontFromOSFont (value, 1024);
-                renderer.material = mesh.font.material;
+                var textMesh = Mesh;
+                textMesh.font = UnityEngine.Font.CreateDynamicFontFromOSFont (value, 1024);
+                renderer.material = textMesh.font.material;
             }
         }
 
@@ -111,8 +124,8 @@ namespace KRPC.Drawing
         /// </summary>
         [KRPCProperty]
         public int Size {
-            get { return mesh.fontSize; }
-            set { mesh.fontSize = value; }
+            get { return Mesh.fontSize; }
+            set { Mesh.fontSize = value; }
         }
 
         /// <summary>
@@ -120,8 +133,8 @@ namespace KRPC.Drawing
         /// </summary>
         [KRPCProperty]
         public float CharacterSize {
-            get { return mesh.characterSize; }
-            set { mesh.characterSize = value; }
+            get { return Mesh.characterSize; }
+            set { Mesh.characterSize = value; }
         }
 
         /// <summary>
@@ -129,8 +142,8 @@ namespace KRPC.Drawing
         /// </summary>
         [KRPCProperty]
         public UI.FontStyle Style {
-            get { return mesh.fontStyle.ToFontStyle (); }
-            set { mesh.fontStyle = value.FromFontStyle (); }
+            get { return Mesh.fontStyle.ToFontStyle (); }
+            set { Mesh.fontStyle = value.FromFontStyle (); }
         }
 
         /// <summary>
@@ -138,8 +151,8 @@ namespace KRPC.Drawing
         /// </summary>
         [KRPCProperty]
         public UI.TextAlignment Alignment {
-            get { return mesh.alignment.ToTextAlignment (); }
-            set { mesh.alignment = value.FromTextAlignment (); }
+            get { return Mesh.alignment.ToTextAlignment (); }
+            set { Mesh.alignment = value.FromTextAlignment (); }
         }
 
         /// <summary>
@@ -147,8 +160,8 @@ namespace KRPC.Drawing
         /// </summary>
         [KRPCProperty]
         public float LineSpacing {
-            get { return mesh.lineSpacing; }
-            set { mesh.lineSpacing = value; }
+            get { return Mesh.lineSpacing; }
+            set { Mesh.lineSpacing = value; }
         }
 
         /// <summary>
@@ -156,8 +169,8 @@ namespace KRPC.Drawing
         /// </summary>
         [KRPCProperty]
         public UI.TextAnchor Anchor {
-            get { return mesh.anchor.ToTextAnchor (); }
-            set { mesh.anchor = value.FromTextAnchor (); }
+            get { return Mesh.anchor.ToTextAnchor (); }
+            set { Mesh.anchor = value.FromTextAnchor (); }
         }
 
         /// <summary>
@@ -165,8 +178,8 @@ namespace KRPC.Drawing
         /// </summary>
         [KRPCProperty]
         public Tuple3 Color {
-            get { return mesh.color.ToTuple (); }
-            set { mesh.color = value.ToColor (); }
+            get { return Mesh.color.ToTuple (); }
+            set { Mesh.color = value.ToColor (); }
         }
     }
 }

--- a/service/Drawing/test/test_line.py
+++ b/service/Drawing/test/test_line.py
@@ -7,9 +7,11 @@ class TestLine(krpctest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.new_save()
-        cls.drawing = cls.connect().drawing
-        cls.vessel = cls.connect().space_center.active_vessel
+        cls.conn = cls.connect()
+        cls.drawing = cls.conn.drawing
+        cls.vessel = cls.conn.space_center.active_vessel
         cls.ref = cls.vessel.reference_frame
+        cls.destroyed = cls.conn.krpc.ObjectDestroyedException
 
     def add_line(self):
         return self.drawing.add_line((0, 0, 0), (0, 10, 0), self.ref, False)
@@ -24,7 +26,17 @@ class TestLine(krpctest.TestCase):
         self.assertEqual("Legacy Shaders/Particles/Additive", line.material)
         self.assertAlmostEqual(0.1, line.thickness)
         line.remove()
-        self.assertRaises(ValueError, line.remove)
+        self.assertRaises(self.destroyed, line.remove)
+
+    def test_reading_a_removed_line_raises(self):
+        line = self.add_line()
+        line.remove()
+        # What raises is what reaches into the game. The start, the end and the color are
+        # the line's own configuration, and answer as they always did.
+        self.assertEqual((0, 0, 0), line.start)
+        self.assertRaises(self.destroyed, getattr, line, "material")
+        self.assertRaises(self.destroyed, setattr, line, "thickness", 1)
+        self.assertRaises(self.destroyed, setattr, line, "color", (1, 0, 0))
 
     def test_color(self):
         line = self.add_line()

--- a/service/Drawing/test/test_navball_marker.py
+++ b/service/Drawing/test/test_navball_marker.py
@@ -7,6 +7,8 @@ class TestNavballMarker(krpctest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.new_save()
+        cls.conn = cls.connect()
+        cls.destroyed = cls.conn.krpc.ObjectDestroyedException
         cls.drawing = cls.connect().drawing
         cls.vessel = cls.connect().space_center.active_vessel
         cls.ref = cls.vessel.reference_frame
@@ -23,7 +25,7 @@ class TestNavballMarker(krpctest.TestCase):
         self.assertEqual("default", marker.icon)
         self.assertAlmostEqual(1, marker.size)
         marker.remove()
-        self.assertRaises(ValueError, marker.remove)
+        self.assertRaises(self.destroyed, marker.remove)
 
     def test_direction(self):
         marker = self.add_marker()
@@ -66,7 +68,7 @@ class TestNavballMarker(krpctest.TestCase):
     def test_clear(self):
         marker = self.add_marker()
         self.drawing.clear()
-        self.assertRaises(ValueError, marker.remove)
+        self.assertRaises(self.destroyed, marker.remove)
 
 
 if __name__ == "__main__":

--- a/service/Drawing/test/test_polygon.py
+++ b/service/Drawing/test/test_polygon.py
@@ -7,6 +7,8 @@ class TestPolygon(krpctest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.new_save()
+        cls.conn = cls.connect()
+        cls.destroyed = cls.conn.krpc.ObjectDestroyedException
         cls.drawing = cls.connect().drawing
         cls.vessel = cls.connect().space_center.active_vessel
         cls.ref = cls.vessel.reference_frame
@@ -26,7 +28,7 @@ class TestPolygon(krpctest.TestCase):
         self.assertEqual("Legacy Shaders/Particles/Additive", polygon.material)
         self.assertAlmostEqual(0.1, polygon.thickness)
         polygon.remove()
-        self.assertRaises(ValueError, polygon.remove)
+        self.assertRaises(self.destroyed, polygon.remove)
 
     def test_color(self):
         polygon = self.add_polygon()

--- a/service/Drawing/test/test_text.py
+++ b/service/Drawing/test/test_text.py
@@ -7,6 +7,8 @@ class TestText(krpctest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.new_save()
+        cls.conn = cls.connect()
+        cls.destroyed = cls.conn.krpc.ObjectDestroyedException
         cls.drawing = cls.connect().drawing
         cls.vessel = cls.connect().space_center.active_vessel
         cls.ref = cls.vessel.reference_frame
@@ -37,7 +39,7 @@ class TestText(krpctest.TestCase):
         self.assertEqual(1, text.line_spacing)
         self.assertEqual(self.anchor.upper_left, text.anchor)
         text.remove()
-        self.assertRaises(ValueError, text.remove)
+        self.assertRaises(self.destroyed, text.remove)
 
     def test_text_properties(self):
         text = self.add_text()
@@ -59,7 +61,7 @@ class TestText(krpctest.TestCase):
         self.assertEqual(2, text.line_spacing)
         self.assertEqual(self.anchor.upper_right, text.anchor)
         text.remove()
-        self.assertRaises(ValueError, text.remove)
+        self.assertRaises(self.destroyed, text.remove)
 
 
 if __name__ == "__main__":

--- a/service/InfernalRobotics/CHANGELOG.md
+++ b/service/InfernalRobotics/CHANGELOG.md
@@ -1,3 +1,17 @@
+## [v0.7.0] - unreleased
+
+- Fix `Servo` and `ServoGroup` objects accumulating for the rest of the session, one per
+  servo or group per call that lists any, and the same servo or group obtained twice
+  comparing unequal (#1051)
+- A servo and a servo group keep working across a quickload, driving what the game rebuilt
+  rather than what they were obtained from, and raise `KRPC.ObjectDestroyedException` once
+  the part or the vessel they belong to is gone. A servo is named by the part it is on, and
+  a group by its vessel and the group's name, so renaming a group leaves every object for
+  it, the one the rename was made through included, standing for a group that no longer
+  exists; an object for the group has to be obtained again under the new name (#1051)
+- `ServoGroup.Vessel` is the vessel the group was obtained for, and is no longer `null` when
+  Infernal Robotics does not report one (#1051)
+
 ## [v0.6.0]
 - Add to `Servo`: `UID`, `Mode` (with a new `ServoMode` enum), `TargetPosition`, `TargetSpeed`,
   `CommandedPosition`, `DefaultPosition`, `ForceLimit`, `MaxForce`, `MaxAcceleration`, `MaxSpeed`,

--- a/service/InfernalRobotics/src/IRWrapper.cs
+++ b/service/InfernalRobotics/src/IRWrapper.cs
@@ -869,6 +869,31 @@ namespace KRPC.InfernalRobotics
 			return APIReady;
 		}
 
+		// The module that makes a part a servo. IServo.UID is the part's craft id, so the mod
+		// names a servo by its part, and a part carries at most one.
+		internal const string ServoModuleName = "ModuleIRServo_v3";
+
+		// The servo on a given part, or null if it has none. This is what an object standing
+		// for a servo resolves through, so that it finds the servo the game has now rather
+		// than holding the one it was built from, which belongs to a part and a game state
+		// that the game can replace.
+		internal static IServo ServoOnPart (Part part)
+		{
+			if(part == null)
+				return null;
+			EnsureReady ();
+			if(!isWrapped)
+				return null;
+			var modules = part.Modules;
+			for(int i = 0; i < modules.Count; i++)
+			{
+				var module = modules [i];
+				if(module != null && module.moduleName == ServoModuleName)
+					return new IRServo (module);
+			}
+			return null;
+		}
+
 		// Servos for a given vessel. IR's Controller only tracks the active vessel, so prefer
 		// its data (full fidelity) when it holds the requested vessel, and otherwise fall back
 		// to enumerating the vessel's servo modules directly - which works for any loaded,

--- a/service/InfernalRobotics/src/IRWrapper.cs
+++ b/service/InfernalRobotics/src/IRWrapper.cs
@@ -92,6 +92,11 @@ namespace KRPC.InfernalRobotics
 				? ModuleServoType.GetField ("groupName")
 				: null;
 
+			// The wrappers bind the mod's members once and keep them for the assembly, so
+			// anything bound against the types of a previous run is dropped here.
+			IRServo.Unbind();
+			IRServoGroup.Unbind();
+
 			LogFormatted("Got Assembly Types, grabbing Instance");
 
 			try
@@ -197,35 +202,56 @@ namespace KRPC.InfernalRobotics
 		{
 			private readonly object actualControlGroup;
 
-			private PropertyInfo nameProperty;
-			private PropertyInfo vesselProperty;
-			private PropertyInfo expandedProperty;
-			private PropertyInfo groupSpeedFactorProperty;
+			private static PropertyInfo nameProperty;
+			private static PropertyInfo vesselProperty;
+			private static PropertyInfo expandedProperty;
+			private static PropertyInfo groupSpeedFactorProperty;
 
-			private PropertyInfo forwardKeyProperty;
-			private PropertyInfo reverseKeyProperty;
+			private static PropertyInfo forwardKeyProperty;
+			private static PropertyInfo reverseKeyProperty;
 
-			private PropertyInfo movingDirectionProperty;
-			private PropertyInfo advancedModeProperty;
-			private PropertyInfo totalElectricChargeRequirementProperty;
-			private PropertyInfo buildAidProperty;
-			private PropertyInfo ikActiveProperty;
+			private static PropertyInfo movingDirectionProperty;
+			private static PropertyInfo advancedModeProperty;
+			private static PropertyInfo totalElectricChargeRequirementProperty;
+			private static PropertyInfo buildAidProperty;
+			private static PropertyInfo ikActiveProperty;
 
-			private MethodInfo moveRightMethod;
-			private MethodInfo moveLeftMethod;
-			private MethodInfo moveCenterMethod;
-			private MethodInfo moveNextPresetMethod;
-			private MethodInfo movePrevPresetMethod;
-			private MethodInfo stopMethod;
+			private static MethodInfo moveRightMethod;
+			private static MethodInfo moveLeftMethod;
+			private static MethodInfo moveCenterMethod;
+			private static MethodInfo moveNextPresetMethod;
+			private static MethodInfo movePrevPresetMethod;
+			private static MethodInfo stopMethod;
 
 			public IRServoGroup (object cg)
 			{
 				actualControlGroup = cg;
-				FindProperties();
-				FindMethods();
+				EnsureBound();
+				ActualServos = servosProperty.GetValue(actualControlGroup, null);
 			}
 
-			private void FindProperties()
+			// The lookups below depend on the mod's group type alone, so they are made once
+			// for the assembly rather than for each group wrapped. A group is wrapped every
+			// time one is listed, and there are a dozen of them.
+			private static bool bound;
+
+			internal static void Unbind()
+			{
+				bound = false;
+			}
+
+			private static void EnsureBound()
+			{
+				if(bound)
+					return;
+				FindProperties();
+				FindMethods();
+				bound = true;
+			}
+
+			private static PropertyInfo servosProperty;
+
+			private static void FindProperties()
 			{
 				nameProperty = IRServoGroupType.GetProperty("Name");
 				vesselProperty = IRServoGroupType.GetProperty("Vessel");
@@ -239,11 +265,10 @@ namespace KRPC.InfernalRobotics
 				buildAidProperty = IRServoGroupType.GetProperty("BuildAid");
 				ikActiveProperty = IRServoGroupType.GetProperty("IKActive");
 
-				var servosProperty = IRServoGroupType.GetProperty("Servos");
-				ActualServos = servosProperty.GetValue(actualControlGroup, null);
+				servosProperty = IRServoGroupType.GetProperty("Servos");
 			}
 
-			private void FindMethods()
+			private static void FindMethods()
 			{
 				moveRightMethod = IRServoGroupType.GetMethod ("MoveRight", BindingFlags.Public | BindingFlags.Instance);
 				moveLeftMethod = IRServoGroupType.GetMethod ("MoveLeft", BindingFlags.Public | BindingFlags.Instance);
@@ -379,73 +404,90 @@ namespace KRPC.InfernalRobotics
 
 		public class IRServo : IServo
 		{
-			private PropertyInfo nameProperty;
-			private PropertyInfo UIDProperty;
-			private PropertyInfo HostPartProperty;
-			private PropertyInfo highlightProperty;
+			private static PropertyInfo nameProperty;
+			private static PropertyInfo UIDProperty;
+			private static PropertyInfo HostPartProperty;
+			private static PropertyInfo highlightProperty;
 
-			private PropertyInfo minPositionProperty;
-			private PropertyInfo maxPositionProperty;
-			private PropertyInfo isFreeMovingProperty;
+			private static PropertyInfo minPositionProperty;
+			private static PropertyInfo maxPositionProperty;
+			private static PropertyInfo isFreeMovingProperty;
 
-			private PropertyInfo minPositionLimitProperty;
-			private PropertyInfo maxPositionLimitProperty;
+			private static PropertyInfo minPositionLimitProperty;
+			private static PropertyInfo maxPositionLimitProperty;
 
-			private PropertyInfo forceLimitProperty;
-			private PropertyInfo accelerationLimitProperty;
-			private PropertyInfo speedLimitProperty;
-			private PropertyInfo defaultSpeedProperty;
+			private static PropertyInfo forceLimitProperty;
+			private static PropertyInfo accelerationLimitProperty;
+			private static PropertyInfo speedLimitProperty;
+			private static PropertyInfo defaultSpeedProperty;
 
-			private PropertyInfo isMovingProperty;
-			private PropertyInfo isLockedProperty;
-			private PropertyInfo isInvertedProperty;
+			private static PropertyInfo isMovingProperty;
+			private static PropertyInfo isLockedProperty;
+			private static PropertyInfo isInvertedProperty;
 
-			private PropertyInfo commandedPositionProperty;
-			private PropertyInfo commandedSpeedProperty;
+			private static PropertyInfo commandedPositionProperty;
+			private static PropertyInfo commandedSpeedProperty;
 
-			private PropertyInfo positionProperty;
+			private static PropertyInfo positionProperty;
 
-			private PropertyInfo forwardKeyProperty;
-			private PropertyInfo reverseKeyProperty;
+			private static PropertyInfo forwardKeyProperty;
+			private static PropertyInfo reverseKeyProperty;
 
-			private PropertyInfo targetPositionProperty;
-			private PropertyInfo targetSpeedProperty;
-			private PropertyInfo defaultPositionProperty;
-			private PropertyInfo maxForceProperty;
-			private PropertyInfo maxAccelerationProperty;
-			private PropertyInfo maxSpeedProperty;
-			private PropertyInfo electricChargeRequiredProperty;
-			private PropertyInfo springPowerProperty;
-			private PropertyInfo dampingPowerProperty;
-			private PropertyInfo rotorAccelerationProperty;
-			private PropertyInfo isLimitedProperty;
-			private PropertyInfo isRotationalProperty;
-			private PropertyInfo isServoProperty;
-			private PropertyInfo canHaveLimitsProperty;
-			private PropertyInfo hasSpringProperty;
-			private PropertyInfo isRunningProperty;
-			private PropertyInfo modeProperty;
-			private PropertyInfo presetPositionsProperty;
-			private PropertyInfo presetsProperty;
-			private MethodInfo presetAddMethod;
-			private MethodInfo presetRemoveAtMethod;
-			private MethodInfo presetSortMethod;
+			private static PropertyInfo targetPositionProperty;
+			private static PropertyInfo targetSpeedProperty;
+			private static PropertyInfo defaultPositionProperty;
+			private static PropertyInfo maxForceProperty;
+			private static PropertyInfo maxAccelerationProperty;
+			private static PropertyInfo maxSpeedProperty;
+			private static PropertyInfo electricChargeRequiredProperty;
+			private static PropertyInfo springPowerProperty;
+			private static PropertyInfo dampingPowerProperty;
+			private static PropertyInfo rotorAccelerationProperty;
+			private static PropertyInfo isLimitedProperty;
+			private static PropertyInfo isRotationalProperty;
+			private static PropertyInfo isServoProperty;
+			private static PropertyInfo canHaveLimitsProperty;
+			private static PropertyInfo hasSpringProperty;
+			private static PropertyInfo isRunningProperty;
+			private static PropertyInfo modeProperty;
+			private static PropertyInfo presetPositionsProperty;
+			private static PropertyInfo presetsProperty;
+			private static MethodInfo presetAddMethod;
+			private static MethodInfo presetRemoveAtMethod;
+			private static MethodInfo presetSortMethod;
 
-			private MethodInfo moveLeftMethod;
-			private MethodInfo moveCenterMethod;
-			private MethodInfo moveRightMethod;
-			private MethodInfo moveToMethod;
-			private MethodInfo stopMethod;
+			private static MethodInfo moveLeftMethod;
+			private static MethodInfo moveCenterMethod;
+			private static MethodInfo moveRightMethod;
+			private static MethodInfo moveToMethod;
+			private static MethodInfo stopMethod;
 
 			public IRServo(object s)
 			{
 				actualServo = s;
-
-				FindProperties();
-				FindMethods();
+				EnsureBound();
 			}
 
-			private void FindProperties()
+			// The lookups below depend on the mod's servo type alone, so they are made once
+			// for the assembly rather than for each servo wrapped. A servo is wrapped every
+			// time one is listed, and there are around forty lookups.
+			private static bool bound;
+
+			internal static void Unbind()
+			{
+				bound = false;
+			}
+
+			private static void EnsureBound()
+			{
+				if(bound)
+					return;
+				FindProperties();
+				FindMethods();
+				bound = true;
+			}
+
+			private static void FindProperties()
 			{
 				nameProperty = IRServoType.GetProperty("Name");
 				UIDProperty = IRServoType.GetProperty("UID");
@@ -503,7 +545,7 @@ namespace KRPC.InfernalRobotics
 				}
 			}
 
-			private void FindMethods()
+			private static void FindMethods()
 			{
 				moveLeftMethod = IRServoType.GetMethod("MoveLeft", BindingFlags.Public | BindingFlags.Instance);
 				moveCenterMethod = IRServoType.GetMethod("MoveCenter", BindingFlags.Public | BindingFlags.Instance);

--- a/service/InfernalRobotics/src/InfernalRobotics.cs
+++ b/service/InfernalRobotics/src/InfernalRobotics.cs
@@ -64,7 +64,8 @@ namespace KRPC.InfernalRobotics
         public static IList<ServoGroup> ServoGroups (SpaceCenter.Services.Vessel vessel)
         {
             CheckAvailable ();
-            return IRWrapper.ServoGroupsForVessel (vessel.InternalVessel).Select (x => new ServoGroup (x)).ToList ();
+            return IRWrapper.ServoGroupsForVessel (vessel.InternalVessel)
+                .Select (x => new ServoGroup (vessel, x.Name)).ToList ();
         }
 
         /// <summary>
@@ -78,7 +79,7 @@ namespace KRPC.InfernalRobotics
         {
             CheckAvailable ();
             var servoGroup = IRWrapper.ServoGroupsForVessel (vessel.InternalVessel).FirstOrDefault (x => x.Name == name);
-            return servoGroup != null ? new ServoGroup (servoGroup) : null;
+            return servoGroup != null ? new ServoGroup (vessel, servoGroup.Name) : null;
         }
 
         /// <summary>

--- a/service/InfernalRobotics/src/Servo.cs
+++ b/service/InfernalRobotics/src/Servo.cs
@@ -1,6 +1,8 @@
+using System;
 using System.Collections.Generic;
 using KRPC.Service.Attributes;
 using KRPC.Utils;
+using ObjectDestroyedException = KRPC.Service.KRPC.ObjectDestroyedException;
 
 namespace KRPC.InfernalRobotics
 {
@@ -11,13 +13,24 @@ namespace KRPC.InfernalRobotics
     /// or <see cref="InfernalRobotics.ServoWithName"/>.
     /// </summary>
     [KRPCClass (Service = "InfernalRobotics")]
-    public class Servo : Equatable<Servo>
+    public class Servo : Equatable<Servo>, IGameObjectState
     {
-        readonly IRWrapper.IServo servo;
+        // The part the servo is on, which is what identifies it: a servo is a module the mod
+        // adds to a part, and the mod names one by its part. The wrapper the mod hands out
+        // is built afresh every time a servo is listed, so holding one would leave two
+        // objects for one servo comparing unequal, and would keep a destroyed part alive.
+        readonly SpaceCenter.Services.Parts.Part part;
+
+        internal Servo (SpaceCenter.Services.Parts.Part servoPart)
+        {
+            if (ReferenceEquals (servoPart, null))
+                throw new ArgumentNullException (nameof (servoPart));
+            part = servoPart;
+        }
 
         internal Servo (IRWrapper.IServo innerServo)
+            : this (new SpaceCenter.Services.Parts.Part (innerServo.HostPart))
         {
-            servo = innerServo;
         }
 
         /// <summary>
@@ -25,7 +38,7 @@ namespace KRPC.InfernalRobotics
         /// </summary>
         public override bool Equals (Servo other)
         {
-            return !ReferenceEquals (other, null) && servo == other.servo;
+            return !ReferenceEquals (other, null) && part == other.part;
         }
 
         /// <summary>
@@ -33,7 +46,35 @@ namespace KRPC.InfernalRobotics
         /// </summary>
         public override int GetHashCode ()
         {
-            return servo.GetHashCode ();
+            return part.GetHashCode ();
+        }
+
+        /// <summary>
+        /// What the game holds for the servo. It belongs to its part, so it is exactly as
+        /// live, dormant or destroyed as the part, and destroyed when a part that is there
+        /// to look at no longer carries the servo module.
+        /// </summary>
+        public GameObjectState GameObjectState {
+            get {
+                var state = part.GameObjectState;
+                if (state != GameObjectState.Live)
+                    return state;
+                return IRWrapper.ServoOnPart (part.InternalPart) != null
+                    ? GameObjectState.Live : GameObjectState.Destroyed;
+            }
+        }
+
+        // The servo the mod has on the part now. Every member reaches the mod through this,
+        // so a servo taken before a game state was replaced reads the one that stands in
+        // its place rather than the one it was built from.
+        IRWrapper.IServo Internal {
+            get {
+                var servo = IRWrapper.ServoOnPart (part.InternalPart);
+                if (servo == null)
+                    throw new ObjectDestroyedException (
+                        "The servo no longer exists, as its part no longer has one.");
+                return servo;
+            }
         }
 
         /// <summary>
@@ -41,8 +82,8 @@ namespace KRPC.InfernalRobotics
         /// </summary>
         [KRPCProperty]
         public string Name {
-            get { return servo.Name; }
-            set { servo.Name = value; }
+            get { return Internal.Name; }
+            set { Internal.Name = value; }
         }
 
         /// <summary>
@@ -50,7 +91,7 @@ namespace KRPC.InfernalRobotics
         /// </summary>
         [KRPCProperty]
         public uint UID {
-            get { return servo.UID; }
+            get { return Internal.UID; }
         }
 
         /// <summary>
@@ -58,7 +99,7 @@ namespace KRPC.InfernalRobotics
         /// </summary>
         [KRPCProperty]
         public SpaceCenter.Services.Parts.Part Part {
-            get { return new SpaceCenter.Services.Parts.Part (servo.HostPart); }
+            get { return part; }
         }
 
         /// <summary>
@@ -66,7 +107,7 @@ namespace KRPC.InfernalRobotics
         /// </summary>
         [KRPCProperty]
         public ServoMode Mode {
-            get { return (ServoMode)servo.Mode; }
+            get { return (ServoMode)Internal.Mode; }
         }
 
         /// <summary>
@@ -74,7 +115,7 @@ namespace KRPC.InfernalRobotics
         /// </summary>
         [KRPCProperty]
         public bool Highlight {
-            set { servo.Highlight = value; }
+            set { Internal.Highlight = value; }
         }
 
         /// <summary>
@@ -82,7 +123,7 @@ namespace KRPC.InfernalRobotics
         /// </summary>
         [KRPCProperty]
         public float Position {
-            get { return servo.Position; }
+            get { return Internal.Position; }
         }
 
         /// <summary>
@@ -90,7 +131,7 @@ namespace KRPC.InfernalRobotics
         /// </summary>
         [KRPCProperty]
         public float MinConfigPosition {
-            get { return servo.MinPosition; }
+            get { return Internal.MinPosition; }
         }
 
         /// <summary>
@@ -98,7 +139,7 @@ namespace KRPC.InfernalRobotics
         /// </summary>
         [KRPCProperty]
         public float MaxConfigPosition {
-            get { return servo.MaxPosition; }
+            get { return Internal.MaxPosition; }
         }
 
         /// <summary>
@@ -106,8 +147,8 @@ namespace KRPC.InfernalRobotics
         /// </summary>
         [KRPCProperty]
         public float MinPosition {
-            get { return servo.MinPositionLimit; }
-            set { servo.MinPositionLimit = value; }
+            get { return Internal.MinPositionLimit; }
+            set { Internal.MinPositionLimit = value; }
         }
 
         /// <summary>
@@ -115,8 +156,8 @@ namespace KRPC.InfernalRobotics
         /// </summary>
         [KRPCProperty]
         public float MaxPosition {
-            get { return servo.MaxPositionLimit; }
-            set { servo.MaxPositionLimit = value; }
+            get { return Internal.MaxPositionLimit; }
+            set { Internal.MaxPositionLimit = value; }
         }
 
         /// <summary>
@@ -124,7 +165,7 @@ namespace KRPC.InfernalRobotics
         /// </summary>
         [KRPCProperty]
         public float ConfigSpeed {
-            get { return servo.DefaultSpeed; }
+            get { return Internal.DefaultSpeed; }
         }
 
         /// <summary>
@@ -132,8 +173,8 @@ namespace KRPC.InfernalRobotics
         /// </summary>
         [KRPCProperty]
         public float Speed {
-            get { return servo.SpeedLimit; }
-            set { servo.SpeedLimit = value; }
+            get { return Internal.SpeedLimit; }
+            set { Internal.SpeedLimit = value; }
         }
 
         /// <summary>
@@ -141,7 +182,7 @@ namespace KRPC.InfernalRobotics
         /// </summary>
         [KRPCProperty]
         public float CurrentSpeed {
-            get { return servo.CommandedSpeed; }
+            get { return Internal.CommandedSpeed; }
         }
 
         /// <summary>
@@ -149,8 +190,8 @@ namespace KRPC.InfernalRobotics
         /// </summary>
         [KRPCProperty]
         public float Acceleration {
-            get { return servo.AccelerationLimit; }
-            set { servo.AccelerationLimit = value; }
+            get { return Internal.AccelerationLimit; }
+            set { Internal.AccelerationLimit = value; }
         }
 
         /// <summary>
@@ -158,7 +199,7 @@ namespace KRPC.InfernalRobotics
         /// </summary>
         [KRPCProperty]
         public bool IsMoving {
-            get { return servo.IsMoving; }
+            get { return Internal.IsMoving; }
         }
 
         /// <summary>
@@ -166,7 +207,7 @@ namespace KRPC.InfernalRobotics
         /// </summary>
         [KRPCProperty]
         public bool IsFreeMoving {
-            get { return servo.IsFreeMoving; }
+            get { return Internal.IsFreeMoving; }
         }
 
         /// <summary>
@@ -174,8 +215,8 @@ namespace KRPC.InfernalRobotics
         /// </summary>
         [KRPCProperty]
         public bool IsLocked {
-            get { return servo.IsLocked; }
-            set { servo.IsLocked = value; }
+            get { return Internal.IsLocked; }
+            set { Internal.IsLocked = value; }
         }
 
         /// <summary>
@@ -183,8 +224,8 @@ namespace KRPC.InfernalRobotics
         /// </summary>
         [KRPCProperty]
         public bool IsAxisInverted {
-            get { return servo.IsInverted; }
-            set { servo.IsInverted = value; }
+            get { return Internal.IsInverted; }
+            set { Internal.IsInverted = value; }
         }
 
         /// <summary>
@@ -192,7 +233,7 @@ namespace KRPC.InfernalRobotics
         /// </summary>
         [KRPCProperty]
         public float TargetPosition {
-            get { return servo.TargetPosition; }
+            get { return Internal.TargetPosition; }
         }
 
         /// <summary>
@@ -200,7 +241,7 @@ namespace KRPC.InfernalRobotics
         /// </summary>
         [KRPCProperty]
         public float TargetSpeed {
-            get { return servo.TargetSpeed; }
+            get { return Internal.TargetSpeed; }
         }
 
         /// <summary>
@@ -208,7 +249,7 @@ namespace KRPC.InfernalRobotics
         /// </summary>
         [KRPCProperty]
         public float CommandedPosition {
-            get { return servo.CommandedPosition; }
+            get { return Internal.CommandedPosition; }
         }
 
         /// <summary>
@@ -216,7 +257,7 @@ namespace KRPC.InfernalRobotics
         /// </summary>
         [KRPCProperty]
         public float DefaultPosition {
-            get { return servo.DefaultPosition; }
+            get { return Internal.DefaultPosition; }
         }
 
         /// <summary>
@@ -224,8 +265,8 @@ namespace KRPC.InfernalRobotics
         /// </summary>
         [KRPCProperty]
         public float ForceLimit {
-            get { return servo.ForceLimit; }
-            set { servo.ForceLimit = value; }
+            get { return Internal.ForceLimit; }
+            set { Internal.ForceLimit = value; }
         }
 
         /// <summary>
@@ -233,7 +274,7 @@ namespace KRPC.InfernalRobotics
         /// </summary>
         [KRPCProperty]
         public float MaxForce {
-            get { return servo.MaxForce; }
+            get { return Internal.MaxForce; }
         }
 
         /// <summary>
@@ -241,7 +282,7 @@ namespace KRPC.InfernalRobotics
         /// </summary>
         [KRPCProperty]
         public float MaxAcceleration {
-            get { return servo.MaxAcceleration; }
+            get { return Internal.MaxAcceleration; }
         }
 
         /// <summary>
@@ -249,7 +290,7 @@ namespace KRPC.InfernalRobotics
         /// </summary>
         [KRPCProperty]
         public float MaxSpeed {
-            get { return servo.MaxSpeed; }
+            get { return Internal.MaxSpeed; }
         }
 
         /// <summary>
@@ -257,7 +298,7 @@ namespace KRPC.InfernalRobotics
         /// </summary>
         [KRPCProperty]
         public float ElectricChargeRequired {
-            get { return servo.ElectricChargeRequired; }
+            get { return Internal.ElectricChargeRequired; }
         }
 
         /// <summary>
@@ -265,8 +306,8 @@ namespace KRPC.InfernalRobotics
         /// </summary>
         [KRPCProperty]
         public float SpringPower {
-            get { return servo.SpringPower; }
-            set { servo.SpringPower = value; }
+            get { return Internal.SpringPower; }
+            set { Internal.SpringPower = value; }
         }
 
         /// <summary>
@@ -274,8 +315,8 @@ namespace KRPC.InfernalRobotics
         /// </summary>
         [KRPCProperty]
         public float DampingPower {
-            get { return servo.DampingPower; }
-            set { servo.DampingPower = value; }
+            get { return Internal.DampingPower; }
+            set { Internal.DampingPower = value; }
         }
 
         /// <summary>
@@ -283,8 +324,8 @@ namespace KRPC.InfernalRobotics
         /// </summary>
         [KRPCProperty]
         public float RotorAcceleration {
-            get { return servo.RotorAcceleration; }
-            set { servo.RotorAcceleration = value; }
+            get { return Internal.RotorAcceleration; }
+            set { Internal.RotorAcceleration = value; }
         }
 
         /// <summary>
@@ -293,8 +334,8 @@ namespace KRPC.InfernalRobotics
         /// </summary>
         [KRPCProperty]
         public bool IsLimited {
-            get { return servo.IsLimited; }
-            set { servo.IsLimited = value; }
+            get { return Internal.IsLimited; }
+            set { Internal.IsLimited = value; }
         }
 
         /// <summary>
@@ -302,7 +343,7 @@ namespace KRPC.InfernalRobotics
         /// </summary>
         [KRPCProperty]
         public bool IsRotational {
-            get { return servo.IsRotational; }
+            get { return Internal.IsRotational; }
         }
 
         /// <summary>
@@ -310,7 +351,7 @@ namespace KRPC.InfernalRobotics
         /// </summary>
         [KRPCProperty]
         public bool IsServo {
-            get { return servo.IsServo; }
+            get { return Internal.IsServo; }
         }
 
         /// <summary>
@@ -318,7 +359,7 @@ namespace KRPC.InfernalRobotics
         /// </summary>
         [KRPCProperty]
         public bool CanHaveLimits {
-            get { return servo.CanHaveLimits; }
+            get { return Internal.CanHaveLimits; }
         }
 
         /// <summary>
@@ -326,7 +367,7 @@ namespace KRPC.InfernalRobotics
         /// </summary>
         [KRPCProperty]
         public bool HasSpring {
-            get { return servo.HasSpring; }
+            get { return Internal.HasSpring; }
         }
 
         /// <summary>
@@ -334,7 +375,7 @@ namespace KRPC.InfernalRobotics
         /// </summary>
         [KRPCProperty]
         public bool IsRunning {
-            get { return servo.IsRunning; }
+            get { return Internal.IsRunning; }
         }
 
         /// <summary>
@@ -342,7 +383,7 @@ namespace KRPC.InfernalRobotics
         /// </summary>
         [KRPCProperty]
         public IList<float> PresetPositions {
-            get { return servo.PresetPositions; }
+            get { return Internal.PresetPositions; }
         }
 
         /// <summary>
@@ -351,7 +392,7 @@ namespace KRPC.InfernalRobotics
         [KRPCMethod]
         public void MoveRight ()
         {
-            servo.MoveRight ();
+            Internal.MoveRight ();
         }
 
         /// <summary>
@@ -360,7 +401,7 @@ namespace KRPC.InfernalRobotics
         [KRPCMethod]
         public void MoveLeft ()
         {
-            servo.MoveLeft ();
+            Internal.MoveLeft ();
         }
 
         /// <summary>
@@ -369,7 +410,7 @@ namespace KRPC.InfernalRobotics
         [KRPCMethod]
         public void MoveCenter ()
         {
-            servo.MoveCenter ();
+            Internal.MoveCenter ();
         }
 
         /// <summary>
@@ -381,7 +422,7 @@ namespace KRPC.InfernalRobotics
         [KRPCMethod]
         public void MoveTo (float position, float speed)
         {
-            servo.MoveTo (position, speed);
+            Internal.MoveTo (position, speed);
         }
 
         /// <summary>
@@ -390,7 +431,7 @@ namespace KRPC.InfernalRobotics
         [KRPCMethod]
         public void Stop ()
         {
-            servo.Stop ();
+            Internal.Stop ();
         }
 
         /// <summary>
@@ -400,7 +441,7 @@ namespace KRPC.InfernalRobotics
         [KRPCMethod]
         public void AddPreset (float position)
         {
-            servo.AddPreset (position);
+            Internal.AddPreset (position);
         }
 
         /// <summary>
@@ -410,7 +451,7 @@ namespace KRPC.InfernalRobotics
         [KRPCMethod]
         public void RemovePresetAt (int index)
         {
-            servo.RemovePresetAt (index);
+            Internal.RemovePresetAt (index);
         }
 
         /// <summary>
@@ -419,7 +460,7 @@ namespace KRPC.InfernalRobotics
         [KRPCMethod]
         public void SortPresets ()
         {
-            servo.SortPresets ();
+            Internal.SortPresets ();
         }
     }
 }

--- a/service/InfernalRobotics/src/ServoGroup.cs
+++ b/service/InfernalRobotics/src/ServoGroup.cs
@@ -1,7 +1,9 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using KRPC.Service.Attributes;
 using KRPC.Utils;
+using ObjectDestroyedException = KRPC.Service.KRPC.ObjectDestroyedException;
 
 namespace KRPC.InfernalRobotics
 {
@@ -11,13 +13,24 @@ namespace KRPC.InfernalRobotics
     /// in the InfernalRobotics UI.
     /// </summary>
     [KRPCClass (Service = "InfernalRobotics")]
-    public class ServoGroup : Equatable<ServoGroup>
+    public class ServoGroup : Equatable<ServoGroup>, IGameObjectState
     {
-        readonly IRWrapper.IServoGroup servoGroup;
+        // The vessel the group belongs to and the name that picks it out among that
+        // vessel's groups, which is what the mod itself groups servos by. Both are fixed for
+        // the object's lifetime: the object store compares and hashes the objects it holds,
+        // so a name that moved would leave two objects naming one group, and the store
+        // unable to tell which entry belongs to which. The group object the mod hands out is
+        // built afresh every time the groups are listed, so holding one would instead leave
+        // two objects for one group comparing unequal.
+        readonly SpaceCenter.Services.Vessel vessel;
+        readonly string name;
 
-        internal ServoGroup (IRWrapper.IServoGroup innerServoGroup)
+        internal ServoGroup (SpaceCenter.Services.Vessel groupVessel, string groupName)
         {
-            servoGroup = innerServoGroup;
+            if (ReferenceEquals (groupVessel, null))
+                throw new ArgumentNullException (nameof (groupVessel));
+            vessel = groupVessel;
+            name = groupName;
         }
 
         /// <summary>
@@ -25,7 +38,7 @@ namespace KRPC.InfernalRobotics
         /// </summary>
         public override bool Equals (ServoGroup other)
         {
-            return !ReferenceEquals (other, null) && servoGroup == other.servoGroup;
+            return !ReferenceEquals (other, null) && vessel == other.vessel && name == other.name;
         }
 
         /// <summary>
@@ -33,16 +46,75 @@ namespace KRPC.InfernalRobotics
         /// </summary>
         public override int GetHashCode ()
         {
-            return servoGroup.GetHashCode ();
+            // A group the mod names with nothing at all still has to hash, as the object
+            // store hashes every object it holds.
+            return vessel.GetHashCode () ^ (name == null ? 0 : name.GetHashCode ());
+        }
+
+        /// <summary>
+        /// What the game holds for the group. It belongs to its vessel, so it is exactly as
+        /// live, dormant or destroyed as the vessel, and destroyed when a vessel that the
+        /// mod can be asked about has no group of the name. The mod not being ready says
+        /// nothing about any group: its controller only ever tracks the active vessel.
+        /// </summary>
+        public GameObjectState GameObjectState {
+            get {
+                var state = vessel.GameObjectState;
+                if (state != GameObjectState.Live)
+                    return state;
+                if (!IRWrapper.AssemblyExists)
+                    return GameObjectState.Dormant;
+                return Find () != null ? GameObjectState.Live : GameObjectState.Destroyed;
+            }
+        }
+
+        // The group the mod has on the vessel under the name, or null if it has none.
+        IRWrapper.IServoGroup Find ()
+        {
+            var groups = IRWrapper.ServoGroupsForVessel (vessel.InternalVessel);
+            for (var i = 0; i < groups.Count; i++) {
+                if (groups [i].Name == name)
+                    return groups [i];
+            }
+            return null;
+        }
+
+        // The group the mod has on the vessel now. Every member reaches the mod through
+        // this, so a group taken before a game state was replaced drives the servos that
+        // stand in its place rather than the ones it was built from.
+        IRWrapper.IServoGroup Internal {
+            get {
+                var group = Find ();
+                if (group == null)
+                    throw NotResolvable ();
+                return group;
+            }
+        }
+
+        Exception NotResolvable ()
+        {
+            if (GameObjectState == GameObjectState.Destroyed)
+                return new ObjectDestroyedException (
+                    "The servo group no longer exists, as its vessel no longer has a group " +
+                    "of its name.");
+            return new InvalidOperationException (
+                "The servo group is not available, as Infernal Robotics is not installed.");
         }
 
         /// <summary>
         /// The name of the group.
         /// </summary>
+        /// <remarks>
+        /// Renaming a group renames it for every servo in it. The name is what this object
+        /// names the group by, and is fixed for its lifetime, so every object for the group
+        /// stands for one the vessel no longer has once it is renamed, the object the rename
+        /// was made through included. An object for the group has to be obtained again under
+        /// the new name.
+        /// </remarks>
         [KRPCProperty]
         public string Name {
-            get { return servoGroup.Name; }
-            set { servoGroup.Name = value; }
+            get { return Internal.Name; }
+            set { Internal.Name = value; }
         }
 
         /// <summary>
@@ -50,8 +122,8 @@ namespace KRPC.InfernalRobotics
         /// </summary>
         [KRPCProperty]
         public string ForwardKey {
-            get { return servoGroup.ForwardKey; }
-            set { servoGroup.ForwardKey = value; }
+            get { return Internal.ForwardKey; }
+            set { Internal.ForwardKey = value; }
         }
 
         /// <summary>
@@ -59,8 +131,8 @@ namespace KRPC.InfernalRobotics
         /// </summary>
         [KRPCProperty]
         public string ReverseKey {
-            get { return servoGroup.ReverseKey; }
-            set { servoGroup.ReverseKey = value; }
+            get { return Internal.ReverseKey; }
+            set { Internal.ReverseKey = value; }
         }
 
         /// <summary>
@@ -68,8 +140,8 @@ namespace KRPC.InfernalRobotics
         /// </summary>
         [KRPCProperty]
         public float Speed {
-            get { return servoGroup.GroupSpeedFactor; }
-            set { servoGroup.GroupSpeedFactor = value; }
+            get { return Internal.GroupSpeedFactor; }
+            set { Internal.GroupSpeedFactor = value; }
         }
 
         /// <summary>
@@ -77,19 +149,16 @@ namespace KRPC.InfernalRobotics
         /// </summary>
         [KRPCProperty]
         public bool Expanded {
-            get { return servoGroup.Expanded; }
-            set { servoGroup.Expanded = value; }
+            get { return Internal.Expanded; }
+            set { Internal.Expanded = value; }
         }
 
         /// <summary>
-        /// The vessel the group belongs to, or <c>null</c> if it is not available.
+        /// The vessel the group belongs to.
         /// </summary>
-        [KRPCProperty (Nullable = true)]
+        [KRPCProperty]
         public SpaceCenter.Services.Vessel Vessel {
-            get {
-                var vessel = servoGroup.Vessel;
-                return vessel != null ? new SpaceCenter.Services.Vessel (vessel) : null;
-            }
+            get { return vessel; }
         }
 
         /// <summary>
@@ -98,7 +167,7 @@ namespace KRPC.InfernalRobotics
         /// </summary>
         [KRPCProperty]
         public int MovingDirection {
-            get { return servoGroup.MovingDirection; }
+            get { return Internal.MovingDirection; }
         }
 
         /// <summary>
@@ -106,8 +175,8 @@ namespace KRPC.InfernalRobotics
         /// </summary>
         [KRPCProperty]
         public bool AdvancedMode {
-            get { return servoGroup.AdvancedMode; }
-            set { servoGroup.AdvancedMode = value; }
+            get { return Internal.AdvancedMode; }
+            set { Internal.AdvancedMode = value; }
         }
 
         /// <summary>
@@ -116,7 +185,7 @@ namespace KRPC.InfernalRobotics
         /// </summary>
         [KRPCProperty]
         public float ElectricChargeRequired {
-            get { return servoGroup.TotalElectricChargeRequirement; }
+            get { return Internal.TotalElectricChargeRequirement; }
         }
 
         /// <summary>
@@ -124,8 +193,8 @@ namespace KRPC.InfernalRobotics
         /// </summary>
         [KRPCProperty]
         public bool BuildAid {
-            get { return servoGroup.BuildAid; }
-            set { servoGroup.BuildAid = value; }
+            get { return Internal.BuildAid; }
+            set { Internal.BuildAid = value; }
         }
 
         /// <summary>
@@ -133,8 +202,8 @@ namespace KRPC.InfernalRobotics
         /// </summary>
         [KRPCProperty]
         public bool IKActive {
-            get { return servoGroup.IKActive; }
-            set { servoGroup.IKActive = value; }
+            get { return Internal.IKActive; }
+            set { Internal.IKActive = value; }
         }
 
         /// <summary>
@@ -142,7 +211,7 @@ namespace KRPC.InfernalRobotics
         /// </summary>
         [KRPCProperty]
         public IList<Servo> Servos {
-            get { return servoGroup.Servos.Select (x => new Servo (x)).ToList (); }
+            get { return Internal.Servos.Select (x => new Servo (x)).ToList (); }
         }
 
         /// <summary>
@@ -153,7 +222,7 @@ namespace KRPC.InfernalRobotics
         [KRPCMethod (Nullable = true)]
         public Servo ServoWithName (string name)
         {
-            var servo = servoGroup.Servos.FirstOrDefault (x => x.Name == name);
+            var servo = Internal.Servos.FirstOrDefault (x => x.Name == name);
             return servo != null ? new Servo (servo) : null;
         }
 
@@ -162,7 +231,7 @@ namespace KRPC.InfernalRobotics
         /// </summary>
         [KRPCProperty]
         public IList<SpaceCenter.Services.Parts.Part> Parts {
-            get { return servoGroup.Servos.Select (x => new SpaceCenter.Services.Parts.Part (x.HostPart)).ToList (); }
+            get { return Internal.Servos.Select (x => new SpaceCenter.Services.Parts.Part (x.HostPart)).ToList (); }
         }
 
         /// <summary>
@@ -171,7 +240,7 @@ namespace KRPC.InfernalRobotics
         [KRPCMethod]
         public void MoveRight ()
         {
-            servoGroup.MoveRight ();
+            Internal.MoveRight ();
         }
 
         /// <summary>
@@ -180,7 +249,7 @@ namespace KRPC.InfernalRobotics
         [KRPCMethod]
         public void MoveLeft ()
         {
-            servoGroup.MoveLeft ();
+            Internal.MoveLeft ();
         }
 
         /// <summary>
@@ -189,7 +258,7 @@ namespace KRPC.InfernalRobotics
         [KRPCMethod]
         public void MoveCenter ()
         {
-            servoGroup.MoveCenter ();
+            Internal.MoveCenter ();
         }
 
         /// <summary>
@@ -198,7 +267,7 @@ namespace KRPC.InfernalRobotics
         [KRPCMethod]
         public void MoveNextPreset ()
         {
-            servoGroup.MoveNextPreset ();
+            Internal.MoveNextPreset ();
         }
 
         /// <summary>
@@ -207,7 +276,7 @@ namespace KRPC.InfernalRobotics
         [KRPCMethod]
         public void MovePrevPreset ()
         {
-            servoGroup.MovePrevPreset ();
+            Internal.MovePrevPreset ();
         }
 
         /// <summary>
@@ -216,7 +285,7 @@ namespace KRPC.InfernalRobotics
         [KRPCMethod]
         public void Stop ()
         {
-            servoGroup.Stop ();
+            Internal.Stop ();
         }
     }
 }

--- a/service/InfernalRobotics/test/test_servo.py
+++ b/service/InfernalRobotics/test/test_servo.py
@@ -32,6 +32,20 @@ class TestServo(krpctest.TestCase):
         finally:
             setattr(obj, attr, original)
 
+    def test_a_servo_read_twice_is_one_object(self):
+        # A servo is named by the part it is on, and a group by its vessel and its name,
+        # so reading either twice gives the same object rather than one per call. The
+        # servo is picked by a name only one of them has: the group has two servos called
+        # "Rotatron - Basic", which are two servos and not one.
+        group = self.ir.servo_group_with_name(self.vessel, "Group1")
+        self.assertEqual(group, self.ir.servo_group_with_name(self.vessel, "Group1"))
+        servo = group.servo_with_name("Joint Pivotron - Basic")
+        self.assertEqual(servo, group.servo_with_name("Joint Pivotron - Basic"))
+        self.assertEqual(
+            servo, self.ir.servo_with_name(self.vessel, "Joint Pivotron - Basic")
+        )
+        self.assertEqual(group.servos, group.servos)
+
     def test_rotatron(self):
         servo = self.ir.servo_with_name(self.vessel, "Rotatron - Basic")
         self.assertEqual("Rotatron - Basic", servo.name)

--- a/service/InfernalRobotics/test/test_servo_group.py
+++ b/service/InfernalRobotics/test/test_servo_group.py
@@ -73,7 +73,24 @@ class TestServoGroup(krpctest.TestCase):
         self._roundtrip(group, "ik_active", True)
         self._roundtrip(group, "forward_key", "n")
         self._roundtrip(group, "reverse_key", "m")
-        self._roundtrip(group, "name", "Renamed")
+
+    def test_renaming_a_group_leaves_its_object_gone(self):
+        # A group is named by its vessel and the group's name, so renaming it leaves every
+        # object for it standing for a group the vessel no longer has, the object the
+        # rename was made through included. An object under the new name has to be
+        # obtained to go on driving the group.
+        destroyed = self.connect().krpc.ObjectDestroyedException
+        group = self.ir.servo_group_with_name(self.vessel, "Group1")
+        group.name = "Renamed"
+        self.wait()
+        try:
+            self.assertRaises(destroyed, getattr, group, "name")
+            renamed = self.ir.servo_group_with_name(self.vessel, "Renamed")
+            self.assertEqual("Renamed", renamed.name)
+            self.assertNotEqual(group, renamed)
+        finally:
+            self.ir.servo_group_with_name(self.vessel, "Renamed").name = "Group1"
+            self.wait()
 
     def test_move(self):
         group = self.ir.servo_group_with_name(self.vessel, "Group2")

--- a/service/KerbalAlarmClock/CHANGELOG.md
+++ b/service/KerbalAlarmClock/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [v0.7.0] - unreleased
+
+- An alarm keeps working across a quickload, reading the alarm Kerbal Alarm Clock rebuilt
+  rather than the one it was obtained from, and raises `KRPC.ObjectDestroyedException` once
+  the mod no longer has an alarm with its id, which is what `Alarm.Remove` leaves behind. It
+  reports that it is unavailable, rather than gone, while the mod is not ready. Alarm
+  objects are freed rather than kept for the rest of the session (#1051)
+
 ## [v0.6.0]
 - Make available in all game scenes (#944)
 - Add `AlarmType.ScienceLab` (#982)

--- a/service/KerbalAlarmClock/src/Alarm.cs
+++ b/service/KerbalAlarmClock/src/Alarm.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using KRPC.KerbalAlarmClock.ExtensionMethods;
 using KRPC.Service.Attributes;
 using KRPC.Utils;
+using ObjectDestroyedException = KRPC.Service.KRPC.ObjectDestroyedException;
 
 namespace KRPC.KerbalAlarmClock
 {
@@ -13,14 +14,18 @@ namespace KRPC.KerbalAlarmClock
     /// <see cref="KerbalAlarmClock.AlarmsWithType"/>.
     /// </summary>
     [KRPCClass (Service = "KerbalAlarmClock")]
-    public class Alarm : Equatable<Alarm>
+    public class Alarm : Equatable<Alarm>, IGameObjectState
     {
+        // The identifier the mod knows the alarm by, which is what it creates and deletes
+        // alarms with. The alarm object the mod hands out is built afresh every time the
+        // alarms are listed, and belongs to the game state it was listed in, so holding one
+        // would leave this reading an alarm the mod no longer has.
         readonly string id;
-        KACWrapper.KACAPI.KACAlarm alarm;
 
         internal Alarm (KACWrapper.KACAPI.KACAlarm innerAlarm)
         {
-            alarm = innerAlarm;
+            if (innerAlarm == null)
+                throw new ArgumentNullException (nameof (innerAlarm));
             id = innerAlarm.ID;
         }
 
@@ -41,10 +46,62 @@ namespace KRPC.KerbalAlarmClock
             return id.GetHashCode ();
         }
 
-        void CheckExists ()
+        /// <summary>
+        /// What the game holds for the alarm. It is live while Kerbal Alarm Clock lists an
+        /// alarm with the identifier, and destroyed once the mod is there to ask and lists
+        /// none, as an alarm that is removed is gone for good. The mod not being ready says
+        /// nothing about any alarm.
+        /// </summary>
+        public GameObjectState GameObjectState {
+            get {
+                if (!KACWrapper.APIReady)
+                    return GameObjectState.Dormant;
+                return Find () != null ? GameObjectState.Live : GameObjectState.Destroyed;
+            }
+        }
+
+        /// <summary>
+        /// The alarm the mod has under the identifier, or null if it has none.
+        /// </summary>
+        KACWrapper.KACAPI.KACAlarm Find ()
         {
-            if (alarm == null)
-                throw new InvalidOperationException ("Alarm does not exist");
+            if (!KACWrapper.APIReady)
+                return null;
+            var alarms = KACWrapper.KAC.Alarms;
+            for (var i = 0; i < alarms.Count; i++) {
+                if (alarms [i].ID == id)
+                    return alarms [i];
+            }
+            return null;
+        }
+
+        /// <summary>
+        /// The alarm the mod has now. Every member reaches the mod through this, so an
+        /// alarm rebuilt by a game being loaded is read in place of the one this was built
+        /// from.
+        /// </summary>
+        KACWrapper.KACAPI.KACAlarm Internal {
+            get {
+                var found = Find ();
+                if (found == null)
+                    throw NotResolvable ();
+                return found;
+            }
+        }
+
+        /// <summary>
+        /// The error to raise when the mod has no alarm with the identifier, which
+        /// <see cref="GameObjectState" /> decides between.
+        /// </summary>
+        Exception NotResolvable ()
+        {
+            if (GameObjectState == GameObjectState.Destroyed)
+                return new ObjectDestroyedException (
+                    "The alarm no longer exists, as Kerbal Alarm Clock no longer has an " +
+                    "alarm with its id.");
+            return new InvalidOperationException (
+                "The alarm is not available, as Kerbal Alarm Clock is not ready. " +
+                "It can be used again once it is.");
         }
 
         /// <summary>
@@ -52,8 +109,8 @@ namespace KRPC.KerbalAlarmClock
         /// </summary>
         [KRPCProperty]
         public AlarmAction Action {
-            get { CheckExists (); return alarm.AlarmAction.ToAlarmAction (); }
-            set { CheckExists (); alarm.AlarmAction = value.FromAlarmAction (); }
+            get { return Internal.AlarmAction.ToAlarmAction (); }
+            set { Internal.AlarmAction = value.FromAlarmAction (); }
         }
 
         /// <summary>
@@ -61,8 +118,8 @@ namespace KRPC.KerbalAlarmClock
         /// </summary>
         [KRPCProperty]
         public double Margin {
-            get { CheckExists (); return alarm.AlarmMargin; }
-            set { CheckExists (); alarm.AlarmMargin = value; }
+            get { return Internal.AlarmMargin; }
+            set { Internal.AlarmMargin = value; }
         }
 
         /// <summary>
@@ -70,8 +127,8 @@ namespace KRPC.KerbalAlarmClock
         /// </summary>
         [KRPCProperty]
         public double Time {
-            get { CheckExists (); return alarm.AlarmTime; }
-            set { CheckExists (); alarm.AlarmTime = value; }
+            get { return Internal.AlarmTime; }
+            set { Internal.AlarmTime = value; }
         }
 
         /// <summary>
@@ -79,7 +136,7 @@ namespace KRPC.KerbalAlarmClock
         /// </summary>
         [KRPCProperty]
         public AlarmType Type {
-            get { CheckExists (); return alarm.AlarmType.ToAlarmType (); }
+            get { return Internal.AlarmType.ToAlarmType (); }
         }
 
         /// <summary>
@@ -87,7 +144,7 @@ namespace KRPC.KerbalAlarmClock
         /// </summary>
         [KRPCProperty]
         public string ID {
-            get { CheckExists (); return alarm.ID; }
+            get { return Internal.ID; }
         }
 
         /// <summary>
@@ -95,8 +152,8 @@ namespace KRPC.KerbalAlarmClock
         /// </summary>
         [KRPCProperty]
         public string Name {
-            get { CheckExists (); return alarm.Name; }
-            set { CheckExists (); alarm.Name = value; }
+            get { return Internal.Name; }
+            set { Internal.Name = value; }
         }
 
         /// <summary>
@@ -104,8 +161,8 @@ namespace KRPC.KerbalAlarmClock
         /// </summary>
         [KRPCProperty]
         public string Notes {
-            get { CheckExists (); return alarm.Notes; }
-            set { CheckExists (); alarm.Notes = value; }
+            get { return Internal.Notes; }
+            set { Internal.Notes = value; }
         }
 
         /// <summary>
@@ -116,7 +173,7 @@ namespace KRPC.KerbalAlarmClock
             // Computed from the alarm time rather than read through the wrapper:
             // the mod stores its remaining time as a KSPTimeSpan object, which the
             // wrapper cannot unbox to a double.
-            get { CheckExists (); return alarm.AlarmTime - Planetarium.GetUniversalTime (); }
+            get { return Internal.AlarmTime - Planetarium.GetUniversalTime (); }
         }
 
         /// <summary>
@@ -124,8 +181,8 @@ namespace KRPC.KerbalAlarmClock
         /// </summary>
         [KRPCProperty]
         public bool Enabled {
-            get { CheckExists (); return alarm.Enabled; }
-            set { CheckExists (); alarm.Enabled = value; }
+            get { return Internal.Enabled; }
+            set { Internal.Enabled = value; }
         }
 
         /// <summary>
@@ -133,8 +190,8 @@ namespace KRPC.KerbalAlarmClock
         /// </summary>
         [KRPCProperty]
         public bool PlaySound {
-            get { CheckExists (); return alarm.PlaySound; }
-            set { CheckExists (); alarm.PlaySound = value; }
+            get { return Internal.PlaySound; }
+            set { Internal.PlaySound = value; }
         }
 
         /// <summary>
@@ -144,7 +201,7 @@ namespace KRPC.KerbalAlarmClock
         /// </summary>
         [KRPCProperty]
         public bool Triggered {
-            get { CheckExists (); return alarm.Triggered; }
+            get { return Internal.Triggered; }
         }
 
         /// <summary>
@@ -154,8 +211,8 @@ namespace KRPC.KerbalAlarmClock
         /// </summary>
         [KRPCProperty]
         public bool Repeat {
-            get { CheckExists (); return alarm.RepeatAlarm; }
-            set { CheckExists (); alarm.RepeatAlarm = value; }
+            get { return Internal.RepeatAlarm; }
+            set { Internal.RepeatAlarm = value; }
         }
 
         /// <summary>
@@ -164,7 +221,7 @@ namespace KRPC.KerbalAlarmClock
         /// </summary>
         [KRPCProperty]
         public bool SupportsRepeat {
-            get { CheckExists (); return alarm.SupportsRepeat; }
+            get { return Internal.SupportsRepeat; }
         }
 
         /// <summary>
@@ -174,8 +231,8 @@ namespace KRPC.KerbalAlarmClock
         /// </summary>
         [KRPCProperty]
         public double RepeatPeriod {
-            get { CheckExists (); return alarm.RepeatAlarmPeriod; }
-            set { CheckExists (); alarm.RepeatAlarmPeriod = value; }
+            get { return Internal.RepeatAlarmPeriod; }
+            set { Internal.RepeatAlarmPeriod = value; }
         }
 
         /// <summary>
@@ -184,7 +241,7 @@ namespace KRPC.KerbalAlarmClock
         /// </summary>
         [KRPCProperty]
         public bool SupportsRepeatPeriod {
-            get { CheckExists (); return alarm.SupportsRepeatPeriod; }
+            get { return Internal.SupportsRepeatPeriod; }
         }
 
         /// <summary>
@@ -193,13 +250,12 @@ namespace KRPC.KerbalAlarmClock
         [KRPCProperty]
         public SpaceCenter.Services.Vessel Vessel {
             get {
-                CheckExists ();
-                var vessel = FlightGlobals.Vessels.First (x => x.id.ToString () == alarm.VesselID);
+                var vesselId = Internal.VesselID;
+                var vessel = FlightGlobals.Vessels.First (x => x.id.ToString () == vesselId);
                 return new SpaceCenter.Services.Vessel (vessel);
             }
             set {
-                CheckExists ();
-                alarm.VesselID = value.Id.ToString ();
+                Internal.VesselID = value.Id.ToString ();
             }
         }
 
@@ -209,13 +265,12 @@ namespace KRPC.KerbalAlarmClock
         [KRPCProperty]
         public SpaceCenter.Services.CelestialBody XferOriginBody {
             get {
-                CheckExists ();
-                var body = FlightGlobals.Bodies.First (x => alarm.XferOriginBodyName == x.bodyName);
+                var bodyName = Internal.XferOriginBodyName;
+                var body = FlightGlobals.Bodies.First (x => bodyName == x.bodyName);
                 return new SpaceCenter.Services.CelestialBody (body);
             }
             set {
-                CheckExists ();
-                alarm.XferOriginBodyName = value.InternalBody.bodyName;
+                Internal.XferOriginBodyName = value.InternalBody.bodyName;
             }
         }
 
@@ -225,25 +280,25 @@ namespace KRPC.KerbalAlarmClock
         [KRPCProperty]
         public SpaceCenter.Services.CelestialBody XferTargetBody {
             get {
-                CheckExists ();
-                var body = FlightGlobals.Bodies.First (x => alarm.XferTargetBodyName == x.bodyName);
+                var bodyName = Internal.XferTargetBodyName;
+                var body = FlightGlobals.Bodies.First (x => bodyName == x.bodyName);
                 return new SpaceCenter.Services.CelestialBody (body);
             }
             set {
-                CheckExists ();
-                alarm.XferTargetBodyName = value.InternalBody.bodyName;
+                Internal.XferTargetBodyName = value.InternalBody.bodyName;
             }
         }
 
         /// <summary>
         /// Removes the alarm. Any further use of this object throws an exception.
         /// </summary>
+        /// <remarks>
+        /// Any further use of this object throws an exception.
+        /// </remarks>
         [KRPCMethod]
         public void Remove ()
         {
-            CheckExists ();
-            KACWrapper.KAC.DeleteAlarm (alarm.ID);
-            alarm = null;
+            KACWrapper.KAC.DeleteAlarm (Internal.ID);
         }
     }
 }

--- a/service/KerbalAlarmClock/src/KACWrapper.cs
+++ b/service/KerbalAlarmClock/src/KACWrapper.cs
@@ -102,6 +102,10 @@ namespace KRPC.KerbalAlarmClock
                 .SelectMany(t => t)
                 .FirstOrDefault(t => t.FullName == "KerbalAlarmClock.KACAlarm");
 
+            // The alarm wrapper binds the mod's fields once and keeps them for the
+            // assembly, so anything bound against the type of a previous run is dropped.
+            KACAPI.KACAlarm.Unbind();
+
             if (KACAlarmType == null)
             {
                 return false;
@@ -382,6 +386,29 @@ namespace KRPC.KerbalAlarmClock
                 internal KACAlarm(Object a)
                 {
                     actualAlarm = a;
+                    EnsureBound();
+                }
+
+                // The lookups below depend on the mod's alarm type alone, so they are made
+                // once for the assembly rather than for each alarm wrapped. An alarm is
+                // wrapped every time the alarms are listed, and there are twenty of them.
+                private static bool bound;
+
+                internal static void Unbind()
+                {
+                    bound = false;
+                }
+
+                private static void EnsureBound()
+                {
+                    if (bound)
+                        return;
+                    Bind();
+                    bound = true;
+                }
+
+                private static void Bind()
+                {
                     VesselIDField = KACAlarmType.GetField("VesselID");
                     IDField = KACAlarmType.GetField("ID");
                     NameField = KACAlarmType.GetField("Name");
@@ -420,7 +447,7 @@ namespace KRPC.KerbalAlarmClock
                 }
                 private Object actualAlarm;
 
-                private FieldInfo VesselIDField;
+                private static FieldInfo VesselIDField;
                 /// <summary>
                 /// Unique Identifier of the Vessel that the alarm is attached to
                 /// </summary>
@@ -430,7 +457,7 @@ namespace KRPC.KerbalAlarmClock
                     set { VesselIDField.SetValue(actualAlarm, value); }
                 }
 
-                private FieldInfo IDField;
+                private static FieldInfo IDField;
                 /// <summary>
                 /// Unique Identifier of this alarm
                 /// </summary>
@@ -439,7 +466,7 @@ namespace KRPC.KerbalAlarmClock
                     get { return (String)IDField.GetValue(actualAlarm); }
                 }
 
-                private FieldInfo NameField;
+                private static FieldInfo NameField;
                 /// <summary>
                 /// Short Text Name for the Alarm
                 /// </summary>
@@ -449,7 +476,7 @@ namespace KRPC.KerbalAlarmClock
                     set { NameField.SetValue(actualAlarm, value); }
                 }
 
-                private FieldInfo NotesField;
+                private static FieldInfo NotesField;
                 /// <summary>
                 /// Longer Text Description for the Alarm
                 /// </summary>
@@ -459,7 +486,7 @@ namespace KRPC.KerbalAlarmClock
                     set { NotesField.SetValue(actualAlarm, value); }
                 }
 
-                private FieldInfo XferOriginBodyNameField;
+                private static FieldInfo XferOriginBodyNameField;
                 /// <summary>
                 /// Name of the origin body for a transfer
                 /// </summary>
@@ -469,7 +496,7 @@ namespace KRPC.KerbalAlarmClock
                     set { XferOriginBodyNameField.SetValue(actualAlarm, value); }
                 }
 
-                private FieldInfo XferTargetBodyNameField;
+                private static FieldInfo XferTargetBodyNameField;
                 /// <summary>
                 /// Name of the destination body for a transfer
                 /// </summary>
@@ -479,13 +506,13 @@ namespace KRPC.KerbalAlarmClock
                     set { XferTargetBodyNameField.SetValue(actualAlarm, value); }
                 }
                 
-                private FieldInfo AlarmTypeField;
+                private static FieldInfo AlarmTypeField;
                 /// <summary>
                 /// What type of Alarm is this - affects icon displayed and some calc options
                 /// </summary>
                 public AlarmTypeEnum AlarmType { get { return (AlarmTypeEnum)AlarmTypeField.GetValue(actualAlarm); } }
 
-                private PropertyInfo AlarmTimeProperty;
+                private static PropertyInfo AlarmTimeProperty;
                 /// <summary>
                 /// In game UT value of the alarm
                 /// </summary>
@@ -495,7 +522,7 @@ namespace KRPC.KerbalAlarmClock
                     set { AlarmTimeProperty.SetValue(actualAlarm, value, null); }
                 }
 
-                private FieldInfo AlarmMarginField;
+                private static FieldInfo AlarmMarginField;
                 /// <summary>
                 /// In game seconds the alarm will fire before the event it is for
                 /// </summary>
@@ -505,7 +532,7 @@ namespace KRPC.KerbalAlarmClock
                     set { AlarmMarginField.SetValue(actualAlarm, value); }
                 }
 
-                private FieldInfo AlarmActionField;
+                private static FieldInfo AlarmActionField;
                 /// <summary>
                 /// What should the Alarm Clock do when the alarm fires
                 /// </summary>
@@ -522,18 +549,18 @@ namespace KRPC.KerbalAlarmClock
                     get { return (AlarmActionEnum)ActionActionProperty.GetValue(actualAlarm); }
                     set { ActionActionProperty.SetValue(actualAlarm, (Int32)value); }
                 }
-                private PropertyInfo ActionActionProperty;
+                private static PropertyInfo ActionActionProperty;
 
 
 
-                private FieldInfo RemainingField;
+                private static FieldInfo RemainingField;
                 /// <summary>
                 /// How much Game time is left before the alarm fires
                 /// </summary>
                 public Double Remaining { get { return (Double)RemainingField.GetValue(actualAlarm); } }
 
 
-                private FieldInfo RepeatAlarmField;
+                private static FieldInfo RepeatAlarmField;
                 /// <summary>
                 /// Whether the alarm will be repeated after it fires
                 /// </summary>
@@ -542,7 +569,7 @@ namespace KRPC.KerbalAlarmClock
                     get { return (Boolean)RepeatAlarmField.GetValue(actualAlarm); }
                     set { RepeatAlarmField.SetValue(actualAlarm, value); }
                 }
-                private PropertyInfo RepeatAlarmPeriodProperty;
+                private static PropertyInfo RepeatAlarmPeriodProperty;
                 /// <summary>
                 /// Value in Seconds after which the alarm will repeat
                 /// </summary>
@@ -555,7 +582,7 @@ namespace KRPC.KerbalAlarmClock
                     }
                     set { RepeatAlarmPeriodProperty.SetValue(actualAlarm, value, null); }
                 }
-                private PropertyInfo SupportsRepeatProperty;
+                private static PropertyInfo SupportsRepeatProperty;
                 /// <summary>
                 /// Whether this alarm's type supports repeating
                 /// </summary>
@@ -563,7 +590,7 @@ namespace KRPC.KerbalAlarmClock
                 {
                     get { return (Boolean)SupportsRepeatProperty.GetValue(actualAlarm, null); }
                 }
-                private PropertyInfo SupportsRepeatPeriodProperty;
+                private static PropertyInfo SupportsRepeatPeriodProperty;
                 /// <summary>
                 /// Whether this alarm's type supports a repeat period
                 /// </summary>
@@ -571,7 +598,7 @@ namespace KRPC.KerbalAlarmClock
                 {
                     get { return (Boolean)SupportsRepeatPeriodProperty.GetValue(actualAlarm, null); }
                 }
-                private FieldInfo EnabledField;
+                private static FieldInfo EnabledField;
                 /// <summary>
                 /// Whether the alarm is enabled
                 /// </summary>
@@ -580,7 +607,7 @@ namespace KRPC.KerbalAlarmClock
                     get { return (Boolean)EnabledField.GetValue(actualAlarm); }
                     set { EnabledField.SetValue(actualAlarm, value); }
                 }
-                private FieldInfo PlaySoundField;
+                private static FieldInfo PlaySoundField;
                 /// <summary>
                 /// Whether the alarm plays a sound when it fires
                 /// </summary>
@@ -589,7 +616,7 @@ namespace KRPC.KerbalAlarmClock
                     get { return (Boolean)PlaySoundField.GetValue(actualAlarm); }
                     set { PlaySoundField.SetValue(actualAlarm, value); }
                 }
-                private FieldInfo TriggeredField;
+                private static FieldInfo TriggeredField;
                 /// <summary>
                 /// Whether the alarm has been triggered (the field is internal to the mod)
                 /// </summary>

--- a/service/LiDAR/CHANGELOG.md
+++ b/service/LiDAR/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [v0.7.0] - unreleased
+
+- A `Laser` whose part the game has destroyed, or that is no longer a laser, raises
+  `KRPC.ObjectDestroyedException` rather than reaching into a part that is gone, and is
+  freed rather than kept for the rest of the session (#1051)
+
 ## [v0.6.0]
 - Fix `LiDAR.Available` incorrectly reporting false in game scenes other than flight (#937)
 

--- a/service/LiDAR/src/Laser.cs
+++ b/service/LiDAR/src/Laser.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using KRPC.Service.Attributes;
 using KRPC.Utils;
 using UnityEngine;
+using ObjectDestroyedException = KRPC.Service.KRPC.ObjectDestroyedException;
 
 namespace KRPC.LiDAR
 {
@@ -11,11 +12,46 @@ namespace KRPC.LiDAR
     /// A LaserDist laser.
     /// </summary>
     [KRPCClass(Service = "LiDAR")]
-    public class Laser : Equatable<Laser>
+    public class Laser : Equatable<Laser>, IGameObjectState
     {
+        // The module that makes a part a laser. The mod's API takes the part rather than
+        // the module, so the part is what identifies this and all it has to reach.
+        const string moduleName = "LiDARModule";
+
         internal static bool Is(SpaceCenter.Services.Parts.Part part)
         {
-            return part.InternalPart.Modules.Contains("LiDARModule");
+            return part.InternalPart.Modules.Contains(moduleName);
+        }
+
+        /// <summary>
+        /// What the game holds for the laser. It belongs to its part, so it is exactly as
+        /// live, dormant or destroyed as the part, and destroyed when a part that is there
+        /// to look at no longer carries the module.
+        /// </summary>
+        public GameObjectState GameObjectState
+        {
+            get
+            {
+                var state = Part.GameObjectState;
+                if (state != GameObjectState.Live)
+                    return state;
+                return Part.InternalPart.Modules.Contains(moduleName)
+                    ? GameObjectState.Live : GameObjectState.Destroyed;
+            }
+        }
+
+        // The part it is on, checked to still carry the module. Every member that reaches
+        // the mod goes through this.
+        global::Part InternalPart
+        {
+            get
+            {
+                var innerPart = Part.InternalPart;
+                if (!innerPart.Modules.Contains(moduleName))
+                    throw new ObjectDestroyedException(
+                        "The laser no longer exists, as its part no longer has one.");
+                return innerPart;
+            }
         }
 
         internal Laser(SpaceCenter.Services.Parts.Part part)
@@ -59,7 +95,7 @@ namespace KRPC.LiDAR
         {
             get {
                 if (API.IsAvailable)
-                    return API.GetCloud(Part.InternalPart);
+                    return API.GetCloud(InternalPart);
                 else
                     return new List<double>();
             }

--- a/service/RemoteTech/CHANGELOG.md
+++ b/service/RemoteTech/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [v0.7.0] - unreleased
+
+- An `Antenna` whose part the game has destroyed, or that is no longer an antenna, and a
+  `Comms` whose vessel is gone, raise `KRPC.ObjectDestroyedException` rather than reaching
+  into what is no longer there, and are freed rather than kept for the rest of the session
+  (#1051)
+
 ## [v0.6.0]
 - Fix `RemoteTech.Available` incorrectly reporting false in game scenes other than flight (#937)
 

--- a/service/RemoteTech/src/Antenna.cs
+++ b/service/RemoteTech/src/Antenna.cs
@@ -2,6 +2,7 @@ using System;
 using System.Linq;
 using KRPC.Service.Attributes;
 using KRPC.Utils;
+using ObjectDestroyedException = KRPC.Service.KRPC.ObjectDestroyedException;
 
 namespace KRPC.RemoteTech
 {
@@ -9,13 +10,18 @@ namespace KRPC.RemoteTech
     /// A RemoteTech antenna. Obtained by calling <see cref="Comms.Antennas"/> or <see cref="RemoteTech.Antenna"/>.
     /// </summary>
     [KRPCClass (Service = "RemoteTech")]
-    public class Antenna : Equatable<Antenna>
+    public class Antenna : Equatable<Antenna>, IGameObjectState
     {
+        // The module that makes a part an antenna. An antenna is a part carrying it, so the
+        // part is what identifies the antenna, and the mod's API takes the part rather than
+        // the module.
+        const string moduleName = "ModuleRTAntenna";
+
         readonly SpaceCenter.Services.Parts.Part part;
 
         internal static bool Is (SpaceCenter.Services.Parts.Part innerPart)
         {
-            return innerPart.InternalPart.Modules.Contains ("ModuleRTAntenna");
+            return innerPart.InternalPart.Modules.Contains (moduleName);
         }
 
         internal Antenna (SpaceCenter.Services.Parts.Part innerPart)
@@ -42,6 +48,33 @@ namespace KRPC.RemoteTech
         }
 
         /// <summary>
+        /// What the game holds for the antenna. It belongs to its part, so it is exactly as
+        /// live, dormant or destroyed as the part, and destroyed when a part that is there
+        /// to look at no longer carries the antenna module.
+        /// </summary>
+        public GameObjectState GameObjectState {
+            get {
+                var state = part.GameObjectState;
+                if (state != GameObjectState.Live)
+                    return state;
+                return part.InternalPart.Modules.Contains (moduleName)
+                    ? GameObjectState.Live : GameObjectState.Destroyed;
+            }
+        }
+
+        // The part the antenna is on, checked to still be an antenna. Every member that
+        // reaches the mod goes through this.
+        global::Part InternalPart {
+            get {
+                var innerPart = part.InternalPart;
+                if (!innerPart.Modules.Contains (moduleName))
+                    throw new ObjectDestroyedException (
+                        "The antenna no longer exists, as its part no longer has one.");
+                return innerPart;
+            }
+        }
+
+        /// <summary>
         /// Get the part containing this antenna.
         /// </summary>
         [KRPCProperty]
@@ -54,7 +87,7 @@ namespace KRPC.RemoteTech
         /// </summary>
         [KRPCProperty]
         public bool HasConnection {
-            get { return API.AntennaHasConnection (part.InternalPart); }
+            get { return API.AntennaHasConnection (InternalPart); }
         }
 
         /// <summary>
@@ -66,7 +99,7 @@ namespace KRPC.RemoteTech
         [KRPCProperty]
         public Target Target {
             get {
-                var target = API.GetAntennaTarget (part.InternalPart);
+                var target = API.GetAntennaTarget (InternalPart);
                 if (target == API.GetNoTargetGuid ())
                     return Target.None;
                 if (target == API.GetActiveVesselGuid ())
@@ -79,9 +112,9 @@ namespace KRPC.RemoteTech
             }
             set {
                 if (value == Target.ActiveVessel)
-                    API.SetAntennaTarget (part.InternalPart, API.GetActiveVesselGuid ());
+                    API.SetAntennaTarget (InternalPart, API.GetActiveVesselGuid ());
                 else if (value == Target.None)
-                    API.SetAntennaTarget (part.InternalPart, API.GetNoTargetGuid ());
+                    API.SetAntennaTarget (InternalPart, API.GetNoTargetGuid ());
                 else
                     throw new ArgumentException ("Failed to set target");
             }
@@ -95,10 +128,10 @@ namespace KRPC.RemoteTech
             get {
                 if (Target != Target.CelestialBody)
                     throw new InvalidOperationException ("Antenna is not targetting a celestial body.");
-                return new SpaceCenter.Services.CelestialBody (RemoteTech.CelestialBodyIds [API.GetAntennaTarget (part.InternalPart)]);
+                return new SpaceCenter.Services.CelestialBody (RemoteTech.CelestialBodyIds [API.GetAntennaTarget (InternalPart)]);
             }
             set {
-                API.SetAntennaTarget (part.InternalPart, API.GetCelestialBodyGuid (value.InternalBody));
+                API.SetAntennaTarget (InternalPart, API.GetCelestialBodyGuid (value.InternalBody));
             }
         }
 
@@ -110,12 +143,12 @@ namespace KRPC.RemoteTech
             get {
                 if (Target != Target.GroundStation)
                     throw new InvalidOperationException ("Antenna is not targetting a ground station.");
-                return RemoteTech.GroundStationIds [API.GetAntennaTarget (part.InternalPart)];
+                return RemoteTech.GroundStationIds [API.GetAntennaTarget (InternalPart)];
             }
             set {
                 if (RemoteTech.GroundStationIds.Values.All (x => x != value))
                     throw new ArgumentException ("Ground station does not exist.");
-                API.SetAntennaTarget (part.InternalPart, API.GetGroundStationGuid (value));
+                API.SetAntennaTarget (InternalPart, API.GetGroundStationGuid (value));
             }
         }
 
@@ -127,10 +160,10 @@ namespace KRPC.RemoteTech
             get {
                 if (Target != Target.Vessel)
                     throw new InvalidOperationException ("Antenna is not targetting a vessel.");
-                return new SpaceCenter.Services.Vessel (API.GetAntennaTarget (part.InternalPart));
+                return new SpaceCenter.Services.Vessel (API.GetAntennaTarget (InternalPart));
             }
             set {
-                API.SetAntennaTarget (part.InternalPart, value.InternalVessel.id);
+                API.SetAntennaTarget (InternalPart, value.InternalVessel.id);
             }
         }
     }

--- a/service/RemoteTech/src/Comms.cs
+++ b/service/RemoteTech/src/Comms.cs
@@ -10,17 +10,31 @@ namespace KRPC.RemoteTech
     /// Communications for a vessel.
     /// </summary>
     [KRPCClass (Service = "RemoteTech")]
-    public class Comms : Equatable<Comms>
+    public class Comms : Equatable<Comms>, IGameObjectState
     {
         readonly SpaceCenter.Services.Vessel vessel;
-        readonly Guid vesselId;
 
         internal Comms (SpaceCenter.Services.Vessel innerVessel)
         {
             if (!API.IsAvailable)
                 throw new InvalidOperationException ("RemoteTech is not installed");
+            if (ReferenceEquals (innerVessel, null))
+                throw new ArgumentNullException (nameof (innerVessel));
             vessel = innerVessel;
-            vesselId = vessel.InternalVessel.id;
+        }
+
+        /// <summary>
+        /// What the game holds for the vessel these communications belong to.
+        /// </summary>
+        public GameObjectState GameObjectState {
+            get { return vessel.GameObjectState; }
+        }
+
+        // The id of the vessel, which the mod's API takes, resolved first so that a vessel
+        // the game no longer has says so rather than the mod answering for an id that names
+        // nothing.
+        Guid VesselId {
+            get { return vessel.InternalVessel.id; }
         }
 
         /// <summary>
@@ -52,7 +66,7 @@ namespace KRPC.RemoteTech
         /// </summary>
         [KRPCProperty]
         public bool HasLocalControl {
-            get { return API.HasLocalControl (vesselId); }
+            get { return API.HasLocalControl (VesselId); }
         }
 
         /// <summary>
@@ -60,7 +74,7 @@ namespace KRPC.RemoteTech
         /// </summary>
         [KRPCProperty]
         public bool HasFlightComputer {
-            get { return API.HasFlightComputer (vesselId); }
+            get { return API.HasFlightComputer (VesselId); }
         }
 
         /// <summary>
@@ -68,7 +82,7 @@ namespace KRPC.RemoteTech
         /// </summary>
         [KRPCProperty]
         public bool HasConnection {
-            get { return API.HasAnyConnection (vesselId); }
+            get { return API.HasAnyConnection (VesselId); }
         }
 
         /// <summary>
@@ -76,7 +90,7 @@ namespace KRPC.RemoteTech
         /// </summary>
         [KRPCProperty]
         public bool HasConnectionToGroundStation {
-            get { return API.HasConnectionToKSC (vesselId); }
+            get { return API.HasConnectionToKSC (VesselId); }
         }
 
         /// <summary>
@@ -84,7 +98,7 @@ namespace KRPC.RemoteTech
         /// </summary>
         [KRPCProperty]
         public double SignalDelay {
-            get { return API.GetShortestSignalDelay (vesselId); }
+            get { return API.GetShortestSignalDelay (VesselId); }
         }
 
         /// <summary>
@@ -92,7 +106,7 @@ namespace KRPC.RemoteTech
         /// </summary>
         [KRPCProperty]
         public double SignalDelayToGroundStation {
-            get { return API.GetSignalDelayToKSC (vesselId); }
+            get { return API.GetSignalDelayToKSC (VesselId); }
         }
 
         /// <summary>
@@ -102,7 +116,9 @@ namespace KRPC.RemoteTech
         [KRPCMethod]
         public double SignalDelayToVessel (SpaceCenter.Services.Vessel other)
         {
-            return API.GetSignalDelayToSatellite (vesselId, other.Id);
+            if (ReferenceEquals (other, null))
+                throw new ArgumentNullException (nameof (other));
+            return API.GetSignalDelayToSatellite (VesselId, other.InternalVessel.id);
         }
 
         /// <summary>

--- a/service/SpaceCenter/CHANGELOG.md
+++ b/service/SpaceCenter/CHANGELOG.md
@@ -59,6 +59,14 @@
   - `EditorVessel.Resources`, `Part.Resources` and `Stage.Resources` report the resources
     the vessel under construction can hold, per vessel, per part and per stage, as they do
     for a vessel in flight (#1038)
+  - A part of the vessel under construction raises `KRPC.ObjectDestroyedException` once it
+    is no longer in that vessel, and once the editor has loaded any vessel over it. A part
+    in the editor is named by an identifier that is only unique within one vessel, so a
+    part of a vessel that has been replaced cannot be told from the part of the new one
+    that answers to the same identifier. An undo or a redo rebuilds the vessel the editor
+    already has rather than loading a new one, so a part it leaves alone keeps working.
+    Leaving the editor destroys the vessel it had open, and everything reached through
+    it (#1051)
 
 - Vessels and crew
   - Add `CrewMember.EVA`, which sends a Kerbal outside through the hatch of the part it is
@@ -75,6 +83,15 @@
     directions the navball marks in that mode, arranged as in
     `Vessel.OrbitalReferenceFrame`, so a direction of (0,1,0) in the frame is prograde
     (#1029)
+  - Using a vessel that no longer exists raises `KRPC.ObjectDestroyedException`, saying that
+    the vessel is gone, rather than an argument error (#1051)
+  - A `CrewMember` is named by the kerbal's name and looks them up on the game's roster on
+    every call, so the same kerbal obtained twice is the same object and one obtained before
+    a load goes on working. A kerbal the roster no longer has raises
+    `KRPC.ObjectDestroyedException`. Renaming a kerbal by setting `CrewMember.Name` renames
+    them on the roster, so every object for that kerbal, the one renamed through included,
+    stands for a kerbal that no longer exists; a fresh object has to be obtained under the
+    new name (#1051)
 
 - Staging
   - Fix stages from `Vessel.Stages`, `Vessel.StageAt`, `Vessel.DecoupleStages` and
@@ -83,6 +100,13 @@
     too, so the game had to be restarted to get working stages back (#1023)
 
 - Orbits, nodes and bodies
+  - An `Orbit` reads the orbit of the vessel, celestial body or maneuver node it belongs to as
+    it is now, rather than the one the game had when it was obtained, so it keeps working
+    across a load instead of reporting the orbit of a game state that has been replaced.
+    Asking the same thing for its orbit again gives back the same object rather than a second
+    one (#764)
+  - A `ClosestApproach` is freed once either of the orbits it describes is gone, rather than
+    being kept for the rest of the session (#1051)
   - Add `CelestialBody.SurfaceNormal`, `CelestialBody.BedrockNormal` and `CelestialBody.MSLNormal`
     to get the slope of the terrain at a given latitude and longitude, as a unit vector normal to
     the surface, to the sea-bed, or to the sphere at sea level (#1030)
@@ -107,6 +131,17 @@
     frame, alongside the existing `Orbit.PositionAt` (#1046)
   - `Orbit.Epoch` is documented as the universal time at which the mean anomaly at epoch
     is measured. It was described as the time since that point (#1046)
+
+- Maneuver nodes
+  - Using a maneuver node that has been removed raises `KRPC.ObjectDestroyedException` rather
+    than reporting the call as invalid. Loading a game replaces the vessel's maneuver nodes,
+    so nodes obtained before the load are also gone (#1051)
+  - Fix removing a maneuver node leaking the object for the rest of the session (#771)
+
+- Reference frames
+  - A reference frame taken from a docking port keeps working across a quickload, and says the
+    port is gone rather than failing with a null reference once its part is destroyed (#885,
+    #764)
 
 - Flight and aerodynamics
   - Add `Flight.SurfaceNormal` to get the slope of the terrain under a vessel, as a unit vector
@@ -152,6 +187,13 @@
     including radial ones and any that a mod derives from the stock modules. It was false for
     all of them regardless of their configuration. The stage a part is assigned to follows the
     same value, so a vessel carrying such a decoupler can be staged differently (#1048)
+  - A force added with `Part.AddForce` stops being applied, and is freed, once its part is
+    destroyed. It previously failed on every physics update for the rest of the session. A
+    force on a part the game has unloaded, or measured in a reference frame that is defined
+    against something that is gone, waits rather than being applied (#1051)
+  - `Force.Remove` leaves the object gone, so using one afterwards raises
+    `KRPC.ObjectDestroyedException` and the object is freed. A removed force previously went
+    on reporting the force it was applying, and was kept for the rest of the session (#1051)
   - `Part.BoundingBox` and `Vessel.BoundingBox` now measure only the meshes of a part's own
     model. The boxes no longer take in the models of physicsless child parts, nor any object
     another mod has attached to a part, which could stretch a box to an arbitrary size (#1024)
@@ -168,10 +210,39 @@
   - Fix `ReactionWheel.AvailableTorque`, and the vessel level torque properties that include
     it, being scaled by the square of the wheel's authority limiter when KSPCommunityFixes is
     installed (#1042)
+  - Fix `Decoupler` objects accumulating for the rest of the session, one per call to
+    `Part.Decoupler`, and the same decoupler obtained twice comparing unequal (#1051)
+  - A `Decoupler` finds its part's decoupler module again on every call, so it keeps working
+    across a quickload. One obtained before a load previously read the module the load
+    replaced, reporting the impulse and fired state it had beforehand and failing outright
+    when fired, while reporting itself as still there (#1051)
+  - Using a part that has been destroyed raises `KRPC.ObjectDestroyedException` instead of
+    failing with a null reference (#885)
+  - Using a part module, or any of the objects built on one such as `Engine`, `Parachute`,
+    `Antenna` or `SolarPanel`, after its part has been destroyed raises
+    `KRPC.ObjectDestroyedException` instead of failing with a null reference (#885)
+  - Part modules, and the objects built on them, read the modules of the loaded game rather
+    than those of a game state that has been replaced, so they keep working across a
+    quickload instead of returning readings from before it (#764)
+  - Using a part of a vessel that the game has unloaded raises an error saying that the part
+    is not loaded. The part works again once the game loads the vessel, and is not treated as
+    destroyed in the meantime (#1051)
+  - The fields, events and actions of a part module read the loaded game's module rather than
+    one belonging to a replaced game state, and say the module is gone when it is (#764)
+  - A `ScienceSubject` belongs to the game state it was read from, and using one after that
+    state has been replaced raises `KRPC.ObjectDestroyedException` rather than returning the
+    replaced game's science. Reading `Experiment.ScienceSubject` repeatedly no longer adds a
+    new object for each read, and reads the science the game has banked against the subject
+    since the first of those reads (#771)
+  - Fix `ScienceSubject.Science` and `ScienceSubject.ScienceCap` scaling by the science gain
+    multiplier that was in force when the object was read, rather than the current one (#1051)
 
 - Resources
   - Add `ResourceTransfer.Cancel` to stop a transfer before it finishes; no more of the
     resource is moved and the transfer is marked as complete (#1028)
+  - Fix a resource transfer failing on every update, and never completing, once one of the
+    parts it runs between is destroyed; the transfer is now canceled. A transfer whose vessel
+    the game unloads waits for it rather than failing (#1051)
 
 - Camera
   - `Camera.NextCamera` and `Camera.PreviousCamera` now move the IVA view between the crew of
@@ -184,6 +255,20 @@
     with a `NullReferenceException`, as does setting it to `null` (#1031)
   - `Camera.FocussedCrewMember` returns `null` when no crew member is in view, instead of
     failing with a `NullReferenceException` (#1031)
+
+- Alarms, contracts and waypoints
+  - `SpaceCenter.Alarm`, `Contract`, `ContractParameter` and `Waypoint` objects find what
+    they stand for again on every call, rather than holding what the game gave them. They
+    keep working when the game rebuilds it, and never read a record belonging to a game
+    state that has since been replaced. One that the game no longer has raises
+    `KRPC.ObjectDestroyedException`, which is what `Alarm.Remove` and `Waypoint.Remove`
+    leave behind, and is freed rather than kept for the rest of the session (#1051)
+
+- Communications
+  - A `CommLink` is named by the two nodes it joins and reports the link between them as it
+    is now. A link over which contact has been lost reports that the two nodes are not
+    connected, rather than the signal strength the link had when contact was lost, and one
+    whose nodes are gone raises `KRPC.ObjectDestroyedException` (#1051)
 
 ## [v0.6.0]
 

--- a/service/SpaceCenter/src/AutoPilotInfoWindow.cs
+++ b/service/SpaceCenter/src/AutoPilotInfoWindow.cs
@@ -214,11 +214,8 @@ namespace KRPC.SpaceCenter
 
         string DisplayName ()
         {
-            try {
-                return FlightGlobalsExtensions.GetVesselById (VesselId).GetDisplayName ();
-            } catch (ArgumentException) {
-                return "Vessel";
-            }
+            var vessel = FlightGlobalsExtensions.FindVesselById (VesselId);
+            return vessel == null ? "Vessel" : vessel.GetDisplayName ();
         }
 
         protected override void Draw (bool needRescale)

--- a/service/SpaceCenter/src/ConstructedOrbitsAddon.cs
+++ b/service/SpaceCenter/src/ConstructedOrbitsAddon.cs
@@ -1,0 +1,47 @@
+using KRPC.Utils;
+using UnityEngine;
+
+namespace KRPC.SpaceCenter
+{
+    /// <summary>
+    /// Addon that holds the orbits clients construct, so that an orbit is let go of when
+    /// the client that asked for it disconnects.
+    /// </summary>
+    /// <remarks>
+    /// A constructed orbit stands for nothing in the game, so nothing the game destroys
+    /// ever retires one and the object would otherwise stay in the object store for the
+    /// rest of the session. Its client going is the only thing that can say it is
+    /// finished with.
+    ///
+    /// It is not a <see cref="ClientCleanupAddon" />, which gives up its collections on
+    /// entering a scene: an orbit is arithmetic the server holds on a client's behalf and
+    /// is as valid in one scene as in another, so a scene change leaves it alone. It runs
+    /// in every game scene because an orbit can be constructed in any of them,
+    /// <see cref="Services.Orbit" /> carrying no scene restriction of its own.
+    /// </remarks>
+    [KSPAddon (KSPAddon.Startup.AllGameScenes, false)]
+    public sealed class ConstructedOrbitsAddon : MonoBehaviour
+    {
+        // Qualified, the global namespace holding a KSP class of the same name.
+        static readonly ClientOwnedObjects<Services.Orbit> orbits =
+            new ClientOwnedObjects<Services.Orbit> (x => x.Release ());
+
+        /// <summary>
+        /// Record an orbit a client has constructed.
+        /// </summary>
+        static internal void Add (Services.Orbit orbit)
+        {
+            orbits.Add (orbit);
+        }
+
+        /// <summary>
+        /// Let go of the orbits of clients that have disconnected. This runs in Update
+        /// rather than FixedUpdate, which stops while the game is paused, as nothing
+        /// about an orbit a client constructed is tied to the physics step.
+        /// </summary>
+        public void Update ()
+        {
+            orbits.Sweep ();
+        }
+    }
+}

--- a/service/SpaceCenter/src/EditorShipAddon.cs
+++ b/service/SpaceCenter/src/EditorShipAddon.cs
@@ -1,0 +1,53 @@
+using UnityEngine;
+
+namespace KRPC.SpaceCenter
+{
+    /// <summary>
+    /// Addon that hears the editor restoring a vessel from its own backup, which is what
+    /// an undo or a redo is, so that the vessel it restores is recognized as the one the
+    /// editor already had rather than as a new one.
+    /// See <see cref="EditorExtensions.ShipGeneration" />.
+    /// </summary>
+    /// <remarks>
+    /// The handlers are instance methods because the game cannot take a static one: the
+    /// delegate is wrapped in an <c>EventData.EvtDelegate</c>, whose constructor reads the
+    /// target the delegate was made over and raises a null reference for a delegate that
+    /// has none. That throws out of whatever registered it, so a handler that never runs
+    /// is what a static one looks like from the outside.
+    /// </remarks>
+    [KSPAddon (KSPAddon.Startup.AllGameScenes, false)]
+    public sealed class EditorShipAddon : MonoBehaviour
+    {
+        /// <summary>
+        /// Start listening for the editor restoring a vessel.
+        /// </summary>
+        public void Awake ()
+        {
+            GameEvents.onEditorUndo.Add (OnRestored);
+            GameEvents.onEditorRedo.Add (OnRestored);
+            GameEvents.onEditorRestoreState.Add (OnRestoredState);
+        }
+
+        /// <summary>
+        /// Stop listening for the editor restoring a vessel.
+        /// </summary>
+        public void OnDestroy ()
+        {
+            GameEvents.onEditorUndo.Remove (OnRestored);
+            GameEvents.onEditorRedo.Remove (OnRestored);
+            GameEvents.onEditorRestoreState.Remove (OnRestoredState);
+        }
+
+        void OnRestored (ShipConstruct ship)
+        {
+            EditorExtensions.ShipRestored (ship);
+        }
+
+        void OnRestoredState ()
+        {
+            // The game raises this from the same call as the two above, once it has built
+            // the vessel it restored, so the vessel the editor has now is that vessel.
+            EditorExtensions.ShipRestored (EditorExtensions.Ship);
+        }
+    }
+}

--- a/service/SpaceCenter/src/ExtensionMethods/EditorExtensions.cs
+++ b/service/SpaceCenter/src/ExtensionMethods/EditorExtensions.cs
@@ -57,10 +57,35 @@ namespace KRPC.SpaceCenter
                 if (!ReferenceEquals (ship, null) &&
                     (lastShip == null || !ReferenceEquals (lastShip.Target, ship))) {
                     lastShip = new WeakReference (ship);
-                    shipGeneration++;
+                    // An undo or a redo hands back a vessel object of its own, built from
+                    // the game's backup, so the object changing is not on its own a new
+                    // vessel. The parts it builds carry the craft ids they had, so what
+                    // a part object names is unchanged; one whose part the undo took away
+                    // is simply no longer there to be found.
+                    var wasRestored = restoredShip != null &&
+                                      ReferenceEquals (restoredShip.Target, ship);
+                    restoredShip = null;
+                    if (!wasRestored)
+                        shipGeneration++;
                 }
                 return shipGeneration;
             }
+        }
+
+        // The vessel the editor last restored from its own backup, held weakly. Set from
+        // EditorShipAddon, which hears the game say so. It is the vessel rather than the
+        // fact that one was restored, because a vessel is only adopted once and nothing
+        // says when that has happened: a flag would still be set when the next craft was
+        // loaded, and would take that craft for the vessel the editor already had.
+        static WeakReference restoredShip;
+
+        /// <summary>
+        /// Called when the editor restores the vessel it had open from its own backup,
+        /// which is what an undo and a redo are.
+        /// </summary>
+        public static void ShipRestored (ShipConstruct ship)
+        {
+            restoredShip = ReferenceEquals (ship, null) ? null : new WeakReference (ship);
         }
 
         /// <summary>

--- a/service/SpaceCenter/src/ExtensionMethods/EditorExtensions.cs
+++ b/service/SpaceCenter/src/ExtensionMethods/EditorExtensions.cs
@@ -27,6 +27,42 @@ namespace KRPC.SpaceCenter
             return ship;
         }
 
+        // The vessel the editor had open when the generation was last taken, held weakly
+        // so that a vessel the editor has finished with is not kept alive by this.
+        static WeakReference lastShip;
+        static uint shipGeneration;
+
+        /// <summary>
+        /// The number of vessels the editor has held since the game started.
+        /// </summary>
+        /// <remarks>
+        /// A part in the editor is named by its craft id, which the game keeps in the
+        /// craft file so that it survives the vessel being built again. That id is only
+        /// unique within one vessel, and a craft file saved from another carries its ids
+        /// over, so two vessels routinely give the same id to different parts. Anything
+        /// naming a part records which vessel it meant, and a part of any earlier one is
+        /// gone rather than whatever now answers to its id.
+        ///
+        /// Which vessel the editor has is taken from the vessel itself rather than from
+        /// an event announcing a new one: the vessel object being a different object is
+        /// the fact any such event would be reporting, and it can be read at any time.
+        ///
+        /// An undo is the one thing that changes the vessel object without making a new
+        /// vessel, so it is the one thing that has to be heard; EditorShipAddon does that
+        /// and calls ShipRestored.
+        /// </remarks>
+        public static uint ShipGeneration {
+            get {
+                var ship = Ship;
+                if (!ReferenceEquals (ship, null) &&
+                    (lastShip == null || !ReferenceEquals (lastShip.Target, ship))) {
+                    lastShip = new WeakReference (ship);
+                    shipGeneration++;
+                }
+                return shipGeneration;
+            }
+        }
+
         /// <summary>
         /// What the game holds for the vessel in the editor. The editor holds one vessel
         /// while it is open and takes it with it when it is left, so anything named

--- a/service/SpaceCenter/src/ExtensionMethods/EditorExtensions.cs
+++ b/service/SpaceCenter/src/ExtensionMethods/EditorExtensions.cs
@@ -1,3 +1,4 @@
+using System;
 using KRPC.Utils;
 
 namespace KRPC.SpaceCenter
@@ -12,6 +13,18 @@ namespace KRPC.SpaceCenter
                 var logic = EditorLogic.fetch;
                 return ReferenceEquals (logic, null) ? null : logic.ship;
             }
+        }
+
+        /// <summary>
+        /// The vessel the editor has open. Throws if it has none, which is the case
+        /// outside the editor and while the editor is still starting up.
+        /// </summary>
+        public static ShipConstruct GetShip ()
+        {
+            var ship = Ship;
+            if (ReferenceEquals (ship, null))
+                throw new InvalidOperationException ("The editor does not contain a vessel.");
+            return ship;
         }
 
         /// <summary>

--- a/service/SpaceCenter/src/ExtensionMethods/EditorExtensions.cs
+++ b/service/SpaceCenter/src/ExtensionMethods/EditorExtensions.cs
@@ -1,0 +1,34 @@
+using KRPC.Utils;
+
+namespace KRPC.SpaceCenter
+{
+    static class EditorExtensions
+    {
+        /// <summary>
+        /// The vessel the editor has open, or null if it has none.
+        /// </summary>
+        public static ShipConstruct Ship {
+            get {
+                var logic = EditorLogic.fetch;
+                return ReferenceEquals (logic, null) ? null : logic.ship;
+            }
+        }
+
+        /// <summary>
+        /// What the game holds for the vessel in the editor. The editor holds one vessel
+        /// while it is open and takes it with it when it is left, so anything named
+        /// against that vessel is live until the game leaves the editor, and gone
+        /// afterwards. An editor that is still starting up has no vessel yet, and nothing
+        /// is concluded from that.
+        /// </summary>
+        public static GameObjectState ShipState {
+            get {
+                if (!HighLogic.LoadedSceneIsEditor)
+                    return GameObjectState.Destroyed;
+                return ReferenceEquals (Ship, null)
+                    ? GameObjectState.Dormant
+                    : GameObjectState.Live;
+            }
+        }
+    }
+}

--- a/service/SpaceCenter/src/ExtensionMethods/FlightGlobalsExtensions.cs
+++ b/service/SpaceCenter/src/ExtensionMethods/FlightGlobalsExtensions.cs
@@ -1,9 +1,30 @@
 using System;
+using KRPC.Service;
+using KRPC.Utils;
+using ObjectDestroyedException = KRPC.Service.KRPC.ObjectDestroyedException;
 
 namespace KRPC.SpaceCenter
 {
     static class FlightGlobalsExtensions
     {
+        /// <summary>
+        /// Whether the game currently knows which vessels exist. It does not while it is
+        /// between game states, when nothing can be concluded from a vessel being absent.
+        /// </summary>
+        /// <remarks>
+        /// A game that has replaced its state fills its vessel list one vessel at a time,
+        /// so the list holding some vessels does not mean it holds them all. The game is
+        /// only taken to know what exists once that state has settled, which is the same
+        /// point at which the object store is swept; before then a vessel that cannot be
+        /// found may be one the game has not rebuilt yet.
+        /// </remarks>
+        public static bool VesselsKnown {
+            get {
+                return HighLogic.CurrentGame != null && GameState.Settled &&
+                FlightGlobals.Vessels != null && FlightGlobals.Vessels.Count > 0;
+            }
+        }
+
         /// <summary>
         /// The vessel with the given id, loaded or not,
         /// or null if the game has no such vessel.
@@ -13,22 +34,61 @@ namespace KRPC.SpaceCenter
             var active = FlightGlobals.ActiveVessel;
             if (active != null && active.id == id)
                 return active;
-            foreach (var vessel in FlightGlobals.Vessels)
+            // A game that is not listing vessels has none to find. Answering that, rather
+            // than raising, is what leaves VesselsKnown to say what the absence means, and
+            // it has to be an answer: the object store asks every vessel it holds for its
+            // state in one pass, and one that raises must not stop the rest being checked.
+            var vessels = FlightGlobals.Vessels;
+            if (vessels == null)
+                return null;
+            foreach (var vessel in vessels)
                 if (vessel != null && vessel.id == id)
                     return vessel;
             return null;
         }
 
         /// <summary>
-        /// The vessel with the given id, loaded or not.
-        /// Throws if the game has no such vessel.
+        /// What the game holds for the vessel with the given id. A vessel is either there
+        /// to be found, loaded or not, or it is gone for good; it has no unloaded form
+        /// that the game can bring back. A game that does not currently know what vessels
+        /// exist says nothing about any of them, so a vessel it cannot find then is
+        /// dormant, and nothing standing for one is dropped on the strength of it.
+        /// </summary>
+        public static GameObjectState VesselState (Guid id)
+        {
+            if (FindVesselById (id) != null)
+                return GameObjectState.Live;
+            return VesselsKnown ? GameObjectState.Destroyed : GameObjectState.Dormant;
+        }
+
+        /// <summary>
+        /// The vessel with the given id, loaded or not. Throws if the game has no such
+        /// vessel, saying whether it is gone for good or whether the game is merely
+        /// between states and cannot say what exists.
         /// </summary>
         public static Vessel GetVesselById (Guid id)
         {
             var vessel = FindVesselById (id);
             if (vessel != null)
                 return vessel;
-            throw new ArgumentException ("No such vessel " + id);
+            throw NotResolvable (id);
+        }
+
+        /// <summary>
+        /// The error to raise when a vessel cannot be looked up, which
+        /// <see cref="VesselState" /> decides between so that one rule says what the
+        /// absence of a vessel means.
+        /// </summary>
+        static Exception NotResolvable (Guid id)
+        {
+            if (VesselState (id) == GameObjectState.Destroyed)
+                return new ObjectDestroyedException (
+                    "The vessel " + id + " no longer exists. " +
+                    "It was destroyed or recovered, or belongs to a game that is no longer loaded.");
+            return new InvalidOperationException (
+                "The vessel " + id + " is not loaded, as the game is between states and " +
+                "does not currently know which vessels exist. " +
+                "It can be used again once the game has finished loading.");
         }
     }
 }

--- a/service/SpaceCenter/src/ExtensionMethods/FlightGlobalsExtensions.cs
+++ b/service/SpaceCenter/src/ExtensionMethods/FlightGlobalsExtensions.cs
@@ -4,13 +4,30 @@ namespace KRPC.SpaceCenter
 {
     static class FlightGlobalsExtensions
     {
+        /// <summary>
+        /// The vessel with the given id, loaded or not,
+        /// or null if the game has no such vessel.
+        /// </summary>
+        public static Vessel FindVesselById (Guid id)
+        {
+            var active = FlightGlobals.ActiveVessel;
+            if (active != null && active.id == id)
+                return active;
+            foreach (var vessel in FlightGlobals.Vessels)
+                if (vessel != null && vessel.id == id)
+                    return vessel;
+            return null;
+        }
+
+        /// <summary>
+        /// The vessel with the given id, loaded or not.
+        /// Throws if the game has no such vessel.
+        /// </summary>
         public static Vessel GetVesselById (Guid id)
         {
-            if (FlightGlobals.ActiveVessel != null && FlightGlobals.ActiveVessel.id == id)
-                return FlightGlobals.ActiveVessel;
-            foreach (var vessel in FlightGlobals.Vessels)
-                if (vessel.id == id)
-                    return vessel;
+            var vessel = FindVesselById (id);
+            if (vessel != null)
+                return vessel;
             throw new ArgumentException ("No such vessel " + id);
         }
     }

--- a/service/SpaceCenter/src/KRPC.SpaceCenter.csproj
+++ b/service/SpaceCenter/src/KRPC.SpaceCenter.csproj
@@ -83,6 +83,7 @@
     <Compile Include="ExtensionMethods\VesselTypeExtensions.cs" />
     <Compile Include="ActuatorControlAddon.cs" />
     <Compile Include="CameraAddon.cs" />
+    <Compile Include="ConstructedOrbitsAddon.cs" />
     <Compile Include="EditorShipAddon.cs" />
     <Compile Include="EVAAddon.cs" />
     <Compile Include="ExternalAPIAddon.cs" />

--- a/service/SpaceCenter/src/KRPC.SpaceCenter.csproj
+++ b/service/SpaceCenter/src/KRPC.SpaceCenter.csproj
@@ -55,6 +55,7 @@
     <Compile Include="ExtensionMethods\ColorExtensions.cs" />
     <Compile Include="ExtensionMethods\ContractStateExtensions.cs" />
     <Compile Include="ExtensionMethods\DeployableStateExtensions.cs" />
+    <Compile Include="ExtensionMethods\EditorExtensions.cs" />
     <Compile Include="ExtensionMethods\FlightCameraModeExtensions.cs" />
     <Compile Include="ExtensionMethods\FlightGlobalsExtensions.cs" />
     <Compile Include="ExtensionMethods\GameModeExtensions.cs" />

--- a/service/SpaceCenter/src/KRPC.SpaceCenter.csproj
+++ b/service/SpaceCenter/src/KRPC.SpaceCenter.csproj
@@ -89,6 +89,7 @@
     <Compile Include="ExternalAPI\RealFuels.cs" />
     <Compile Include="ExternalAPI\RemoteTech.cs" />
     <Compile Include="Lifetime\CachedObject.cs" />
+    <Compile Include="Lifetime\ModuleRef.cs" />
     <Compile Include="NameTag\Career.cs" />
     <Compile Include="NameTag\NameTag.cs" />
     <Compile Include="NameTag\Utils.cs" />

--- a/service/SpaceCenter/src/KRPC.SpaceCenter.csproj
+++ b/service/SpaceCenter/src/KRPC.SpaceCenter.csproj
@@ -83,6 +83,7 @@
     <Compile Include="ExtensionMethods\VesselTypeExtensions.cs" />
     <Compile Include="ActuatorControlAddon.cs" />
     <Compile Include="CameraAddon.cs" />
+    <Compile Include="EditorShipAddon.cs" />
     <Compile Include="EVAAddon.cs" />
     <Compile Include="ExternalAPIAddon.cs" />
     <Compile Include="ExternalAPI\AGExt.cs" />

--- a/service/SpaceCenter/src/KRPC.SpaceCenter.csproj
+++ b/service/SpaceCenter/src/KRPC.SpaceCenter.csproj
@@ -88,6 +88,7 @@
     <Compile Include="ExternalAPI\FAR.cs" />
     <Compile Include="ExternalAPI\RealFuels.cs" />
     <Compile Include="ExternalAPI\RemoteTech.cs" />
+    <Compile Include="Lifetime\CachedObject.cs" />
     <Compile Include="NameTag\Career.cs" />
     <Compile Include="NameTag\NameTag.cs" />
     <Compile Include="NameTag\Utils.cs" />

--- a/service/SpaceCenter/src/Lifetime/CachedObject.cs
+++ b/service/SpaceCenter/src/Lifetime/CachedObject.cs
@@ -1,0 +1,51 @@
+using System;
+using KRPC.Service;
+using UnityEngine;
+
+namespace KRPC.SpaceCenter
+{
+    /// <summary>
+    /// Remembers the game object that a service object last resolved from its identifier,
+    /// so that reading it again does not have to search the game for it.
+    /// </summary>
+    /// <remarks>
+    /// A service object holds one of these as a field, so a cached object costs a single
+    /// weak reference and the code that reads it has no delegate to call through. The
+    /// reference is weak, so caching never keeps a destroyed game object alive, and it
+    /// is stamped with the generation of the game state the object was resolved in, so
+    /// an object left over from a replaced game state is never handed back.
+    /// </remarks>
+    struct CachedObject<T> where T : UnityEngine.Object
+    {
+        WeakReference reference;
+        uint generation;
+
+        /// <summary>
+        /// The game object that was last resolved, or null if it has to be resolved again.
+        /// </summary>
+        public T Get ()
+        {
+            if (reference == null || generation != GameState.Generation)
+                return null;
+            var cached = reference.Target as T;
+            // Unity tears down a game object before the garbage collector gets to the
+            // managed object wrapping it, and reports that wrapper as null. The check has
+            // to be made against UnityEngine.Object, because == on a type parameter is
+            // reference equality and would hand back a torn down object.
+            UnityEngine.Object obj = cached;
+            return obj == null ? null : cached;
+        }
+
+        /// <summary>
+        /// Remember a game object that has just been resolved.
+        /// </summary>
+        public void Set (T obj)
+        {
+            if (reference == null)
+                reference = new WeakReference (obj);
+            else
+                reference.Target = obj;
+            generation = GameState.Generation;
+        }
+    }
+}

--- a/service/SpaceCenter/src/Lifetime/ModuleRef.cs
+++ b/service/SpaceCenter/src/Lifetime/ModuleRef.cs
@@ -1,0 +1,247 @@
+using KRPC.Utils;
+using ObjectDestroyedException = KRPC.Service.KRPC.ObjectDestroyedException;
+
+namespace KRPC.SpaceCenter
+{
+    /// <summary>
+    /// Names one of a part's modules, so that an object standing for that module can find it
+    /// again on every access instead of holding on to it.
+    /// </summary>
+    /// <remarks>
+    /// What a reference is, is the module's class and which of the part's modules of that
+    /// class it is. The game rebuilds a part's modules in the order its configuration lists
+    /// them, so that outlives any one of them, which is why it is all that equality and
+    /// hashing use.
+    ///
+    /// Finding the module is the game's own name for it, its persistent id, and where in the
+    /// part's module list it was last seen. An access reads that position and takes what is
+    /// there if it carries the id, which no other module of the part can. Anything else looks
+    /// the id up along the list, and corrects the position.
+    ///
+    /// The game gives a module an id only when something asks for one, and writes out only
+    /// ids it has already given, so a game state saved before this named the module holds
+    /// nothing to look it up by. Counting the part's modules of the class is what answers
+    /// then, and it settles the id and the position again for next time.
+    ///
+    /// Nothing here allocates, and nothing is generic on the module type, which in a shared
+    /// generic costs more than the lookup itself.
+    /// </remarks>
+    struct ModuleRef
+    {
+        // The module's class name, and which of the part's modules of that class this is.
+        // A null name stands for no module at all.
+        readonly string name;
+        readonly int occurrence;
+        // The game's own name for the module, and where the module was in the part's module
+        // list, or 0 and -1 while it has not been found. Both are ways of finding it, neither
+        // is what the reference stands for.
+        uint id;
+        int index;
+
+        ModuleRef (string moduleName, int moduleOccurrence)
+        {
+            name = moduleName;
+            occurrence = moduleOccurrence;
+            id = 0;
+            index = -1;
+        }
+
+        /// <summary>
+        /// A reference to a module the caller already has.
+        /// </summary>
+        public static ModuleRef ForModule (PartModule module)
+        {
+            var part = module == null ? null : module.part;
+            if (part == null)
+                return None;
+            var modules = part.Modules;
+            var moduleCount = modules.Count;
+            var matches = 0;
+            for (var i = 0; i < moduleCount; i++) {
+                var candidate = modules [i];
+                if (candidate == null || candidate.moduleName != module.moduleName)
+                    continue;
+                if (ReferenceEquals (candidate, module)) {
+                    var reference = new ModuleRef (module.moduleName, matches);
+                    reference.Bind (module, i);
+                    return reference;
+                }
+                matches++;
+            }
+            return None;
+        }
+
+        /// <summary>
+        /// A reference to the first module of the part that is a <typeparamref name="T"/>,
+        /// or to no module at all if the part has none. The type is only used to find the
+        /// module; what the reference stands for afterwards is the class of what it found.
+        /// </summary>
+        public static ModuleRef ForType<T> (global::Part part) where T : PartModule
+        {
+            var modules = part.Modules;
+            for (var i = 0; i < modules.Count; i++) {
+                var module = modules [i] as T;
+                if (module != null)
+                    return ForModule (module);
+            }
+            return None;
+        }
+
+        /// <summary>
+        /// A reference to no module at all, for an object that has one only sometimes.
+        /// </summary>
+        public static ModuleRef None {
+            get { return new ModuleRef (null, -1); }
+        }
+
+        /// <summary>
+        /// The module on the given part, or null if the part does not have it.
+        /// </summary>
+        public PartModule Find (global::Part part)
+        {
+            var modules = part.Modules;
+            if (index >= 0 && index < modules.Count) {
+                var module = modules [index];
+                // The id is unique among the modules of a part from the moment the game hands
+                // it out, so what carries it and is of the reference's class is the module.
+                // Where it sits is only where it was, and says nothing on its own: a change to
+                // the list that leaves its length alone moves modules under it. The class is
+                // what an id loaded from a game state, which no uniqueness was enforced on,
+                // has to agree with before it can be believed.
+                if (module != null && module.PersistentId == id && module.moduleName == name)
+                    return module;
+            }
+            return Search (part);
+        }
+
+        /// <summary>
+        /// The module on the given part. Throws if the part does not have it.
+        /// </summary>
+        public PartModule Get (global::Part part)
+        {
+            var module = Find (part);
+            if (module == null)
+                throw new ObjectDestroyedException (
+                    "The part module no longer exists, as the part it was on no longer has it.");
+            return module;
+        }
+
+        /// <summary>
+        /// What the game holds for the module, for an object that stands for one.
+        /// </summary>
+        /// <remarks>
+        /// A module belongs to its part's game object, so it is exactly as live, dormant or
+        /// destroyed as the part until the part is there to look in. A module of a part the
+        /// game has merely unloaded is no more gone than the part, and cannot be checked
+        /// either, so it answers with the part's own state.
+        /// </remarks>
+        public GameObjectState StateOn (Services.Parts.Part part)
+        {
+            var state = part.GameObjectState;
+            if (state != GameObjectState.Live)
+                return state;
+            return Find (part.InternalPart) != null ? GameObjectState.Live : GameObjectState.Destroyed;
+        }
+
+        /// <summary>
+        /// Look for the module along the part's module list, by the id the game knows it by
+        /// where that answers, and by counting the part's modules of the class where it does
+        /// not, recording where it was found so that the next access is a look at one module.
+        /// </summary>
+        PartModule Search (global::Part part)
+        {
+            index = -1;
+            if (name == null)
+                return null;
+            var modules = part.Modules;
+            var moduleCount = modules.Count;
+            if (id != 0) {
+                for (var i = 0; i < moduleCount; i++) {
+                    var module = modules [i];
+                    // An id is unique among the modules of a part only from the moment the
+                    // game hands it out, so what carries one loaded from a game state has to
+                    // be of the reference's class before it can be its module.
+                    if (module == null || module.PersistentId != id || module.moduleName != name)
+                        continue;
+                    index = i;
+                    return module;
+                }
+            }
+            return Count (modules, moduleCount);
+        }
+
+        /// <summary>
+        /// The module of the reference's class and position among the part's modules of that
+        /// class, which is what finds it when the game knows it by no id.
+        /// </summary>
+        PartModule Count (PartModuleList modules, int moduleCount)
+        {
+            var matches = 0;
+            for (var i = 0; i < moduleCount; i++) {
+                var module = modules [i];
+                if (module == null || module.moduleName != name)
+                    continue;
+                if (matches == occurrence) {
+                    Bind (module, i);
+                    return module;
+                }
+                matches++;
+            }
+            return null;
+        }
+
+        /// <summary>
+        /// Record where a module just found was, and take the game's own name for it, asking
+        /// the game to give it one if it has not already.
+        /// </summary>
+        void Bind (PartModule module, int moduleIndex)
+        {
+            id = module.GetPersistentId ();
+            index = moduleIndex;
+        }
+
+        /// <summary>
+        /// Whether two references name the same module of a part: the same class, and
+        /// the same one of the part's modules of it. Which part that is belongs to the
+        /// object holding the reference, so two references from different parts compare
+        /// equal and the objects holding them are told apart by their parts.
+        /// </summary>
+        public bool Equals (ModuleRef other)
+        {
+            return name == other.name && occurrence == other.occurrence;
+        }
+
+        /// <summary>
+        /// Whether two references name the same module of a part.
+        /// </summary>
+        public override bool Equals (object obj)
+        {
+            return obj is ModuleRef && Equals ((ModuleRef)obj);
+        }
+
+        /// <summary>
+        /// Hash code for the reference, from what it stands for rather than where it last
+        /// found it, so that it does not change over the lifetime of the object holding it.
+        /// </summary>
+        public override int GetHashCode ()
+        {
+            return (name == null ? 0 : name.GetHashCode ()) ^ occurrence;
+        }
+
+        /// <summary>
+        /// Whether two references name the same module of a part.
+        /// </summary>
+        public static bool operator == (ModuleRef lhs, ModuleRef rhs)
+        {
+            return lhs.Equals (rhs);
+        }
+
+        /// <summary>
+        /// Whether two references stand for different modules.
+        /// </summary>
+        public static bool operator != (ModuleRef lhs, ModuleRef rhs)
+        {
+            return !lhs.Equals (rhs);
+        }
+    }
+}

--- a/service/SpaceCenter/src/PartForcesAddon.cs
+++ b/service/SpaceCenter/src/PartForcesAddon.cs
@@ -12,8 +12,10 @@ namespace KRPC.SpaceCenter
     {
         static readonly ClientOwnedObjects<Force> forces =
             new ClientOwnedObjects<Force> ();
+        // An instantaneous force is applied in the update it was added in and is never
+        // handed to the client, so it has no identifier in the object store.
         static readonly ClientOwnedObjects<Force> instantaneousForces =
-            new ClientOwnedObjects<Force> ();
+            new ClientOwnedObjects<Force> (givenToClients: false);
 
         static readonly IClientOwnedCollection[] collections = { forces, instantaneousForces };
 
@@ -50,11 +52,14 @@ namespace KRPC.SpaceCenter
 
         /// <summary>
         /// Apply the forces to the parts, first dropping the forces of any client that
-        /// has disconnected so they are not applied again.
+        /// has disconnected, and those on a part the game has destroyed, so that neither
+        /// is applied again.
         /// </summary>
         public void FixedUpdate ()
         {
             Sweep ();
+            forces.RemoveDestroyed ();
+            instantaneousForces.RemoveDestroyed ();
             foreach (var force in instantaneousForces.Items)
                 force.Update ();
             instantaneousForces.Clear ();

--- a/service/SpaceCenter/src/PartId.cs
+++ b/service/SpaceCenter/src/PartId.cs
@@ -50,7 +50,7 @@ namespace KRPC.SpaceCenter
             if (!inEditor)
                 return FlightGlobals.FindPartByID (id);
             var editorId = id;
-            var construct = EditorShip;
+            var construct = EditorExtensions.Ship;
             return ReferenceEquals (construct, null)
                 ? null
                 : construct.Parts.FirstOrDefault (x => x.craftID == editorId);
@@ -83,10 +83,12 @@ namespace KRPC.SpaceCenter
             get {
                 if (Find () != null)
                     return GameObjectState.Live;
-                if (inEditor)
-                    return !HighLogic.LoadedSceneIsEditor || !ReferenceEquals (EditorShip, null)
-                        ? GameObjectState.Destroyed
-                        : GameObjectState.Dormant;
+                // The editor holds nothing that is not in the vessel it has open, so a
+                // part it does not have is gone as soon as it is known to have one.
+                if (inEditor) {
+                    var ship = EditorExtensions.ShipState;
+                    return ship == GameObjectState.Live ? GameObjectState.Destroyed : ship;
+                }
                 if (!FlightGlobalsExtensions.VesselsKnown)
                     return GameObjectState.Dormant;
                 foreach (var vessel in FlightGlobals.Vessels) {
@@ -119,16 +121,6 @@ namespace KRPC.SpaceCenter
                   "from the vessel, or the editor was left."
                 : "The part no longer exists. It was destroyed, or the vessel " +
                   "carrying it was destroyed or recovered.");
-        }
-
-        /// <summary>
-        /// The vessel the editor has open, or null if it has none.
-        /// </summary>
-        static ShipConstruct EditorShip {
-            get {
-                var logic = EditorLogic.fetch;
-                return ReferenceEquals (logic, null) ? null : logic.ship;
-            }
         }
 
         /// <summary>

--- a/service/SpaceCenter/src/PartId.cs
+++ b/service/SpaceCenter/src/PartId.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Linq;
+using KRPC.Utils;
+using ObjectDestroyedException = KRPC.Service.KRPC.ObjectDestroyedException;
 
 namespace KRPC.SpaceCenter
 {
@@ -24,22 +26,109 @@ namespace KRPC.SpaceCenter
         }
 
         /// <summary>
-        /// The part the reference refers to now.
+        /// A reference to the part in flight with the given flight identifier, which the
+        /// game need not currently have.
         /// </summary>
-        internal Part Resolve ()
+        internal PartId (uint flightId)
+        {
+            inEditor = false;
+            id = flightId;
+        }
+
+        /// <summary>
+        /// Whether the reference names a part in an editor rather than one in flight.
+        /// </summary>
+        internal bool InEditor {
+            get { return inEditor; }
+        }
+
+        /// <summary>
+        /// The part the reference refers to now, or null if the game does not have it.
+        /// </summary>
+        internal Part Find ()
         {
             if (!inEditor)
                 return FlightGlobals.FindPartByID (id);
             var editorId = id;
-            var logic = EditorLogic.fetch;
-            var construct = ReferenceEquals (logic, null) ? null : logic.ship;
-            var part = ReferenceEquals (construct, null)
+            var construct = EditorShip;
+            return ReferenceEquals (construct, null)
                 ? null
                 : construct.Parts.FirstOrDefault (x => x.craftID == editorId);
+        }
+
+        /// <summary>
+        /// The part the reference refers to now. Throws if the game does not have it.
+        /// </summary>
+        internal Part Resolve ()
+        {
+            var part = Find ();
             if (ReferenceEquals (part, null))
-                throw new InvalidOperationException (
-                    "The part is no longer in the vessel in the editor.");
+                throw NotResolvable ();
             return part;
+        }
+
+        /// <summary>
+        /// What the game holds for the part. A part in flight is live while the vessel
+        /// carrying it is loaded, dormant while that vessel is unloaded, as the game then
+        /// keeps only a snapshot of each of its parts, and destroyed once the game holds
+        /// neither. A part in the editor is only ever in the vessel the editor has open,
+        /// so once it is not there it is gone, and leaving the editor takes it with it.
+        /// </summary>
+        /// <remarks>
+        /// Only reached once looking the part up has already failed, so it may take as
+        /// long as it needs to; searching every unloaded vessel is the price of never
+        /// declaring a part that is merely out of range to be gone.
+        /// </remarks>
+        internal GameObjectState GameObjectState {
+            get {
+                if (Find () != null)
+                    return GameObjectState.Live;
+                if (inEditor)
+                    return !HighLogic.LoadedSceneIsEditor || !ReferenceEquals (EditorShip, null)
+                        ? GameObjectState.Destroyed
+                        : GameObjectState.Dormant;
+                if (!FlightGlobalsExtensions.VesselsKnown)
+                    return GameObjectState.Dormant;
+                foreach (var vessel in FlightGlobals.Vessels) {
+                    if (vessel == null || vessel.loaded || vessel.protoVessel == null)
+                        continue;
+                    foreach (var snapshot in vessel.protoVessel.protoPartSnapshots)
+                        if (snapshot.flightID == id)
+                            return GameObjectState.Dormant;
+                }
+                return GameObjectState.Destroyed;
+            }
+        }
+
+        /// <summary>
+        /// The error to raise when the part cannot be looked up, which says whether it is
+        /// gone for good or is only waiting for the game to get back to it.
+        /// </summary>
+        internal Exception NotResolvable ()
+        {
+            if (GameObjectState != GameObjectState.Destroyed)
+                return new InvalidOperationException (
+                    inEditor
+                    ? "The vessel in the editor is not ready to be read. " +
+                      "The part can be used again once the editor has it open."
+                    : "The part is not loaded, as the vessel carrying it is unloaded. " +
+                      "It can be used again once the game loads that vessel.");
+            return new ObjectDestroyedException (
+                inEditor
+                ? "The part is no longer in the vessel in the editor. It was removed " +
+                  "from the vessel, or the editor was left."
+                : "The part no longer exists. It was destroyed, or the vessel " +
+                  "carrying it was destroyed or recovered.");
+        }
+
+        /// <summary>
+        /// The vessel the editor has open, or null if it has none.
+        /// </summary>
+        static ShipConstruct EditorShip {
+            get {
+                var logic = EditorLogic.fetch;
+                return ReferenceEquals (logic, null) ? null : logic.ship;
+            }
         }
 
         /// <summary>

--- a/service/SpaceCenter/src/PartId.cs
+++ b/service/SpaceCenter/src/PartId.cs
@@ -11,11 +11,15 @@ namespace KRPC.SpaceCenter
     /// reference was made in, and which kind of identifier that is: a part is not given
     /// a flight id until the vessel it belongs to is launched, and the id it is given
     /// in the editor is only unique within one vessel, so neither works in both scenes.
+    /// A reference made in the editor also holds which loaded vessel it was made in,
+    /// as a craft id says nothing on its own about which vessel it belongs to; see
+    /// <see cref="EditorExtensions.ShipGeneration" />.
     /// </summary>
     struct PartId : IEquatable<PartId>
     {
         readonly uint id;
         readonly bool inEditor;
+        readonly uint generation;
 
         internal PartId (Part part)
         {
@@ -23,6 +27,7 @@ namespace KRPC.SpaceCenter
                 throw new ArgumentNullException (nameof (part));
             inEditor = HighLogic.LoadedSceneIsEditor;
             id = inEditor ? part.craftID : part.flightID;
+            generation = inEditor ? EditorExtensions.ShipGeneration : 0;
         }
 
         /// <summary>
@@ -33,6 +38,16 @@ namespace KRPC.SpaceCenter
         {
             inEditor = false;
             id = flightId;
+            generation = 0;
+        }
+
+        /// <summary>
+        /// Whether the reference names a part of the vessel the editor has open now. A
+        /// craft id belongs to the vessel it was read from, so one from a vessel the
+        /// editor has since loaded over names nothing, however many parts answer to it.
+        /// </summary>
+        bool OfLoadedShip {
+            get { return !inEditor || generation == EditorExtensions.ShipGeneration; }
         }
 
         /// <summary>
@@ -49,6 +64,8 @@ namespace KRPC.SpaceCenter
         {
             if (!inEditor)
                 return FlightGlobals.FindPartByID (id);
+            if (!OfLoadedShip)
+                return null;
             var editorId = id;
             var construct = EditorExtensions.Ship;
             return ReferenceEquals (construct, null)
@@ -84,8 +101,11 @@ namespace KRPC.SpaceCenter
                 if (Find () != null)
                     return GameObjectState.Live;
                 // The editor holds nothing that is not in the vessel it has open, so a
-                // part it does not have is gone as soon as it is known to have one.
+                // part it does not have is gone as soon as it is known to have one, and a
+                // part of a vessel it has loaded over is gone whatever it has open now.
                 if (inEditor) {
+                    if (!OfLoadedShip)
+                        return GameObjectState.Destroyed;
                     var ship = EditorExtensions.ShipState;
                     return ship == GameObjectState.Live ? GameObjectState.Destroyed : ship;
                 }
@@ -115,6 +135,11 @@ namespace KRPC.SpaceCenter
                       "The part can be used again once the editor has it open."
                     : "The part is not loaded, as the vessel carrying it is unloaded. " +
                       "It can be used again once the game loads that vessel.");
+            if (!OfLoadedShip)
+                return new ObjectDestroyedException (
+                    "The part belongs to a vessel that the editor has loaded another " +
+                    "vessel over. Parts of the vessel the editor has open now have to " +
+                    "be obtained again, as a part is only named within its own vessel.");
             return new ObjectDestroyedException (
                 inEditor
                 ? "The part is no longer in the vessel in the editor. It was removed " +
@@ -128,7 +153,8 @@ namespace KRPC.SpaceCenter
         /// </summary>
         public bool Equals (PartId other)
         {
-            return id == other.id && inEditor == other.inEditor;
+            return id == other.id && inEditor == other.inEditor &&
+                   generation == other.generation;
         }
 
         /// <summary>
@@ -144,7 +170,7 @@ namespace KRPC.SpaceCenter
         /// </summary>
         public override int GetHashCode ()
         {
-            return id.GetHashCode () ^ inEditor.GetHashCode ();
+            return id.GetHashCode () ^ inEditor.GetHashCode () ^ generation.GetHashCode ();
         }
 
         /// <summary>

--- a/service/SpaceCenter/src/Services/Alarm.cs
+++ b/service/SpaceCenter/src/Services/Alarm.cs
@@ -2,6 +2,7 @@ using System;
 using KRPC.Service.Attributes;
 using KRPC.SpaceCenter.ExtensionMethods;
 using KRPC.Utils;
+using ObjectDestroyedException = KRPC.Service.KRPC.ObjectDestroyedException;
 
 namespace KRPC.SpaceCenter.Services
 {
@@ -9,7 +10,7 @@ namespace KRPC.SpaceCenter.Services
     /// An alarm. Can be accessed using <see cref="SpaceCenter.AlarmManager"/>.
     /// </summary>
     [KRPCClass(Service = "SpaceCenter")]
-    public class Alarm : Equatable<Alarm>
+    public class Alarm : Equatable<Alarm>, IGameObjectState
     {
         readonly uint id;
 
@@ -20,14 +21,66 @@ namespace KRPC.SpaceCenter.Services
         {
             if (alarm == null)
                 throw new ArgumentNullException(nameof(alarm));
-            InternalAlarm = alarm;
             id = alarm.Id;
         }
 
         /// <summary>
-        /// The KSP Alarm
+        /// The KSP Alarm, found again from the id it is known by. The game destroys and
+        /// recreates an alarm when it is edited, and builds every alarm again when a game
+        /// is loaded, so the alarm this stands for is whichever one now answers to the id.
         /// </summary>
-        public AlarmTypeBase InternalAlarm { get; private set; }
+        public AlarmTypeBase InternalAlarm
+        {
+            get
+            {
+                var alarm = Find();
+                if (alarm == null)
+                    throw NotResolvable();
+                return alarm;
+            }
+        }
+
+        /// <summary>
+        /// What the game holds for the alarm. It is live while an alarm with the id is in
+        /// the game's alarm clock, and destroyed once the alarm clock is there to ask and
+        /// has none, as an alarm that is removed is gone for good. A game that has no alarm
+        /// clock running has no alarms to look through, which says nothing about this one.
+        /// </summary>
+        public GameObjectState GameObjectState
+        {
+            get
+            {
+                if (AlarmClockScenario.Instance == null)
+                    return GameObjectState.Dormant;
+                return Find() != null ? GameObjectState.Live : GameObjectState.Destroyed;
+            }
+        }
+
+        /// <summary>
+        /// The alarm the game currently has under the id, or null if it has none.
+        /// </summary>
+        AlarmTypeBase Find()
+        {
+            if (AlarmClockScenario.Instance == null)
+                return null;
+            AlarmTypeBase alarm;
+            AlarmClockScenario.TryGetAlarm(id, out alarm);
+            return alarm;
+        }
+
+        /// <summary>
+        /// The error to raise when no alarm answers to the id, which
+        /// <see cref="GameObjectState" /> decides between.
+        /// </summary>
+        Exception NotResolvable()
+        {
+            if (GameObjectState == GameObjectState.Destroyed)
+                return new ObjectDestroyedException(
+                    "The alarm no longer exists, as the game no longer has an alarm with its id.");
+            return new InvalidOperationException(
+                "The alarm is not loaded, as the game has no alarm clock running. " +
+                "It can be used again once the game does.");
+        }
 
         /// <summary>
         /// Returns true if the objects are equal.
@@ -53,11 +106,7 @@ namespace KRPC.SpaceCenter.Services
         [KRPCProperty]
         public uint ID
         {
-            get
-            {
-                UpdateAlarm();
-                return id;
-            }
+            get { return id; }
         }
 
         /// <summary>
@@ -67,7 +116,6 @@ namespace KRPC.SpaceCenter.Services
         public AlarmType Type
         {
             get {
-                UpdateAlarm();
                 return InternalAlarm.ToAlarmType();
             }
         }
@@ -79,13 +127,10 @@ namespace KRPC.SpaceCenter.Services
         public string Title
         {
             get {
-                UpdateAlarm();
                 return InternalAlarm.title;
             }
             set {
-                UpdateAlarm();
                 InternalAlarm.title = value;
-                UpdateAlarm();
             }
         }
 
@@ -96,13 +141,10 @@ namespace KRPC.SpaceCenter.Services
         public string Description
         {
             get {
-                UpdateAlarm();
                 return InternalAlarm.description;
             }
             set {
-                UpdateAlarm();
                 InternalAlarm.description = value;
-                UpdateAlarm();
             }
         }
 
@@ -113,13 +155,10 @@ namespace KRPC.SpaceCenter.Services
         public double Time
         {
             get {
-                UpdateAlarm();
                 return InternalAlarm.ut;
             }
             set {
-                UpdateAlarm();
                 InternalAlarm.ut = value;
-                UpdateAlarm();
             }
         }
 
@@ -130,7 +169,6 @@ namespace KRPC.SpaceCenter.Services
         public double TimeUntil
         {
             get {
-                UpdateAlarm();
                 return InternalAlarm.TimeToAlarm;
             }
         }
@@ -142,13 +180,10 @@ namespace KRPC.SpaceCenter.Services
         public double EventOffset
         {
             get {
-                UpdateAlarm();
                 return InternalAlarm.eventOffset;
             }
             set {
-                UpdateAlarm();
                 InternalAlarm.eventOffset = value;
-                UpdateAlarm();
             }
         }
 
@@ -160,7 +195,6 @@ namespace KRPC.SpaceCenter.Services
         {
             get
             {
-                UpdateAlarm();
                 var vessel = InternalAlarm.Vessel;
                 return vessel != null ? new Vessel(vessel) : null;
             }
@@ -179,12 +213,12 @@ namespace KRPC.SpaceCenter.Services
         {
             get
             {
-                UpdateAlarm();
-                var maneuverAlarm = InternalAlarm as AlarmTypeManeuver;
+                var alarm = InternalAlarm;
+                var maneuverAlarm = alarm as AlarmTypeManeuver;
                 if (maneuverAlarm == null)
                     throw new InvalidOperationException(
                         "Alarm is not a Maneuver alarm, it has no associated maneuver node.");
-                var vessel = InternalAlarm.Vessel;
+                var vessel = alarm.Vessel;
                 var node = maneuverAlarm.Maneuver;
                 if (vessel == null || node == null)
                     throw new InvalidOperationException(
@@ -193,13 +227,11 @@ namespace KRPC.SpaceCenter.Services
             }
             set
             {
-                UpdateAlarm();
                 var maneuverAlarm = InternalAlarm as AlarmTypeManeuver;
                 if (maneuverAlarm == null)
                     throw new InvalidOperationException(
                         "Alarm is not a Maneuver alarm, it has no associated maneuver node.");
                 maneuverAlarm.Maneuver = value.InternalNode;
-                UpdateAlarm();
             }
         }
 
@@ -216,7 +248,6 @@ namespace KRPC.SpaceCenter.Services
         {
             get
             {
-                UpdateAlarm();
                 var transferAlarm = InternalAlarm as AlarmTypeTransferWindow;
                 if (transferAlarm == null)
                     throw new InvalidOperationException(
@@ -229,13 +260,11 @@ namespace KRPC.SpaceCenter.Services
             }
             set
             {
-                UpdateAlarm();
                 var transferAlarm = InternalAlarm as AlarmTypeTransferWindow;
                 if (transferAlarm == null)
                     throw new InvalidOperationException(
                         "Alarm is not a TransferWindow alarm, it has no associated origin body.");
                 transferAlarm.source = value.InternalBody;
-                UpdateAlarm();
             }
         }
 
@@ -252,7 +281,6 @@ namespace KRPC.SpaceCenter.Services
         {
             get
             {
-                UpdateAlarm();
                 var transferAlarm = InternalAlarm as AlarmTypeTransferWindow;
                 if (transferAlarm == null)
                     throw new InvalidOperationException(
@@ -265,13 +293,11 @@ namespace KRPC.SpaceCenter.Services
             }
             set
             {
-                UpdateAlarm();
                 var transferAlarm = InternalAlarm as AlarmTypeTransferWindow;
                 if (transferAlarm == null)
                     throw new InvalidOperationException(
                         "Alarm is not a TransferWindow alarm, it has no associated destination body.");
                 transferAlarm.dest = value.InternalBody;
-                UpdateAlarm();
             }
         }
 
@@ -283,14 +309,11 @@ namespace KRPC.SpaceCenter.Services
         {
             get
             {
-                UpdateAlarm();
                 return InternalAlarm.actions.warp.ToAlarmWarpAction();
             }
             set
             {
-                UpdateAlarm();
                 InternalAlarm.actions.warp = value.FromAlarmWarpAction();
-                UpdateAlarm();
             }
         }
 
@@ -302,14 +325,11 @@ namespace KRPC.SpaceCenter.Services
         {
             get
             {
-                UpdateAlarm();
                 return InternalAlarm.actions.message.ToAlarmMessageAction();
             }
             set
             {
-                UpdateAlarm();
                 InternalAlarm.actions.message = value.FromAlarmMessageAction();
-                UpdateAlarm();
             }
         }
 
@@ -321,14 +341,11 @@ namespace KRPC.SpaceCenter.Services
         {
             get
             {
-                UpdateAlarm();
                 return InternalAlarm.actions.playSound;
             }
             set
             {
-                UpdateAlarm();
                 InternalAlarm.actions.playSound = value;
-                UpdateAlarm();
             }
         }
 
@@ -341,14 +358,11 @@ namespace KRPC.SpaceCenter.Services
         {
             get
             {
-                UpdateAlarm();
                 return InternalAlarm.actions.deleteWhenDone;
             }
             set
             {
-                UpdateAlarm();
                 InternalAlarm.actions.deleteWhenDone = value;
-                UpdateAlarm();
             }
         }
 
@@ -360,7 +374,6 @@ namespace KRPC.SpaceCenter.Services
         {
             get
             {
-                UpdateAlarm();
                 return InternalAlarm.Triggered;
             }
         }
@@ -373,7 +386,6 @@ namespace KRPC.SpaceCenter.Services
         {
             get
             {
-                UpdateAlarm();
                 return InternalAlarm.Actioned;
             }
         }
@@ -381,22 +393,16 @@ namespace KRPC.SpaceCenter.Services
         /// <summary>
         /// Removes the alarm.
         /// </summary>
+        /// <remarks>
+        /// Any further use of this object throws an exception.
+        /// </remarks>
         [KRPCMethod]
         public void Remove()
         {
-            UpdateAlarm();
-            AlarmClockScenario.DeleteAlarm(id);
-            InternalAlarm = null;
-        }
-
-        private void UpdateAlarm()
-        {
-            if (InternalAlarm == null)
-                throw new InvalidOperationException("Alarm does not exist");
-            AlarmTypeBase alarm;
-            AlarmClockScenario.TryGetAlarm(id, out alarm);
-            if (alarm != null)
-                InternalAlarm = alarm;
+            // Resolve first, so that removing an alarm the game does not have reports that
+            // rather than passing an id the alarm clock knows nothing about.
+            var alarm = InternalAlarm;
+            AlarmClockScenario.DeleteAlarm(alarm.Id);
         }
     }
 }

--- a/service/SpaceCenter/src/Services/AutoPilot.cs
+++ b/service/SpaceCenter/src/Services/AutoPilot.cs
@@ -20,7 +20,7 @@ namespace KRPC.SpaceCenter.Services
     /// the auto-pilot will be disengaged. Its configuration and target are left unchanged.
     /// </remarks>
     [KRPCClass (Service = "SpaceCenter", GameScene = GameScene.Flight)]
-    public class AutoPilot : Equatable<AutoPilot>
+    public class AutoPilot : Equatable<AutoPilot>, IGameObjectState
     {
         static readonly HashSet<Guid> showInfoUI = new HashSet<Guid> ();
         readonly Guid vesselId;
@@ -28,6 +28,13 @@ namespace KRPC.SpaceCenter.Services
         internal AutoPilot (global::Vessel vessel)
         {
             vesselId = vessel.id;
+        }
+
+        /// <summary>
+        /// What the game holds for the vessel this belongs to.
+        /// </summary>
+        public GameObjectState GameObjectState {
+            get { return FlightGlobalsExtensions.VesselState (vesselId); }
         }
 
         /// <summary>

--- a/service/SpaceCenter/src/Services/AutoPilot.cs
+++ b/service/SpaceCenter/src/Services/AutoPilot.cs
@@ -199,11 +199,8 @@ namespace KRPC.SpaceCenter.Services
             var controller = PilotAddon.FindAttitudeController (id);
             if (controller == null || !controller.Engaged)
                 return null;
-            try {
-                return new AutoPilot (FlightGlobalsExtensions.GetVesselById (id));
-            } catch (ArgumentException) {
-                return null;
-            }
+            var vessel = FlightGlobalsExtensions.FindVesselById (id);
+            return vessel == null ? null : new AutoPilot (vessel);
         }
 
         /// <summary>

--- a/service/SpaceCenter/src/Services/ClosestApproach.cs
+++ b/service/SpaceCenter/src/Services/ClosestApproach.cs
@@ -17,7 +17,7 @@ namespace KRPC.SpaceCenter.Services
     /// self).
     /// </remarks>
     [KRPCClass (Service = "SpaceCenter")]
-    public class ClosestApproach : Equatable<ClosestApproach>
+    public class ClosestApproach : Equatable<ClosestApproach>, IGameObjectState
     {
         readonly Orbit orbit;
         readonly Orbit target;
@@ -52,6 +52,15 @@ namespace KRPC.SpaceCenter.Services
         public override int GetHashCode ()
         {
             return orbit.GetHashCode () ^ target.GetHashCode () ^ ut.GetHashCode ();
+        }
+
+        /// <summary>
+        /// What the game holds for the approach. It describes the two orbits at a moment,
+        /// and every member reads both of them, so it needs both: it is as live, dormant or
+        /// destroyed as the less alive of the two.
+        /// </summary>
+        public GameObjectState GameObjectState {
+            get { return orbit.GameObjectState.LeastAlive (target.GameObjectState); }
         }
 
         // The world-space position of the given orbit at the closest approach.

--- a/service/SpaceCenter/src/Services/CommLink.cs
+++ b/service/SpaceCenter/src/Services/CommLink.cs
@@ -2,6 +2,7 @@ using System;
 using KRPC.Service.Attributes;
 using KRPC.SpaceCenter.ExtensionMethods;
 using KRPC.Utils;
+using ObjectDestroyedException = KRPC.Service.KRPC.ObjectDestroyedException;
 
 namespace KRPC.SpaceCenter.Services
 {
@@ -9,29 +10,104 @@ namespace KRPC.SpaceCenter.Services
     /// Represents a communication node in the network. For example, a vessel or the KSC.
     /// </summary>
     [KRPCClass (Service = "SpaceCenter")]
-    public class CommLink : Equatable<CommLink>
+    public class CommLink : Equatable<CommLink>, IGameObjectState
     {
+        // A link is a hop in one vessel's control path, and the two nodes it joins are what
+        // identify it: the game builds the path again, out of new link objects, every time
+        // it works out the vessel's connection, so a link object stands for the state of
+        // one hop at one moment rather than for the hop itself.
+        readonly Guid vesselId;
+        readonly CommNode start;
+        readonly CommNode end;
+
         /// <summary>
-        /// Construct from a KSP CommLink object.
+        /// Construct from a KSP CommLink object, and the vessel whose control path it is
+        /// a hop in.
         /// </summary>
-        public CommLink (CommNet.CommLink link)
+        public CommLink (Guid vessel, CommNet.CommLink link)
         {
             if (ReferenceEquals (link, null))
                 throw new ArgumentNullException (nameof (link));
-            InternalLink = link;
+            vesselId = vessel;
+            start = new CommNode (link.start);
+            end = new CommNode (link.end);
         }
 
         /// <summary>
-        /// KSP CommLink object.
+        /// KSP CommLink object, found again in the vessel's control path as it is now.
         /// </summary>
-        public CommNet.CommLink InternalLink { get; private set;}
+        public CommNet.CommLink InternalLink {
+            get {
+                var link = Find ();
+                if (link == null)
+                    throw NotResolvable ();
+                return link;
+            }
+        }
+
+        /// <summary>
+        /// What the game holds for the link. It is live while the vessel's control path
+        /// still runs through the two nodes, and destroyed once the vessel is gone. A path
+        /// that no longer takes the hop has lost contact rather than destroyed anything,
+        /// and takes it again when the two are in range of each other, so the link is
+        /// dormant.
+        /// </summary>
+        public GameObjectState GameObjectState {
+            get {
+                var state = FlightGlobalsExtensions.VesselState (vesselId)
+                    .LeastAlive (start.GameObjectState)
+                    .LeastAlive (end.GameObjectState);
+                if (state != GameObjectState.Live)
+                    return state;
+                return Find () != null ? GameObjectState.Live : GameObjectState.Dormant;
+            }
+        }
+
+        /// <summary>
+        /// The hop between the two nodes in the vessel's control path as it is now, or null
+        /// if the path does not take it.
+        /// </summary>
+        CommNet.CommLink Find ()
+        {
+            var vessel = FlightGlobalsExtensions.FindVesselById (vesselId);
+            if (vessel == null)
+                return null;
+            var connection = vessel.Connection;
+            var path = connection == null ? null : connection.ControlPath;
+            if (path == null)
+                return null;
+            for (var i = 0; i < path.Count; i++) {
+                var link = path [i];
+                if (link != null &&
+                    ReferenceEquals (link.start, start.InternalNode) &&
+                    ReferenceEquals (link.end, end.InternalNode))
+                    return link;
+            }
+            return null;
+        }
+
+        /// <summary>
+        /// The error to raise when the vessel's control path no longer takes the hop, which
+        /// <see cref="GameObjectState" /> decides between.
+        /// </summary>
+        Exception NotResolvable ()
+        {
+            if (GameObjectState == GameObjectState.Destroyed)
+                return new ObjectDestroyedException (
+                    "The comm link no longer exists, as the vessel whose control path it " +
+                    "was part of, or one of the nodes it joins, is gone.");
+            return new InvalidOperationException (
+                "The comm link is not part of the vessel's control path at the moment. " +
+                "It can be used again if the path takes it again.");
+        }
 
         /// <summary>
         /// Returns true if the objects are equal.
         /// </summary>
         public override bool Equals (CommLink other)
         {
-            return !ReferenceEquals (other, null) && InternalLink == other.InternalLink;
+            return !ReferenceEquals (other, null) && vesselId == other.vesselId &&
+            start.Equals (other.start) && end.Equals (other.end);
         }
 
         /// <summary>
@@ -39,7 +115,7 @@ namespace KRPC.SpaceCenter.Services
         /// </summary>
         public override int GetHashCode ()
         {
-            return InternalLink.GetHashCode ();
+            return vesselId.GetHashCode () ^ start.GetHashCode () ^ end.GetHashCode ();
         }
 
         /// <summary>
@@ -63,7 +139,7 @@ namespace KRPC.SpaceCenter.Services
         /// </summary>
         [KRPCProperty]
         public CommNode Start {
-            get { return new CommNode (InternalLink.start); }
+            get { return start; }
         }
 
         /// <summary>
@@ -71,7 +147,7 @@ namespace KRPC.SpaceCenter.Services
         /// </summary>
         [KRPCProperty]
         public CommNode End {
-            get { return new CommNode (InternalLink.end); }
+            get { return end; }
         }
     }
 }

--- a/service/SpaceCenter/src/Services/CommNode.cs
+++ b/service/SpaceCenter/src/Services/CommNode.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Runtime.CompilerServices;
 using KRPC.Service.Attributes;
 using KRPC.Utils;
 
@@ -8,7 +9,7 @@ namespace KRPC.SpaceCenter.Services
     /// Represents a communication node in the network. For example, a vessel or the KSC.
     /// </summary>
     [KRPCClass (Service = "SpaceCenter")]
-    public class CommNode : Equatable<CommNode>
+    public class CommNode : Equatable<CommNode>, IGameObjectState
     {
         /// <summary>
         /// Construct from a KSP CommNode object.
@@ -26,11 +27,27 @@ namespace KRPC.SpaceCenter.Services
         public CommNet.CommNode InternalNode { get; private set; }
 
         /// <summary>
+        /// What the game holds for the thing the node hangs off. The game gives nothing to
+        /// identify a node by, so the node itself is held; what can be checked is the
+        /// transform it was built with, which the game tears down with the vessel. A node
+        /// that never had one, such as a ground station, says nothing either way and is
+        /// therefore kept.
+        /// </summary>
+        public GameObjectState GameObjectState {
+            get {
+                var transform = InternalNode.transform;
+                if (ReferenceEquals (transform, null))
+                    return GameObjectState.Live;
+                return transform != null ? GameObjectState.Live : GameObjectState.Destroyed;
+            }
+        }
+
+        /// <summary>
         /// Returns true if the objects are equal.
         /// </summary>
         public override bool Equals (CommNode other)
         {
-            return !ReferenceEquals (other, null) && InternalNode == other.InternalNode;
+            return !ReferenceEquals (other, null) && ReferenceEquals (InternalNode, other.InternalNode);
         }
 
         /// <summary>
@@ -38,7 +55,9 @@ namespace KRPC.SpaceCenter.Services
         /// </summary>
         public override int GetHashCode ()
         {
-            return InternalNode.GetHashCode ();
+            // The node's identity hash rather than its own, so that nothing the game does to
+            // the node can change it while a client holds this object.
+            return RuntimeHelpers.GetHashCode (InternalNode);
         }
 
         /// <summary>

--- a/service/SpaceCenter/src/Services/Comms.cs
+++ b/service/SpaceCenter/src/Services/Comms.cs
@@ -12,7 +12,7 @@ namespace KRPC.SpaceCenter.Services
     /// Obtained by calling <see cref="Vessel.Comms"/>.
     /// </summary>
     [KRPCClass (Service = "SpaceCenter", GameScene = GameScene.Flight)]
-    public class Comms : Equatable<Comms>
+    public class Comms : Equatable<Comms>, IGameObjectState
     {
         /// <summary>
         /// Construct from a KSP vessel object.
@@ -30,6 +30,13 @@ namespace KRPC.SpaceCenter.Services
         public Comms (Guid vesselId)
         {
             VesselId = vesselId;
+        }
+
+        /// <summary>
+        /// What the game holds for the vessel this belongs to.
+        /// </summary>
+        public GameObjectState GameObjectState {
+            get { return FlightGlobalsExtensions.VesselState (VesselId); }
         }
 
         /// <summary>

--- a/service/SpaceCenter/src/Services/Comms.cs
+++ b/service/SpaceCenter/src/Services/Comms.cs
@@ -146,7 +146,7 @@ namespace KRPC.SpaceCenter.Services
             get {
                 if (!InNetwork)
                     return new List<CommLink> ();
-                return InternalComms.ControlPath.Select (x => new CommLink (x)).ToList ();
+                return InternalComms.ControlPath.Select (x => new CommLink (VesselId, x)).ToList ();
             }
         }
     }

--- a/service/SpaceCenter/src/Services/Contract.cs
+++ b/service/SpaceCenter/src/Services/Contract.cs
@@ -1,8 +1,10 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using KRPC.Service.Attributes;
 using KRPC.SpaceCenter.ExtensionMethods;
 using KRPC.Utils;
+using ObjectDestroyedException = KRPC.Service.KRPC.ObjectDestroyedException;
 
 namespace KRPC.SpaceCenter.Services
 {
@@ -10,27 +12,100 @@ namespace KRPC.SpaceCenter.Services
     /// A contract. Can be accessed using <see cref="SpaceCenter.ContractManager"/>.
     /// </summary>
     [KRPCClass(Service = "SpaceCenter")]
-    public class Contract : Equatable<Contract>
+    public class Contract : Equatable<Contract>, IGameObjectState
     {
+        // The guid the game gives a contract, which it writes into the save and reads back,
+        // so it names the contract across a load. The contract system builds new contract
+        // objects for a game it loads, so holding one would leave this reading a contract
+        // out of a game state that is no longer loaded.
+        readonly Guid contractGuid;
+
         /// <summary>
         /// Create a contract object from a KSP contract.
         /// </summary>
         public Contract(Contracts.Contract contract)
         {
-            InternalContract = contract;
+            if (contract == null)
+                throw new ArgumentNullException(nameof(contract));
+            contractGuid = contract.ContractGuid;
         }
 
         /// <summary>
-        /// The KSP contract.
+        /// The KSP contract, found again from the guid that names it.
         /// </summary>
-        public Contracts.Contract InternalContract { get; private set; }
+        public Contracts.Contract InternalContract
+        {
+            get
+            {
+                var contract = Find();
+                if (contract == null)
+                    throw NotResolvable();
+                return contract;
+            }
+        }
+
+        /// <summary>
+        /// What the game holds for the contract. It is live while the contract system
+        /// lists it, running or finished, and destroyed once the system is there to ask and
+        /// does not. A game with no contract system has no contracts to look through, which
+        /// says nothing about this one.
+        /// </summary>
+        public GameObjectState GameObjectState
+        {
+            get
+            {
+                if (Contracts.ContractSystem.Instance == null)
+                    return GameObjectState.Dormant;
+                return Find() != null ? GameObjectState.Live : GameObjectState.Destroyed;
+            }
+        }
+
+        /// <summary>
+        /// The contract the game currently has under the guid, or null if it has none.
+        /// A finished contract is still a contract this can stand for, and the game's own
+        /// lookup by guid searches the running ones only, so both lists are searched.
+        /// </summary>
+        internal Contracts.Contract Find()
+        {
+            var system = Contracts.ContractSystem.Instance;
+            if (system == null)
+                return null;
+            return FindIn(system.Contracts) ?? FindIn(system.ContractsFinished);
+        }
+
+        Contracts.Contract FindIn(IList<Contracts.Contract> contracts)
+        {
+            if (contracts == null)
+                return null;
+            for (var i = 0; i < contracts.Count; i++)
+            {
+                var contract = contracts[i];
+                if (contract != null && contract.ContractGuid == contractGuid)
+                    return contract;
+            }
+            return null;
+        }
+
+        /// <summary>
+        /// The error to raise when no contract answers to the guid, which
+        /// <see cref="GameObjectState" /> decides between.
+        /// </summary>
+        Exception NotResolvable()
+        {
+            if (GameObjectState == GameObjectState.Destroyed)
+                return new ObjectDestroyedException(
+                    "The contract no longer exists, as the game no longer has a contract with its id.");
+            return new InvalidOperationException(
+                "The contract is not loaded, as the game has no contract system running. " +
+                "It can be used again once the game does.");
+        }
 
         /// <summary>
         /// Returns true if the objects are equal.
         /// </summary>
         public override bool Equals(Contract other)
         {
-            return !ReferenceEquals(other, null) && InternalContract.ContractID == other.InternalContract.ContractID;
+            return !ReferenceEquals(other, null) && contractGuid == other.contractGuid;
         }
 
         /// <summary>
@@ -38,7 +113,7 @@ namespace KRPC.SpaceCenter.Services
         /// </summary>
         public override int GetHashCode()
         {
-            return InternalContract.ContractID.GetHashCode();
+            return contractGuid.GetHashCode();
         }
 
         /// <summary>
@@ -252,7 +327,7 @@ namespace KRPC.SpaceCenter.Services
                 var contract = InternalContract;
                 var result = new List<ContractParameter>();
                 for (int i = 0; i < contract.ParameterCount; i++)
-                    result.Add(new ContractParameter(contract.GetParameter(i)));
+                    result.Add(new ContractParameter(this, new [] { i }));
                 return result;
             }
         }

--- a/service/SpaceCenter/src/Services/ContractParameter.cs
+++ b/service/SpaceCenter/src/Services/ContractParameter.cs
@@ -1,6 +1,8 @@
+using System;
 using System.Collections.Generic;
 using KRPC.Service.Attributes;
 using KRPC.Utils;
+using ObjectDestroyedException = KRPC.Service.KRPC.ObjectDestroyedException;
 
 namespace KRPC.SpaceCenter.Services
 {
@@ -8,27 +10,150 @@ namespace KRPC.SpaceCenter.Services
     /// A contract parameter. See <see cref="Contract.Parameters"/>.
     /// </summary>
     [KRPCClass(Service = "SpaceCenter")]
-    public class ContractParameter : Equatable<ContractParameter>
+    public class ContractParameter : Equatable<ContractParameter>, IGameObjectState
     {
+        // The contract the parameter belongs to, and the indices that lead to it: a
+        // contract's parameters are an ordered list and so are each parameter's own, so the
+        // path names the parameter for as long as the contract exists. The game gives a
+        // parameter nothing else to be named by, and builds new parameter objects whenever
+        // it builds the contract.
+        readonly Contract contract;
+        readonly int[] path;
+
         /// <summary>
         /// Create a contract parameter object from a KSP contract parameter.
         /// </summary>
         public ContractParameter(Contracts.ContractParameter parameter)
         {
-            InternalParameter = parameter;
+            if (parameter == null)
+                throw new ArgumentNullException(nameof(parameter));
+            var root = parameter.Root;
+            if (root == null)
+                throw new ArgumentException("Contract parameter does not belong to a contract");
+            contract = new Contract(root);
+            path = PathTo(root, parameter);
+            if (path == null)
+                throw new ArgumentException("Contract parameter was not found in its contract");
+        }
+
+        internal ContractParameter(Contract parameterContract, int[] parameterPath)
+        {
+            contract = parameterContract;
+            path = parameterPath;
         }
 
         /// <summary>
-        /// The KSP contract parameter.
+        /// The KSP contract parameter, found again by walking the contract's parameters.
         /// </summary>
-        public Contracts.ContractParameter InternalParameter { get; private set; }
+        public Contracts.ContractParameter InternalParameter
+        {
+            get
+            {
+                var parameter = Find();
+                if (parameter == null)
+                    throw NotResolvable();
+                return parameter;
+            }
+        }
+
+        /// <summary>
+        /// What the game holds for the parameter. It belongs to its contract, so it is
+        /// exactly as live, dormant or destroyed as the contract is, and destroyed when a
+        /// contract that is there to look in no longer has it.
+        /// </summary>
+        public GameObjectState GameObjectState
+        {
+            get
+            {
+                var state = contract.GameObjectState;
+                if (state != GameObjectState.Live)
+                    return state;
+                return Find() != null ? GameObjectState.Live : GameObjectState.Destroyed;
+            }
+        }
+
+        /// <summary>
+        /// The parameter the path leads to now, or null if it leads nowhere.
+        /// </summary>
+        Contracts.ContractParameter Find()
+        {
+            var current = contract.Find();
+            if (current == null)
+                return null;
+            Contracts.ContractParameter parameter = null;
+            foreach (var index in path)
+            {
+                var count = parameter == null ? current.ParameterCount : parameter.ParameterCount;
+                if (index < 0 || index >= count)
+                    return null;
+                parameter = parameter == null
+                    ? current.GetParameter(index) : parameter.GetParameter(index);
+                if (parameter == null)
+                    return null;
+            }
+            return parameter;
+        }
+
+        /// <summary>
+        /// The indices that lead from the contract to the given parameter, or null if it is
+        /// not one of the contract's.
+        /// </summary>
+        static int[] PathTo(Contracts.Contract contract, Contracts.ContractParameter parameter)
+        {
+            for (var i = 0; i < contract.ParameterCount; i++)
+            {
+                var found = PathTo(contract.GetParameter(i), parameter, new List<int> { i });
+                if (found != null)
+                    return found;
+            }
+            return null;
+        }
+
+        static int[] PathTo(
+            Contracts.ContractParameter candidate,
+            Contracts.ContractParameter parameter,
+            List<int> pathToCandidate)
+        {
+            if (ReferenceEquals(candidate, parameter))
+                return pathToCandidate.ToArray();
+            for (var i = 0; i < candidate.ParameterCount; i++)
+            {
+                pathToCandidate.Add(i);
+                var found = PathTo(candidate.GetParameter(i), parameter, pathToCandidate);
+                if (found != null)
+                    return found;
+                pathToCandidate.RemoveAt(pathToCandidate.Count - 1);
+            }
+            return null;
+        }
+
+        /// <summary>
+        /// The error to raise when the path leads nowhere, which
+        /// <see cref="GameObjectState" /> decides between.
+        /// </summary>
+        Exception NotResolvable()
+        {
+            if (GameObjectState == GameObjectState.Destroyed)
+                return new ObjectDestroyedException(
+                    "The contract parameter no longer exists, as the contract it belongs to " +
+                    "no longer has it.");
+            return new InvalidOperationException(
+                "The contract parameter is not loaded, as the game has no contract system " +
+                "running. It can be used again once the game does.");
+        }
 
         /// <summary>
         /// Returns true if the objects are equal.
         /// </summary>
         public override bool Equals(ContractParameter other)
         {
-            return !ReferenceEquals(other, null) && InternalParameter == other.InternalParameter;
+            if (ReferenceEquals(other, null) || !contract.Equals(other.contract) ||
+                path.Length != other.path.Length)
+                return false;
+            for (var i = 0; i < path.Length; i++)
+                if (path[i] != other.path[i])
+                    return false;
+            return true;
         }
 
         /// <summary>
@@ -36,7 +161,10 @@ namespace KRPC.SpaceCenter.Services
         /// </summary>
         public override int GetHashCode()
         {
-            return InternalParameter.GetHashCode();
+            var hash = contract.GetHashCode();
+            foreach (var index in path)
+                hash = hash * 31 + index;
+            return hash;
         }
 
         /// <summary>
@@ -65,7 +193,7 @@ namespace KRPC.SpaceCenter.Services
                 var parameter = InternalParameter;
                 var result = new List<ContractParameter> ();
                 for (int i = 0; i < parameter.ParameterCount; i++)
-                    result.Add(new ContractParameter(parameter.GetParameter(i)));
+                    result.Add(new ContractParameter(contract, PathToChild(i)));
                 return result;
             }
         }
@@ -142,6 +270,17 @@ namespace KRPC.SpaceCenter.Services
             get {
                 return InternalParameter.ScienceCompletion;
             }
+        }
+
+        /// <summary>
+        /// The path that leads to the child of this parameter at the given index.
+        /// </summary>
+        int[] PathToChild(int index)
+        {
+            var result = new int[path.Length + 1];
+            Array.Copy(path, result, path.Length);
+            result[path.Length] = index;
+            return result;
         }
     }
 }

--- a/service/SpaceCenter/src/Services/Control.cs
+++ b/service/SpaceCenter/src/Services/Control.cs
@@ -38,7 +38,7 @@ namespace KRPC.SpaceCenter.Services
     /// passes on the way.
     /// </remarks>
     [KRPCClass (Service = "SpaceCenter", GameScene = GameScene.Flight)]
-    public class Control : Equatable<Control>
+    public class Control : Equatable<Control>, IGameObjectState
     {
         readonly Guid vesselId;
         readonly Parts.Parts parts;
@@ -47,6 +47,13 @@ namespace KRPC.SpaceCenter.Services
         {
             vesselId = vessel.id;
             parts = new Vessel (vessel).Parts;
+        }
+
+        /// <summary>
+        /// What the game holds for the vessel this belongs to.
+        /// </summary>
+        public GameObjectState GameObjectState {
+            get { return FlightGlobalsExtensions.VesselState (vesselId); }
         }
 
         /// <summary>

--- a/service/SpaceCenter/src/Services/CrewMember.cs
+++ b/service/SpaceCenter/src/Services/CrewMember.cs
@@ -12,7 +12,7 @@ namespace KRPC.SpaceCenter.Services
     /// Represents crew in a vessel. Can be obtained using <see cref="Vessel.Crew"/>.
     /// </summary>
     [KRPCClass (Service = "SpaceCenter")]
-    public class CrewMember : Equatable<CrewMember>
+    public class CrewMember : Equatable<CrewMember>, IGameObjectState
     {
         /// <summary>
         /// Construct a crew member from a KSP crew member.
@@ -23,11 +23,35 @@ namespace KRPC.SpaceCenter.Services
         }
 
         /// <summary>
+        /// What the game holds for the crew member, who is live while the game still
+        /// has them on its roster. A game that has not been loaded has no roster to look
+        /// in, which says nothing about anyone.
+        /// </summary>
+        public GameObjectState GameObjectState {
+            get {
+                var roster = HighLogic.CurrentGame?.CrewRoster;
+                if (roster == null)
+                    return GameObjectState.Dormant;
+                return roster [m_protoCrewMemberName] != null
+                    ? GameObjectState.Live : GameObjectState.Destroyed;
+            }
+        }
+
+        /// <summary>
         /// Returns true if the objects are equal.
         /// </summary>
+        /// <remarks>
+        /// The kerbal's name is what this stands for, and comparing it is all this may do.
+        /// The object store compares and hashes the objects it holds, including while removing
+        /// one whose kerbal the game no longer has, so this has to agree with the hash code
+        /// wherever the hash code can be taken. Looking the kerbal up here instead would make
+        /// two objects standing for different kerbals the game no longer has, which both look
+        /// up to nothing, compare equal while hashing differently.
+        /// </remarks>
         public override bool Equals (CrewMember other)
         {
-            return !ReferenceEquals (other, null) && InternalCrewMember == other.InternalCrewMember;
+            return !ReferenceEquals (other, null) &&
+            m_protoCrewMemberName == other.m_protoCrewMemberName;
         }
 
         /// <summary>
@@ -48,7 +72,7 @@ namespace KRPC.SpaceCenter.Services
                 return HighLogic.CurrentGame?.CrewRoster?[m_protoCrewMemberName];
             }
         }
-        private string m_protoCrewMemberName;
+        readonly string m_protoCrewMemberName;
 
         /// <summary>
         /// The crew members name.

--- a/service/SpaceCenter/src/Services/Editor.cs
+++ b/service/SpaceCenter/src/Services/Editor.cs
@@ -214,8 +214,7 @@ namespace KRPC.SpaceCenter.Services
                 var driver = EditorDriver.fetch;
                 if (driver == null || driver.restartingEditor)
                     return false;
-                var logic = EditorLogic.fetch;
-                return logic != null && !ReferenceEquals (logic.ship, null);
+                return !ReferenceEquals (EditorExtensions.Ship, null);
             }
         }
 

--- a/service/SpaceCenter/src/Services/EditorDeltaV.cs
+++ b/service/SpaceCenter/src/Services/EditorDeltaV.cs
@@ -21,9 +21,8 @@ namespace KRPC.SpaceCenter.Services
         /// </summary>
         internal static VesselDeltaV Simulation {
             get {
-                var logic = EditorLogic.fetch;
-                var construct = logic == null ? null : logic.ship;
-                return ReferenceEquals (construct, null) ? null : construct.vesselDeltaV;
+                var ship = EditorExtensions.Ship;
+                return ReferenceEquals (ship, null) ? null : ship.vesselDeltaV;
             }
         }
 

--- a/service/SpaceCenter/src/Services/EditorVessel.cs
+++ b/service/SpaceCenter/src/Services/EditorVessel.cs
@@ -44,11 +44,7 @@ namespace KRPC.SpaceCenter.Services
         /// </summary>
         public ShipConstruct InternalShipConstruct {
             get {
-                var logic = EditorLogic.fetch;
-                var construct = ReferenceEquals (logic, null) ? null : logic.ship;
-                if (ReferenceEquals (construct, null))
-                    throw new InvalidOperationException ("The editor does not contain a vessel.");
-                return construct;
+                return EditorExtensions.GetShip ();
             }
         }
 

--- a/service/SpaceCenter/src/Services/Flight.cs
+++ b/service/SpaceCenter/src/Services/Flight.cs
@@ -22,7 +22,7 @@ namespace KRPC.SpaceCenter.Services
     /// To get orbital information, such as the apoapsis or inclination, see <see cref="Orbit"/>.
     /// </remarks>
     [KRPCClass (Service = "SpaceCenter", GameScene = GameScene.Flight)]
-    public class Flight : Equatable<Flight>
+    public class Flight : Equatable<Flight>, IGameObjectState
     {
         readonly Guid vesselId;
         readonly ReferenceFrame referenceFrame;
@@ -31,6 +31,13 @@ namespace KRPC.SpaceCenter.Services
         {
             vesselId = vessel.id;
             this.referenceFrame = referenceFrame;
+        }
+
+        /// <summary>
+        /// What the game holds for the vessel this belongs to.
+        /// </summary>
+        public GameObjectState GameObjectState {
+            get { return FlightGlobalsExtensions.VesselState (vesselId); }
         }
 
         /// <summary>

--- a/service/SpaceCenter/src/Services/Node.cs
+++ b/service/SpaceCenter/src/Services/Node.cs
@@ -1,8 +1,10 @@
 using System;
+using System.Runtime.CompilerServices;
 using KRPC.Service;
 using KRPC.Service.Attributes;
 using KRPC.SpaceCenter.ExtensionMethods;
 using KRPC.Utils;
+using ObjectDestroyedException = KRPC.Service.KRPC.ObjectDestroyedException;
 using Tuple3 = System.Tuple<double, double, double>;
 using Tuple4 = System.Tuple<double, double, double, double>;
 
@@ -11,9 +13,8 @@ namespace KRPC.SpaceCenter.Services
     /// <summary>
     /// Represents a maneuver node. Can be created using <see cref="Control.AddNode"/>.
     /// </summary>
-    // FIXME: need to perform memory management for node objects
     [KRPCClass (Service = "SpaceCenter", GameScene = GameScene.Flight)]
-    public class Node : Equatable<Node>
+    public class Node : Equatable<Node>, IGameObjectState
     {
         /// Note: Maneuver node delta-v vectors use a special coordinate system.
         /// The z-component is the prograde component.
@@ -21,29 +22,42 @@ namespace KRPC.SpaceCenter.Services
         /// The x-component is the radial component.
 
         readonly Guid vesselId;
+        // The game's own maneuver node. It offers nothing to identify a node by, so this is
+        // held rather than found again; a node the game no longer has in the vessel's flight
+        // plan, which includes every node after a game is loaded, is reclaimed instead.
+        readonly ManeuverNode node;
 
         internal Node (global::Vessel vessel, double ut, double prograde, double normal, double radial)
         {
             vesselId = vessel.id;
             if (InternalVessel.patchedConicSolver == null)
                 throw new InvalidOperationException ("Cannot add maneuver node");
-            var node = vessel.patchedConicSolver.AddManeuverNode (ut);
+            node = vessel.patchedConicSolver.AddManeuverNode (ut);
             node.DeltaV = new Vector3d (radial, normal, prograde);
             Update ();
-            InternalNode = node;
+        }
+
+        /// <summary>
+        /// Construct a node from a KSP node and the id of the vessel whose flight plan it
+        /// belongs to, for a caller that has the id and must not resolve it.
+        /// </summary>
+        internal Node (Guid vessel, ManeuverNode maneuverNode)
+        {
+            vesselId = vessel;
+            node = maneuverNode;
         }
 
         /// <summary>
         /// Construct a node from a KSP node.
         /// </summary>
-        public Node (global::Vessel vessel, ManeuverNode node)
+        public Node (global::Vessel vessel, ManeuverNode maneuverNode)
         {
             if (ReferenceEquals (vessel, null))
                 throw new ArgumentNullException (nameof (vessel));
-            if (ReferenceEquals (node, null))
-                throw new ArgumentNullException (nameof (node));
+            if (ReferenceEquals (maneuverNode, null))
+                throw new ArgumentNullException (nameof (maneuverNode));
             vesselId = vessel.id;
-            InternalNode = node;
+            node = maneuverNode;
         }
 
         /// <summary>
@@ -51,7 +65,8 @@ namespace KRPC.SpaceCenter.Services
         /// </summary>
         public override bool Equals (Node other)
         {
-            return !ReferenceEquals (other, null) && vesselId == other.vesselId && InternalNode == other.InternalNode;
+            return !ReferenceEquals (other, null) && vesselId == other.vesselId &&
+            ReferenceEquals (node, other.node);
         }
 
         /// <summary>
@@ -59,11 +74,9 @@ namespace KRPC.SpaceCenter.Services
         /// </summary>
         public override int GetHashCode ()
         {
-            int hash = vesselId.GetHashCode ();
-            // Note: InternalNode could be set to null by Remove
-            if (InternalNode != null)
-                hash ^= InternalNode.GetHashCode ();
-            return hash;
+            // The node's identity hash rather than its own: it is what the game holds, and
+            // nothing about it may change while a client has this object.
+            return vesselId.GetHashCode () ^ RuntimeHelpers.GetHashCode (node);
         }
 
         /// <summary>
@@ -74,32 +87,61 @@ namespace KRPC.SpaceCenter.Services
         }
 
         /// <summary>
-        /// The KSP node.
+        /// The KSP maneuver node, checked to still be part of the vessel's flight plan.
+        /// A node can be removed through this object, through another object standing for
+        /// the same node (including Control.RemoveNodes), or by the player in the in-game
+        /// UI, and loading a game replaces every node the vessel had; in all cases the node
+        /// this stands for is gone for good. A vessel the game is not solving conics for has
+        /// no flight plan to look in, which says nothing about the node either way.
         /// </summary>
-        public ManeuverNode InternalNode { get; private set; }
+        public ManeuverNode InternalNode {
+            get {
+                var solver = InternalVessel.patchedConicSolver;
+                if (solver != null && solver.maneuverNodes.Contains (node))
+                    return node;
+                throw NotResolvable ();
+            }
+        }
 
         /// <summary>
-        /// The KSP maneuver node, checked to still be part of the vessel's flight plan.
-        /// A node can be removed through this object, through another object wrapping
-        /// the same node (including Control.RemoveNodes), or manually in the in-game
-        /// UI; in all cases accessing it through this object is an error.
+        /// The error to raise when the node cannot be found in the vessel's flight plan,
+        /// which <see cref="GameObjectState" /> decides between so that one rule says what
+        /// the absence of the node from the plan means.
         /// </summary>
-        ManeuverNode SafeNode {
+        Exception NotResolvable ()
+        {
+            if (GameObjectState == GameObjectState.Destroyed)
+                return new ObjectDestroyedException (
+                    "The maneuver node no longer exists, as it is not in the vessel's flight plan.");
+            return new InvalidOperationException (
+                "The maneuver node is not loaded, as the game is not computing a flight " +
+                "plan for the vessel it belongs to. It can be used again once the game does.");
+        }
+
+        /// <summary>
+        /// What the game holds for the node. It is live while the vessel still has it in
+        /// its flight plan, and destroyed once the vessel is there to ask and does not,
+        /// as a node that leaves the plan is gone for good. A vessel the game is not
+        /// solving conics for has no flight plan to look in, which says nothing about the
+        /// node either way.
+        /// </summary>
+        public GameObjectState GameObjectState {
             get {
-                var node = InternalNode;
-                if (node != null) {
-                    var solver = InternalVessel.patchedConicSolver;
-                    if (solver != null && solver.maneuverNodes.Contains (node))
-                        return node;
-                }
-                throw new InvalidOperationException ("Maneuver node has been removed");
+                var vesselState = FlightGlobalsExtensions.VesselState (vesselId);
+                if (vesselState != GameObjectState.Live)
+                    return vesselState;
+                var solver = FlightGlobalsExtensions.FindVesselById (vesselId).patchedConicSolver;
+                if (solver == null)
+                    return GameObjectState.Dormant;
+                return solver.maneuverNodes.Contains (node)
+                    ? GameObjectState.Live : GameObjectState.Destroyed;
             }
         }
 
         internal Vector3d WorldBurnVector {
             get {
-                var prograde = SafeNode.patch.getOrbitalVelocityAtUT (SafeNode.UT).SwapYZ ().normalized;
-                var normal = SafeNode.patch.GetOrbitNormal ().SwapYZ ().normalized;
+                var prograde = InternalNode.patch.getOrbitalVelocityAtUT (InternalNode.UT).SwapYZ ().normalized;
+                var normal = InternalNode.patch.GetOrbitNormal ().SwapYZ ().normalized;
                 var radial = Vector3d.Cross (normal, prograde);
                 return Prograde * prograde + Normal * normal + Radial * radial;
             }
@@ -111,9 +153,9 @@ namespace KRPC.SpaceCenter.Services
         /// </summary>
         [KRPCProperty]
         public double Prograde {
-            get { return SafeNode.DeltaV.z; }
+            get { return InternalNode.DeltaV.z; }
             set {
-                SafeNode.DeltaV.z = value;
+                InternalNode.DeltaV.z = value;
                 Update ();
             }
         }
@@ -124,9 +166,9 @@ namespace KRPC.SpaceCenter.Services
         /// </summary>
         [KRPCProperty]
         public double Normal {
-            get { return SafeNode.DeltaV.y; }
+            get { return InternalNode.DeltaV.y; }
             set {
-                SafeNode.DeltaV.y = value;
+                InternalNode.DeltaV.y = value;
                 Update ();
             }
         }
@@ -137,9 +179,9 @@ namespace KRPC.SpaceCenter.Services
         /// </summary>
         [KRPCProperty]
         public double Radial {
-            get { return SafeNode.DeltaV.x; }
+            get { return InternalNode.DeltaV.x; }
             set {
-                SafeNode.DeltaV.x = value;
+                InternalNode.DeltaV.x = value;
                 Update ();
             }
         }
@@ -152,10 +194,10 @@ namespace KRPC.SpaceCenter.Services
         /// </remarks>
         [KRPCProperty]
         public double DeltaV {
-            get { return SafeNode.DeltaV.magnitude; }
+            get { return InternalNode.DeltaV.magnitude; }
             set {
-                var direction = SafeNode.DeltaV.normalized;
-                SafeNode.DeltaV = new Vector3d (direction.x * value, direction.y * value, direction.z * value);
+                var direction = InternalNode.DeltaV.normalized;
+                InternalNode.DeltaV = new Vector3d (direction.x * value, direction.y * value, direction.z * value);
                 Update ();
             }
         }
@@ -166,7 +208,7 @@ namespace KRPC.SpaceCenter.Services
         /// </summary>
         [KRPCProperty]
         public double RemainingDeltaV {
-            get { return SafeNode.GetBurnVector (SafeNode.patch).magnitude; }
+            get { return InternalNode.GetBurnVector (InternalNode.patch).magnitude; }
         }
 
         /// <summary>
@@ -204,7 +246,7 @@ namespace KRPC.SpaceCenter.Services
         {
             if (ReferenceEquals (referenceFrame, null))
                 referenceFrame = ReferenceFrame.Orbital (InternalVessel);
-            return referenceFrame.DirectionFromWorldSpace (SafeNode.GetBurnVector (SafeNode.patch)).ToTuple ();
+            return referenceFrame.DirectionFromWorldSpace (InternalNode.GetBurnVector (InternalNode.patch)).ToTuple ();
         }
 
         /// <summary>
@@ -212,9 +254,9 @@ namespace KRPC.SpaceCenter.Services
         /// </summary>
         [KRPCProperty]
         public double UT {
-            get { return SafeNode.UT; }
+            get { return InternalNode.UT; }
             set {
-                SafeNode.UT = value;
+                InternalNode.UT = value;
                 Update ();
             }
         }
@@ -248,10 +290,7 @@ namespace KRPC.SpaceCenter.Services
         [KRPCMethod]
         public void Remove ()
         {
-            // Note: the Node object itself is not removed from the object store; that
-            // is the object-lifetime gap tracked by issue #771
-            SafeNode.RemoveSelf ();
-            InternalNode = null;
+            InternalNode.RemoveSelf ();
         }
 
         /// <summary>
@@ -264,7 +303,7 @@ namespace KRPC.SpaceCenter.Services
         /// </summary>
         [KRPCProperty]
         public ReferenceFrame ReferenceFrame {
-            get { return ReferenceFrame.Object (InternalVessel, SafeNode); }
+            get { return ReferenceFrame.Object (InternalVessel, InternalNode); }
         }
 
         /// <summary>
@@ -283,7 +322,7 @@ namespace KRPC.SpaceCenter.Services
         /// </summary>
         [KRPCProperty]
         public ReferenceFrame OrbitalReferenceFrame {
-            get { return ReferenceFrame.Orbital (InternalVessel, SafeNode); }
+            get { return ReferenceFrame.Orbital (InternalVessel, InternalNode); }
         }
 
         /// <summary>
@@ -295,7 +334,7 @@ namespace KRPC.SpaceCenter.Services
         [KRPCMethod]
         public Tuple3 Position (ReferenceFrame referenceFrame)
         {
-            return referenceFrame.PositionFromWorldSpace (SafeNode.patch.getPositionAtUT (SafeNode.UT)).ToTuple ();
+            return referenceFrame.PositionFromWorldSpace (InternalNode.patch.getPositionAtUT (InternalNode.UT)).ToTuple ();
         }
 
         /// <summary>

--- a/service/SpaceCenter/src/Services/Orbit.cs
+++ b/service/SpaceCenter/src/Services/Orbit.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using KRPC.Service.Attributes;
 using KRPC.SpaceCenter.ExtensionMethods;
 using KRPC.Utils;
@@ -13,29 +14,38 @@ namespace KRPC.SpaceCenter.Services
     /// <see cref="CelestialBody.Orbit"/>.
     /// </summary>
     [KRPCClass (Service = "SpaceCenter")]
-    public class Orbit : Equatable<Orbit>
+    public class Orbit : Equatable<Orbit>, IGameObjectState
     {
         readonly Vessel ownerVessel;
         readonly CelestialBody ownerBody;
         readonly Node ownerNode;
+        // The KSP orbit, held only where it is not the orbit of the thing the object
+        // belongs to and so cannot be asked for again: a patch, or an orbit a caller
+        // handed in. An orbit that has an owner is looked up on it instead, because the
+        // game builds a new one whenever it builds the owner, and the object has to read
+        // the loaded game rather than the state it was made in.
+        readonly global::Orbit patch;
 
         internal Orbit (Vessel vessel)
         {
-            InternalOrbit = vessel.InternalVessel.GetOrbit ();
+            if (ReferenceEquals (vessel, null))
+                throw new ArgumentNullException (nameof (vessel));
             ownerVessel = vessel;
         }
 
         internal Orbit (CelestialBody body)
         {
+            if (ReferenceEquals (body, null))
+                throw new ArgumentNullException (nameof (body));
             if (body.InternalBody == body.InternalBody.referenceBody)
                 throw new ArgumentException ("Body does not orbit anything");
-            InternalOrbit = body.InternalBody.GetOrbit ();
             ownerBody = body;
         }
 
         internal Orbit (Node node)
         {
-            InternalOrbit = node.InternalNode.nextPatch;
+            if (ReferenceEquals (node, null))
+                throw new ArgumentNullException (nameof (node));
             ownerNode = node;
         }
 
@@ -44,7 +54,9 @@ namespace KRPC.SpaceCenter.Services
         /// </summary>
         public Orbit (global::Orbit orbit)
         {
-            InternalOrbit = orbit;
+            if (ReferenceEquals (orbit, null))
+                throw new ArgumentNullException (nameof (orbit));
+            patch = orbit;
         }
 
         // Construct an orbit from a KSP orbit object, inheriting the owner of an
@@ -52,18 +64,45 @@ namespace KRPC.SpaceCenter.Services
         // which belongs to the same object).
         internal Orbit (global::Orbit orbit, Orbit owner)
         {
-            InternalOrbit = orbit;
+            patch = orbit;
             ownerVessel = owner.ownerVessel;
             ownerBody = owner.ownerBody;
             ownerNode = owner.ownerNode;
         }
 
         /// <summary>
+        /// What the game holds for the thing the orbit belongs to. An orbit built from a KSP
+        /// orbit alone has no owner to ask, so it is kept.
+        /// </summary>
+        public GameObjectState GameObjectState {
+            get {
+                if (ownerVessel != null)
+                    return ownerVessel.GameObjectState;
+                if (ownerNode != null)
+                    return ownerNode.GameObjectState;
+                return GameObjectState.Live;
+            }
+        }
+
+        /// <summary>
         /// Returns true if the objects are equal.
         /// </summary>
+        /// <remarks>
+        /// What the object stands for is the thing whose orbit it is, so two objects for
+        /// one vessel's orbit are the same orbit however often the game rebuilds it. Only
+        /// an orbit with no owner to name it by, a patch or one a caller handed in, is
+        /// named by the KSP orbit itself. Neither may look anything up: the object store
+        /// compares and hashes the objects it holds, including while removing one whose
+        /// owner the game no longer has.
+        /// </remarks>
         public override bool Equals (Orbit other)
         {
-            return !ReferenceEquals (other, null) && InternalOrbit == other.InternalOrbit;
+            if (ReferenceEquals (other, null))
+                return false;
+            if (!ReferenceEquals (patch, null) || !ReferenceEquals (other.patch, null))
+                return ReferenceEquals (patch, other.patch);
+            return ownerVessel == other.ownerVessel && ownerBody == other.ownerBody &&
+            ownerNode == other.ownerNode;
         }
 
         /// <summary>
@@ -71,13 +110,35 @@ namespace KRPC.SpaceCenter.Services
         /// </summary>
         public override int GetHashCode ()
         {
-            return InternalOrbit.GetHashCode ();
+            if (!ReferenceEquals (patch, null))
+                return RuntimeHelpers.GetHashCode (patch);
+            int hash = 0;
+            if (ownerVessel != null)
+                hash ^= ownerVessel.GetHashCode ();
+            if (ownerBody != null)
+                hash ^= ownerBody.GetHashCode ();
+            if (ownerNode != null)
+                hash ^= ownerNode.GetHashCode ();
+            return hash;
         }
 
         /// <summary>
-        /// The KSP orbit object.
+        /// The KSP orbit object, asked of the thing the orbit belongs to on each use, so
+        /// that the object keeps working across a load that rebuilds that thing and its
+        /// orbit with it. A patch, and an orbit a caller handed in, have nothing to be
+        /// asked of and are held.
         /// </summary>
-        public global::Orbit InternalOrbit { get; private set; }
+        public global::Orbit InternalOrbit {
+            get {
+                if (!ReferenceEquals (patch, null))
+                    return patch;
+                if (ownerVessel != null)
+                    return ownerVessel.InternalVessel.GetOrbit ();
+                if (ownerBody != null)
+                    return ownerBody.InternalBody.GetOrbit ();
+                return ownerNode.InternalNode.nextPatch;
+            }
+        }
 
         /// <summary>
         /// The celestial body (e.g. planet or moon) around which the object is orbiting.

--- a/service/SpaceCenter/src/Services/Orbit.cs
+++ b/service/SpaceCenter/src/Services/Orbit.cs
@@ -25,6 +25,11 @@ namespace KRPC.SpaceCenter.Services
         // game builds a new one whenever it builds the owner, and the object has to read
         // the loaded game rather than the state it was made in.
         readonly global::Orbit patch;
+        // Whether the client that constructed the orbit has gone. A constructed orbit is
+        // as valid on the last frame of the session as on the first, so it stands for
+        // nothing the game can destroy, and its client going is the only thing that can
+        // say the object is finished with.
+        bool released;
 
         internal Orbit (Vessel vessel)
         {
@@ -72,16 +77,28 @@ namespace KRPC.SpaceCenter.Services
 
         /// <summary>
         /// What the game holds for the thing the orbit belongs to. An orbit built from a KSP
-        /// orbit alone has no owner to ask, so it is kept.
+        /// orbit alone has no owner to ask, so it is kept, and an orbit constructed for a
+        /// client is kept until that client goes.
         /// </summary>
         public GameObjectState GameObjectState {
             get {
+                if (released)
+                    return GameObjectState.Destroyed;
                 if (ownerVessel != null)
                     return ownerVessel.GameObjectState;
                 if (ownerNode != null)
                     return ownerNode.GameObjectState;
                 return GameObjectState.Live;
             }
+        }
+
+        /// <summary>
+        /// Let go of an orbit constructed for a client that has gone, so that it and the
+        /// reference frames defined against it leave the object store at the next sweep.
+        /// </summary>
+        internal void Release ()
+        {
+            released = true;
         }
 
         /// <summary>
@@ -505,7 +522,7 @@ namespace KRPC.SpaceCenter.Services
             // change is reported as one in the past. Zero, the value an orbit is built
             // with, is not in the past at a universal time of zero.
             orbit.UTsoi = -1;
-            return new Orbit (orbit);
+            return Constructed (orbit);
         }
 
         /// <summary>
@@ -600,7 +617,19 @@ namespace KRPC.SpaceCenter.Services
             // change is reported as one in the past. Zero, the value an orbit is built
             // with, is not in the past at a universal time of zero.
             orbit.UTsoi = -1;
-            return new Orbit (orbit);
+            return Constructed (orbit);
+        }
+
+        // The object for an orbit a client asked to be built, recorded as the client's so
+        // that it is let go of when the client is. An orbit read off a vessel, a body or a
+        // maneuver node is not recorded: it is named by the thing whose orbit it is, so
+        // the object store gives back one object for it however often it is asked for,
+        // and dropping it when one client goes would take it away from the others.
+        static Orbit Constructed (global::Orbit orbit)
+        {
+            var result = new Orbit (orbit);
+            ConstructedOrbitsAddon.Add (result);
+            return result;
         }
 
         static bool IsFinite (double value)

--- a/service/SpaceCenter/src/Services/Parts/ActionGroupAction.cs
+++ b/service/SpaceCenter/src/Services/Parts/ActionGroupAction.cs
@@ -8,7 +8,7 @@ namespace KRPC.SpaceCenter.Services.Parts
     /// Obtained by calling <see cref="Control.GetActionGroupActions"/>.
     /// </summary>
     [KRPCClass (Service = "SpaceCenter")]
-    public class ActionGroupAction : Equatable<ActionGroupAction>
+    public class ActionGroupAction : Equatable<ActionGroupAction>, IGameObjectState
     {
         readonly Part part;
         readonly Module module;
@@ -21,6 +21,14 @@ namespace KRPC.SpaceCenter.Services.Parts
             module = actionModule;
             name = actionName;
             id = actionId;
+        }
+
+        /// <summary>
+        /// What the game holds for the module the action belongs to, or for its part
+        /// where the action has no module.
+        /// </summary>
+        public GameObjectState GameObjectState {
+            get { return module != null ? module.GameObjectState : part.GameObjectState; }
         }
 
         /// <summary>

--- a/service/SpaceCenter/src/Services/Parts/Antenna.cs
+++ b/service/SpaceCenter/src/Services/Parts/Antenna.cs
@@ -10,10 +10,10 @@ namespace KRPC.SpaceCenter.Services.Parts
     /// An antenna. Obtained by calling <see cref="Part.Antenna"/>.
     /// </summary>
     [KRPCClass (Service = "SpaceCenter", GameScene = GameScene.Flight)]
-    public class Antenna : Equatable<Antenna>
+    public class Antenna : Equatable<Antenna>, IGameObjectState
     {
-        readonly ModuleDataTransmitter transmitter;
-        readonly ModuleDeployableAntenna deployment;
+        ModuleRef transmitterRef;
+        ModuleRef deploymentRef;
 
         internal static bool Is (Part part)
         {
@@ -26,8 +26,24 @@ namespace KRPC.SpaceCenter.Services.Parts
                 throw new ArgumentException ("Part is not an antenna");
             Part = part;
             var internalPart = part.InternalPart;
-            transmitter = internalPart.Module<ModuleDataTransmitter> ();
-            deployment = internalPart.Module<ModuleDeployableAntenna> ();
+            transmitterRef = ModuleRef.ForType<ModuleDataTransmitter> (internalPart);
+            deploymentRef = ModuleRef.ForType<ModuleDeployableAntenna> (internalPart);
+        }
+
+        ModuleDataTransmitter InternalTransmitter {
+            get { return (ModuleDataTransmitter)transmitterRef.Get (Part.InternalPart); }
+        }
+
+        ModuleDeployableAntenna InternalDeployment {
+            get { return (ModuleDeployableAntenna)deploymentRef.Find (Part.InternalPart); }
+        }
+
+        /// <summary>
+        /// What the game holds for the antenna: the state of the part
+        /// carrying it, or destroyed once that part no longer has the module.
+        /// </summary>
+        public GameObjectState GameObjectState {
+            get { return transmitterRef.StateOn (Part); }
         }
 
         /// <summary>
@@ -35,7 +51,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         public override bool Equals (Antenna other)
         {
-            return !ReferenceEquals (other, null) && Part == other.Part && transmitter == other.transmitter;
+            return !ReferenceEquals (other, null) && Part == other.Part && transmitterRef == other.transmitterRef;
         }
 
         /// <summary>
@@ -43,7 +59,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         public override int GetHashCode ()
         {
-            return Part.GetHashCode () ^ transmitter.GetHashCode ();
+            return Part.GetHashCode () ^ transmitterRef.GetHashCode ();
         }
 
         /// <summary>
@@ -58,9 +74,9 @@ namespace KRPC.SpaceCenter.Services.Parts
         [KRPCProperty]
         public DeployableState State {
             get {
-                if (deployment == null)
+                if (InternalDeployment == null)
                     return DeployableState.Deployed;
-                return deployment.deployState.ToDeployableState ();
+                return InternalDeployment.deployState.ToDeployableState ();
             }
         }
 
@@ -69,7 +85,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         [KRPCProperty (GameScene = GameScene.Flight | GameScene.Editor)]
         public bool Deployable {
-            get { return deployment != null; }
+            get { return InternalDeployment != null; }
         }
 
         /// <summary>
@@ -83,12 +99,12 @@ namespace KRPC.SpaceCenter.Services.Parts
         public bool Deployed {
             get { return State == DeployableState.Deployed; }
             set {
-                if (deployment == null)
+                if (InternalDeployment == null)
                     throw new InvalidOperationException ("Antenna is not deployable");
                 if (value)
-                    deployment.Extend ();
+                    InternalDeployment.Extend ();
                 else
-                    deployment.Retract ();
+                    InternalDeployment.Retract ();
             }
         }
 
@@ -97,7 +113,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         [KRPCProperty]
         public bool CanTransmit {
-            get { return transmitter.CanTransmit(); }
+            get { return InternalTransmitter.CanTransmit(); }
         }
 
         /// <summary>
@@ -106,7 +122,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         [KRPCMethod]
         public void Transmit ()
         {
-            transmitter.StartTransmission ();
+            InternalTransmitter.StartTransmission ();
         }
 
         /// <summary>
@@ -115,7 +131,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         [KRPCMethod]
         public void Cancel ()
         {
-            transmitter.StopTransmission ();
+            InternalTransmitter.StopTransmission ();
         }
 
         /// <summary>
@@ -124,10 +140,10 @@ namespace KRPC.SpaceCenter.Services.Parts
         [KRPCProperty]
         public bool AllowPartial
         {
-            get { return transmitter.xmitIncomplete; }
+            get { return InternalTransmitter.xmitIncomplete; }
             set {
-                if (value != transmitter.xmitIncomplete)
-                    transmitter.TransmitIncompleteToggle ();
+                if (value != InternalTransmitter.xmitIncomplete)
+                    InternalTransmitter.TransmitIncompleteToggle ();
             }
         }
 
@@ -136,7 +152,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         [KRPCProperty (GameScene = GameScene.Flight | GameScene.Editor)]
         public double Power {
-            get { return transmitter.CommPower; }
+            get { return InternalTransmitter.CommPower; }
         }
 
         /// <summary>
@@ -145,7 +161,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         [KRPCProperty (GameScene = GameScene.Flight | GameScene.Editor)]
         public bool Combinable {
-            get { return transmitter.CommCombinable; }
+            get { return InternalTransmitter.CommCombinable; }
         }
 
         /// <summary>
@@ -153,7 +169,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         [KRPCProperty (GameScene = GameScene.Flight | GameScene.Editor)]
         public double CombinableExponent {
-            get { return transmitter.CommCombinableExponent; }
+            get { return InternalTransmitter.CommCombinableExponent; }
         }
 
         /// <summary>
@@ -161,7 +177,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         [KRPCProperty (GameScene = GameScene.Flight | GameScene.Editor)]
         public float PacketInterval {
-            get { return transmitter.packetInterval; }
+            get { return InternalTransmitter.packetInterval; }
         }
 
         /// <summary>
@@ -169,7 +185,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         [KRPCProperty (GameScene = GameScene.Flight | GameScene.Editor)]
         public float PacketSize {
-            get { return transmitter.packetSize; }
+            get { return InternalTransmitter.packetSize; }
         }
 
         /// <summary>
@@ -177,7 +193,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         [KRPCProperty (GameScene = GameScene.Flight | GameScene.Editor)]
         public double PacketResourceCost {
-            get { return transmitter.packetResourceCost; }
+            get { return InternalTransmitter.packetResourceCost; }
         }
     }
 }

--- a/service/SpaceCenter/src/Services/Parts/CargoBay.cs
+++ b/service/SpaceCenter/src/Services/Parts/CargoBay.cs
@@ -10,10 +10,10 @@ namespace KRPC.SpaceCenter.Services.Parts
     /// A cargo bay. Obtained by calling <see cref="Part.CargoBay"/>.
     /// </summary>
     [KRPCClass (Service = "SpaceCenter", GameScene = GameScene.Flight)]
-    public class CargoBay : Equatable<CargoBay>
+    public class CargoBay : Equatable<CargoBay>, IGameObjectState
     {
-        readonly ModuleCargoBay bay;
-        readonly ModuleAnimateGeneric animation;
+        ModuleRef bayRef;
+        ModuleRef animationRef;
 
         internal static bool Is (Part part)
         {
@@ -30,8 +30,24 @@ namespace KRPC.SpaceCenter.Services.Parts
                 throw new ArgumentException ("Part is not a cargo bay");
             Part = part;
             var internalPart = part.InternalPart;
-            bay = internalPart.Module<ModuleCargoBay> ();
-            animation = internalPart.Module<ModuleAnimateGeneric> ();
+            bayRef = ModuleRef.ForType<ModuleCargoBay> (internalPart);
+            animationRef = ModuleRef.ForType<ModuleAnimateGeneric> (internalPart);
+        }
+
+        ModuleCargoBay InternalBay {
+            get { return (ModuleCargoBay)bayRef.Get (Part.InternalPart); }
+        }
+
+        ModuleAnimateGeneric InternalAnimation {
+            get { return (ModuleAnimateGeneric)animationRef.Find (Part.InternalPart); }
+        }
+
+        /// <summary>
+        /// What the game holds for the cargo bay: the state of the part
+        /// carrying it, or destroyed once that part no longer has the module.
+        /// </summary>
+        public GameObjectState GameObjectState {
+            get { return bayRef.StateOn (Part); }
         }
 
         /// <summary>
@@ -39,7 +55,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         public override bool Equals (CargoBay other)
         {
-            return !ReferenceEquals (other, null) && Part == other.Part && bay.Equals (other.bay);
+            return !ReferenceEquals (other, null) && Part == other.Part && bayRef == other.bayRef;
         }
 
         /// <summary>
@@ -47,7 +63,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         public override int GetHashCode ()
         {
-            return Part.GetHashCode () ^ bay.GetHashCode ();
+            return Part.GetHashCode () ^ bayRef.GetHashCode ();
         }
 
         /// <summary>
@@ -70,7 +86,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         [KRPCProperty]
         public DeployableState State {
             get {
-                if (animation.IsMoving ())
+                if (InternalAnimation.IsMoving ())
                     return OpeningOrOpen
                         ? DeployableState.Deploying
                         : DeployableState.Retracting;
@@ -110,7 +126,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// the last frame to land.
         /// </remarks>
         bool OpeningOrOpen {
-            get { return !animation.animSwitch == (bay.closedPosition < 0.5f); }
+            get { return !InternalAnimation.animSwitch == (InternalBay.closedPosition < 0.5f); }
         }
 
         /// <summary>
@@ -121,7 +137,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         BaseEvent ToggleEvent {
             get {
-                var toggle = animation.Events ["Toggle"];
+                var toggle = InternalAnimation.Events ["Toggle"];
                 if (toggle == null)
                     return null;
                 var available = HighLogic.LoadedSceneIsEditor ? toggle.guiActiveEditor : toggle.guiActive;

--- a/service/SpaceCenter/src/Services/Parts/ConfigNode.cs
+++ b/service/SpaceCenter/src/Services/Parts/ConfigNode.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Runtime.CompilerServices;
 using System.Collections.Generic;
 using KRPC.Service.Attributes;
 using KRPC.Utils;
@@ -36,7 +37,9 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         public override int GetHashCode ()
         {
-            return node.GetHashCode ();
+            // The node's identity hash rather than its own: a config node's contents are
+            // not what this object stands for, and a hash must not move under the store.
+            return RuntimeHelpers.GetHashCode (node);
         }
 
         /// <summary>

--- a/service/SpaceCenter/src/Services/Parts/ControlSurface.cs
+++ b/service/SpaceCenter/src/Services/Parts/ControlSurface.cs
@@ -13,9 +13,9 @@ namespace KRPC.SpaceCenter.Services.Parts
     /// An aerodynamic control surface. Obtained by calling <see cref="Part.ControlSurface"/>.
     /// </summary>
     [KRPCClass (Service = "SpaceCenter", GameScene = GameScene.Flight)]
-    public class ControlSurface : Equatable<ControlSurface>
+    public class ControlSurface : Equatable<ControlSurface>, IGameObjectState
     {
-        readonly ModuleControlSurface controlSurface;
+        ModuleRef controlSurfaceRef;
 
         internal static bool Is (Part part)
         {
@@ -30,9 +30,21 @@ namespace KRPC.SpaceCenter.Services.Parts
         internal ControlSurface (Part part)
         {
             Part = part;
-            controlSurface = part.InternalPart.Module<ModuleControlSurface> ();
-            if (controlSurface == null)
+            controlSurfaceRef = ModuleRef.ForType<ModuleControlSurface> (part.InternalPart);
+            if (controlSurfaceRef.Find (part.InternalPart) == null)
                 throw new ArgumentException ("Part does not have a ModuleControlSurface PartModule");
+        }
+
+        ModuleControlSurface InternalControlSurface {
+            get { return (ModuleControlSurface)controlSurfaceRef.Get (Part.InternalPart); }
+        }
+
+        /// <summary>
+        /// What the game holds for the control surface: the state of the part
+        /// carrying it, or destroyed once that part no longer has the module.
+        /// </summary>
+        public GameObjectState GameObjectState {
+            get { return controlSurfaceRef.StateOn (Part); }
         }
 
         /// <summary>
@@ -40,7 +52,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         public override bool Equals (ControlSurface other)
         {
-            return !ReferenceEquals (other, null) && Part == other.Part && controlSurface.Equals (other.controlSurface);
+            return !ReferenceEquals (other, null) && Part == other.Part && controlSurfaceRef == other.controlSurfaceRef;
         }
 
         /// <summary>
@@ -48,7 +60,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         public override int GetHashCode ()
         {
-            return Part.GetHashCode () ^ controlSurface.GetHashCode ();
+            return Part.GetHashCode () ^ controlSurfaceRef.GetHashCode ();
         }
 
         /// <summary>
@@ -62,8 +74,8 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         [KRPCProperty (GameScene = GameScene.Flight | GameScene.Editor)]
         public bool PitchEnabled {
-            get { return !controlSurface.ignorePitch; }
-            set { controlSurface.ignorePitch = !value; }
+            get { return !InternalControlSurface.ignorePitch; }
+            set { InternalControlSurface.ignorePitch = !value; }
         }
 
         /// <summary>
@@ -71,8 +83,8 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         [KRPCProperty (GameScene = GameScene.Flight | GameScene.Editor)]
         public bool YawEnabled {
-            get { return !controlSurface.ignoreYaw; }
-            set { controlSurface.ignoreYaw = !value; }
+            get { return !InternalControlSurface.ignoreYaw; }
+            set { InternalControlSurface.ignoreYaw = !value; }
         }
 
         /// <summary>
@@ -80,8 +92,8 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         [KRPCProperty (GameScene = GameScene.Flight | GameScene.Editor)]
         public bool RollEnabled {
-            get { return !controlSurface.ignoreRoll; }
-            set { controlSurface.ignoreRoll = !value; }
+            get { return !InternalControlSurface.ignoreRoll; }
+            set { InternalControlSurface.ignoreRoll = !value; }
         }
 
         /// <summary>
@@ -90,8 +102,8 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         [KRPCProperty (GameScene = GameScene.Flight | GameScene.Editor)]
         public float AuthorityLimiter {
-            get { return controlSurface.authorityLimiter; }
-            set { controlSurface.authorityLimiter = value; }
+            get { return InternalControlSurface.authorityLimiter; }
+            set { InternalControlSurface.authorityLimiter = value; }
         }
 
         /// <summary>
@@ -99,8 +111,8 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         [KRPCProperty (GameScene = GameScene.Flight | GameScene.Editor)]
         public bool Inverted {
-            get { return controlSurface.deployInvert; }
-            set { controlSurface.deployInvert = value; }
+            get { return InternalControlSurface.deployInvert; }
+            set { InternalControlSurface.deployInvert = value; }
         }
 
         /// <summary>
@@ -108,8 +120,8 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         [KRPCProperty (GameScene = GameScene.Flight | GameScene.Editor)]
         public bool Deployed {
-            get { return controlSurface.deploy; }
-            set { controlSurface.deploy = value; }
+            get { return InternalControlSurface.deploy; }
+            set { InternalControlSurface.deploy = value; }
         }
 
         /// <summary>
@@ -121,8 +133,8 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         [KRPCProperty]
         public bool DeflectionOverride {
-            get { return ActuatorControlAddon.GetControlSurfaceOverride (controlSurface); }
-            set { ActuatorControlAddon.SetControlSurfaceOverride (controlSurface, value); }
+            get { return ActuatorControlAddon.GetControlSurfaceOverride (InternalControlSurface); }
+            set { ActuatorControlAddon.SetControlSurfaceOverride (InternalControlSurface, value); }
         }
 
         /// <summary>
@@ -131,8 +143,8 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         [KRPCProperty]
         public float Deflection {
-            get { return ActuatorControlAddon.GetControlSurfaceDeflection (controlSurface); }
-            set { ActuatorControlAddon.SetControlSurfaceDeflection (controlSurface, value); }
+            get { return ActuatorControlAddon.GetControlSurfaceDeflection (InternalControlSurface); }
+            set { ActuatorControlAddon.SetControlSurfaceDeflection (InternalControlSurface, value); }
         }
 
         /// <summary>
@@ -140,7 +152,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         [KRPCProperty (GameScene = GameScene.Flight | GameScene.Editor)]
         public float SurfaceArea {
-            get { return controlSurface.ctrlSurfaceArea; }
+            get { return InternalControlSurface.ctrlSurfaceArea; }
         }
 
         /// <summary>
@@ -158,7 +170,7 @@ namespace KRPC.SpaceCenter.Services.Parts
                 // GetPotentialTorque already applies the authority limiter (via
                 // ModuleControlSurface.GetPotentialLift, which scales the deflection by
                 // authorityLimiter * 0.01), so no further scaling is needed here.
-                var torque = controlSurface.GetPotentialTorque ();
+                var torque = InternalControlSurface.GetPotentialTorque ();
                 // ModuleControlSurface.GetPotentialTorque negates the roll (y) axis of both the
                 // positive and negative torque vectors, unlike other ITorqueProvider
                 // implementations. Normalise to the kRPC convention (positive torque >= 0,

--- a/service/SpaceCenter/src/Services/Parts/Decoupler.cs
+++ b/service/SpaceCenter/src/Services/Parts/Decoupler.cs
@@ -11,9 +11,9 @@ namespace KRPC.SpaceCenter.Services.Parts
     /// A decoupler. Obtained by calling <see cref="Part.Decoupler"/>
     /// </summary>
     [KRPCClass (Service = "SpaceCenter", GameScene = GameScene.Flight)]
-    public class Decoupler : Equatable<Decoupler>
+    public class Decoupler : Equatable<Decoupler>, IGameObjectState
     {
-        readonly ModuleDecouplerBase decoupler;
+        ModuleRef decouplerRef;
 
         internal static bool Is (Part part)
         {
@@ -26,9 +26,25 @@ namespace KRPC.SpaceCenter.Services.Parts
         internal Decoupler (Part part)
         {
             Part = part;
-            decoupler = part.InternalPart.DecouplerModule ();
-            if (decoupler == null)
+            var module = part.InternalPart.DecouplerModule ();
+            if (module == null)
                 throw new ArgumentException("Part is not a decoupler");
+            decouplerRef = ModuleRef.ForModule (module);
+        }
+
+        /// <summary>
+        /// The decoupler's part module, found on the part again on every access.
+        /// </summary>
+        ModuleDecouplerBase InternalDecoupler {
+            get { return (ModuleDecouplerBase)decouplerRef.Get (Part.InternalPart); }
+        }
+
+        /// <summary>
+        /// What the game holds for the decoupler: the state of the part carrying it, or
+        /// destroyed once that part no longer has the module.
+        /// </summary>
+        public GameObjectState GameObjectState {
+            get { return decouplerRef.StateOn (Part); }
         }
 
         /// <summary>
@@ -36,10 +52,8 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         public override bool Equals (Decoupler other)
         {
-            return
-            !ReferenceEquals(other, null) &&
-            Part != other.Part &&
-            decoupler == other.decoupler;
+            return !ReferenceEquals (other, null) &&
+            Part == other.Part && decouplerRef == other.decouplerRef;
         }
 
         /// <summary>
@@ -47,7 +61,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         public override int GetHashCode ()
         {
-            return Part.GetHashCode () ^ decoupler.GetHashCode();
+            return Part.GetHashCode () ^ decouplerRef.GetHashCode ();
         }
 
         /// <summary>
@@ -74,7 +88,7 @@ namespace KRPC.SpaceCenter.Services.Parts
             var preVesselIds = FlightGlobals.Vessels.Select (v => v.id).ToList ();
 
             // Fire the decoupler
-            decoupler.Decouple ();
+            InternalDecoupler.Decouple ();
 
             return PartSeparation.NewVessel (Part, preVesselIds, () => Decoupled);
         }
@@ -85,7 +99,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         [KRPCProperty]
         public bool Decoupled {
             get {
-                return decoupler.isDecoupled;
+                return InternalDecoupler.isDecoupled;
             }
         }
 
@@ -94,7 +108,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         [KRPCProperty (GameScene = GameScene.Flight | GameScene.Editor)]
         public bool Staged {
-            get { return decoupler.StagingEnabled (); }
+            get { return InternalDecoupler.StagingEnabled (); }
         }
 
         /// <summary>
@@ -102,7 +116,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         [KRPCProperty (GameScene = GameScene.Flight | GameScene.Editor)]
         public float Impulse {
-            get { return decoupler.ejectionForce * 10f; }
+            get { return InternalDecoupler.ejectionForce * 10f; }
         }
 
         /// <summary>
@@ -111,7 +125,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         [KRPCProperty (GameScene = GameScene.Flight | GameScene.Editor)]
         public bool IsOmniDecoupler
         {
-            get { return decoupler.isOmniDecoupler; }
+            get { return InternalDecoupler.isOmniDecoupler; }
         }
 
         /// <summary>
@@ -122,7 +136,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         {
             get
             {
-                var attach = decoupler.ExplosiveNode;
+                var attach = InternalDecoupler.ExplosiveNode;
                 if (attach == null || attach.attachedPart == null)
                 {
                     return null;

--- a/service/SpaceCenter/src/Services/Parts/DockingPort.cs
+++ b/service/SpaceCenter/src/Services/Parts/DockingPort.cs
@@ -14,10 +14,10 @@ namespace KRPC.SpaceCenter.Services.Parts
     /// A docking port. Obtained by calling <see cref="Part.DockingPort"/>
     /// </summary>
     [KRPCClass (Service = "SpaceCenter", GameScene = GameScene.Flight)]
-    public class DockingPort : Equatable<DockingPort>
+    public class DockingPort : Equatable<DockingPort>, IGameObjectState
     {
-        readonly ModuleDockingNode port;
-        readonly ModuleAnimateGeneric shield;
+        ModuleRef portRef;
+        ModuleRef shieldRef;
 
         internal static bool Is (Part part)
         {
@@ -28,10 +28,22 @@ namespace KRPC.SpaceCenter.Services.Parts
         {
             Part = part;
             var internalPart = part.InternalPart;
-            port = internalPart.Module<ModuleDockingNode> ();
-            shield = internalPart.Module<ModuleAnimateGeneric> ();
-            if (port == null)
+            portRef = ModuleRef.ForType<ModuleDockingNode> (internalPart);
+            shieldRef = ModuleRef.ForType<ModuleAnimateGeneric> (internalPart);
+            if (portRef.Find (internalPart) == null)
                 throw new ArgumentException ("Part is not a docking port");
+        }
+
+        ModuleAnimateGeneric InternalShield {
+            get { return (ModuleAnimateGeneric)shieldRef.Find (Part.InternalPart); }
+        }
+
+        /// <summary>
+        /// What the game holds for the docking port: the state of the part
+        /// carrying it, or destroyed once that part no longer has the module.
+        /// </summary>
+        public GameObjectState GameObjectState {
+            get { return portRef.StateOn (Part); }
         }
 
         /// <summary>
@@ -42,8 +54,8 @@ namespace KRPC.SpaceCenter.Services.Parts
             return
             !ReferenceEquals (other, null) &&
             Part == other.Part &&
-            port.Equals (other.port) &&
-            (shield == other.shield || shield.Equals (other.shield));
+            portRef == other.portRef &&
+            shieldRef == other.shieldRef;
         }
 
         /// <summary>
@@ -51,17 +63,14 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         public override int GetHashCode ()
         {
-            int hash = Part.GetHashCode () ^ port.GetHashCode ();
-            if (shield != null)
-                hash ^= shield.GetHashCode ();
-            return hash;
+            return Part.GetHashCode () ^ portRef.GetHashCode () ^ shieldRef.GetHashCode ();
         }
 
         /// <summary>
         /// The KSP docking node object.
         /// </summary>
         public ModuleDockingNode InternalPort {
-            get { return port; }
+            get { return (ModuleDockingNode)portRef.Get (Part.InternalPart); }
         }
 
         /// <summary>
@@ -77,7 +86,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         public DockingPortState State {
             get {
                 // Get the state of this docking port
-                var state = IndividualState (port);
+                var state = IndividualState (InternalPort);
                 // Get the part and port docked to this docking port, if any
                 var dockedPart = GetDockedPart;
                 var dockedPort = dockedPart != null ? dockedPart.Module<ModuleDockingNode> () : null;
@@ -134,7 +143,7 @@ namespace KRPC.SpaceCenter.Services.Parts
             // Try decoupling or undocking this part, and then the port we are docked to, if any.
             // Decouple detaches a port that was attached in the editor, Undock separates two ports
             // that docked in flight; a given port only ever offers one of them.
-            if (port.InvokeEvent ("Decouple") || port.InvokeEvent ("Undock") ||
+            if (InternalPort.InvokeEvent ("Decouple") || InternalPort.InvokeEvent ("Undock") ||
                 (dockedPort != null && (dockedPort.InvokeEvent ("Decouple") || dockedPort.InvokeEvent ("Undock")))) {
                 return PartSeparation.NewVessel (Part, preVesselIds, () => State != DockingPortState.Docked);
             }
@@ -149,7 +158,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         [KRPCProperty]
         public float ReengageDistance {
-            get { return port.minDistanceToReEngage; }
+            get { return InternalPort.minDistanceToReEngage; }
         }
 
         /// <summary>
@@ -157,7 +166,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         [KRPCProperty]
         public bool HasShield {
-            get { return shield != null; }
+            get { return InternalShield != null; }
         }
 
         /// <summary>
@@ -183,7 +192,7 @@ namespace KRPC.SpaceCenter.Services.Parts
                 // name of the method implementing it -- which the game does not translate, unlike
                 // the display name shown on the button.
                 if (value != Shielded)
-                    shield.Events ["Toggle"].Invoke ();
+                    InternalShield.Events ["Toggle"].Invoke ();
             }
         }
 
@@ -193,7 +202,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         [KRPCProperty]
         public bool CanRotate
         {
-            get { return port.canRotate; }
+            get { return InternalPort.canRotate; }
         }
 
         /// <summary>
@@ -202,7 +211,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         [KRPCProperty]
         public float MaximumRotation
         {
-            get { return port.hardMinMaxLimits.y; }
+            get { return InternalPort.hardMinMaxLimits.y; }
         }
 
         /// <summary>
@@ -211,7 +220,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         [KRPCProperty]
         public float MinimumRotation
         {
-            get { return port.hardMinMaxLimits.x; }
+            get { return InternalPort.hardMinMaxLimits.x; }
         }
 
         /// <summary>
@@ -220,8 +229,8 @@ namespace KRPC.SpaceCenter.Services.Parts
         [KRPCProperty]
         public float RotationTarget
         {
-            get { return port.targetAngle; }
-            set { port.targetAngle = value; }
+            get { return InternalPort.targetAngle; }
+            set { InternalPort.targetAngle = value; }
         }
 
         /// <summary>
@@ -230,8 +239,8 @@ namespace KRPC.SpaceCenter.Services.Parts
         [KRPCProperty]
         public bool RotationLocked
         {
-            get { return port.nodeIsLocked; }
-            set { port.nodeIsLocked = value; }
+            get { return InternalPort.nodeIsLocked; }
+            set { InternalPort.nodeIsLocked = value; }
         }
 
         /// <summary>
@@ -243,7 +252,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         [KRPCMethod]
         public Tuple3 Position (ReferenceFrame referenceFrame)
         {
-            return referenceFrame.PositionFromWorldSpace (port.nodeTransform.position).ToTuple ();
+            return referenceFrame.PositionFromWorldSpace (InternalPort.nodeTransform.position).ToTuple ();
         }
 
         /// <summary>
@@ -255,7 +264,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         [KRPCMethod]
         public Tuple3 Direction (ReferenceFrame referenceFrame)
         {
-            return referenceFrame.DirectionFromWorldSpace (port.nodeTransform.forward).ToTuple ();
+            return referenceFrame.DirectionFromWorldSpace (InternalPort.nodeTransform.forward).ToTuple ();
         }
 
         /// <summary>
@@ -267,7 +276,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         [KRPCMethod]
         public Tuple4 Rotation (ReferenceFrame referenceFrame)
         {
-            return referenceFrame.RotationFromWorldSpace (port.nodeTransform.rotation * Quaternion.Euler (90, 0, 0)).ToTuple ();
+            return referenceFrame.RotationFromWorldSpace (InternalPort.nodeTransform.rotation * Quaternion.Euler (90, 0, 0)).ToTuple ();
         }
 
         /// <summary>
@@ -291,7 +300,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </remarks>
         [KRPCProperty]
         public ReferenceFrame ReferenceFrame {
-            get { return ReferenceFrame.Object (port); }
+            get { return ReferenceFrame.Object (InternalPort); }
         }
 
         /// <summary>
@@ -300,7 +309,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         global::Part GetDockedPart {
             get {
                 var part = Part.InternalPart;
-                if (port.state == "PreAttached") {
+                if (InternalPort.state == "PreAttached") {
                     // If the port is "PreAttached" (docked from the VAB/SPH) find the connected part
                     // If the docking port points at an axially connected child part, return it
                     var child = part.children.SingleOrDefault (p => p.attachMode == AttachModes.STACK);
@@ -313,7 +322,7 @@ namespace KRPC.SpaceCenter.Services.Parts
                     throw new InvalidOperationException ("Docking port is 'PreAttached' but is not docked to any parts");
                 }
                 // Find the port that is "Docked" to this port, if any
-                return part.vessel [port.dockedPartUId];
+                return part.vessel [InternalPort.dockedPartUId];
             }
         }
 
@@ -322,7 +331,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         bool PointsTowards (global::Part otherPart)
         {
-            return Vector3d.Dot (port.nodeTransform.forward, otherPart.transform.position - port.transform.position) > 0;
+            return Vector3d.Dot (InternalPort.nodeTransform.forward, otherPart.transform.position - InternalPort.transform.position) > 0;
         }
 
         /// <summary>

--- a/service/SpaceCenter/src/Services/Parts/Engine.cs
+++ b/service/SpaceCenter/src/Services/Parts/Engine.cs
@@ -21,12 +21,14 @@ namespace KRPC.SpaceCenter.Services.Parts
     /// For RCS thrusters <see cref="Part.RCS"/>.
     /// </remarks>
     [KRPCClass (Service = "SpaceCenter", GameScene = GameScene.Flight)]
-    public class Engine : Equatable<Engine>
+    public class Engine : Equatable<Engine>, IGameObjectState
     {
-        readonly IList<ModuleEngines> engines;
-        readonly MultiModeEngine multiModeEngine;
-        readonly ModuleGimbal gimbal;
-        readonly IThrustReverser thrustReverser;
+        // A multi-mode engine has two ModuleEngines, one per mode; every other engine has one.
+        ModuleRef primaryRef;
+        ModuleRef secondaryRef;
+        ModuleRef multiModeRef;
+        ModuleRef gimbalRef;
+        readonly IThrustReverser InternalThrustReverser;
 
         internal static bool Is (Part part)
         {
@@ -42,25 +44,46 @@ namespace KRPC.SpaceCenter.Services.Parts
         {
             Part = part;
             var internalPart = part.InternalPart;
-            engines = internalPart.Modules.OfType<ModuleEngines> ().ToList ();
-            multiModeEngine = internalPart.Module<MultiModeEngine> ();
-            gimbal = internalPart.Module<ModuleGimbal> ();
-            thrustReverser = ThrustReverser.Create (internalPart);
+            var engines = internalPart.Modules.OfType<ModuleEngines> ().ToList ();
             if (engines.Count == 0)
                 throw new ArgumentException ("Part is not an engine");
+            primaryRef = ModuleRef.ForModule (engines [0]);
+            secondaryRef = engines.Count > 1
+                ? ModuleRef.ForModule (engines [1])
+                : ModuleRef.None;
+            multiModeRef = ModuleRef.ForType<MultiModeEngine> (internalPart);
+            gimbalRef = ModuleRef.ForType<ModuleGimbal> (internalPart);
+            InternalThrustReverser = ThrustReverser.Create (part);
         }
 
         Engine (ModuleEngines engine)
         {
-            Part = new Part (engine.part);
-            engines = new List<ModuleEngines>
-            {
-                engine
-            };
-            gimbal = Part.InternalPart.Module<ModuleGimbal> ();
-            thrustReverser = ThrustReverser.Create (Part.InternalPart);
             if (engine == null)
                 throw new ArgumentException ("Part does not have a ModuleEngines PartModule");
+            Part = new Part (engine.part);
+            var internalPart = Part.InternalPart;
+            // One mode of a multi-mode engine, so it has that mode's ModuleEngines and no other.
+            primaryRef = ModuleRef.ForModule (engine);
+            secondaryRef = ModuleRef.None;
+            multiModeRef = ModuleRef.None;
+            gimbalRef = ModuleRef.ForType<ModuleGimbal> (internalPart);
+            InternalThrustReverser = ThrustReverser.Create (Part);
+        }
+
+        MultiModeEngine InternalMultiModeEngine {
+            get { return (MultiModeEngine)multiModeRef.Find (Part.InternalPart); }
+        }
+
+        ModuleGimbal InternalGimbal {
+            get { return (ModuleGimbal)gimbalRef.Find (Part.InternalPart); }
+        }
+
+        /// <summary>
+        /// What the game holds for the engine: the state of the part
+        /// carrying it, or destroyed once that part no longer has the module.
+        /// </summary>
+        public GameObjectState GameObjectState {
+            get { return primaryRef.StateOn (Part); }
         }
 
         /// <summary>
@@ -71,9 +94,10 @@ namespace KRPC.SpaceCenter.Services.Parts
             return
             !ReferenceEquals (other, null) &&
             Part == other.Part &&
-            engines.SequenceEqual (other.engines) &&
-            (multiModeEngine == other.multiModeEngine || multiModeEngine.Equals (other.multiModeEngine)) &&
-            (gimbal == other.gimbal || gimbal.Equals (other.gimbal));
+            primaryRef == other.primaryRef &&
+            secondaryRef == other.secondaryRef &&
+            multiModeRef == other.multiModeRef &&
+            gimbalRef == other.gimbalRef;
         }
 
         /// <summary>
@@ -81,15 +105,12 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         public override int GetHashCode ()
         {
-            int hash = Part.GetHashCode ();
-            hash ^= engines.GetHashCode ();
-            foreach (var engine in engines)
-                hash ^= engine.GetHashCode ();
-            if (multiModeEngine != null)
-                hash ^= multiModeEngine.GetHashCode ();
-            if (gimbal != null)
-                hash ^= gimbal.GetHashCode ();
-            return hash;
+            return
+            Part.GetHashCode () ^
+            primaryRef.GetHashCode () ^
+            secondaryRef.GetHashCode () ^
+            multiModeRef.GetHashCode () ^
+            gimbalRef.GetHashCode ();
         }
 
         /// <summary>
@@ -98,7 +119,13 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// the ModulesEngine for the current mode.
         /// </summary>
         ModuleEngines CurrentEngine {
-            get { return engines [(multiModeEngine == null || multiModeEngine.runningPrimary) ? 0 : 1]; }
+            get {
+                var internalPart = Part.InternalPart;
+                var multiMode = (MultiModeEngine)multiModeRef.Find (internalPart);
+                return (ModuleEngines)(multiMode == null || multiMode.runningPrimary
+                    ? primaryRef.Get (internalPart)
+                    : secondaryRef.Get (internalPart));
+            }
         }
 
         /// <summary>
@@ -272,7 +299,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         public IList<Thruster> Thrusters {
             get {
                 var engine = CurrentEngine;
-                return Enumerable.Range (0, engine.thrustTransforms.Count).Select (i => new Thruster (Part, engine, gimbal, i)).ToList ();
+                return Enumerable.Range (0, engine.thrustTransforms.Count).Select (i => new Thruster (Part, engine, InternalGimbal, i)).ToList ();
             }
         }
 
@@ -442,14 +469,14 @@ namespace KRPC.SpaceCenter.Services.Parts
 
         void CheckMultiMode ()
         {
-            if (multiModeEngine == null)
+            if (InternalMultiModeEngine == null)
                 throw new InvalidOperationException ("The engine only has a single mode");
         }
 
         void CheckHasMode (string id)
         {
             CheckMultiMode ();
-            if (multiModeEngine.primaryEngineID != id && multiModeEngine.secondaryEngineID != id)
+            if (InternalMultiModeEngine.primaryEngineID != id && InternalMultiModeEngine.secondaryEngineID != id)
                 throw new InvalidOperationException ("The engine does not have the given mode");
         }
 
@@ -458,7 +485,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         [KRPCProperty (GameScene = GameScene.Flight | GameScene.Editor)]
         public bool HasModes {
-            get { return multiModeEngine != null; }
+            get { return InternalMultiModeEngine != null; }
         }
 
         /// <summary>
@@ -468,13 +495,13 @@ namespace KRPC.SpaceCenter.Services.Parts
         public string Mode {
             get {
                 CheckMultiMode ();
-                return multiModeEngine.mode;
+                return InternalMultiModeEngine.mode;
             }
             set {
                 CheckHasMode (value);
-                if (value == multiModeEngine.mode)
+                if (value == InternalMultiModeEngine.mode)
                     return;
-                multiModeEngine.Invoke ("ModeEvent", 0);
+                InternalMultiModeEngine.Invoke ("ModeEvent", 0);
             }
         }
 
@@ -488,8 +515,8 @@ namespace KRPC.SpaceCenter.Services.Parts
                 CheckMultiMode ();
                 var result = new Dictionary<string, Engine>
                 {
-                    [multiModeEngine.primaryEngineID] = new Engine(engines[0]),
-                    [multiModeEngine.secondaryEngineID] = new Engine(engines[1])
+                    [InternalMultiModeEngine.primaryEngineID] = new Engine ((ModuleEngines)primaryRef.Get (Part.InternalPart)),
+                    [InternalMultiModeEngine.secondaryEngineID] = new Engine ((ModuleEngines)secondaryRef.Get (Part.InternalPart))
                 };
                 return result;
             }
@@ -502,7 +529,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         public void ToggleMode ()
         {
             CheckMultiMode ();
-            multiModeEngine.Invoke ("ModeEvent", 0);
+            InternalMultiModeEngine.Invoke ("ModeEvent", 0);
         }
 
         /// <summary>
@@ -512,28 +539,28 @@ namespace KRPC.SpaceCenter.Services.Parts
         public bool AutoModeSwitch {
             get {
                 CheckMultiMode ();
-                return multiModeEngine.autoSwitch;
+                return InternalMultiModeEngine.autoSwitch;
             }
             set {
                 CheckMultiMode ();
-                if (value == multiModeEngine.autoSwitch)
+                if (value == InternalMultiModeEngine.autoSwitch)
                     return;
                 if (value)
-                    multiModeEngine.Invoke ("EnableAutoSwitch", 0);
+                    InternalMultiModeEngine.Invoke ("EnableAutoSwitch", 0);
                 else
-                    multiModeEngine.Invoke ("DisableAutoSwitch", 0);
+                    InternalMultiModeEngine.Invoke ("DisableAutoSwitch", 0);
             }
         }
 
         void CheckGimballed ()
         {
-            if (gimbal == null)
+            if (InternalGimbal == null)
                 throw new InvalidOperationException ("Engine is not gimballed");
         }
 
         void CheckReverser ()
         {
-            if (thrustReverser == null)
+            if (InternalThrustReverser == null)
                 throw new InvalidOperationException ("Engine does not have a thrust reverser");
         }
 
@@ -542,7 +569,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         [KRPCProperty (GameScene = GameScene.Flight | GameScene.Editor)]
         public bool Gimballed {
-            get { return gimbal != null; }
+            get { return InternalGimbal != null; }
         }
 
         /// <summary>
@@ -551,7 +578,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         [KRPCProperty (GameScene = GameScene.Flight | GameScene.Editor)]
         public float GimbalRange {
-            get { return gimbal != null && !gimbal.gimbalLock ? gimbal.gimbalRange : 0f; }
+            get { return InternalGimbal != null && !InternalGimbal.gimbalLock ? InternalGimbal.gimbalRange : 0f; }
         }
 
         /// <summary>
@@ -562,14 +589,14 @@ namespace KRPC.SpaceCenter.Services.Parts
         public bool GimbalLocked {
             get {
                 CheckGimballed ();
-                return gimbal.gimbalLock;
+                return InternalGimbal.gimbalLock;
             }
             set {
                 CheckGimballed ();
-                if (value && !gimbal.gimbalLock) {
-                    gimbal.LockAction (new KSPActionParam (KSPActionGroup.None, KSPActionType.Activate));
-                } else if (!value && gimbal.gimbalLock) {
-                    gimbal.FreeAction (new KSPActionParam (KSPActionGroup.None, KSPActionType.Activate));
+                if (value && !InternalGimbal.gimbalLock) {
+                    InternalGimbal.LockAction (new KSPActionParam (KSPActionGroup.None, KSPActionType.Activate));
+                } else if (!value && InternalGimbal.gimbalLock) {
+                    InternalGimbal.FreeAction (new KSPActionParam (KSPActionGroup.None, KSPActionType.Activate));
                 }
             }
         }
@@ -582,11 +609,11 @@ namespace KRPC.SpaceCenter.Services.Parts
         public float GimbalLimit {
             get {
                 CheckGimballed ();
-                return GimbalLocked ? 0f : gimbal.gimbalLimiter / 100f;
+                return GimbalLocked ? 0f : InternalGimbal.gimbalLimiter / 100f;
             }
             set {
                 CheckGimballed ();
-                gimbal.gimbalLimiter = (value * 100f).Clamp (0f, 100f);
+                InternalGimbal.gimbalLimiter = (value * 100f).Clamp (0f, 100f);
             }
         }
 
@@ -601,11 +628,11 @@ namespace KRPC.SpaceCenter.Services.Parts
         public bool GimbalOverride {
             get {
                 CheckGimballed ();
-                return ActuatorControlAddon.GetGimbalOverride (gimbal);
+                return ActuatorControlAddon.GetGimbalOverride (InternalGimbal);
             }
             set {
                 CheckGimballed ();
-                ActuatorControlAddon.SetGimbalOverride (gimbal, value);
+                ActuatorControlAddon.SetGimbalOverride (InternalGimbal, value);
             }
         }
 
@@ -620,11 +647,11 @@ namespace KRPC.SpaceCenter.Services.Parts
         public Tuple3 GimbalActuation {
             get {
                 CheckGimballed ();
-                return ActuatorControlAddon.GetGimbalActuation (gimbal).ToTuple ();
+                return ActuatorControlAddon.GetGimbalActuation (InternalGimbal).ToTuple ();
             }
             set {
                 CheckGimballed ();
-                ActuatorControlAddon.SetGimbalActuation (gimbal, value.ToVector ());
+                ActuatorControlAddon.SetGimbalActuation (InternalGimbal, value.ToVector ());
             }
         }
 
@@ -646,7 +673,7 @@ namespace KRPC.SpaceCenter.Services.Parts
                 // GetPotentialTorque already applies the gimbal limiter (via
                 // ModuleGimbal.GimbalRotation, which scales the deflection by
                 // gimbalLimiter * 0.01), so no further scaling is needed here.
-                var torque = gimbal.GetPotentialTorque ();
+                var torque = InternalGimbal.GetPotentialTorque ();
                 // Note: GetPotentialTorque returns negative torques with incorrect sign
                 return new TupleV3 (torque.Item1, -torque.Item2);
             }
@@ -661,7 +688,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         [KRPCProperty (GameScene = GameScene.Flight | GameScene.Editor)]
         public bool CanReverseThrust {
-            get { return thrustReverser != null; }
+            get { return InternalThrustReverser != null; }
         }
 
         /// <summary>
@@ -676,11 +703,11 @@ namespace KRPC.SpaceCenter.Services.Parts
         public bool ThrustReversed {
             get {
                 CheckReverser ();
-                return thrustReverser.Reversed;
+                return InternalThrustReverser.Reversed;
             }
             set {
                 CheckReverser ();
-                thrustReverser.Reversed = value;
+                InternalThrustReverser.Reversed = value;
             }
         }
 
@@ -692,7 +719,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         public void ToggleThrustReversal ()
         {
             CheckReverser ();
-            thrustReverser.Toggle ();
+            InternalThrustReverser.Toggle ();
         }
 
         /// <summary>

--- a/service/SpaceCenter/src/Services/Parts/Experiment.cs
+++ b/service/SpaceCenter/src/Services/Parts/Experiment.cs
@@ -14,21 +14,35 @@ namespace KRPC.SpaceCenter.Services.Parts
     /// Obtained by calling <see cref="Part.Experiment"/>.
     /// </summary>
     [KRPCClass (Service = "SpaceCenter", GameScene = GameScene.Flight)]
-    public class Experiment : Equatable<Experiment>
+    public class Experiment : Equatable<Experiment>, IGameObjectState
     {
-        readonly ModuleScienceExperiment experiment;
-        // Note: IScienceDataContainer needs to be used for some methods, rather than
-        // ModuleScienceExperiment, as method dispatch uses the wrong method implementation for
-        // DMagic science experiments
-        readonly IScienceDataContainer dataContainer;
+        ModuleRef experimentRef;
 
         internal Experiment(Part part, ModuleScienceExperiment experiment_)
         {
-            Part = part;
-            experiment = experiment_;
-            dataContainer = experiment_;
-            if (experiment == null)
+            if (experiment_ == null)
                 throw new ArgumentException ("Part is not a science experiment");
+            Part = part;
+            experimentRef = ModuleRef.ForModule (experiment_);
+        }
+
+        ModuleScienceExperiment InternalExperiment {
+            get { return (ModuleScienceExperiment)experimentRef.Get (Part.InternalPart); }
+        }
+
+        // Note: IScienceDataContainer needs to be used for some methods, rather than
+        // ModuleScienceExperiment, as method dispatch uses the wrong method implementation for
+        // DMagic science experiments
+        IScienceDataContainer InternalDataContainer {
+            get { return InternalExperiment; }
+        }
+
+        /// <summary>
+        /// What the game holds for the experiment: the state of the part
+        /// carrying it, or destroyed once that part no longer has the module.
+        /// </summary>
+        public GameObjectState GameObjectState {
+            get { return experimentRef.StateOn (Part); }
         }
 
         /// <summary>
@@ -36,7 +50,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         public override bool Equals (Experiment other)
         {
-            return !ReferenceEquals (other, null) && Part == other.Part && experiment == other.experiment;
+            return !ReferenceEquals (other, null) && Part == other.Part && experimentRef == other.experimentRef;
         }
 
         /// <summary>
@@ -44,7 +58,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         public override int GetHashCode ()
         {
-            return Part.GetHashCode () ^ experiment.GetHashCode ();
+            return Part.GetHashCode () ^ experimentRef.GetHashCode ();
         }
 
         /// <summary>
@@ -61,7 +75,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         [KRPCProperty]
         public string Name
         {
-            get { return experiment.experimentID; }
+            get { return InternalExperiment.experimentID; }
         }
 
         /// <summary>
@@ -70,7 +84,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         [KRPCProperty]
         public string Title
         {
-            get { return experiment.experiment.experimentTitle; }
+            get { return InternalExperiment.experiment.experimentTitle; }
         }
 
         /// <summary>
@@ -88,17 +102,17 @@ namespace KRPC.SpaceCenter.Services.Parts
             // DeployExperimentExternal all start gatherData(showDialog: true), and the only
             // dialog-free caller, OnActive, is gated on staging configuration. So invoke the
             // private gatherData coroutine directly, mirroring KSP's own staging path.
-            var gatherData = experiment.GetType ().GetMethod ("gatherData", BindingFlags.NonPublic | BindingFlags.Instance);
+            var gatherData = InternalExperiment.GetType ().GetMethod ("gatherData", BindingFlags.NonPublic | BindingFlags.Instance);
             if (gatherData != null)
             {
-                var result = (IEnumerator)gatherData.Invoke(experiment, new object[] { false });
-                experiment.StartCoroutine(result);
+                var result = (IEnumerator)gatherData.Invoke(InternalExperiment, new object[] { false });
+                InternalExperiment.StartCoroutine(result);
                 return;
             }
             // DMagic experiments
-            gatherData = experiment.GetType().GetMethod("gatherScienceData", BindingFlags.Public | BindingFlags.Instance | BindingFlags.FlattenHierarchy);
+            gatherData = InternalExperiment.GetType().GetMethod("gatherScienceData", BindingFlags.Public | BindingFlags.Instance | BindingFlags.FlattenHierarchy);
             if (gatherData != null) {
-                gatherData.Invoke(experiment, new object[] { true });
+                gatherData.Invoke(InternalExperiment, new object[] { true });
                 return;
             }
             throw new InvalidOperationException("Failed to find a gather data method for this experiment");
@@ -110,24 +124,24 @@ namespace KRPC.SpaceCenter.Services.Parts
         [KRPCMethod]
         public void Transmit ()
         {
-            var data = dataContainer.GetData ();
+            var data = InternalDataContainer.GetData ();
             for (int i = 0; i < data.Length; i++) {
                 // Use ExperimentResultDialogPage to compute the science value
                 // This object creation modifies the data object
                 new ExperimentResultDialogPage(
-                    experiment.part, data[i], data[i].baseTransmitValue, data[i].transmitBonus,
+                    InternalExperiment.part, data[i], data[i].baseTransmitValue, data[i].transmitBonus,
                     false, string.Empty, false,
-                    new ScienceLabSearch(experiment.part.vessel, data[i]),
+                    new ScienceLabSearch(InternalExperiment.part.vessel, data[i]),
                     null, null, null, null);
             }
-            var transmitter = ScienceUtil.GetBestTransmitter(experiment.vessel);
+            var transmitter = ScienceUtil.GetBestTransmitter(InternalExperiment.vessel);
             if (transmitter == null)
                 throw new InvalidOperationException ("No transmitters available to transmit the data");
             transmitter.TransmitData (data.ToList ());
             for (int i = 0; i < data.Length; i++)
-                dataContainer.DumpData(data[i]);
-            if (experiment.useCooldown)
-                experiment.cooldownToGo = experiment.cooldownTimer;
+                InternalDataContainer.DumpData(data[i]);
+            if (InternalExperiment.useCooldown)
+                InternalExperiment.cooldownToGo = InternalExperiment.cooldownTimer;
         }
 
         /// <summary>
@@ -136,8 +150,8 @@ namespace KRPC.SpaceCenter.Services.Parts
         [KRPCMethod]
         public void Dump ()
         {
-            foreach (var data in dataContainer.GetData ())
-                dataContainer.DumpData (data);
+            foreach (var data in InternalDataContainer.GetData ())
+                InternalDataContainer.DumpData (data);
         }
 
         /// <summary>
@@ -148,12 +162,12 @@ namespace KRPC.SpaceCenter.Services.Parts
         {
             if (Inoperable)
                 throw new InvalidOperationException ("Experiment is inoperable");
-            experiment.ResetExperiment ();
+            InternalExperiment.ResetExperiment ();
             // ResetExperiment only clears the base ModuleScienceExperiment slot. DMagic science
             // experiments keep their results in their own IScienceDataContainer, which the base
             // reset leaves untouched, so dump the container through the interface reference too.
-            foreach (var data in dataContainer.GetData ())
-                dataContainer.DumpData (data);
+            foreach (var data in InternalDataContainer.GetData ())
+                InternalDataContainer.DumpData (data);
         }
 
         /// <summary>
@@ -161,7 +175,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         [KRPCProperty]
         public bool Inoperable {
-            get { return experiment.Inoperable; }
+            get { return InternalExperiment.Inoperable; }
         }
 
         /// <summary>
@@ -169,7 +183,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         [KRPCProperty]
         public bool Deployed {
-            get { return experiment.Deployed; }
+            get { return InternalExperiment.Deployed; }
         }
 
         /// <summary>
@@ -177,7 +191,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         [KRPCProperty]
         public bool Rerunnable {
-            get { return dataContainer.IsRerunnable (); }
+            get { return InternalDataContainer.IsRerunnable (); }
         }
 
         /// <summary>
@@ -185,7 +199,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         [KRPCProperty]
         public bool HasData {
-            get { return dataContainer.GetData().Any (); }
+            get { return InternalDataContainer.GetData().Any (); }
         }
 
         /// <summary>
@@ -193,7 +207,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         [KRPCProperty]
         public IList<ScienceData> Data {
-            get { return dataContainer.GetData().Select (data => new ScienceData (experiment, data)).ToList (); }
+            get { return InternalDataContainer.GetData().Select (data => new ScienceData (InternalExperiment, data)).ToList (); }
         }
 
         /// <summary>
@@ -204,7 +218,7 @@ namespace KRPC.SpaceCenter.Services.Parts
             get {
                 var vessel = Part.InternalPart.vessel;
                 var situation = ScienceUtil.GetExperimentSituation (vessel);
-                var rndExperiment = ResearchAndDevelopment.GetExperiment (experiment.experimentID);
+                var rndExperiment = ResearchAndDevelopment.GetExperiment (InternalExperiment.experimentID);
                 return rndExperiment.IsAvailableWhile (situation, vessel.mainBody);
             }
         }
@@ -237,7 +251,7 @@ namespace KRPC.SpaceCenter.Services.Parts
             get {
                 if (!Available)
                     return null;
-                var id = experiment.experimentID;
+                var id = InternalExperiment.experimentID;
                 var vessel = Part.InternalPart.vessel;
                 var bodyName = vessel.mainBody.name;
                 var situation = ScienceUtil.GetExperimentSituation (vessel);

--- a/service/SpaceCenter/src/Services/Parts/Experiment.cs
+++ b/service/SpaceCenter/src/Services/Parts/Experiment.cs
@@ -207,7 +207,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         [KRPCProperty]
         public IList<ScienceData> Data {
-            get { return InternalDataContainer.GetData().Select (data => new ScienceData (InternalExperiment, data)).ToList (); }
+            get { return InternalDataContainer.GetData().Select (data => new ScienceData (Part, InternalExperiment, data)).ToList (); }
         }
 
         /// <summary>

--- a/service/SpaceCenter/src/Services/Parts/Fairing.cs
+++ b/service/SpaceCenter/src/Services/Parts/Fairing.cs
@@ -11,7 +11,7 @@ namespace KRPC.SpaceCenter.Services.Parts
     /// Supports both stock fairings, and those from the ProceduralFairings mod.
     /// </summary>
     [KRPCClass (Service = "SpaceCenter", GameScene = GameScene.Flight)]
-    public class Fairing : Equatable<Fairing>
+    public class Fairing : Equatable<Fairing>, IGameObjectState
     {
         readonly Module fairing;
         readonly Module proceduralFairing;
@@ -33,6 +33,14 @@ namespace KRPC.SpaceCenter.Services.Parts
                 proceduralFairing = new Module(part, internalPart.Module("ProceduralFairingDecoupler"));
             if (fairing == null && proceduralFairing == null)
                 throw new ArgumentException ("Part is not a fairing");
+        }
+
+        /// <summary>
+        /// What the game holds for the fairing. The module objects it is built from
+        /// find their part modules again on each access, so this follows them.
+        /// </summary>
+        public GameObjectState GameObjectState {
+            get { return (fairing ?? proceduralFairing).GameObjectState; }
         }
 
         /// <summary>

--- a/service/SpaceCenter/src/Services/Parts/Force.cs
+++ b/service/SpaceCenter/src/Services/Parts/Force.cs
@@ -1,7 +1,9 @@
 using KRPC.Service;
 using KRPC.Service.Attributes;
 using KRPC.SpaceCenter.ExtensionMethods;
+using KRPC.Utils;
 using UnityEngine;
+using ObjectDestroyedException = KRPC.Service.KRPC.ObjectDestroyedException;
 using Tuple3 = System.Tuple<double, double, double>;
 
 namespace KRPC.SpaceCenter.Services.Parts
@@ -10,17 +12,22 @@ namespace KRPC.SpaceCenter.Services.Parts
     /// Obtained by calling <see cref="Part.AddForce"/>.
     /// </summary>
     [KRPCClass (Service = "SpaceCenter", GameScene = GameScene.Flight)]
-    public sealed class Force
+    public sealed class Force : IGameObjectState
     {
         Vector3 force;
         Vector3 position;
+        ReferenceFrame frame;
+        // Whether the force has been taken off the part. The object goes on standing for
+        // an instruction the game is no longer given, so it says it is gone rather than
+        // reporting a force that is not being applied.
+        bool removed;
 
         internal Force (Part part, Tuple3 forceVector, Tuple3 forcePosition, ReferenceFrame referenceFrame)
         {
             Part = part;
             force = forceVector.ToVector ();
             position = forcePosition.ToVector ();
-            ReferenceFrame = referenceFrame;
+            frame = referenceFrame;
         }
 
         /// <summary>
@@ -30,14 +37,35 @@ namespace KRPC.SpaceCenter.Services.Parts
         public Part Part { get; private set; }
 
         /// <summary>
+        /// What the game holds for the force. A force is applied to a part, so it is
+        /// exactly as live, dormant or destroyed as that part: a part the game has
+        /// destroyed can never be pushed again, and one it has merely unloaded has no
+        /// rigidbody to push until it is loaded. A force the client has taken off its
+        /// part is gone whatever the part is doing, as nothing applies it again.
+        /// </summary>
+        public GameObjectState GameObjectState {
+            get { return removed ? GameObjectState.Destroyed : Part.GameObjectState; }
+        }
+
+        /// <summary>
+        /// Raise if the force is no longer applied to its part.
+        /// </summary>
+        void CheckExists ()
+        {
+            if (removed)
+                throw new ObjectDestroyedException (
+                    "The force no longer exists, as it has been removed.");
+        }
+
+        /// <summary>
         /// The force vector, in Newtons.
         /// </summary>
         /// <returns>A vector pointing in the direction that the force acts,
         /// with its magnitude equal to the strength of the force in Newtons.</returns>
         [KRPCProperty]
         public Tuple3 ForceVector {
-            get { return force.ToTuple (); }
-            set { force = value.ToVector (); }
+            get { CheckExists (); return force.ToTuple (); }
+            set { CheckExists (); force = value.ToVector (); }
         }
 
         /// <summary>
@@ -46,30 +74,46 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// <returns>The position as a vector.</returns>
         [KRPCProperty]
         public Tuple3 Position {
-            get { return position.ToTuple (); }
-            set { position = value.ToVector (); }
+            get { CheckExists (); return position.ToTuple (); }
+            set { CheckExists (); position = value.ToVector (); }
         }
 
         /// <summary>
         /// The reference frame of the force vector and position.
         /// </summary>
         [KRPCProperty]
-        public ReferenceFrame ReferenceFrame { get; set; }
+        public ReferenceFrame ReferenceFrame {
+            get { CheckExists (); return frame; }
+            set { CheckExists (); frame = value; }
+        }
 
         /// <summary>
         /// Remove the force.
         /// </summary>
+        /// <remarks>
+        /// Any further use of this object throws an exception.
+        /// </remarks>
         [KRPCMethod]
         public void Remove ()
         {
+            CheckExists ();
+            removed = true;
             PartForcesAddon.Remove (this);
-            // TODO: delete the object
         }
 
+        /// <summary>
+        /// Apply the force for one physics step, if there is a part to apply it to and a
+        /// reference frame to measure it in. The addon has already dropped the forces whose
+        /// part is gone; what is left to skip is a part the game has unloaded, and a frame
+        /// defined against something that is gone, which the client can point elsewhere.
+        /// </summary>
         internal void Update ()
         {
-            var worldForce = ReferenceFrame.DirectionToWorldSpace (force);
-            var worldPosition = ReferenceFrame.PositionToWorldSpace (position);
+            if (Part.GameObjectState != GameObjectState.Live ||
+                frame.GameObjectState != GameObjectState.Live)
+                return;
+            var worldForce = frame.DirectionToWorldSpace (force);
+            var worldPosition = frame.PositionToWorldSpace (position);
             Part.InternalPart.AddForceAtPosition (worldForce / 1000f, worldPosition);
         }
     }

--- a/service/SpaceCenter/src/Services/Parts/Intake.cs
+++ b/service/SpaceCenter/src/Services/Parts/Intake.cs
@@ -10,9 +10,9 @@ namespace KRPC.SpaceCenter.Services.Parts
     /// An air intake. Obtained by calling <see cref="Part.Intake"/>.
     /// </summary>
     [KRPCClass (Service = "SpaceCenter", GameScene = GameScene.Flight)]
-    public class Intake : Equatable<Intake>
+    public class Intake : Equatable<Intake>, IGameObjectState
     {
-        readonly ModuleResourceIntake intake;
+        ModuleRef intakeRef;
 
         internal static bool Is (Part part)
         {
@@ -22,9 +22,21 @@ namespace KRPC.SpaceCenter.Services.Parts
         internal Intake (Part part)
         {
             Part = part;
-            intake = part.InternalPart.Module<ModuleResourceIntake> ();
-            if (intake == null)
+            intakeRef = ModuleRef.ForType<ModuleResourceIntake> (part.InternalPart);
+            if (intakeRef.Find (part.InternalPart) == null)
                 throw new ArgumentException ("Part is not an intake");
+        }
+
+        ModuleResourceIntake InternalIntake {
+            get { return (ModuleResourceIntake)intakeRef.Get (Part.InternalPart); }
+        }
+
+        /// <summary>
+        /// What the game holds for the intake: the state of the part
+        /// carrying it, or destroyed once that part no longer has the module.
+        /// </summary>
+        public GameObjectState GameObjectState {
+            get { return intakeRef.StateOn (Part); }
         }
 
         /// <summary>
@@ -32,7 +44,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         public override bool Equals (Intake other)
         {
-            return !ReferenceEquals (other, null) && Part == other.Part && intake.Equals (other.intake);
+            return !ReferenceEquals (other, null) && Part == other.Part && intakeRef == other.intakeRef;
         }
 
         /// <summary>
@@ -40,7 +52,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         public override int GetHashCode ()
         {
-            return Part.GetHashCode () ^ intake.GetHashCode ();
+            return Part.GetHashCode () ^ intakeRef.GetHashCode ();
         }
 
         /// <summary>
@@ -54,12 +66,12 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         [KRPCProperty]
         public bool Open {
-            get { return intake.intakeEnabled; }
+            get { return InternalIntake.intakeEnabled; }
             set {
                 if (value)
-                    intake.Activate ();
+                    InternalIntake.Activate ();
                 else
-                    intake.Deactivate ();
+                    InternalIntake.Deactivate ();
             }
         }
 
@@ -68,7 +80,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         [KRPCProperty]
         public float Speed {
-            get { return Open ? (float)intake.intakeSpeed : 0f; }
+            get { return Open ? (float)InternalIntake.intakeSpeed : 0f; }
         }
 
         /// <summary>
@@ -76,7 +88,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         [KRPCProperty]
         public float Flow {
-            get { return Open ? intake.airFlow : 0f; }
+            get { return Open ? InternalIntake.airFlow : 0f; }
         }
 
         /// <summary>
@@ -84,7 +96,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         [KRPCProperty (GameScene = GameScene.Flight | GameScene.Editor)]
         public float Area {
-            get { return (float)intake.area; }
+            get { return (float)InternalIntake.area; }
         }
     }
 }

--- a/service/SpaceCenter/src/Services/Parts/LaunchClamp.cs
+++ b/service/SpaceCenter/src/Services/Parts/LaunchClamp.cs
@@ -10,9 +10,9 @@ namespace KRPC.SpaceCenter.Services.Parts
     /// A launch clamp. Obtained by calling <see cref="Part.LaunchClamp"/>.
     /// </summary>
     [KRPCClass (Service = "SpaceCenter", GameScene = GameScene.Flight)]
-    public class LaunchClamp : Equatable<LaunchClamp>
+    public class LaunchClamp : Equatable<LaunchClamp>, IGameObjectState
     {
-        readonly global::LaunchClamp launchClamp;
+        ModuleRef launchClampRef;
 
         internal static bool Is (Part part)
         {
@@ -22,9 +22,21 @@ namespace KRPC.SpaceCenter.Services.Parts
         internal LaunchClamp (Part part)
         {
             Part = part;
-            launchClamp = part.InternalPart.Module<global::LaunchClamp> ();
-            if (launchClamp == null)
+            launchClampRef = ModuleRef.ForType<global::LaunchClamp> (part.InternalPart);
+            if (launchClampRef.Find (part.InternalPart) == null)
                 throw new ArgumentException ("Part is not a launch clamp");
+        }
+
+        global::LaunchClamp InternalLaunchClamp {
+            get { return (global::LaunchClamp)launchClampRef.Get (Part.InternalPart); }
+        }
+
+        /// <summary>
+        /// What the game holds for the launch clamp: the state of the part
+        /// carrying it, or destroyed once that part no longer has the module.
+        /// </summary>
+        public GameObjectState GameObjectState {
+            get { return launchClampRef.StateOn (Part); }
         }
 
         /// <summary>
@@ -32,7 +44,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         public override bool Equals (LaunchClamp other)
         {
-            return !ReferenceEquals (other, null) && Part == other.Part && launchClamp.Equals (other.launchClamp);
+            return !ReferenceEquals (other, null) && Part == other.Part && launchClampRef == other.launchClampRef;
         }
 
         /// <summary>
@@ -40,7 +52,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         public override int GetHashCode ()
         {
-            return Part.GetHashCode () ^ launchClamp.GetHashCode ();
+            return Part.GetHashCode () ^ launchClampRef.GetHashCode ();
         }
 
         /// <summary>
@@ -55,7 +67,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         [KRPCMethod]
         public void Release ()
         {
-            launchClamp.Release ();
+            InternalLaunchClamp.Release ();
         }
     }
 }

--- a/service/SpaceCenter/src/Services/Parts/Leg.cs
+++ b/service/SpaceCenter/src/Services/Parts/Leg.cs
@@ -11,11 +11,11 @@ namespace KRPC.SpaceCenter.Services.Parts
     /// A landing leg. Obtained by calling <see cref="Part.Leg"/>.
     /// </summary>
     [KRPCClass (Service = "SpaceCenter", GameScene = GameScene.Flight)]
-    public class Leg : Equatable<Leg>
+    public class Leg : Equatable<Leg>, IGameObjectState
     {
-        readonly ModuleWheelBase wheel;
-        readonly ModuleWheels.ModuleWheelDeployment deployment;
-        readonly ModuleWheels.ModuleWheelDamage damage;
+        ModuleRef wheelRef;
+        ModuleRef deploymentRef;
+        ModuleRef damageRef;
 
         internal static bool Is (Part part)
         {
@@ -30,9 +30,29 @@ namespace KRPC.SpaceCenter.Services.Parts
                 throw new ArgumentException ("Part is not a landing leg");
             Part = part;
             var internalPart = part.InternalPart;
-            wheel = internalPart.Module<ModuleWheelBase> ();
-            deployment = internalPart.Module<ModuleWheels.ModuleWheelDeployment> ();
-            damage = internalPart.Module<ModuleWheels.ModuleWheelDamage> ();
+            wheelRef = ModuleRef.ForType<ModuleWheelBase> (internalPart);
+            deploymentRef = ModuleRef.ForType<ModuleWheels.ModuleWheelDeployment> (internalPart);
+            damageRef = ModuleRef.ForType<ModuleWheels.ModuleWheelDamage> (internalPart);
+        }
+
+        ModuleWheelBase InternalWheel {
+            get { return (ModuleWheelBase)wheelRef.Get (Part.InternalPart); }
+        }
+
+        ModuleWheels.ModuleWheelDeployment InternalDeployment {
+            get { return (ModuleWheels.ModuleWheelDeployment)deploymentRef.Find (Part.InternalPart); }
+        }
+
+        ModuleWheels.ModuleWheelDamage InternalDamage {
+            get { return (ModuleWheels.ModuleWheelDamage)damageRef.Find (Part.InternalPart); }
+        }
+
+        /// <summary>
+        /// What the game holds for the landing leg: the state of the part
+        /// carrying it, or destroyed once that part no longer has the module.
+        /// </summary>
+        public GameObjectState GameObjectState {
+            get { return wheelRef.StateOn (Part); }
         }
 
         /// <summary>
@@ -40,7 +60,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         public override bool Equals (Leg other)
         {
-            return !ReferenceEquals (other, null) && Part == other.Part && wheel == other.wheel;
+            return !ReferenceEquals (other, null) && Part == other.Part && wheelRef == other.wheelRef;
         }
 
         /// <summary>
@@ -48,7 +68,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         public override int GetHashCode ()
         {
-            return Part.GetHashCode () ^ wheel.GetHashCode ();
+            return Part.GetHashCode () ^ wheelRef.GetHashCode ();
         }
 
         /// <summary>
@@ -62,7 +82,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         [KRPCProperty]
         public DeployableState State {
-            get { return deployment.ToDeployableState (damage); }
+            get { return InternalDeployment.ToDeployableState (InternalDamage); }
         }
 
         /// <summary>
@@ -70,7 +90,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         [KRPCProperty (GameScene = GameScene.Flight | GameScene.Editor)]
         public bool Deployable {
-            get { return deployment != null; }
+            get { return InternalDeployment != null; }
         }
 
         /// <summary>
@@ -84,9 +104,9 @@ namespace KRPC.SpaceCenter.Services.Parts
         public bool Deployed {
             get { return State == DeployableState.Deployed; }
             set {
-                if (deployment == null)
+                if (InternalDeployment == null)
                     throw new InvalidOperationException ("Landing leg is not deployable");
-                deployment.ActionToggle(new KSPActionParam(0, value ? KSPActionType.Activate : KSPActionType.Deactivate));
+                InternalDeployment.ActionToggle(new KSPActionParam(0, value ? KSPActionType.Activate : KSPActionType.Deactivate));
             }
         }
 
@@ -95,7 +115,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         [KRPCProperty]
         public bool IsGrounded {
-            get { return wheel.isGrounded; }
+            get { return InternalWheel.isGrounded; }
         }
     }
 }

--- a/service/SpaceCenter/src/Services/Parts/Light.cs
+++ b/service/SpaceCenter/src/Services/Parts/Light.cs
@@ -12,9 +12,9 @@ namespace KRPC.SpaceCenter.Services.Parts
     /// A light. Obtained by calling <see cref="Part.Light"/>.
     /// </summary>
     [KRPCClass (Service = "SpaceCenter", GameScene = GameScene.Flight)]
-    public class Light : Equatable<Light>
+    public class Light : Equatable<Light>, IGameObjectState
     {
-        readonly ModuleLight light;
+        ModuleRef lightRef;
 
         internal static bool Is (Part part)
         {
@@ -24,9 +24,21 @@ namespace KRPC.SpaceCenter.Services.Parts
         internal Light (Part part)
         {
             Part = part;
-            light = part.InternalPart.Module<ModuleLight> ();
-            if (light == null)
+            lightRef = ModuleRef.ForType<ModuleLight> (part.InternalPart);
+            if (lightRef.Find (part.InternalPart) == null)
                 throw new ArgumentException ("Part is not a light");
+        }
+
+        ModuleLight InternalLight {
+            get { return (ModuleLight)lightRef.Get (Part.InternalPart); }
+        }
+
+        /// <summary>
+        /// What the game holds for the light: the state of the part
+        /// carrying it, or destroyed once that part no longer has the module.
+        /// </summary>
+        public GameObjectState GameObjectState {
+            get { return lightRef.StateOn (Part); }
         }
 
         /// <summary>
@@ -34,7 +46,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         public override bool Equals (Light other)
         {
-            return !ReferenceEquals (other, null) && Part == other.Part && light.Equals (other.light);
+            return !ReferenceEquals (other, null) && Part == other.Part && lightRef == other.lightRef;
         }
 
         /// <summary>
@@ -42,7 +54,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         public override int GetHashCode ()
         {
-            return Part.GetHashCode () ^ light.GetHashCode ();
+            return Part.GetHashCode () ^ lightRef.GetHashCode ();
         }
 
         /// <summary>
@@ -56,8 +68,8 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         [KRPCProperty]
         public bool Active {
-            get { return light.isOn; }
-            set { light.ToggleLightAction(new KSPActionParam(0, value ? KSPActionType.Activate : KSPActionType.Deactivate)); }
+            get { return InternalLight.isOn; }
+            set { InternalLight.ToggleLightAction(new KSPActionParam(0, value ? KSPActionType.Activate : KSPActionType.Deactivate)); }
         }
 
         /// <summary>
@@ -65,15 +77,15 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         [KRPCProperty (GameScene = GameScene.Flight | GameScene.Editor)]
         public Tuple3 Color {
-            get { return new Tuple3 (light.lightR, light.lightG, light.lightB); }
+            get { return new Tuple3 (InternalLight.lightR, InternalLight.lightG, InternalLight.lightB); }
             set {
                 if (value == null)
                     throw new ArgumentNullException (nameof (Color));
-                light.lightR = value.Item1;
-                light.lightG = value.Item2;
-                light.lightB = value.Item3;
-                light.SetFlareColor(new Color(value.Item1, value.Item2, value.Item3));
-                foreach (var unityLight in light.lights)
+                InternalLight.lightR = value.Item1;
+                InternalLight.lightG = value.Item2;
+                InternalLight.lightB = value.Item3;
+                InternalLight.SetFlareColor(new Color(value.Item1, value.Item2, value.Item3));
+                foreach (var unityLight in InternalLight.lights)
                     unityLight.color = new Color (value.Item1, value.Item2, value.Item3);
             }
         }
@@ -84,8 +96,8 @@ namespace KRPC.SpaceCenter.Services.Parts
         [KRPCProperty (GameScene = GameScene.Flight | GameScene.Editor)]
         public bool Blink
         {
-            get { return light.blinkState; }
-            set { light.SetBlinkState(value); }
+            get { return InternalLight.blinkState; }
+            set { InternalLight.SetBlinkState(value); }
         }
 
         /// <summary>
@@ -94,8 +106,8 @@ namespace KRPC.SpaceCenter.Services.Parts
         [KRPCProperty (GameScene = GameScene.Flight | GameScene.Editor)]
         public float BlinkRate
         {
-            get { return light.blinkRate; }
-            set { light.blinkRate = value; }
+            get { return InternalLight.blinkRate; }
+            set { InternalLight.blinkRate = value; }
         }
 
         /// <summary>
@@ -103,7 +115,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         [KRPCProperty]
         public float PowerUsage {
-            get { return Active ? light.resourceAmount : 0f; }
+            get { return Active ? InternalLight.resourceAmount : 0f; }
         }
     }
 }

--- a/service/SpaceCenter/src/Services/Parts/Module.cs
+++ b/service/SpaceCenter/src/Services/Parts/Module.cs
@@ -18,14 +18,14 @@ namespace KRPC.SpaceCenter.Services.Parts
     /// functionality of an engine.
     /// </summary>
     [KRPCClass (Service = "SpaceCenter")]
-    public class Module : Equatable<Module>
+    public class Module : Equatable<Module>, IGameObjectState
     {
-        readonly PartModule module;
+        ModuleRef reference;
 
         internal Module (Part part, PartModule partModule)
         {
             Part = part;
-            module = partModule;
+            reference = ModuleRef.ForModule (partModule);
         }
 
         /// <summary>
@@ -33,7 +33,15 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// and <see cref="PartAction"/> to read and write against the host module.
         /// </summary>
         internal PartModule InternalModule {
-            get { return module; }
+            get { return reference.Get (Part.InternalPart); }
+        }
+
+        /// <summary>
+        /// What the game holds for the module. A module belongs to its part's game object,
+        /// so a module of a part that is not loaded is no more gone than the part is.
+        /// </summary>
+        public GameObjectState GameObjectState {
+            get { return reference.StateOn (Part); }
         }
 
         /// <summary>
@@ -41,7 +49,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         public override bool Equals (Module other)
         {
-            return !ReferenceEquals (other, null) && Part == other.Part && module.Equals (other.module);
+            return !ReferenceEquals (other, null) && Part == other.Part && reference == other.reference;
         }
 
         /// <summary>
@@ -49,7 +57,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         public override int GetHashCode ()
         {
-            return Part.GetHashCode () ^ module.GetHashCode ();
+            return Part.GetHashCode () ^ reference.GetHashCode ();
         }
 
         /// <summary>
@@ -57,7 +65,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         [KRPCProperty]
         public string Name {
-            get { return module.moduleName; }
+            get { return InternalModule.moduleName; }
         }
 
         /// <summary>
@@ -83,13 +91,15 @@ namespace KRPC.SpaceCenter.Services.Parts
 
         global::ConfigNode FindConfigNode ()
         {
-            var info = Part.InternalPart.partInfo;
+            var part = Part.InternalPart;
+            var info = part.partInfo;
             if (info == null || info.partConfig == null)
                 return null;
             // Find the position of this module among the modules on the part that share
             // its name, then return the config node for the same occurrence.
+            var module = reference.Get (part);
             int occurrence = 0;
-            var modules = Part.InternalPart.Modules;
+            var modules = part.Modules;
             for (int i = 0; i < modules.Count; i++) {
                 if (ReferenceEquals (modules [i], module))
                     break;
@@ -108,23 +118,23 @@ namespace KRPC.SpaceCenter.Services.Parts
         }
 
         IEnumerable<BaseField> VisibleFields {
-            get { return module.Fields.Cast<BaseField> ().Where (f => f != null && (HighLogic.LoadedSceneIsEditor ? f.guiActiveEditor : f.guiActive)); }
+            get { return InternalModule.Fields.Cast<BaseField> ().Where (f => f != null && (HighLogic.LoadedSceneIsEditor ? f.guiActiveEditor : f.guiActive)); }
         }
 
         IEnumerable<BaseField> AllBaseFields {
-            get { return module.Fields.Cast<BaseField> ().Where (f => f != null); }
+            get { return InternalModule.Fields.Cast<BaseField> ().Where (f => f != null); }
         }
 
         IEnumerable<BaseEvent> AllEvents {
-            get { return module.Events.Where (e => e != null && (HighLogic.LoadedSceneIsEditor ? e.guiActiveEditor : e.guiActive) && e.active); }
+            get { return InternalModule.Events.Where (e => e != null && (HighLogic.LoadedSceneIsEditor ? e.guiActiveEditor : e.guiActive) && e.active); }
         }
 
         IEnumerable<BaseEvent> AllBaseEvents {
-            get { return module.Events.Where (e => e != null); }
+            get { return InternalModule.Events.Where (e => e != null); }
         }
 
         IEnumerable<BaseAction> AllActions {
-            get { return module.Actions; }
+            get { return InternalModule.Actions; }
         }
 
         // The following three helpers match on the display name, which the game translates.
@@ -201,7 +211,7 @@ namespace KRPC.SpaceCenter.Services.Parts
             get {
                 var result = new Dictionary<string,string> ();
                 foreach (var f in VisibleFields)
-                    result.Add (f.guiName, f.GetValueString (module));
+                    result.Add (f.guiName, f.GetValueString (InternalModule));
                 return result;
             }
         }
@@ -216,7 +226,7 @@ namespace KRPC.SpaceCenter.Services.Parts
             get {
                 var result = new Dictionary<string,string> ();
                 foreach (var f in VisibleFields)
-                    result.Add (f.name, f.GetValueString (module));
+                    result.Add (f.name, f.GetValueString (InternalModule));
                 return result;
             }
         }
@@ -261,7 +271,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         [KRPCMethod]
         public string GetField (string name)
         {
-            return GetBaseFieldByName (name).GetValueString (module);
+            return GetBaseFieldByName (name).GetValueString (InternalModule);
         }
 
         /// <summary>
@@ -272,7 +282,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         [KRPCMethod]
         public string GetFieldById (string id)
         {
-            return GetBaseFieldById (id).GetValueString (module);
+            return GetBaseFieldById (id).GetValueString (InternalModule);
         }
 
         /// <summary>
@@ -286,7 +296,7 @@ namespace KRPC.SpaceCenter.Services.Parts
             if (!type.IsAssignableFrom(value.GetType()))
                 throw new ArgumentException(
                     "Cannot set field with type " + type + " to a value of type " + value.GetType());
-            field.SetValue (value, module);
+            field.SetValue (value, InternalModule);
         }
 
         /// <summary>
@@ -299,7 +309,7 @@ namespace KRPC.SpaceCenter.Services.Parts
             var original = field.originalValue;
             if (original == null && field.FieldInfo.FieldType.IsValueType)
                 return;
-            field.SetValue (original, module);
+            field.SetValue (original, InternalModule);
         }
 
         private void AssignFieldByName(string name, object value) {

--- a/service/SpaceCenter/src/Services/Parts/Parachute.cs
+++ b/service/SpaceCenter/src/Services/Parts/Parachute.cs
@@ -4,6 +4,7 @@ using KRPC.Service;
 using KRPC.Service.Attributes;
 using KRPC.SpaceCenter.ExtensionMethods;
 using KRPC.Utils;
+using ObjectDestroyedException = KRPC.Service.KRPC.ObjectDestroyedException;
 
 namespace KRPC.SpaceCenter.Services.Parts
 {
@@ -11,9 +12,9 @@ namespace KRPC.SpaceCenter.Services.Parts
     /// A parachute. Obtained by calling <see cref="Part.Parachute"/>.
     /// </summary>
     [KRPCClass (Service = "SpaceCenter", GameScene = GameScene.Flight)]
-    public class Parachute : Equatable<Parachute>
+    public class Parachute : Equatable<Parachute>, IGameObjectState
     {
-        readonly ModuleParachute parachute;
+        ModuleRef parachuteRef;
         readonly Module realChute;
 
         internal static bool Is (Part part)
@@ -27,12 +28,40 @@ namespace KRPC.SpaceCenter.Services.Parts
         {
             Part = part;
             var internalPart = part.InternalPart;
-            parachute = internalPart.Module<ModuleParachute> ();
+            parachuteRef = ModuleRef.ForType<ModuleParachute> (internalPart);
             var realChuteModule = internalPart.Module ("RealChuteModule");
             if (realChuteModule != null)
                 realChute = new Module(part, realChuteModule);
-            if (parachute == null && realChute == null)
+            if (parachuteRef.Find (internalPart) == null && realChute == null)
                 throw new ArgumentException ("Part is not a parachute");
+        }
+
+        /// <summary>
+        /// The stock parachute module, or null where the part carries a RealChutes one
+        /// instead, which every member that reads this falls back to. A part that carries
+        /// neither has no parachute left for this to stand for, so it raises rather than
+        /// handing back a null for the fallback to be tried against.
+        /// </summary>
+        ModuleParachute InternalParachute {
+            get {
+                var parachute = (ModuleParachute)parachuteRef.Find (Part.InternalPart);
+                if (parachute == null && realChute == null)
+                    throw new ObjectDestroyedException (
+                        "The parachute no longer exists, as its part no longer has one.");
+                return parachute;
+            }
+        }
+
+        /// <summary>
+        /// What the game holds for the parachute. A part carries a stock parachute
+        /// module, a RealChutes one, or both, and either is enough for the parachute,
+        /// so it is as alive as the more alive of them.
+        /// </summary>
+        public GameObjectState GameObjectState {
+            get {
+                var state = parachuteRef.StateOn (Part);
+                return realChute == null ? state : state.MostAlive (realChute.GameObjectState);
+            }
         }
 
         /// <summary>
@@ -53,7 +82,7 @@ namespace KRPC.SpaceCenter.Services.Parts
 
         void CheckStock ()
         {
-            if (parachute == null || realChute != null)
+            if (InternalParachute == null || realChute != null)
                 throw new InvalidOperationException ("Operation not defined for a RealChutes parachute");
         }
 
@@ -70,6 +99,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         [KRPCMethod]
         public void Deploy ()
         {
+            var parachute = InternalParachute;
             if (parachute)
                 parachute.Deploy ();
             else if (realChute.HasVisibleEvent ("Deploy Chute"))
@@ -82,6 +112,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         [KRPCProperty]
         public bool Deployed {
             get {
+                var parachute = InternalParachute;
                 if (parachute)
                     return parachute.deploymentState != ModuleParachute.deploymentStates.STOWED;
                 return realChute.VisibleEventNames.Any (x => x.Contains ("Cut"));
@@ -99,8 +130,10 @@ namespace KRPC.SpaceCenter.Services.Parts
             {
                 if (realChute.HasVisibleEvent("Arm parachute"))
                     realChute.TriggerVisibleEvent("Arm parachute");
+                return;
             }
-            else if (parachute)
+            var parachute = InternalParachute;
+            if (parachute)
                 parachute.Deploy();
         }
 
@@ -112,10 +145,8 @@ namespace KRPC.SpaceCenter.Services.Parts
             get {
                 if (realChute != null)
                     return realChute.HasVisibleEvent("Disarm parachute");
-                else if (parachute)
-                    return parachute.deploymentState == ModuleParachute.deploymentStates.ACTIVE;
-                else
-                    return false;
+                var parachute = InternalParachute;
+                return parachute && parachute.deploymentState == ModuleParachute.deploymentStates.ACTIVE;
             }
         }
 
@@ -128,8 +159,10 @@ namespace KRPC.SpaceCenter.Services.Parts
             if (realChute != null) {
                 if (realChute.HasVisibleEvent("Cut main chute"))
                     realChute.TriggerVisibleEvent("Cut main chute");
+                return;
             }
-            else if (parachute)
+            var parachute = InternalParachute;
+            if (parachute)
                 parachute.CutParachute();
         }
 
@@ -139,6 +172,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         [KRPCProperty]
         public ParachuteState State {
             get {
+                var parachute = InternalParachute;
                 if (parachute)
                     return parachute.deploymentState.ToParachuteState ();
                 if (Armed)
@@ -159,11 +193,11 @@ namespace KRPC.SpaceCenter.Services.Parts
         public float DeployAltitude {
             get {
                 CheckStock();
-                return parachute.deployAltitude;
+                return InternalParachute.deployAltitude;
             }
             set {
                 CheckStock();
-                parachute.deployAltitude = value;
+                InternalParachute.deployAltitude = value;
             }
         }
 
@@ -175,11 +209,11 @@ namespace KRPC.SpaceCenter.Services.Parts
         public float DeployMinPressure {
             get {
                 CheckStock ();
-                return parachute.minAirPressureToOpen;
+                return InternalParachute.minAirPressureToOpen;
             }
             set {
                 CheckStock ();
-                parachute.minAirPressureToOpen = value;
+                InternalParachute.minAirPressureToOpen = value;
             }
         }
 
@@ -194,7 +228,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         public ParachuteSafeState SafeState {
             get {
                 CheckStock ();
-                return parachute.deploymentSafeState.ToParachuteSafeState ();
+                return InternalParachute.deploymentSafeState.ToParachuteSafeState ();
             }
         }
     }

--- a/service/SpaceCenter/src/Services/Parts/Part.cs
+++ b/service/SpaceCenter/src/Services/Parts/Part.cs
@@ -20,9 +20,10 @@ namespace KRPC.SpaceCenter.Services.Parts
     /// Instances of this class can be obtained by several methods in <see cref="Parts"/>.
     /// </summary>
     [KRPCClass (Service = "SpaceCenter")]
-    public class Part : Equatable<Part>
+    public class Part : Equatable<Part>, IGameObjectState
     {
         readonly PartId partId;
+        CachedObject<global::Part> cache;
 
         /// <summary>
         /// Create a part object for the given KSP part
@@ -30,6 +31,15 @@ namespace KRPC.SpaceCenter.Services.Parts
         public Part (global::Part part)
         {
             partId = new PartId (part);
+        }
+
+        /// <summary>
+        /// Create a part object for the part in flight with the given flight identifier,
+        /// which the game need not currently have.
+        /// </summary>
+        internal Part (uint flightId)
+        {
+            partId = new PartId (flightId);
         }
 
         /// <summary>
@@ -49,11 +59,38 @@ namespace KRPC.SpaceCenter.Services.Parts
         }
 
         /// <summary>
-        /// The KSP part. Looked up by identifier on each use, so the object keeps working
-        /// across a reload that destroys the part and recreates it.
+        /// The KSP part. Looked up by identifier whenever the last part looked up is gone,
+        /// so the object keeps working across a reload that destroys the part and
+        /// recreates it.
         /// </summary>
         public global::Part InternalPart {
-            get { return partId.Resolve (); }
+            get {
+                var part = cache.Get ();
+                if (part != null)
+                    return part;
+                part = partId.Resolve ();
+                cache.Set (part);
+                return part;
+            }
+        }
+
+        /// <summary>
+        /// What the game holds for the part.
+        /// </summary>
+        /// <remarks>
+        /// A part looked up in this game state and still there is the part, so there is
+        /// nothing to search for. That is what makes this affordable to a caller that asks
+        /// on every update, such as a force being applied or a resource being transferred.
+        /// It holds in flight only: a part in an editor belongs to the vessel it was taken
+        /// from, and one of a vessel the editor has loaded over is gone however alive the
+        /// game object it was is.
+        /// </remarks>
+        public GameObjectState GameObjectState {
+            get {
+                if (!partId.InEditor && cache.Get () != null)
+                    return GameObjectState.Live;
+                return partId.GameObjectState;
+            }
         }
 
         /// <summary>

--- a/service/SpaceCenter/src/Services/Parts/PartAction.cs
+++ b/service/SpaceCenter/src/Services/Parts/PartAction.cs
@@ -1,6 +1,7 @@
 using System;
 using KRPC.Service.Attributes;
 using KRPC.Utils;
+using ObjectDestroyedException = KRPC.Service.KRPC.ObjectDestroyedException;
 
 namespace KRPC.SpaceCenter.Services.Parts
 {
@@ -9,14 +10,34 @@ namespace KRPC.SpaceCenter.Services.Parts
     /// in the in-game editor. Obtained by calling <see cref="Module.ActionList"/>.
     /// </summary>
     [KRPCClass (Service = "SpaceCenter")]
-    public class PartAction : Equatable<PartAction>
+    public class PartAction : Equatable<PartAction>, IGameObjectState
     {
-        readonly BaseAction action;
+        readonly string name;
 
         internal PartAction (Module module, BaseAction baseAction)
         {
             Module = module;
-            action = baseAction;
+            name = baseAction.name;
+        }
+
+        /// <summary>
+        /// The underlying KSP action, found on the module by its identifier.
+        /// </summary>
+        BaseAction InternalAction {
+            get {
+                var action = Module.InternalModule.Actions [name];
+                if (action == null)
+                    throw new ObjectDestroyedException (
+                        "The part module no longer has a action called " + name + ".");
+                return action;
+            }
+        }
+
+        /// <summary>
+        /// What the game holds for the module this belongs to.
+        /// </summary>
+        public GameObjectState GameObjectState {
+            get { return Module.GameObjectState; }
         }
 
         /// <summary>
@@ -24,7 +45,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         public override bool Equals (PartAction other)
         {
-            return !ReferenceEquals (other, null) && Module == other.Module && ReferenceEquals (action, other.action);
+            return !ReferenceEquals (other, null) && Module == other.Module && name == other.name;
         }
 
         /// <summary>
@@ -32,7 +53,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         public override int GetHashCode ()
         {
-            return Module.GetHashCode () ^ action.GetHashCode ();
+            return Module.GetHashCode () ^ name.GetHashCode ();
         }
 
         /// <summary>
@@ -47,7 +68,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         [KRPCProperty]
         public string Name {
-            get { return action.name; }
+            get { return name; }
         }
 
         /// <summary>
@@ -55,7 +76,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         [KRPCProperty]
         public string GuiName {
-            get { return action.guiName; }
+            get { return InternalAction.guiName; }
         }
 
         /// <summary>
@@ -65,8 +86,8 @@ namespace KRPC.SpaceCenter.Services.Parts
         [KRPCProperty]
         public bool Activated {
             set {
-                action.Invoke (new KSPActionParam (
-                    action.actionGroup,
+                InternalAction.Invoke (new KSPActionParam (
+                    InternalAction.actionGroup,
                     value ? KSPActionType.Activate : KSPActionType.Deactivate
                 ));
             }

--- a/service/SpaceCenter/src/Services/Parts/PartEvent.cs
+++ b/service/SpaceCenter/src/Services/Parts/PartEvent.cs
@@ -1,6 +1,7 @@
 using System;
 using KRPC.Service.Attributes;
 using KRPC.Utils;
+using ObjectDestroyedException = KRPC.Service.KRPC.ObjectDestroyedException;
 
 namespace KRPC.SpaceCenter.Services.Parts
 {
@@ -9,14 +10,34 @@ namespace KRPC.SpaceCenter.Services.Parts
     /// of the part. Obtained by calling <see cref="Module.EventList"/>.
     /// </summary>
     [KRPCClass (Service = "SpaceCenter")]
-    public class PartEvent : Equatable<PartEvent>
+    public class PartEvent : Equatable<PartEvent>, IGameObjectState
     {
-        readonly BaseEvent partEvent;
+        readonly string name;
 
         internal PartEvent (Module module, BaseEvent baseEvent)
         {
             Module = module;
-            partEvent = baseEvent;
+            name = baseEvent.name;
+        }
+
+        /// <summary>
+        /// The underlying KSP event, found on the module by its identifier.
+        /// </summary>
+        BaseEvent InternalEvent {
+            get {
+                var partEvent = Module.InternalModule.Events [name];
+                if (partEvent == null)
+                    throw new ObjectDestroyedException (
+                        "The part module no longer has an event called " + name + ".");
+                return partEvent;
+            }
+        }
+
+        /// <summary>
+        /// What the game holds for the module this belongs to.
+        /// </summary>
+        public GameObjectState GameObjectState {
+            get { return Module.GameObjectState; }
         }
 
         /// <summary>
@@ -24,7 +45,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         public override bool Equals (PartEvent other)
         {
-            return !ReferenceEquals (other, null) && Module == other.Module && ReferenceEquals (partEvent, other.partEvent);
+            return !ReferenceEquals (other, null) && Module == other.Module && name == other.name;
         }
 
         /// <summary>
@@ -32,7 +53,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         public override int GetHashCode ()
         {
-            return Module.GetHashCode () ^ partEvent.GetHashCode ();
+            return Module.GetHashCode () ^ name.GetHashCode ();
         }
 
         /// <summary>
@@ -47,7 +68,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         [KRPCProperty]
         public string Name {
-            get { return partEvent.name; }
+            get { return name; }
         }
 
         /// <summary>
@@ -55,7 +76,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         [KRPCProperty]
         public string GuiName {
-            get { return partEvent.guiName; }
+            get { return InternalEvent.guiName; }
         }
 
         /// <summary>
@@ -64,7 +85,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         [KRPCProperty]
         public bool Visible {
-            get { return HighLogic.LoadedSceneIsEditor ? partEvent.guiActiveEditor : partEvent.guiActive; }
+            get { return HighLogic.LoadedSceneIsEditor ? InternalEvent.guiActiveEditor : InternalEvent.guiActive; }
         }
 
         /// <summary>
@@ -72,7 +93,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         [KRPCProperty]
         public bool Active {
-            get { return partEvent.active; }
+            get { return InternalEvent.active; }
         }
 
         /// <summary>
@@ -81,7 +102,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         [KRPCMethod]
         public void Trigger ()
         {
-            partEvent.Invoke ();
+            InternalEvent.Invoke ();
         }
     }
 }

--- a/service/SpaceCenter/src/Services/Parts/PartField.cs
+++ b/service/SpaceCenter/src/Services/Parts/PartField.cs
@@ -2,6 +2,7 @@ using System;
 using KRPC.Service.Attributes;
 using KRPC.SpaceCenter.ExtensionMethods;
 using KRPC.Utils;
+using ObjectDestroyedException = KRPC.Service.KRPC.ObjectDestroyedException;
 
 namespace KRPC.SpaceCenter.Services.Parts
 {
@@ -9,14 +10,34 @@ namespace KRPC.SpaceCenter.Services.Parts
     /// A field of a part module. Obtained by calling <see cref="Module.FieldList"/>.
     /// </summary>
     [KRPCClass (Service = "SpaceCenter")]
-    public class PartField : Equatable<PartField>
+    public class PartField : Equatable<PartField>, IGameObjectState
     {
-        readonly BaseField baseField;
+        readonly string name;
 
         internal PartField (Module module, BaseField partField)
         {
             Module = module;
-            baseField = partField;
+            name = partField.name;
+        }
+
+        /// <summary>
+        /// The underlying KSP field, found on the module by its identifier.
+        /// </summary>
+        BaseField InternalField {
+            get {
+                var field = Module.InternalModule.Fields [name];
+                if (field == null)
+                    throw new ObjectDestroyedException (
+                        "The part module no longer has a field called " + name + ".");
+                return field;
+            }
+        }
+
+        /// <summary>
+        /// What the game holds for the module this belongs to.
+        /// </summary>
+        public GameObjectState GameObjectState {
+            get { return Module.GameObjectState; }
         }
 
         /// <summary>
@@ -24,7 +45,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         public override bool Equals (PartField other)
         {
-            return !ReferenceEquals (other, null) && Module == other.Module && ReferenceEquals (baseField, other.baseField);
+            return !ReferenceEquals (other, null) && Module == other.Module && name == other.name;
         }
 
         /// <summary>
@@ -32,7 +53,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         public override int GetHashCode ()
         {
-            return Module.GetHashCode () ^ baseField.GetHashCode ();
+            return Module.GetHashCode () ^ name.GetHashCode ();
         }
 
         /// <summary>
@@ -47,7 +68,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         [KRPCProperty]
         public string Name {
-            get { return baseField.name; }
+            get { return name; }
         }
 
         /// <summary>
@@ -56,7 +77,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         [KRPCProperty]
         public string GuiName {
-            get { return baseField.guiName; }
+            get { return InternalField.guiName; }
         }
 
         /// <summary>
@@ -65,7 +86,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         [KRPCProperty]
         public bool Visible {
-            get { return HighLogic.LoadedSceneIsEditor ? baseField.guiActiveEditor : baseField.guiActive; }
+            get { return HighLogic.LoadedSceneIsEditor ? InternalField.guiActiveEditor : InternalField.guiActive; }
         }
 
         /// <summary>
@@ -73,7 +94,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         [KRPCProperty]
         public FieldType Type {
-            get { return TypeOf (baseField.FieldInfo.FieldType); }
+            get { return TypeOf (InternalField.FieldInfo.FieldType); }
         }
 
         static FieldType TypeOf (Type type)
@@ -102,18 +123,18 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         void Assign (object value)
         {
-            var type = baseField.FieldInfo.FieldType;
+            var type = InternalField.FieldInfo.FieldType;
             if (!type.IsAssignableFrom (value.GetType ()))
                 throw new ArgumentException (
                     "Cannot set field with type " + type + " to a value of type " + value.GetType ());
-            baseField.SetValue (value, Module.InternalModule);
+            InternalField.SetValue (value, Module.InternalModule);
         }
 
         void CheckType (FieldType expected)
         {
             if (Type != expected)
                 throw new InvalidOperationException (
-                    "Field " + baseField.name + " has type " + Type + ", not " + expected);
+                    "Field " + InternalField.name + " has type " + Type + ", not " + expected);
         }
 
         /// <summary>
@@ -127,7 +148,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </remarks>
         [KRPCProperty]
         public string Value {
-            get { return baseField.GetValueString (Module.InternalModule); }
+            get { return InternalField.GetValueString (Module.InternalModule); }
             set { Assign (value); }
         }
 
@@ -142,7 +163,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         public bool BoolValue {
             get {
                 CheckType (FieldType.Boolean);
-                return Convert.ToBoolean (baseField.GetValue (Module.InternalModule));
+                return Convert.ToBoolean (InternalField.GetValue (Module.InternalModule));
             }
             set { Assign (value); }
         }
@@ -158,7 +179,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         public int IntValue {
             get {
                 CheckType (FieldType.Integer);
-                return Convert.ToInt32 (baseField.GetValue (Module.InternalModule));
+                return Convert.ToInt32 (InternalField.GetValue (Module.InternalModule));
             }
             set { Assign (value); }
         }
@@ -174,7 +195,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         public float FloatValue {
             get {
                 CheckType (FieldType.Float);
-                return Convert.ToSingle (baseField.GetValue (Module.InternalModule));
+                return Convert.ToSingle (InternalField.GetValue (Module.InternalModule));
             }
             set { Assign (value); }
         }
@@ -190,7 +211,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         public double DoubleValue {
             get {
                 CheckType (FieldType.Double);
-                return Convert.ToDouble (baseField.GetValue (Module.InternalModule));
+                return Convert.ToDouble (InternalField.GetValue (Module.InternalModule));
             }
             set { Assign (value); }
         }
@@ -205,7 +226,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         [KRPCMethod]
         public void Reset ()
         {
-            Module.RestoreOriginalFieldValue (baseField);
+            Module.RestoreOriginalFieldValue (InternalField);
         }
     }
 }

--- a/service/SpaceCenter/src/Services/Parts/Parts.cs
+++ b/service/SpaceCenter/src/Services/Parts/Parts.cs
@@ -13,7 +13,7 @@ namespace KRPC.SpaceCenter.Services.Parts
     /// An instance can be obtained by calling <see cref="Vessel.Parts"/>.
     /// </summary>
     [KRPCClass (Service = "SpaceCenter")]
-    public class Parts : Equatable<Parts>
+    public class Parts : Equatable<Parts>, IGameObjectState
     {
         /// <summary>
         /// The id of the vessel the parts belong to. Unused when the parts belong to the
@@ -35,6 +35,17 @@ namespace KRPC.SpaceCenter.Services.Parts
         internal Parts ()
         {
             editorVessel = true;
+        }
+
+        /// <summary>
+        /// What the game holds for the vessel this belongs to.
+        /// </summary>
+        public GameObjectState GameObjectState {
+            get {
+                return editorVessel
+                    ? EditorExtensions.ShipState
+                    : FlightGlobalsExtensions.VesselState (vesselId);
+            }
         }
 
         /// <summary>

--- a/service/SpaceCenter/src/Services/Parts/Parts.cs
+++ b/service/SpaceCenter/src/Services/Parts/Parts.cs
@@ -72,13 +72,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         public IShipconstruct InternalShipConstruct {
             get {
-                if (!editorVessel)
-                    return InternalVessel;
-                var logic = EditorLogic.fetch;
-                var construct = ReferenceEquals (logic, null) ? null : logic.ship;
-                if (ReferenceEquals (construct, null))
-                    throw new InvalidOperationException ("The editor does not contain a vessel.");
-                return construct;
+                return editorVessel ? (IShipconstruct)EditorExtensions.GetShip () : InternalVessel;
             }
         }
 

--- a/service/SpaceCenter/src/Services/Parts/Propellant.cs
+++ b/service/SpaceCenter/src/Services/Parts/Propellant.cs
@@ -9,7 +9,7 @@ namespace KRPC.SpaceCenter.Services.Parts
     /// A propellant for an engine. Obtains by calling <see cref="Engine.Propellants"/>.
     /// </summary>
     [KRPCClass (Service = "SpaceCenter", GameScene = GameScene.Flight)]
-    public class Propellant : Equatable<Propellant>
+    public class Propellant : Equatable<Propellant>, IGameObjectState
     {
         readonly int resourceId;
         readonly uint partId;
@@ -19,6 +19,13 @@ namespace KRPC.SpaceCenter.Services.Parts
             propellantResource.UpdateConnectedResources(underlyingPart);
             resourceId = propellantResource.id;
             partId = underlyingPart.flightID;
+        }
+
+        /// <summary>
+        /// What the game holds for the part this belongs to.
+        /// </summary>
+        public GameObjectState GameObjectState {
+            get { return new Part (partId).GameObjectState; }
         }
 
         /// <summary>

--- a/service/SpaceCenter/src/Services/Parts/RCS.cs
+++ b/service/SpaceCenter/src/Services/Parts/RCS.cs
@@ -15,9 +15,9 @@ namespace KRPC.SpaceCenter.Services.Parts
     /// An RCS block or thruster. Obtained by calling <see cref="Part.RCS"/>.
     /// </summary>
     [KRPCClass (Service = "SpaceCenter", GameScene = GameScene.Flight)]
-    public class RCS : Equatable<RCS>
+    public class RCS : Equatable<RCS>, IGameObjectState
     {
-        readonly ModuleRCS rcs;
+        ModuleRef rcsRef;
 
         internal static bool Is (Part part)
         {
@@ -32,9 +32,21 @@ namespace KRPC.SpaceCenter.Services.Parts
         internal RCS (Part part)
         {
             Part = part;
-            rcs = part.InternalPart.Module<ModuleRCS> ();
-            if (rcs == null)
+            rcsRef = ModuleRef.ForType<ModuleRCS> (part.InternalPart);
+            if (rcsRef.Find (part.InternalPart) == null)
                 throw new ArgumentException ("Part does not have a ModuleRCS PartModule");
+        }
+
+        ModuleRCS InternalRCS {
+            get { return (ModuleRCS)rcsRef.Get (Part.InternalPart); }
+        }
+
+        /// <summary>
+        /// What the game holds for the RCS thrusters: the state of the part
+        /// carrying it, or destroyed once that part no longer has the module.
+        /// </summary>
+        public GameObjectState GameObjectState {
+            get { return rcsRef.StateOn (Part); }
         }
 
         /// <summary>
@@ -42,7 +54,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         public override bool Equals (RCS other)
         {
-            return !ReferenceEquals (other, null) && Part == other.Part && rcs.Equals (other.rcs);
+            return !ReferenceEquals (other, null) && Part == other.Part && rcsRef == other.rcsRef;
         }
 
         /// <summary>
@@ -50,7 +62,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         public override int GetHashCode ()
         {
-            return Part.GetHashCode () ^ rcs.GetHashCode ();
+            return Part.GetHashCode () ^ rcsRef.GetHashCode ();
         }
 
         /// <summary>
@@ -72,10 +84,10 @@ namespace KRPC.SpaceCenter.Services.Parts
                 var p = Part.InternalPart;
                 return
                 p.vessel.ActionGroups.groups [BaseAction.GetGroupIndex (KSPActionGroup.RCS)] &&
-                (!p.ShieldedFromAirstream || rcs.shieldedCanThrust) &&
-                rcs.rcsEnabled &&
-                rcs.isEnabled &&
-                !rcs.isJustForShow;
+                (!p.ShieldedFromAirstream || InternalRCS.shieldedCanThrust) &&
+                InternalRCS.rcsEnabled &&
+                InternalRCS.isEnabled &&
+                !InternalRCS.isJustForShow;
             }
         }
 
@@ -84,8 +96,8 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         [KRPCProperty (GameScene = GameScene.Flight | GameScene.Editor)]
         public bool Enabled {
-            get { return rcs.rcsEnabled; }
-            set { rcs.rcsEnabled = value; }
+            get { return InternalRCS.rcsEnabled; }
+            set { InternalRCS.rcsEnabled = value; }
         }
 
         /// <summary>
@@ -93,8 +105,8 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         [KRPCProperty (GameScene = GameScene.Flight | GameScene.Editor)]
         public bool PitchEnabled {
-            get { return rcs.enablePitch; }
-            set { rcs.enablePitch = value; }
+            get { return InternalRCS.enablePitch; }
+            set { InternalRCS.enablePitch = value; }
         }
 
         /// <summary>
@@ -102,8 +114,8 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         [KRPCProperty (GameScene = GameScene.Flight | GameScene.Editor)]
         public bool YawEnabled {
-            get { return rcs.enableYaw; }
-            set { rcs.enableYaw = value; }
+            get { return InternalRCS.enableYaw; }
+            set { InternalRCS.enableYaw = value; }
         }
 
         /// <summary>
@@ -111,8 +123,8 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         [KRPCProperty (GameScene = GameScene.Flight | GameScene.Editor)]
         public bool RollEnabled {
-            get { return rcs.enableRoll; }
-            set { rcs.enableRoll = value; }
+            get { return InternalRCS.enableRoll; }
+            set { InternalRCS.enableRoll = value; }
         }
 
         /// <summary>
@@ -120,8 +132,8 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         [KRPCProperty (GameScene = GameScene.Flight | GameScene.Editor)]
         public bool ForwardEnabled {
-            get { return rcs.enableZ; }
-            set { rcs.enableZ = value; }
+            get { return InternalRCS.enableZ; }
+            set { InternalRCS.enableZ = value; }
         }
 
         /// <summary>
@@ -129,8 +141,8 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         [KRPCProperty (GameScene = GameScene.Flight | GameScene.Editor)]
         public bool UpEnabled {
-            get { return rcs.enableY; }
-            set { rcs.enableY = value; }
+            get { return InternalRCS.enableY; }
+            set { InternalRCS.enableY = value; }
         }
 
         /// <summary>
@@ -138,8 +150,8 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         [KRPCProperty (GameScene = GameScene.Flight | GameScene.Editor)]
         public bool RightEnabled {
-            get { return rcs.enableX; }
-            set { rcs.enableX = value; }
+            get { return InternalRCS.enableX; }
+            set { InternalRCS.enableX = value; }
         }
 
         /// <summary>
@@ -151,8 +163,8 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         [KRPCProperty]
         public bool InputOverride {
-            get { return ActuatorControlAddon.GetRCSOverride (rcs); }
-            set { ActuatorControlAddon.SetRCSOverride (rcs, value); }
+            get { return ActuatorControlAddon.GetRCSOverride (InternalRCS); }
+            set { ActuatorControlAddon.SetRCSOverride (InternalRCS, value); }
         }
 
         /// <summary>
@@ -161,8 +173,8 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         [KRPCProperty]
         public Tuple3 RotationOverride {
-            get { return ActuatorControlAddon.GetRCSRotation (rcs).ToTuple (); }
-            set { ActuatorControlAddon.SetRCSRotation (rcs, value.ToVector ()); }
+            get { return ActuatorControlAddon.GetRCSRotation (InternalRCS).ToTuple (); }
+            set { ActuatorControlAddon.SetRCSRotation (InternalRCS, value.ToVector ()); }
         }
 
         /// <summary>
@@ -172,8 +184,8 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         [KRPCProperty]
         public Tuple3 TranslationOverride {
-            get { return ActuatorControlAddon.GetRCSTranslation (rcs).ToTuple (); }
-            set { ActuatorControlAddon.SetRCSTranslation (rcs, value.ToVector ()); }
+            get { return ActuatorControlAddon.GetRCSTranslation (InternalRCS).ToTuple (); }
+            set { ActuatorControlAddon.SetRCSTranslation (InternalRCS, value.ToVector ()); }
         }
 
         /// <summary>
@@ -240,15 +252,15 @@ namespace KRPC.SpaceCenter.Services.Parts
                 var posZ = thrustPosition.Item3;
                 double torque = 0;
                 // Torque around X axis (pitch)
-                torque = rcs.enablePitch ? posY * forceZ - posZ * forceY : 0d;
+                torque = InternalRCS.enablePitch ? posY * forceZ - posZ * forceY : 0d;
                 if (torque > 0) torqueX += torque;
                 else torqueXn += -torque;
                 // Torque around Y axis (roll)
-                torque = rcs.enableRoll ? posZ * forceX - posX * forceZ : 0d;
+                torque = InternalRCS.enableRoll ? posZ * forceX - posX * forceZ : 0d;
                 if (torque > 0) torqueY += torque;
                 else torqueYn += -torque;
                 // Torque around Z axis (yaw)
-                torque = rcs.enableYaw ? posX * forceY - posY * forceX : 0d;
+                torque = InternalRCS.enableYaw ? posX * forceY - posY * forceX : 0d;
                 if (torque > 0) torqueZ += torque;
                 else torqueZn += -torque;
             }
@@ -295,7 +307,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         float GetThrust (double throttle, double pressure)
         {
             pressure *= PhysicsGlobals.KpaToAtmospheres;
-            return 1000f * (float)rcs.maxFuelFlow * (float)throttle * (float)rcs.G * rcs.atmosphereCurve.Evaluate ((float)pressure);
+            return 1000f * (float)InternalRCS.maxFuelFlow * (float)throttle * (float)InternalRCS.G * InternalRCS.atmosphereCurve.Evaluate ((float)pressure);
         }
 
         /// <summary>
@@ -309,7 +321,7 @@ namespace KRPC.SpaceCenter.Services.Parts
             get {
                 if (!HasFuel)
                     return 0f;
-                return GetThrust (ThrustLimit, rcs.vessel.staticPressurekPa);
+                return GetThrust (ThrustLimit, InternalRCS.vessel.staticPressurekPa);
             }
         }
 
@@ -320,7 +332,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         [KRPCProperty]
         public float MaxThrust {
-            get { return GetThrust (1f, rcs.vessel.staticPressurekPa); }
+            get { return GetThrust (1f, InternalRCS.vessel.staticPressurekPa); }
         }
 
         /// <summary>
@@ -329,7 +341,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         [KRPCProperty (GameScene = GameScene.Flight | GameScene.Editor)]
         public float MaxVacuumThrust {
-            get { return rcs.thrusterPower * 1000f; }
+            get { return InternalRCS.thrusterPower * 1000f; }
         }
 
         /// <summary>
@@ -337,8 +349,8 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         [KRPCProperty (GameScene = GameScene.Flight | GameScene.Editor)]
         public float ThrustLimit {
-            get { return rcs.thrustPercentage / 100f; }
-            set { rcs.thrustPercentage = (value * 100f).Clamp (0f, 100f); }
+            get { return InternalRCS.thrustPercentage / 100f; }
+            set { InternalRCS.thrustPercentage = (value * 100f).Clamp (0f, 100f); }
         }
 
         /// <summary>
@@ -346,7 +358,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         [KRPCProperty]
         public IList<Thruster> Thrusters {
-            get { return Enumerable.Range (0, rcs.thrusterTransforms.Count).Select (i => new Thruster (Part, rcs, i)).ToList (); }
+            get { return Enumerable.Range (0, InternalRCS.thrusterTransforms.Count).Select (i => new Thruster (Part, InternalRCS, i)).ToList (); }
         }
 
         /// <summary>
@@ -355,7 +367,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         [KRPCProperty]
         public float SpecificImpulse {
-            get { return rcs.realISP; }
+            get { return InternalRCS.realISP; }
         }
 
         /// <summary>
@@ -363,7 +375,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         [KRPCProperty (GameScene = GameScene.Flight | GameScene.Editor)]
         public float VacuumSpecificImpulse {
-            get { return rcs.atmosphereCurve.Evaluate (0); }
+            get { return InternalRCS.atmosphereCurve.Evaluate (0); }
         }
 
         /// <summary>
@@ -371,7 +383,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         [KRPCProperty (GameScene = GameScene.Flight | GameScene.Editor)]
         public float KerbinSeaLevelSpecificImpulse {
-            get { return rcs.atmosphereCurve.Evaluate (1); }
+            get { return InternalRCS.atmosphereCurve.Evaluate (1); }
         }
 
         /// <summary>
@@ -380,8 +392,8 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         void UpdateConnectedResources()
         {
-            foreach (var propellant in rcs.propellants)
-                propellant.UpdateConnectedResources(rcs.part);
+            foreach (var propellant in InternalRCS.propellants)
+                propellant.UpdateConnectedResources(InternalRCS.part);
         }
 
         /// <summary>
@@ -389,7 +401,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         [KRPCProperty (GameScene = GameScene.Flight | GameScene.Editor)]
         public IList<string> Propellants {
-            get { return rcs.propellants.Select (x => x.name).ToList (); }
+            get { return InternalRCS.propellants.Select (x => x.name).ToList (); }
         }
 
         /// <summary>
@@ -401,8 +413,8 @@ namespace KRPC.SpaceCenter.Services.Parts
             get
             {
                 UpdateConnectedResources();
-                var max = rcs.propellants.Max (p => p.ratio);
-                return rcs.propellants.ToDictionary (p => p.name, p => p.ratio / max);
+                var max = InternalRCS.propellants.Max (p => p.ratio);
+                return InternalRCS.propellants.ToDictionary (p => p.name, p => p.ratio / max);
             }
         }
 
@@ -414,7 +426,7 @@ namespace KRPC.SpaceCenter.Services.Parts
             get
             {
                 UpdateConnectedResources();
-                foreach (var propellant in rcs.propellants)
+                foreach (var propellant in InternalRCS.propellants)
                     if (propellant.actualTotalAvailable < 0.001)
                         return false;
                 return true;

--- a/service/SpaceCenter/src/Services/Parts/Radiator.cs
+++ b/service/SpaceCenter/src/Services/Parts/Radiator.cs
@@ -10,10 +10,10 @@ namespace KRPC.SpaceCenter.Services.Parts
     /// A radiator. Obtained by calling <see cref="Part.Radiator"/>.
     /// </summary>
     [KRPCClass (Service = "SpaceCenter", GameScene = GameScene.Flight)]
-    public class Radiator : Equatable<Radiator>
+    public class Radiator : Equatable<Radiator>, IGameObjectState
     {
-        readonly ModuleActiveRadiator activeRadiator;
-        readonly ModuleDeployableRadiator deployableRadiator;
+        ModuleRef activeRadiatorRef;
+        ModuleRef deployableRadiatorRef;
 
         internal static bool Is (Part part)
         {
@@ -27,10 +27,28 @@ namespace KRPC.SpaceCenter.Services.Parts
         {
             Part = part;
             var internalPart = part.InternalPart;
-            activeRadiator = internalPart.Module<ModuleActiveRadiator> ();
-            deployableRadiator = internalPart.Module<ModuleDeployableRadiator> ();
-            if (activeRadiator == null && deployableRadiator == null)
+            activeRadiatorRef = ModuleRef.ForType<ModuleActiveRadiator> (internalPart);
+            deployableRadiatorRef = ModuleRef.ForType<ModuleDeployableRadiator> (internalPart);
+            if (activeRadiatorRef.Find (internalPart) == null &&
+                deployableRadiatorRef.Find (internalPart) == null)
                 throw new ArgumentException ("Part is not a radiator");
+        }
+
+        ModuleActiveRadiator InternalActiveRadiator {
+            get { return (ModuleActiveRadiator)activeRadiatorRef.Find (Part.InternalPart); }
+        }
+
+        ModuleDeployableRadiator InternalDeployableRadiator {
+            get { return (ModuleDeployableRadiator)deployableRadiatorRef.Find (Part.InternalPart); }
+        }
+
+        /// <summary>
+        /// What the game holds for the radiator. A part carries an active radiator
+        /// module, a deployable one, or both, and either is enough for the radiator, so
+        /// it is as alive as the more alive of them.
+        /// </summary>
+        public GameObjectState GameObjectState {
+            get { return activeRadiatorRef.StateOn (Part).MostAlive (deployableRadiatorRef.StateOn (Part)); }
         }
 
         /// <summary>
@@ -41,8 +59,8 @@ namespace KRPC.SpaceCenter.Services.Parts
             return
             !ReferenceEquals (other, null) &&
             Part == other.Part &&
-            activeRadiator == other.activeRadiator &&
-            deployableRadiator == other.deployableRadiator;
+            activeRadiatorRef == other.activeRadiatorRef &&
+            deployableRadiatorRef == other.deployableRadiatorRef;
         }
 
         /// <summary>
@@ -50,12 +68,10 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         public override int GetHashCode ()
         {
-            int hash = Part.GetHashCode ();
-            if (activeRadiator != null)
-                hash ^= activeRadiator.GetHashCode ();
-            if (deployableRadiator != null)
-                hash ^= deployableRadiator.GetHashCode ();
-            return hash;
+            return
+            Part.GetHashCode () ^
+            activeRadiatorRef.GetHashCode () ^
+            deployableRadiatorRef.GetHashCode ();
         }
 
         /// <summary>
@@ -69,7 +85,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         [KRPCProperty (GameScene = GameScene.Flight | GameScene.Editor)]
         public bool Deployable {
-            get { return deployableRadiator != null; }
+            get { return InternalDeployableRadiator != null; }
         }
 
         /// <summary>
@@ -81,16 +97,16 @@ namespace KRPC.SpaceCenter.Services.Parts
             get {
                 return
                 !Deployable ||
-                deployableRadiator.deployState == ModuleDeployablePart.DeployState.EXTENDED ||
-                deployableRadiator.deployState == ModuleDeployablePart.DeployState.EXTENDING;
+                InternalDeployableRadiator.deployState == ModuleDeployablePart.DeployState.EXTENDED ||
+                InternalDeployableRadiator.deployState == ModuleDeployablePart.DeployState.EXTENDING;
             }
             set {
                 if (!Deployable)
                     throw new InvalidOperationException ("Radiator is not deployable");
                 if (value)
-                    deployableRadiator.Extend ();
+                    InternalDeployableRadiator.Extend ();
                 else
-                    deployableRadiator.Retract ();
+                    InternalDeployableRadiator.Retract ();
             }
         }
 
@@ -105,7 +121,7 @@ namespace KRPC.SpaceCenter.Services.Parts
             get {
                 if (!Deployable)
                     return DeployableState.Deployed;
-                return deployableRadiator.deployState.ToDeployableState ();
+                return InternalDeployableRadiator.deployState.ToDeployableState ();
             }
         }
     }

--- a/service/SpaceCenter/src/Services/Parts/ReactionWheel.cs
+++ b/service/SpaceCenter/src/Services/Parts/ReactionWheel.cs
@@ -13,9 +13,9 @@ namespace KRPC.SpaceCenter.Services.Parts
     /// A reaction wheel. Obtained by calling <see cref="Part.ReactionWheel"/>.
     /// </summary>
     [KRPCClass (Service = "SpaceCenter", GameScene = GameScene.Flight)]
-    public class ReactionWheel : Equatable<ReactionWheel>
+    public class ReactionWheel : Equatable<ReactionWheel>, IGameObjectState
     {
-        readonly ModuleReactionWheel reactionWheel;
+        ModuleRef reactionWheelRef;
 
         internal static bool Is (Part part)
         {
@@ -30,9 +30,21 @@ namespace KRPC.SpaceCenter.Services.Parts
         internal ReactionWheel (Part part)
         {
             Part = part;
-            reactionWheel = part.InternalPart.Module<ModuleReactionWheel> ();
-            if (reactionWheel == null)
+            reactionWheelRef = ModuleRef.ForType<ModuleReactionWheel> (part.InternalPart);
+            if (reactionWheelRef.Find (part.InternalPart) == null)
                 throw new ArgumentException ("Part is not a reaction wheel");
+        }
+
+        ModuleReactionWheel InternalReactionWheel {
+            get { return (ModuleReactionWheel)reactionWheelRef.Get (Part.InternalPart); }
+        }
+
+        /// <summary>
+        /// What the game holds for the reaction wheel: the state of the part
+        /// carrying it, or destroyed once that part no longer has the module.
+        /// </summary>
+        public GameObjectState GameObjectState {
+            get { return reactionWheelRef.StateOn (Part); }
         }
 
         /// <summary>
@@ -40,7 +52,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         public override bool Equals (ReactionWheel other)
         {
-            return !ReferenceEquals (other, null) && Part == other.Part && reactionWheel == other.reactionWheel;
+            return !ReferenceEquals (other, null) && Part == other.Part && reactionWheelRef == other.reactionWheelRef;
         }
 
         /// <summary>
@@ -48,7 +60,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         public override int GetHashCode ()
         {
-            return Part.GetHashCode () ^ reactionWheel.GetHashCode ();
+            return Part.GetHashCode () ^ reactionWheelRef.GetHashCode ();
         }
 
         /// <summary>
@@ -62,11 +74,11 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         [KRPCProperty]
         public bool Active {
-            get { return reactionWheel.State == ModuleReactionWheel.WheelState.Active; }
+            get { return InternalReactionWheel.State == ModuleReactionWheel.WheelState.Active; }
             set {
                 var active = Active;
                 if ((value && !active) || (!value && active))
-                    reactionWheel.Toggle (new KSPActionParam (KSPActionGroup.None, KSPActionType.Activate));
+                    InternalReactionWheel.Toggle (new KSPActionParam (KSPActionGroup.None, KSPActionType.Activate));
             }
         }
 
@@ -75,7 +87,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         [KRPCProperty]
         public bool Broken {
-            get { return reactionWheel.State == ModuleReactionWheel.WheelState.Broken; }
+            get { return InternalReactionWheel.State == ModuleReactionWheel.WheelState.Broken; }
         }
 
         /// <summary>
@@ -84,8 +96,8 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         [KRPCProperty (GameScene = GameScene.Flight | GameScene.Editor)]
         public float AuthorityLimiter {
-            get { return reactionWheel.authorityLimiter / 100f; }
-            set { reactionWheel.authorityLimiter = (value * 100f).Clamp (0f, 100f); }
+            get { return InternalReactionWheel.authorityLimiter / 100f; }
+            set { InternalReactionWheel.authorityLimiter = (value * 100f).Clamp (0f, 100f); }
         }
 
         /// <summary>
@@ -116,6 +128,7 @@ namespace KRPC.SpaceCenter.Services.Parts
                 // varies between the stock module and modded replacements of it. The
                 // conditions under which the wheel produces no torque match the stock ones:
                 // the module must be enabled and active, and actuator mode 2 disables it.
+                var reactionWheel = InternalReactionWheel;
                 if (!reactionWheel.moduleIsEnabled || !Active || reactionWheel.actuatorModeCycle == 2)
                     return ITorqueProviderExtensions.zero;
                 var torque = MaxTorqueVectors.Item1 * (reactionWheel.authorityLimiter / 100.0);
@@ -125,7 +138,7 @@ namespace KRPC.SpaceCenter.Services.Parts
 
         internal TupleV3 MaxTorqueVectors {
             get {
-                var torque = new Vector3d (reactionWheel.PitchTorque, reactionWheel.RollTorque, reactionWheel.YawTorque) * 1000.0d;
+                var torque = new Vector3d (InternalReactionWheel.PitchTorque, InternalReactionWheel.RollTorque, InternalReactionWheel.YawTorque) * 1000.0d;
                 return new TupleV3 (torque, -torque);
             }
         }

--- a/service/SpaceCenter/src/Services/Parts/ResourceConverter.cs
+++ b/service/SpaceCenter/src/Services/Parts/ResourceConverter.cs
@@ -13,9 +13,11 @@ namespace KRPC.SpaceCenter.Services.Parts
     /// A resource converter. Obtained by calling <see cref="Part.ResourceConverter"/>.
     /// </summary>
     [KRPCClass (Service = "SpaceCenter", GameScene = GameScene.Flight)]
-    public class ResourceConverter: Equatable<ResourceConverter>
+    public class ResourceConverter: Equatable<ResourceConverter>, IGameObjectState
     {
-        readonly IList<ModuleResourceConverter> converters;
+        // One reference per converter the part has, in the order the part lists them, which
+        // is the order the index arguments of this class count in.
+        readonly ModuleRef[] converterRefs;
 
         internal static bool Is (Part part)
         {
@@ -25,9 +27,26 @@ namespace KRPC.SpaceCenter.Services.Parts
         internal ResourceConverter (Part part)
         {
             Part = part;
-            converters = part.InternalPart.Modules.OfType<ModuleResourceConverter> ().ToList ();
-            if (converters.Count == 0)
+            var internalPart = part.InternalPart;
+            var modules = internalPart.Modules.OfType<ModuleResourceConverter> ().ToList ();
+            if (modules.Count == 0)
                 throw new ArgumentException ("Part is does not contain any resource converters");
+            converterRefs = new ModuleRef [modules.Count];
+            for (var i = 0; i < modules.Count; i++)
+                converterRefs [i] = ModuleRef.ForModule (modules [i]);
+        }
+
+        ModuleResourceConverter Converter (int index)
+        {
+            return (ModuleResourceConverter)converterRefs [index].Get (Part.InternalPart);
+        }
+
+        /// <summary>
+        /// What the game holds for the converters: the state of the part carrying
+        /// them, or destroyed once that part no longer has them.
+        /// </summary>
+        public GameObjectState GameObjectState {
+            get { return converterRefs [0].StateOn (Part); }
         }
 
         /// <summary>
@@ -35,7 +54,8 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         public override bool Equals (ResourceConverter other)
         {
-            return !ReferenceEquals (other, null) && Part == other.Part && converters.SequenceEqual (other.converters);
+            return !ReferenceEquals (other, null) && Part == other.Part &&
+            converterRefs.SequenceEqual (other.converterRefs);
         }
 
         /// <summary>
@@ -44,7 +64,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         public override int GetHashCode ()
         {
             int hash = Part.GetHashCode ();
-            foreach (var converter in converters)
+            foreach (var converter in converterRefs)
                 hash ^= converter.GetHashCode ();
             return hash;
         }
@@ -60,7 +80,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         [KRPCProperty]
         public int Count {
-            get { return converters.Count; }
+            get { return converterRefs.Length; }
         }
 
         void CheckConverterExists (int index)
@@ -77,7 +97,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         public bool Active (int index)
         {
             CheckConverterExists (index);
-            return converters [index].IsActivated;
+            return Converter (index).IsActivated;
         }
 
         /// <summary>
@@ -88,7 +108,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         public string Name (int index)
         {
             CheckConverterExists (index);
-            return converters [index].ConverterName;
+            return Converter (index).ConverterName;
         }
 
         /// <summary>
@@ -99,7 +119,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         public void Start (int index)
         {
             CheckConverterExists (index);
-            converters [index].StartResourceConverter ();
+            Converter (index).StartResourceConverter ();
         }
 
         /// <summary>
@@ -110,7 +130,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         public void Stop (int index)
         {
             CheckConverterExists (index);
-            converters [index].StopResourceConverter ();
+            Converter (index).StopResourceConverter ();
         }
 
         /// <summary>
@@ -121,7 +141,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         public ResourceConverterState State (int index)
         {
             CheckConverterExists (index);
-            var converter = converters [index];
+            var converter = Converter (index);
             // Use IsActivated for the active/idle distinction rather than matching
             // the localized "Inactive" status string. A running converter reports
             // either "<x>% load" (while thermally throttled) or "Operational" (at
@@ -180,7 +200,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         public string StatusInfo (int index)
         {
             CheckConverterExists (index);
-            return converters [index].status;
+            return Converter (index).status;
         }
 
         /// <summary>
@@ -191,7 +211,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         public IList<string> Inputs (int index)
         {
             CheckConverterExists (index);
-            return converters [index].inputList.Select (x => x.ResourceName).ToList ();
+            return Converter (index).inputList.Select (x => x.ResourceName).ToList ();
         }
 
         /// <summary>
@@ -202,7 +222,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         public IList<string> Outputs (int index)
         {
             CheckConverterExists (index);
-            return converters [index].outputList.Select (x => x.ResourceName).ToList ();
+            return Converter (index).outputList.Select (x => x.ResourceName).ToList ();
         }
 
         /// <summary>
@@ -211,7 +231,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         [KRPCProperty]
         public float ThermalEfficiency {
             get {
-                var core = converters[0];
+                var core = Converter (0);
                 var temp = Convert.ToSingle(core.GetCoreTemperature());
                 return core.ThermalEfficiency.Evaluate(temp);
             }
@@ -222,7 +242,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         [KRPCProperty]
         public float CoreTemperature {
-            get { return (float)converters[0].GetCoreTemperature (); }
+            get { return (float)Converter (0).GetCoreTemperature (); }
         }
 
         /// <summary>
@@ -230,7 +250,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         [KRPCProperty]
         public float OptimumCoreTemperature {
-            get { return (float)converters[0].GetGoalTemperature (); }
+            get { return (float)Converter (0).GetGoalTemperature (); }
         }
     }
 }

--- a/service/SpaceCenter/src/Services/Parts/ResourceDrain.cs
+++ b/service/SpaceCenter/src/Services/Parts/ResourceDrain.cs
@@ -16,9 +16,9 @@ namespace KRPC.SpaceCenter.Services.Parts
     /// A resource drain. Obtained by calling <see cref="Part.ResourceDrain"/>.
     /// </summary>
     [KRPCClass(Service = "SpaceCenter", GameScene = GameScene.Flight)]
-    public class ResourceDrain : Equatable<ResourceDrain>
+    public class ResourceDrain : Equatable<ResourceDrain>, IGameObjectState
     {
-        readonly ModuleResourceDrain drain;
+        ModuleRef drainRef;
 
         internal static bool Is(Part part)
         {
@@ -31,7 +31,19 @@ namespace KRPC.SpaceCenter.Services.Parts
                 throw new ArgumentException ("Part is not a resource drain");
             Part = part;
             var internalPart = part.InternalPart;
-            drain = internalPart.Module<ModuleResourceDrain>();
+            drainRef = ModuleRef.ForType<ModuleResourceDrain> (internalPart);
+        }
+
+        ModuleResourceDrain InternalDrain {
+            get { return (ModuleResourceDrain)drainRef.Get (Part.InternalPart); }
+        }
+
+        /// <summary>
+        /// What the game holds for the resource drain: the state of the part
+        /// carrying it, or destroyed once that part no longer has the module.
+        /// </summary>
+        public GameObjectState GameObjectState {
+            get { return drainRef.StateOn (Part); }
         }
 
         /// <summary>
@@ -39,7 +51,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         public override bool Equals(ResourceDrain other)
         {
-            return !ReferenceEquals(other, null) && Part == other.Part && drain == other.drain;
+            return !ReferenceEquals(other, null) && Part == other.Part && drainRef == other.drainRef;
         }
 
         /// <summary>
@@ -47,7 +59,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         public override int GetHashCode()
         {
-            return Part.GetHashCode() ^ drain.GetHashCode();
+            return Part.GetHashCode() ^ drainRef.GetHashCode();
         }
 
         /// <summary>
@@ -62,7 +74,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         [KRPCProperty]
         public List<Resource> AvailableResources
         {
-            get { return drain.resourcesAvailable.Select(x => new Resource(x)).ToList(); }
+            get { return InternalDrain.resourcesAvailable.Select(x => new Resource(x)).ToList(); }
         }
 
         /// <summary>
@@ -71,7 +83,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         [KRPCMethod]
         public void SetResource(Resource resource, bool enabled)
         {
-            drain.TogglePartResource(resource.InternalResource, enabled);
+            InternalDrain.TogglePartResource(resource.InternalResource, enabled);
         }
 
         /// <summary>
@@ -80,7 +92,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         [KRPCMethod]
         public bool CheckResource(Resource resource)
         {
-            return drain.IsResourceDraining(resource.InternalResource);
+            return InternalDrain.IsResourceDraining(resource.InternalResource);
         }
 
         /// <summary>
@@ -89,29 +101,29 @@ namespace KRPC.SpaceCenter.Services.Parts
         [KRPCProperty]
         public DrainMode DrainMode
         {
-            get { return drain.flowMode ? DrainMode.Vessel : DrainMode.Part; }
-            set { drain.flowMode = (value == DrainMode.Vessel); }
+            get { return InternalDrain.flowMode ? DrainMode.Vessel : DrainMode.Part; }
+            set { InternalDrain.flowMode = (value == DrainMode.Vessel); }
         }
 
         /// <summary>
         /// Maximum possible drain rate.
         /// </summary>
         [KRPCProperty]
-        public float MaxRate { get { return drain.maxDrainRate; } }
+        public float MaxRate { get { return InternalDrain.maxDrainRate; } }
 
         /// <summary>
         /// Minimum possible drain rate
         /// </summary>
         [KRPCProperty]
-        public float MinRate { get { return drain.minDrainRate; } }
+        public float MinRate { get { return InternalDrain.minDrainRate; } }
 
         /// <summary>
         /// Current drain rate.
         /// </summary>
         [KRPCProperty]
         public float Rate {
-            get { return drain.drainRate; }
-            set { drain.drainRate = value; }
+            get { return InternalDrain.drainRate; }
+            set { InternalDrain.drainRate = value; }
         }
 
         /// <summary>
@@ -120,7 +132,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         [KRPCMethod]
         public void Start()
         {
-            drain.TurnOnDrain();
+            InternalDrain.TurnOnDrain();
         }
 
         /// <summary>
@@ -129,7 +141,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         [KRPCMethod]
         public void Stop()
         {
-            drain.TurnOffDrain();
+            InternalDrain.TurnOffDrain();
         }
     }
 }

--- a/service/SpaceCenter/src/Services/Parts/ResourceHarvester.cs
+++ b/service/SpaceCenter/src/Services/Parts/ResourceHarvester.cs
@@ -11,10 +11,10 @@ namespace KRPC.SpaceCenter.Services.Parts
     /// A resource harvester (drill). Obtained by calling <see cref="Part.ResourceHarvester"/>.
     /// </summary>
     [KRPCClass (Service = "SpaceCenter", GameScene = GameScene.Flight)]
-    public class ResourceHarvester : Equatable<ResourceHarvester>
+    public class ResourceHarvester : Equatable<ResourceHarvester>, IGameObjectState
     {
-        readonly ModuleResourceHarvester harvester;
-        readonly ModuleAnimationGroup animator;
+        ModuleRef harvesterRef;
+        ModuleRef animatorRef;
 
         internal static bool Is (Part part)
         {
@@ -28,10 +28,26 @@ namespace KRPC.SpaceCenter.Services.Parts
         {
             Part = part;
             var internalPart = part.InternalPart;
-            harvester = internalPart.Module<ModuleResourceHarvester> ();
-            animator = internalPart.Module<ModuleAnimationGroup> ();
-            if (harvester == null || animator == null)
+            harvesterRef = ModuleRef.ForType<ModuleResourceHarvester> (internalPart);
+            animatorRef = ModuleRef.ForType<ModuleAnimationGroup> (internalPart);
+            if (harvesterRef.Find (internalPart) == null || animatorRef.Find (internalPart) == null)
                 throw new ArgumentException ("Part is not a resource harvester");
+        }
+
+        ModuleResourceHarvester InternalHarvester {
+            get { return (ModuleResourceHarvester)harvesterRef.Get (Part.InternalPart); }
+        }
+
+        ModuleAnimationGroup InternalAnimator {
+            get { return (ModuleAnimationGroup)animatorRef.Get (Part.InternalPart); }
+        }
+
+        /// <summary>
+        /// What the game holds for the resource harvester: the state of the part
+        /// carrying it, or destroyed once that part no longer has the module.
+        /// </summary>
+        public GameObjectState GameObjectState {
+            get { return harvesterRef.StateOn (Part); }
         }
 
         /// <summary>
@@ -42,7 +58,7 @@ namespace KRPC.SpaceCenter.Services.Parts
             return
             !ReferenceEquals (other, null) &&
             Part == other.Part &&
-            (harvester == other.harvester || harvester.Equals (other.harvester));
+            harvesterRef == other.harvesterRef;
         }
 
         /// <summary>
@@ -50,7 +66,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         public override int GetHashCode ()
         {
-            return Part.GetHashCode () ^ harvester.GetHashCode ();
+            return Part.GetHashCode () ^ harvesterRef.GetHashCode ();
         }
 
         /// <summary>
@@ -73,14 +89,14 @@ namespace KRPC.SpaceCenter.Services.Parts
                 // An activated harvester is necessarily fully deployed. This has to be
                 // checked first, as the drill keeps animating while it is running and
                 // so the animation alone cannot tell operation from deployment.
-                if (harvester.IsActivated)
+                if (InternalHarvester.IsActivated)
                     return DeployableState.Deployed;
                 // ActiveAnimation can be null/destroyed (e.g. while the vessel is
                 // packed); guard it so the state can still be reported.
-                var animation = animator.ActiveAnimation;
+                var animation = InternalAnimator.ActiveAnimation;
                 if (animation != null && animation.isPlaying)
-                    return animator.isDeployed ? DeployableState.Deploying : DeployableState.Retracting;
-                return animator.isDeployed ? DeployableState.Deployed : DeployableState.Retracted;
+                    return InternalAnimator.isDeployed ? DeployableState.Deploying : DeployableState.Retracting;
+                return InternalAnimator.isDeployed ? DeployableState.Deployed : DeployableState.Retracted;
             }
         }
 
@@ -91,10 +107,10 @@ namespace KRPC.SpaceCenter.Services.Parts
         public bool Deployed {
             get { return State == DeployableState.Deployed; }
             set {
-                if (value && !animator.isDeployed)
-                    animator.DeployModule ();
-                if (!value && animator.isDeployed)
-                    animator.RetractModule ();
+                if (value && !InternalAnimator.isDeployed)
+                    InternalAnimator.DeployModule ();
+                if (!value && InternalAnimator.isDeployed)
+                    InternalAnimator.RetractModule ();
             }
         }
 
@@ -110,21 +126,21 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </remarks>
         [KRPCProperty]
         public bool Active {
-            get { return harvester.IsActivated; }
+            get { return InternalHarvester.IsActivated; }
             set {
                 if (!Deployed) {
                     // The converter cannot start until the deploy animation has
                     // finished; defer the requested state until then rather than
                     // silently dropping it.
                     if (State == DeployableState.Deploying)
-                        ResourceHarvesterAddon.Request (harvester, animator, value);
+                        ResourceHarvesterAddon.Request (InternalHarvester, InternalAnimator, value);
                     return;
                 }
-                ResourceHarvesterAddon.Cancel (harvester);
-                if (value && !harvester.IsActivated)
-                    harvester.StartResourceConverter ();
-                if (!value && harvester.IsActivated)
-                    harvester.StopResourceConverter ();
+                ResourceHarvesterAddon.Cancel (InternalHarvester);
+                if (value && !InternalHarvester.IsActivated)
+                    InternalHarvester.StartResourceConverter ();
+                if (!value && InternalHarvester.IsActivated)
+                    InternalHarvester.StopResourceConverter ();
             }
         }
 
@@ -139,7 +155,7 @@ namespace KRPC.SpaceCenter.Services.Parts
             get {
                 if (!Active)
                     return 0;
-                return Convert.ToSingle (resFlowField.GetValue (harvester));
+                return Convert.ToSingle (resFlowField.GetValue (InternalHarvester));
             }
         }
 
@@ -156,8 +172,8 @@ namespace KRPC.SpaceCenter.Services.Parts
                 // harvester's "status" string is not used: a drill never reports a
                 // "<x>% load" status, and its "Ore rate" readout is only populated
                 // while the part's right-click window is open.
-                var temp = Convert.ToSingle (harvester.GetCoreTemperature ());
-                return harvester.ThermalEfficiency.Evaluate (temp);
+                var temp = Convert.ToSingle (InternalHarvester.GetCoreTemperature ());
+                return InternalHarvester.ThermalEfficiency.Evaluate (temp);
             }
         }
 
@@ -166,7 +182,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         [KRPCProperty]
         public float CoreTemperature {
-            get { return (float)harvester.GetCoreTemperature (); }
+            get { return (float)InternalHarvester.GetCoreTemperature (); }
         }
 
         /// <summary>
@@ -174,7 +190,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         [KRPCProperty]
         public float OptimumCoreTemperature {
-            get { return (float)harvester.GetGoalTemperature (); }
+            get { return (float)InternalHarvester.GetGoalTemperature (); }
         }
     }
 }

--- a/service/SpaceCenter/src/Services/Parts/RoboticController.cs
+++ b/service/SpaceCenter/src/Services/Parts/RoboticController.cs
@@ -12,9 +12,9 @@ namespace KRPC.SpaceCenter.Services.Parts
     /// A robotic controller. Obtained by calling <see cref="Part.RoboticController"/>.
     /// </summary>
     [KRPCClass(Service = "SpaceCenter", GameScene = GameScene.Flight)]
-    public class RoboticController : Equatable<RoboticController>
+    public class RoboticController : Equatable<RoboticController>, IGameObjectState
     {
-        readonly Expansions.Serenity.ModuleRoboticController controller;
+        ModuleRef controllerRef;
 
         internal static bool Is(Part part)
         {
@@ -27,7 +27,19 @@ namespace KRPC.SpaceCenter.Services.Parts
                 throw new ArgumentException("Part is not a robotics controller");
             Part = part;
             var internalPart = part.InternalPart;
-            controller = internalPart.Module<Expansions.Serenity.ModuleRoboticController>();
+            controllerRef = ModuleRef.ForType<Expansions.Serenity.ModuleRoboticController> (internalPart);
+        }
+
+        Expansions.Serenity.ModuleRoboticController InternalController {
+            get { return (Expansions.Serenity.ModuleRoboticController)controllerRef.Get (Part.InternalPart); }
+        }
+
+        /// <summary>
+        /// What the game holds for the robotic controller: the state of the part
+        /// carrying it, or destroyed once that part no longer has the module.
+        /// </summary>
+        public GameObjectState GameObjectState {
+            get { return controllerRef.StateOn (Part); }
         }
 
         /// <summary>
@@ -35,7 +47,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         public override bool Equals(RoboticController other)
         {
-            return !ReferenceEquals(other, null) && Part == other.Part && controller.Equals(other.controller);
+            return !ReferenceEquals(other, null) && Part == other.Part && controllerRef == other.controllerRef;
         }
 
         /// <summary>
@@ -43,7 +55,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         public override int GetHashCode()
         {
-            return Part.GetHashCode() ^ controller.GetHashCode();
+            return Part.GetHashCode() ^ controllerRef.GetHashCode();
         }
 
         /// <summary>
@@ -58,8 +70,8 @@ namespace KRPC.SpaceCenter.Services.Parts
         [KRPCProperty]
         public bool Enabled
         {
-            get { return controller.controllerEnabled; }
-            set { controller.controllerEnabled = value; }
+            get { return InternalController.controllerEnabled; }
+            set { InternalController.controllerEnabled = value; }
         }
 
         /// <summary>
@@ -68,7 +80,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         [KRPCProperty]
         public bool Playing
         {
-            get { return controller.SequenceIsPlaying; }
+            get { return InternalController.SequenceIsPlaying; }
         }
 
         /// <summary>
@@ -77,8 +89,8 @@ namespace KRPC.SpaceCenter.Services.Parts
         [KRPCProperty]
         public float Position
         {
-            get { return controller.SequencePosition; }
-            set { controller.SetSequencePosition(value); }
+            get { return InternalController.SequencePosition; }
+            set { InternalController.SetSequencePosition(value); }
         }
 
         /// <summary>
@@ -87,7 +99,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         [KRPCProperty]
         public float Length
         {
-            get { return controller.SequenceLength; }
+            get { return InternalController.SequenceLength; }
         }
 
         /// <summary>
@@ -96,7 +108,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         [KRPCProperty]
         public float PlaySpeed
         {
-            get { return controller.SequencePlaySpeed; }
+            get { return InternalController.SequencePlaySpeed; }
         }
 
         /// <summary>
@@ -105,7 +117,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         [KRPCMethod]
         public void Play()
         {
-            controller.SequencePlay();
+            InternalController.SequencePlay();
         }
 
         /// <summary>
@@ -114,7 +126,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         [KRPCMethod]
         public void Stop()
         {
-            controller.SequenceStop();
+            InternalController.SequenceStop();
         }
 
         /// <summary>
@@ -123,7 +135,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         [KRPCMethod]
         public bool HasPart(Part part)
         {
-            return controller.HasPart(part.InternalPart);
+            return InternalController.HasPart(part.InternalPart);
         }
 
         /// <summary>
@@ -133,7 +145,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         public IList<IList<string>> Axes()
         {
             var output = new List<IList<string>>();
-            foreach (var axis in controller.ControlledAxes)
+            foreach (var axis in InternalController.ControlledAxes)
             {
                 output.Add(new List<string>() { axis.Part.name, axis.AxisField.name });
             }
@@ -155,7 +167,7 @@ namespace KRPC.SpaceCenter.Services.Parts
             var axisField = internalModule.Fields[fieldName] as BaseAxisField;
             if (axisField == null)
                 return false;
-            controller.AddPartAxis(internalPart, internalModule, axisField);
+            InternalController.AddPartAxis(internalPart, internalModule, axisField);
             return true;
         }
 
@@ -174,12 +186,12 @@ namespace KRPC.SpaceCenter.Services.Parts
             var internalPart = module.Part.InternalPart;
             var internalModule = internalPart.Modules[module.Name];
 
-            foreach (var axis in controller.ControlledAxes)
+            foreach (var axis in InternalController.ControlledAxes)
             {
                 if (internalModule == axis.Module && fieldName == axis.AxisField.name)
                 {
                     Expansions.Serenity.ControlledAxis outAxis;
-                    controller.TryGetPartAxisField(axis.Part, axis.AxisField, out outAxis);
+                    InternalController.TryGetPartAxisField(axis.Part, axis.AxisField, out outAxis);
                     if (outAxis != null)
                     {
                         outAxis.timeValue.Curve.AddKey(time, value);
@@ -204,12 +216,12 @@ namespace KRPC.SpaceCenter.Services.Parts
             var internalPart = module.Part.InternalPart;
             var internalModule = internalPart.Modules[module.Name];
 
-            foreach (var axis in controller.ControlledAxes)
+            foreach (var axis in InternalController.ControlledAxes)
             {
                 if (internalModule == axis.Module && fieldName == axis.AxisField.name)
                 {
                     Expansions.Serenity.ControlledAxis outAxis;
-                    controller.TryGetPartAxisField(axis.Part, axis.AxisField, out outAxis);
+                    InternalController.TryGetPartAxisField(axis.Part, axis.AxisField, out outAxis);
                     if (outAxis != null)
                     {
                         while (outAxis.timeValue.Curve.keys.Length > 0)

--- a/service/SpaceCenter/src/Services/Parts/RoboticHinge.cs
+++ b/service/SpaceCenter/src/Services/Parts/RoboticHinge.cs
@@ -13,9 +13,9 @@ namespace KRPC.SpaceCenter.Services.Parts
     /// A robotic hinge. Obtained by calling <see cref="Part.RoboticHinge"/>.
     /// </summary>
     [KRPCClass(Service = "SpaceCenter", GameScene = GameScene.Flight)]
-    public class RoboticHinge : Equatable<RoboticHinge>
+    public class RoboticHinge : Equatable<RoboticHinge>, IGameObjectState
     {
-        readonly ModuleRoboticServoHinge servo;
+        ModuleRef servoRef;
 
         internal static bool Is(Part part)
         {
@@ -28,7 +28,19 @@ namespace KRPC.SpaceCenter.Services.Parts
                 throw new ArgumentException("Part is not a robotic hinge");
             Part = part;
             var internalPart = part.InternalPart;
-            servo = internalPart.Module<ModuleRoboticServoHinge>();
+            servoRef = ModuleRef.ForType<ModuleRoboticServoHinge> (internalPart);
+        }
+
+        ModuleRoboticServoHinge InternalServo {
+            get { return (ModuleRoboticServoHinge)servoRef.Get (Part.InternalPart); }
+        }
+
+        /// <summary>
+        /// What the game holds for the hinge servo: the state of the part
+        /// carrying it, or destroyed once that part no longer has the module.
+        /// </summary>
+        public GameObjectState GameObjectState {
+            get { return servoRef.StateOn (Part); }
         }
 
         /// <summary>
@@ -36,7 +48,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         public override bool Equals(RoboticHinge other)
         {
-            return !ReferenceEquals(other, null) && Part == other.Part && servo.Equals(other.servo);
+            return !ReferenceEquals(other, null) && Part == other.Part && servoRef == other.servoRef;
         }
 
         /// <summary>
@@ -44,7 +56,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         public override int GetHashCode()
         {
-            return Part.GetHashCode() ^ servo.GetHashCode();
+            return Part.GetHashCode() ^ servoRef.GetHashCode();
         }
 
         /// <summary>
@@ -58,8 +70,8 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         [KRPCProperty]
         public float TargetAngle {
-            get { return servo.targetAngle; }
-            set { servo.targetAngle = value; }
+            get { return InternalServo.targetAngle; }
+            set { InternalServo.targetAngle = value; }
         }
 
         /// <summary>
@@ -70,9 +82,9 @@ namespace KRPC.SpaceCenter.Services.Parts
         {
             get
             {
-                return servo.modelInitialAngle + (float)typeof(ModuleRoboticServoHinge)
+                return InternalServo.modelInitialAngle + (float)typeof(ModuleRoboticServoHinge)
                     .GetMethod("currentTransformAngle", BindingFlags.Instance | BindingFlags.NonPublic)
-                    .Invoke(servo, null);
+                    .Invoke(InternalServo, null);
             }
         }
 
@@ -82,8 +94,8 @@ namespace KRPC.SpaceCenter.Services.Parts
         [KRPCProperty]
         public float MinAngle
         {
-            get { return servo.softMinMaxAngles.x; }
-            set { servo.SetSoftLimits("targetAngle", new Vector2(value, servo.softMinMaxAngles.y)); }
+            get { return InternalServo.softMinMaxAngles.x; }
+            set { InternalServo.SetSoftLimits("targetAngle", new Vector2(value, InternalServo.softMinMaxAngles.y)); }
         }
 
         /// <summary>
@@ -92,8 +104,8 @@ namespace KRPC.SpaceCenter.Services.Parts
         [KRPCProperty]
         public float MaxAngle
         {
-            get { return servo.softMinMaxAngles.y; }
-            set { servo.SetSoftLimits("targetAngle", new Vector2(servo.softMinMaxAngles.x, value)); }
+            get { return InternalServo.softMinMaxAngles.y; }
+            set { InternalServo.SetSoftLimits("targetAngle", new Vector2(InternalServo.softMinMaxAngles.x, value)); }
         }
 
         /// <summary>
@@ -102,8 +114,8 @@ namespace KRPC.SpaceCenter.Services.Parts
         [KRPCProperty]
         public float Rate
         {
-            get { return servo.traverseVelocity; }
-            set { servo.traverseVelocity = value; }
+            get { return InternalServo.traverseVelocity; }
+            set { InternalServo.traverseVelocity = value; }
         }
 
         /// <summary>
@@ -112,8 +124,8 @@ namespace KRPC.SpaceCenter.Services.Parts
         [KRPCProperty]
         public float Damping
         {
-            get { return servo.hingeDamping; }
-            set { servo.hingeDamping = value; }
+            get { return InternalServo.hingeDamping; }
+            set { InternalServo.hingeDamping = value; }
         }
 
         /// <summary>
@@ -122,12 +134,12 @@ namespace KRPC.SpaceCenter.Services.Parts
         [KRPCProperty]
         public bool Locked
         {
-            get { return servo.servoIsLocked; }
+            get { return InternalServo.servoIsLocked; }
             set {
                 if (value == true)
-                    servo.EngageServoLock();
+                    InternalServo.EngageServoLock();
                 else
-                    servo.DisengageServoLock();
+                    InternalServo.DisengageServoLock();
             }
         }
 
@@ -137,13 +149,13 @@ namespace KRPC.SpaceCenter.Services.Parts
         [KRPCProperty]
         public bool MotorEngaged
         {
-            get { return servo.servoMotorIsEngaged; }
+            get { return InternalServo.servoMotorIsEngaged; }
             set
             {
                 if (value == true)
-                    servo.EngageMotor();
+                    InternalServo.EngageMotor();
                 else
-                    servo.DisengageMotor();
+                    InternalServo.DisengageMotor();
             }
         }
 
@@ -157,7 +169,7 @@ namespace KRPC.SpaceCenter.Services.Parts
             {
                 return (bool)typeof(BaseServo)
                     .GetMethod("IsMoving", BindingFlags.Instance | BindingFlags.NonPublic)
-                    .Invoke(servo, null);
+                    .Invoke(InternalServo, null);
             }
         }
 
@@ -167,7 +179,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         [KRPCMethod]
         public void MoveHome()
         {
-            servo.targetAngle = servo.modelInitialAngle;
+            InternalServo.targetAngle = InternalServo.modelInitialAngle;
         }
     }
 }

--- a/service/SpaceCenter/src/Services/Parts/RoboticPiston.cs
+++ b/service/SpaceCenter/src/Services/Parts/RoboticPiston.cs
@@ -13,9 +13,9 @@ namespace KRPC.SpaceCenter.Services.Parts
     /// A robotic piston part. Obtained by calling <see cref="Part.RoboticPiston"/>.
     /// </summary>
     [KRPCClass(Service = "SpaceCenter", GameScene = GameScene.Flight)]
-    public class RoboticPiston : Equatable<RoboticPiston>
+    public class RoboticPiston : Equatable<RoboticPiston>, IGameObjectState
     {
-        readonly ModuleRoboticServoPiston servo;
+        ModuleRef servoRef;
 
         internal static bool Is(Part part)
         {
@@ -28,7 +28,19 @@ namespace KRPC.SpaceCenter.Services.Parts
                 throw new ArgumentException("Part is not a robotic piston");
             Part = part;
             var internalPart = part.InternalPart;
-            servo = internalPart.Module<ModuleRoboticServoPiston>();
+            servoRef = ModuleRef.ForType<ModuleRoboticServoPiston> (internalPart);
+        }
+
+        ModuleRoboticServoPiston InternalServo {
+            get { return (ModuleRoboticServoPiston)servoRef.Get (Part.InternalPart); }
+        }
+
+        /// <summary>
+        /// What the game holds for the piston servo: the state of the part
+        /// carrying it, or destroyed once that part no longer has the module.
+        /// </summary>
+        public GameObjectState GameObjectState {
+            get { return servoRef.StateOn (Part); }
         }
 
         /// <summary>
@@ -36,7 +48,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         public override bool Equals(RoboticPiston other)
         {
-            return !ReferenceEquals(other, null) && Part == other.Part && servo.Equals(other.servo);
+            return !ReferenceEquals(other, null) && Part == other.Part && servoRef == other.servoRef;
         }
 
         /// <summary>
@@ -44,7 +56,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         public override int GetHashCode()
         {
-            return Part.GetHashCode() ^ servo.GetHashCode();
+            return Part.GetHashCode() ^ servoRef.GetHashCode();
         }
 
         /// <summary>
@@ -59,7 +71,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         [KRPCProperty]
         public float TargetExtension
         {
-            get { return servo.targetExtension; }
+            get { return InternalServo.targetExtension; }
             set { SetExtension(value); }
         }
 
@@ -69,7 +81,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         [KRPCProperty]
         public float CurrentExtension
         {
-            get { return servo.currentExtension; }
+            get { return InternalServo.currentExtension; }
         }
 
         /// <summary>
@@ -78,8 +90,8 @@ namespace KRPC.SpaceCenter.Services.Parts
         [KRPCProperty]
         public float MinExtension
         {
-            get { return servo.softMinMaxExtension.x; }
-            set { servo.SetSoftLimits("targetExtension", new Vector2(value, servo.softMinMaxExtension.y)); }
+            get { return InternalServo.softMinMaxExtension.x; }
+            set { InternalServo.SetSoftLimits("targetExtension", new Vector2(value, InternalServo.softMinMaxExtension.y)); }
         }
 
         /// <summary>
@@ -88,8 +100,8 @@ namespace KRPC.SpaceCenter.Services.Parts
         [KRPCProperty]
         public float MaxExtension
         {
-            get { return servo.softMinMaxExtension.y; }
-            set { servo.SetSoftLimits("targetExtension", new Vector2(servo.softMinMaxExtension.x, value)); }
+            get { return InternalServo.softMinMaxExtension.y; }
+            set { InternalServo.SetSoftLimits("targetExtension", new Vector2(InternalServo.softMinMaxExtension.x, value)); }
         }
 
         /// <summary>
@@ -97,8 +109,8 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         [KRPCProperty]
         public float Rate {
-            get { return servo.traverseVelocity; }
-            set { servo.traverseVelocity = value; }
+            get { return InternalServo.traverseVelocity; }
+            set { InternalServo.traverseVelocity = value; }
         }
 
         /// <summary>
@@ -106,8 +118,8 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         [KRPCProperty]
         public float Damping {
-            get { return servo.pistonDamping; }
-            set { servo.pistonDamping = value; }
+            get { return InternalServo.pistonDamping; }
+            set { InternalServo.pistonDamping = value; }
         }
 
         /// <summary>
@@ -116,13 +128,13 @@ namespace KRPC.SpaceCenter.Services.Parts
         [KRPCProperty]
         public bool Locked
         {
-            get { return servo.servoIsLocked; }
+            get { return InternalServo.servoIsLocked; }
             set
             {
                 if (value == true)
-                    servo.EngageServoLock();
+                    InternalServo.EngageServoLock();
                 else
-                    servo.DisengageServoLock();
+                    InternalServo.DisengageServoLock();
             }
         }
 
@@ -132,13 +144,13 @@ namespace KRPC.SpaceCenter.Services.Parts
         [KRPCProperty]
         public bool MotorEngaged
         {
-            get { return servo.servoMotorIsEngaged; }
+            get { return InternalServo.servoMotorIsEngaged; }
             set
             {
                 if (value == true)
-                    servo.EngageMotor();
+                    InternalServo.EngageMotor();
                 else
-                    servo.DisengageMotor();
+                    InternalServo.DisengageMotor();
             }
         }
 
@@ -152,7 +164,7 @@ namespace KRPC.SpaceCenter.Services.Parts
             {
                 return (bool)typeof(BaseServo)
                     .GetMethod("IsMoving", BindingFlags.Instance | BindingFlags.NonPublic)
-                    .Invoke(servo, null);
+                    .Invoke(InternalServo, null);
             }
         }
 
@@ -162,13 +174,13 @@ namespace KRPC.SpaceCenter.Services.Parts
         [KRPCMethod]
         public void MoveHome()
         {
-            SetExtension(servo.launchPosition);
+            SetExtension(InternalServo.launchPosition);
         }
 
         private void SetExtension(float value)
         {
             BaseAxisField field = (BaseAxisField)typeof(ModuleRoboticServoPiston)
-                .GetField("targetExtensionAxisField", BindingFlags.Instance | BindingFlags.NonPublic).GetValue(servo);
+                .GetField("targetExtensionAxisField", BindingFlags.Instance | BindingFlags.NonPublic).GetValue(InternalServo);
             field.SetValue((float)value, field.module);
         }
     }

--- a/service/SpaceCenter/src/Services/Parts/RoboticRotation.cs
+++ b/service/SpaceCenter/src/Services/Parts/RoboticRotation.cs
@@ -13,9 +13,9 @@ namespace KRPC.SpaceCenter.Services.Parts
     /// A robotic rotation servo. Obtained by calling <see cref="Part.RoboticRotation"/>.
     /// </summary>
     [KRPCClass(Service = "SpaceCenter", GameScene = GameScene.Flight)]
-    public class RoboticRotation : Equatable<RoboticRotation>
+    public class RoboticRotation : Equatable<RoboticRotation>, IGameObjectState
     {
-        readonly ModuleRoboticRotationServo servo;
+        ModuleRef servoRef;
 
         internal static bool Is(Part part)
         {
@@ -28,7 +28,19 @@ namespace KRPC.SpaceCenter.Services.Parts
                 throw new ArgumentException("Part is not a robotic rotation servo");
             Part = part;
             var internalPart = part.InternalPart;
-            servo = internalPart.Module<ModuleRoboticRotationServo>();
+            servoRef = ModuleRef.ForType<ModuleRoboticRotationServo> (internalPart);
+        }
+
+        ModuleRoboticRotationServo InternalServo {
+            get { return (ModuleRoboticRotationServo)servoRef.Get (Part.InternalPart); }
+        }
+
+        /// <summary>
+        /// What the game holds for the rotation servo: the state of the part
+        /// carrying it, or destroyed once that part no longer has the module.
+        /// </summary>
+        public GameObjectState GameObjectState {
+            get { return servoRef.StateOn (Part); }
         }
 
         /// <summary>
@@ -36,7 +48,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         public override bool Equals(RoboticRotation other)
         {
-            return !ReferenceEquals(other, null) && Part == other.Part && servo.Equals(other.servo);
+            return !ReferenceEquals(other, null) && Part == other.Part && servoRef == other.servoRef;
         }
 
         /// <summary>
@@ -44,7 +56,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         public override int GetHashCode()
         {
-            return Part.GetHashCode() ^ servo.GetHashCode();
+            return Part.GetHashCode() ^ servoRef.GetHashCode();
         }
 
         /// <summary>
@@ -59,8 +71,8 @@ namespace KRPC.SpaceCenter.Services.Parts
         [KRPCProperty]
         public float TargetAngle
         {
-            get { return servo.targetAngle; }
-            set { servo.targetAngle= value; }
+            get { return InternalServo.targetAngle; }
+            set { InternalServo.targetAngle= value; }
         }
 
         /// <summary>
@@ -74,7 +86,7 @@ namespace KRPC.SpaceCenter.Services.Parts
             {
                 return (float)typeof(ModuleRoboticRotationServo)
                     .GetMethod("currentTransformAngle", BindingFlags.Instance | BindingFlags.NonPublic)
-                    .Invoke(servo, null);
+                    .Invoke(InternalServo, null);
             }
         }
 
@@ -84,8 +96,8 @@ namespace KRPC.SpaceCenter.Services.Parts
         [KRPCProperty]
         public float MinAngle
         {
-            get { return servo.softMinMaxAngles.x; }
-            set { servo.SetSoftLimits("targetAngle", new Vector2(value, servo.softMinMaxAngles.y)); }
+            get { return InternalServo.softMinMaxAngles.x; }
+            set { InternalServo.SetSoftLimits("targetAngle", new Vector2(value, InternalServo.softMinMaxAngles.y)); }
         }
 
         /// <summary>
@@ -94,8 +106,8 @@ namespace KRPC.SpaceCenter.Services.Parts
         [KRPCProperty]
         public float MaxAngle
         {
-            get { return servo.softMinMaxAngles.y; }
-            set { servo.SetSoftLimits("targetAngle", new Vector2(servo.softMinMaxAngles.x, value)); }
+            get { return InternalServo.softMinMaxAngles.y; }
+            set { InternalServo.SetSoftLimits("targetAngle", new Vector2(InternalServo.softMinMaxAngles.x, value)); }
         }
 
         /// <summary>
@@ -105,8 +117,8 @@ namespace KRPC.SpaceCenter.Services.Parts
         [KRPCProperty]
         public bool AllowFullRotation
         {
-            get { return servo.allowFullRotation; }
-            set { servo.allowFullRotation = value; }
+            get { return InternalServo.allowFullRotation; }
+            set { InternalServo.allowFullRotation = value; }
         }
 
         /// <summary>
@@ -115,8 +127,8 @@ namespace KRPC.SpaceCenter.Services.Parts
         [KRPCProperty]
         public float Rate
         {
-            get { return servo.traverseVelocity; }
-            set { servo.traverseVelocity = value; }
+            get { return InternalServo.traverseVelocity; }
+            set { InternalServo.traverseVelocity = value; }
         }
 
         /// <summary>
@@ -125,8 +137,8 @@ namespace KRPC.SpaceCenter.Services.Parts
         [KRPCProperty]
         public float Damping
         {
-            get { return servo.hingeDamping; }
-            set { servo.hingeDamping = value; }
+            get { return InternalServo.hingeDamping; }
+            set { InternalServo.hingeDamping = value; }
         }
 
         /// <summary>
@@ -135,13 +147,13 @@ namespace KRPC.SpaceCenter.Services.Parts
         [KRPCProperty]
         public bool Locked
         {
-            get { return servo.servoIsLocked; }
+            get { return InternalServo.servoIsLocked; }
             set
             {
                 if (value == true)
-                    servo.EngageServoLock();
+                    InternalServo.EngageServoLock();
                 else
-                    servo.DisengageServoLock();
+                    InternalServo.DisengageServoLock();
             }
         }
 
@@ -151,13 +163,13 @@ namespace KRPC.SpaceCenter.Services.Parts
         [KRPCProperty]
         public bool MotorEngaged
         {
-            get { return servo.servoMotorIsEngaged; }
+            get { return InternalServo.servoMotorIsEngaged; }
             set
             {
                 if (value == true)
-                    servo.EngageMotor();
+                    InternalServo.EngageMotor();
                 else
-                    servo.DisengageMotor();
+                    InternalServo.DisengageMotor();
             }
         }
 
@@ -171,7 +183,7 @@ namespace KRPC.SpaceCenter.Services.Parts
             {
                 return (bool)typeof(BaseServo)
                     .GetMethod("IsMoving", BindingFlags.Instance | BindingFlags.NonPublic)
-                    .Invoke(servo, null);
+                    .Invoke(InternalServo, null);
             }
         }
 
@@ -181,7 +193,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         [KRPCMethod]
         public void MoveHome()
         {
-            servo.targetAngle = servo.launchPosition;
+            InternalServo.targetAngle = InternalServo.launchPosition;
         }
     }
 }

--- a/service/SpaceCenter/src/Services/Parts/RoboticRotor.cs
+++ b/service/SpaceCenter/src/Services/Parts/RoboticRotor.cs
@@ -13,9 +13,9 @@ namespace KRPC.SpaceCenter.Services.Parts
     /// A robotic rotor. Obtained by calling <see cref="Part.RoboticRotor"/>.
     /// </summary>
     [KRPCClass(Service = "SpaceCenter", GameScene = GameScene.Flight)]
-    public class RoboticRotor : Equatable<RoboticRotor>
+    public class RoboticRotor : Equatable<RoboticRotor>, IGameObjectState
     {
-        readonly ModuleRoboticServoRotor servo;
+        ModuleRef servoRef;
 
         internal static bool Is(Part part)
         {
@@ -28,7 +28,19 @@ namespace KRPC.SpaceCenter.Services.Parts
                 throw new ArgumentException("Part is not a robotic rotor");
             Part = part;
             var internalPart = part.InternalPart;
-            servo = internalPart.Module<ModuleRoboticServoRotor>();
+            servoRef = ModuleRef.ForType<ModuleRoboticServoRotor> (internalPart);
+        }
+
+        ModuleRoboticServoRotor InternalServo {
+            get { return (ModuleRoboticServoRotor)servoRef.Get (Part.InternalPart); }
+        }
+
+        /// <summary>
+        /// What the game holds for the rotor servo: the state of the part
+        /// carrying it, or destroyed once that part no longer has the module.
+        /// </summary>
+        public GameObjectState GameObjectState {
+            get { return servoRef.StateOn (Part); }
         }
 
         /// <summary>
@@ -36,7 +48,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         public override bool Equals(RoboticRotor other)
         {
-            return !ReferenceEquals(other, null) && Part == other.Part && servo.Equals(other.servo);
+            return !ReferenceEquals(other, null) && Part == other.Part && servoRef == other.servoRef;
         }
 
         /// <summary>
@@ -44,7 +56,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         public override int GetHashCode()
         {
-            return Part.GetHashCode() ^ servo.GetHashCode();
+            return Part.GetHashCode() ^ servoRef.GetHashCode();
         }
 
         /// <summary>
@@ -59,9 +71,9 @@ namespace KRPC.SpaceCenter.Services.Parts
         [KRPCProperty]
         public float TargetRPM
         {
-            get { return servo.rpmLimit; }
+            get { return InternalServo.rpmLimit; }
             set {
-                var axisField = (BaseAxisField)typeof(ModuleRoboticServoRotor).GetField("rpmLimitAxisField", BindingFlags.NonPublic | BindingFlags.Instance).GetValue(servo);
+                var axisField = (BaseAxisField)typeof(ModuleRoboticServoRotor).GetField("rpmLimitAxisField", BindingFlags.NonPublic | BindingFlags.Instance).GetValue(InternalServo);
                 axisField.SetValue(value, axisField.module);
             }
         }
@@ -78,7 +90,7 @@ namespace KRPC.SpaceCenter.Services.Parts
             {
                 return (float)typeof(BaseServo)
                     .GetField("transformRateOfMotion", BindingFlags.Instance | BindingFlags.NonPublic)
-                    .GetValue(servo);
+                    .GetValue(InternalServo);
             }
         }
 
@@ -88,8 +100,8 @@ namespace KRPC.SpaceCenter.Services.Parts
         [KRPCProperty]
         public bool Inverted
         {
-            get { return servo.inverted; }
-            set { servo.inverted = value; }
+            get { return InternalServo.inverted; }
+            set { InternalServo.inverted = value; }
         }
 
         /// <summary>
@@ -98,13 +110,13 @@ namespace KRPC.SpaceCenter.Services.Parts
         [KRPCProperty]
         public bool Locked
         {
-            get { return servo.servoIsLocked; }
+            get { return InternalServo.servoIsLocked; }
             set
             {
                 if (value == true)
-                    servo.EngageServoLock();
+                    InternalServo.EngageServoLock();
                 else
-                    servo.DisengageServoLock();
+                    InternalServo.DisengageServoLock();
             }
         }
 
@@ -114,13 +126,13 @@ namespace KRPC.SpaceCenter.Services.Parts
         [KRPCProperty]
         public bool MotorEngaged
         {
-            get { return servo.servoMotorIsEngaged; }
+            get { return InternalServo.servoMotorIsEngaged; }
             set
             {
                 if (value == true)
-                    servo.EngageMotor();
+                    InternalServo.EngageMotor();
                 else
-                    servo.DisengageMotor();
+                    InternalServo.DisengageMotor();
             }
         }
 
@@ -130,8 +142,8 @@ namespace KRPC.SpaceCenter.Services.Parts
         [KRPCProperty]
         public float TorqueLimit
         {
-            get { return servo.servoMotorLimit; }
-            set { servo.Fields["servoMotorLimit"].SetValue((float)value, servo); }
+            get { return InternalServo.servoMotorLimit; }
+            set { InternalServo.Fields["servoMotorLimit"].SetValue((float)value, InternalServo); }
         }
 
         /// <summary>
@@ -140,8 +152,8 @@ namespace KRPC.SpaceCenter.Services.Parts
         [KRPCProperty]
         public float MaxTorque
         {
-            get { return servo.maxTorque; }
-            set { servo.maxTorque = value; }
+            get { return InternalServo.maxTorque; }
+            set { InternalServo.maxTorque = value; }
         }
 
         /// <summary>
@@ -150,8 +162,8 @@ namespace KRPC.SpaceCenter.Services.Parts
         [KRPCProperty]
         public float BrakePercentage
         {
-            get { return servo.brakePercentage; }
-            set { servo.brakePercentage = value; }
+            get { return InternalServo.brakePercentage; }
+            set { InternalServo.brakePercentage = value; }
         }
 
         /// <summary>
@@ -164,7 +176,7 @@ namespace KRPC.SpaceCenter.Services.Parts
             {
                 return (bool)typeof(BaseServo)
                     .GetMethod("IsMoving", BindingFlags.Instance | BindingFlags.NonPublic)
-                    .Invoke(servo, null);
+                    .Invoke(InternalServo, null);
             }
         }
 

--- a/service/SpaceCenter/src/Services/Parts/ScienceData.cs
+++ b/service/SpaceCenter/src/Services/Parts/ScienceData.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using KRPC.Service;
 using KRPC.Service.Attributes;
 using KRPC.Utils;
@@ -8,15 +9,41 @@ namespace KRPC.SpaceCenter.Services.Parts
     /// Obtained by calling <see cref="Experiment.Data"/>.
     /// </summary>
     [KRPCClass (Service = "SpaceCenter", GameScene = GameScene.Flight)]
-    public class ScienceData : Equatable<ScienceData>
+    public class ScienceData : Equatable<ScienceData>, IGameObjectState
     {
-        readonly ModuleScienceExperiment experiment;
+        readonly Part part;
+        ModuleRef experimentRef;
+        // The game's own record of the data. It is a plain object rather than something in
+        // the scene, and the game offers nothing to identify it by, so it is the one thing
+        // here that is held on to rather than found again. When the game replaces it, which
+        // it does whenever it rebuilds the experiment, this object is reclaimed instead.
         readonly global::ScienceData data;
 
-        internal ScienceData (ModuleScienceExperiment experimentModule, global::ScienceData scienceData)
+        internal ScienceData (Part dataPart, ModuleScienceExperiment experimentModule, global::ScienceData scienceData)
         {
-            experiment = experimentModule;
+            part = dataPart;
+            experimentRef = ModuleRef.ForModule (experimentModule);
             data = scienceData;
+        }
+
+        ModuleScienceExperiment InternalExperiment {
+            get { return (ModuleScienceExperiment)experimentRef.Get (part.InternalPart); }
+        }
+
+        /// <summary>
+        /// What the game holds for the record. It is as live, dormant or destroyed as the
+        /// experiment holding it until that experiment is there to look in, and destroyed
+        /// once the experiment no longer holds this record.
+        /// </summary>
+        public GameObjectState GameObjectState {
+            get {
+                var state = experimentRef.StateOn (part);
+                if (state != GameObjectState.Live)
+                    return state;
+                var container = experimentRef.Find (part.InternalPart) as IScienceDataContainer;
+                return container != null && container.GetData ().Contains (data)
+                    ? GameObjectState.Live : GameObjectState.Destroyed;
+            }
         }
 
         /// <summary>
@@ -24,7 +51,8 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         public override bool Equals (ScienceData other)
         {
-            return !ReferenceEquals (other, null) && experiment == other.experiment && data == other.data;
+            return !ReferenceEquals (other, null) && part == other.part &&
+            experimentRef == other.experimentRef && data == other.data;
         }
 
         /// <summary>
@@ -32,7 +60,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         public override int GetHashCode ()
         {
-            return experiment.GetHashCode () ^ data.GetHashCode ();
+            return part.GetHashCode () ^ experimentRef.GetHashCode () ^ data.GetHashCode ();
         }
 
         /// <summary>
@@ -64,9 +92,9 @@ namespace KRPC.SpaceCenter.Services.Parts
             get {
                 // Use ExperimentResultDialogPage to compute the science value
                 ExperimentResultDialogPage page = new ExperimentResultDialogPage(
-                    experiment.part, data, data.baseTransmitValue, data.transmitBonus,
+                    InternalExperiment.part, data, data.baseTransmitValue, data.transmitBonus,
                     false, string.Empty, false,
-                    new ScienceLabSearch(experiment.part.vessel, data),
+                    new ScienceLabSearch(InternalExperiment.part.vessel, data),
                     null, null, null, null);
                 return page.baseTransmitValue * page.TransmitBonus;
             }

--- a/service/SpaceCenter/src/Services/Parts/ScienceSubject.cs
+++ b/service/SpaceCenter/src/Services/Parts/ScienceSubject.cs
@@ -1,6 +1,8 @@
 using System;
 using KRPC.Service;
 using KRPC.Service.Attributes;
+using KRPC.Utils;
+using ObjectDestroyedException = KRPC.Service.KRPC.ObjectDestroyedException;
 
 namespace KRPC.SpaceCenter.Services.Parts
 {
@@ -8,15 +10,85 @@ namespace KRPC.SpaceCenter.Services.Parts
     /// Obtained by calling <see cref="Experiment.ScienceSubject"/>.
     /// </summary>
     [KRPCClass (Service = "SpaceCenter", GameScene = GameScene.Flight)]
-    public class ScienceSubject
+    public class ScienceSubject : Equatable<ScienceSubject>, IGameObjectState
     {
+        // The game's own science subject. A subject the game has recorded science for is
+        // named by its id, but one that has not yet been researched is built on the spot
+        // and the game keeps nothing to look it up by, so the object itself is held. It
+        // belongs to the game state it was taken from, and goes when that state does.
         readonly global::ScienceSubject data;
-
-        readonly float gainMultiplier = HighLogic.CurrentGame.Parameters.Career.ScienceGainMultiplier;
+        readonly string subjectId;
+        readonly uint generation;
 
         internal ScienceSubject (global::ScienceSubject subject)
         {
+            if (ReferenceEquals (subject, null))
+                throw new ArgumentNullException (nameof (subject));
             data = subject;
+            subjectId = subject.id;
+            generation = GameState.Generation;
+        }
+
+        /// <summary>
+        /// Returns true if the objects are equal.
+        /// </summary>
+        /// <remarks>
+        /// The game state the subject was taken from is part of what this stands for:
+        /// the science recorded against a subject belongs to the game that recorded it,
+        /// so subjects with the same id taken from two game states are not the same one.
+        /// </remarks>
+        public override bool Equals (ScienceSubject other)
+        {
+            return !ReferenceEquals (other, null) &&
+            subjectId == other.subjectId && generation == other.generation;
+        }
+
+        /// <summary>
+        /// Hash code for the object.
+        /// </summary>
+        public override int GetHashCode ()
+        {
+            return subjectId.GetHashCode () ^ (int)generation;
+        }
+
+        /// <summary>
+        /// What the game holds for the subject. It belongs to the game state it was taken
+        /// from, so it is destroyed once another state is loaded, with no dormant state to
+        /// return to.
+        /// </summary>
+        public GameObjectState GameObjectState {
+            get {
+                return generation == GameState.Generation
+                    ? GameObjectState.Live : GameObjectState.Destroyed;
+            }
+        }
+
+        /// <summary>
+        /// The KSP science subject, checked to belong to the game state that is loaded.
+        /// </summary>
+        /// <remarks>
+        /// The game keeps a subject only once science has been banked against it, and
+        /// builds one that has none on the spot, so this asks for the game's own record
+        /// and falls back to what it was made from. Without that, a subject read before
+        /// any science was banked would go on reporting none, as the object that stands
+        /// for it is shared by every later read of the same subject.
+        /// </remarks>
+        global::ScienceSubject InternalSubject {
+            get {
+                if (generation != GameState.Generation)
+                    throw new ObjectDestroyedException (
+                        "The science subject no longer exists, as it was taken from a game " +
+                        "state that has since been replaced.");
+                return ResearchAndDevelopment.GetSubjectByID (subjectId) ?? data;
+            }
+        }
+
+        /// <summary>
+        /// How much the game scales the science earned from a subject, which a game's
+        /// difficulty settings fix and the player can change while it is running.
+        /// </summary>
+        static float GainMultiplier {
+            get { return HighLogic.CurrentGame.Parameters.Career.ScienceGainMultiplier; }
         }
 
         /// <summary>
@@ -25,7 +97,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         [KRPCProperty]
         public float Science {
-            get { return data.science * gainMultiplier; }
+            get { return InternalSubject.science * GainMultiplier; }
         }
 
         /// <summary>
@@ -33,7 +105,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         [KRPCProperty]
         public float ScienceCap {
-            get { return data.scienceCap * gainMultiplier; }
+            get { return InternalSubject.scienceCap * GainMultiplier; }
         }
 
         /// <summary>
@@ -54,7 +126,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         [KRPCProperty]
         public float DataScale {
-            get { return data.dataScale; }
+            get { return InternalSubject.dataScale; }
         }
 
         /// <summary>
@@ -63,7 +135,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         [KRPCProperty]
         public float ScientificValue {
-            get { return data.scientificValue; }
+            get { return InternalSubject.scientificValue; }
         }
 
         /// <summary>
@@ -71,7 +143,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         [KRPCProperty]
         public float SubjectValue {
-            get { return data.subjectValue; }
+            get { return InternalSubject.subjectValue; }
         }
 
         /// <summary>
@@ -79,7 +151,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         [KRPCProperty]
         public string Title {
-            get { return data.title; }
+            get { return InternalSubject.title; }
         }
     }
 }

--- a/service/SpaceCenter/src/Services/Parts/Sensor.cs
+++ b/service/SpaceCenter/src/Services/Parts/Sensor.cs
@@ -11,9 +11,9 @@ namespace KRPC.SpaceCenter.Services.Parts
     /// A sensor, such as a thermometer. Obtained by calling <see cref="Part.Sensor"/>.
     /// </summary>
     [KRPCClass (Service = "SpaceCenter", GameScene = GameScene.Flight)]
-    public class Sensor : Equatable<Sensor>
+    public class Sensor : Equatable<Sensor>, IGameObjectState
     {
-        readonly ModuleEnviroSensor sensor;
+        ModuleRef sensorRef;
 
         internal static bool Is (Part part)
         {
@@ -23,9 +23,21 @@ namespace KRPC.SpaceCenter.Services.Parts
         internal Sensor (Part part)
         {
             Part = part;
-            sensor = part.InternalPart.Module<ModuleEnviroSensor> ();
-            if (sensor == null)
+            sensorRef = ModuleRef.ForType<ModuleEnviroSensor> (part.InternalPart);
+            if (sensorRef.Find (part.InternalPart) == null)
                 throw new ArgumentException ("Part is not a sensor");
+        }
+
+        ModuleEnviroSensor InternalSensor {
+            get { return (ModuleEnviroSensor)sensorRef.Get (Part.InternalPart); }
+        }
+
+        /// <summary>
+        /// What the game holds for the sensor: the state of the part
+        /// carrying it, or destroyed once that part no longer has the module.
+        /// </summary>
+        public GameObjectState GameObjectState {
+            get { return sensorRef.StateOn (Part); }
         }
 
         /// <summary>
@@ -33,7 +45,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         public override bool Equals (Sensor other)
         {
-            return !ReferenceEquals (other, null) && Part == other.Part && sensor == other.sensor;
+            return !ReferenceEquals (other, null) && Part == other.Part && sensorRef == other.sensorRef;
         }
 
         /// <summary>
@@ -41,7 +53,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         public override int GetHashCode ()
         {
-            return Part.GetHashCode () ^ sensor.GetHashCode ();
+            return Part.GetHashCode () ^ sensorRef.GetHashCode ();
         }
 
         /// <summary>
@@ -55,8 +67,8 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         [KRPCProperty]
         public bool Active {
-            get { return sensor.sensorActive; }
-            set { sensor.sensorActive = value; }
+            get { return InternalSensor.sensorActive; }
+            set { InternalSensor.sensorActive = value; }
         }
 
         /// <summary>
@@ -83,14 +95,14 @@ namespace KRPC.SpaceCenter.Services.Parts
                 // readout exactly.
                 var off = Localizer.Format ("#autoLOC_237153");
                 var internalPart = Part.InternalPart;
-                if (!sensor.sensorActive || !internalPart.started)
+                if (!InternalSensor.sensorActive || !internalPart.started)
                     return off;
                 // No power: only reachable for sensors with a declared input
                 // resource (stock sensors have none); the game reports "Off".
-                if (sensor.resHandler.currentResourceLowerThanLayoff)
+                if (InternalSensor.resHandler.currentResourceLowerThanLayoff)
                     return off;
                 var internalVessel = internalPart.vessel;
-                switch (sensor.sensorType) {
+                switch (InternalSensor.sensorType) {
                 case ModuleEnviroSensor.SensorType.TEMP:
                     return internalPart.temperature.ToString ("0.##") + " " +
                         Localizer.Format ("#autoLOC_7001406");

--- a/service/SpaceCenter/src/Services/Parts/SolarPanel.cs
+++ b/service/SpaceCenter/src/Services/Parts/SolarPanel.cs
@@ -10,9 +10,9 @@ namespace KRPC.SpaceCenter.Services.Parts
     /// A solar panel. Obtained by calling <see cref="Part.SolarPanel"/>.
     /// </summary>
     [KRPCClass (Service = "SpaceCenter", GameScene = GameScene.Flight)]
-    public class SolarPanel : Equatable<SolarPanel>
+    public class SolarPanel : Equatable<SolarPanel>, IGameObjectState
     {
-        readonly ModuleDeployableSolarPanel panel;
+        ModuleRef panelRef;
 
         internal static bool Is (Part part)
         {
@@ -22,9 +22,21 @@ namespace KRPC.SpaceCenter.Services.Parts
         internal SolarPanel (Part part)
         {
             Part = part;
-            panel = part.InternalPart.Module<ModuleDeployableSolarPanel> ();
-            if (panel == null)
+            panelRef = ModuleRef.ForType<ModuleDeployableSolarPanel> (part.InternalPart);
+            if (panelRef.Find (part.InternalPart) == null)
                 throw new ArgumentException ("Part is not a solar panel");
+        }
+
+        ModuleDeployableSolarPanel InternalPanel {
+            get { return (ModuleDeployableSolarPanel)panelRef.Get (Part.InternalPart); }
+        }
+
+        /// <summary>
+        /// What the game holds for the solar panel: the state of the part
+        /// carrying it, or destroyed once that part no longer has the module.
+        /// </summary>
+        public GameObjectState GameObjectState {
+            get { return panelRef.StateOn (Part); }
         }
 
         /// <summary>
@@ -32,7 +44,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         public override bool Equals (SolarPanel other)
         {
-            return !ReferenceEquals (other, null) && Part == other.Part && panel == other.panel;
+            return !ReferenceEquals (other, null) && Part == other.Part && panelRef == other.panelRef;
         }
 
         /// <summary>
@@ -40,7 +52,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         public override int GetHashCode ()
         {
-            return Part.GetHashCode () ^ panel.GetHashCode ();
+            return Part.GetHashCode () ^ panelRef.GetHashCode ();
         }
 
         /// <summary>
@@ -56,9 +68,9 @@ namespace KRPC.SpaceCenter.Services.Parts
         public bool Deployable {
             get {
                 return
-                    panel.Events ["Extend"].active || panel.Events ["Retract"].active ||
-                    panel.deployState == ModuleDeployablePart.DeployState.EXTENDING ||
-                    panel.deployState == ModuleDeployablePart.DeployState.RETRACTING;
+                    InternalPanel.Events ["Extend"].active || InternalPanel.Events ["Retract"].active ||
+                    InternalPanel.deployState == ModuleDeployablePart.DeployState.EXTENDING ||
+                    InternalPanel.deployState == ModuleDeployablePart.DeployState.RETRACTING;
             }
         }
 
@@ -69,16 +81,16 @@ namespace KRPC.SpaceCenter.Services.Parts
         public bool Deployed {
             get {
                 return
-                panel.deployState == ModuleDeployablePart.DeployState.EXTENDED ||
-                panel.deployState == ModuleDeployablePart.DeployState.EXTENDING;
+                InternalPanel.deployState == ModuleDeployablePart.DeployState.EXTENDED ||
+                InternalPanel.deployState == ModuleDeployablePart.DeployState.EXTENDING;
             }
             set {
                 if (!Deployable)
                     throw new InvalidOperationException ("Solar panel is not deployable");
                 if (value)
-                    panel.Extend ();
+                    InternalPanel.Extend ();
                 else
-                    panel.Retract ();
+                    InternalPanel.Retract ();
             }
         }
 
@@ -87,7 +99,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         [KRPCProperty]
         public DeployableState State {
-            get { return panel.deployState.ToDeployableState (); }
+            get { return InternalPanel.deployState.ToDeployableState (); }
         }
 
         /// <summary>
@@ -96,7 +108,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         [KRPCProperty]
         public float EnergyFlow {
-            get { return panel.flowRate; }
+            get { return InternalPanel.flowRate; }
         }
 
         /// <summary>
@@ -105,7 +117,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         [KRPCProperty]
         public float SunExposure {
-            get { return panel.sunAOA; }
+            get { return InternalPanel.sunAOA; }
         }
     }
 }

--- a/service/SpaceCenter/src/Services/Parts/ThrustReverser.cs
+++ b/service/SpaceCenter/src/Services/Parts/ThrustReverser.cs
@@ -34,24 +34,25 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// Returns an adapter for the part's thrust reverser, or <c>null</c> if the part
         /// has no recognized reverser.
         /// </summary>
-        internal static IThrustReverser Create (global::Part part)
+        internal static IThrustReverser Create (Part part)
         {
+            var internalPart = part.InternalPart;
             // Stock and recognized-mod reversers implemented as a ModuleAnimateGeneric
             // whose animation rotates or repositions the engine's thrust transform.
-            foreach (var animation in part.Modules.OfType<ModuleAnimateGeneric> ()) {
+            foreach (var animation in internalPart.Modules.OfType<ModuleAnimateGeneric> ()) {
                 bool reversedWhenDeployed;
-                if (IsAnimationReverser (animation, part, out reversedWhenDeployed))
-                    return new AnimationThrustReverser (animation, reversedWhenDeployed);
+                if (IsAnimationReverser (animation, internalPart, out reversedWhenDeployed))
+                    return new AnimationThrustReverser (part, animation, reversedWhenDeployed);
             }
             // Recognized mod modules that reverse thrust by switching the active thrust
             // transform, driven through the stock part module API by field/event/action
             // name so kRPC does not need a compile-time reference to the mod.
-            var firespitter = part.Module ("FSswitchEngineThrustTransform");
+            var firespitter = internalPart.Module ("FSswitchEngineThrustTransform");
             if (firespitter != null && FirespitterCanReverse (firespitter))
-                return new FirespitterThrustReverser (firespitter);
-            var propSpinner = part.Module ("WBIPropSpinner");
+                return new FirespitterThrustReverser (part, firespitter);
+            var propSpinner = internalPart.Module ("WBIPropSpinner");
             if (propSpinner != null && PropSpinnerCanReverse (propSpinner))
-                return new PropSpinnerThrustReverser (propSpinner);
+                return new PropSpinnerThrustReverser (part, propSpinner);
             return null;
         }
 
@@ -116,13 +117,19 @@ namespace KRPC.SpaceCenter.Services.Parts
     /// </summary>
     sealed class AnimationThrustReverser : IThrustReverser
     {
-        readonly ModuleAnimateGeneric animation;
+        readonly Part part;
+        ModuleRef reference;
         readonly bool reversedWhenDeployed;
 
-        internal AnimationThrustReverser (ModuleAnimateGeneric animation, bool reversedWhenDeployed)
+        internal AnimationThrustReverser (Part part, ModuleAnimateGeneric animation, bool reversedWhenDeployed)
         {
-            this.animation = animation;
+            this.part = part;
+            reference = ModuleRef.ForModule (animation);
             this.reversedWhenDeployed = reversedWhenDeployed;
+        }
+
+        ModuleAnimateGeneric Animation {
+            get { return (ModuleAnimateGeneric)reference.Get (part.InternalPart); }
         }
 
         public bool Reversed {
@@ -131,13 +138,13 @@ namespace KRPC.SpaceCenter.Services.Parts
             // animation's progress. Reading progress would make the setter
             // non-idempotent: a set re-issued while the animation is still short of
             // its midpoint would toggle a second time and cancel the first.
-            get { return !animation.animSwitch == reversedWhenDeployed; }
-            set { if (value != Reversed) animation.Toggle (); }
+            get { return !Animation.animSwitch == reversedWhenDeployed; }
+            set { if (value != Reversed) Animation.Toggle (); }
         }
 
         public void Toggle ()
         {
-            animation.Toggle ();
+            Animation.Toggle ();
         }
     }
 
@@ -147,24 +154,30 @@ namespace KRPC.SpaceCenter.Services.Parts
     /// </summary>
     sealed class FirespitterThrustReverser : IThrustReverser
     {
-        readonly global::PartModule module;
+        readonly Part part;
+        ModuleRef reference;
 
-        internal FirespitterThrustReverser (global::PartModule module)
+        internal FirespitterThrustReverser (Part part, global::PartModule module)
         {
-            this.module = module;
+            this.part = part;
+            reference = ModuleRef.ForModule (module);
+        }
+
+        global::PartModule InternalModule {
+            get { return (global::PartModule)reference.Get (part.InternalPart); }
         }
 
         public bool Reversed {
-            get { return (bool)module.Fields ["isReversed"].GetValue (module); }
+            get { return (bool)InternalModule.Fields ["isReversed"].GetValue (InternalModule); }
             set {
-                module.Actions [value ? "reverseTTAction" : "normalTTAction"].Invoke (
+                InternalModule.Actions [value ? "reverseTTAction" : "normalTTAction"].Invoke (
                     new KSPActionParam (KSPActionGroup.None, KSPActionType.Activate));
             }
         }
 
         public void Toggle ()
         {
-            module.Actions ["switchTTAction"].Invoke (
+            InternalModule.Actions ["switchTTAction"].Invoke (
                 new KSPActionParam (KSPActionGroup.None, KSPActionType.Activate));
         }
     }
@@ -175,15 +188,21 @@ namespace KRPC.SpaceCenter.Services.Parts
     /// </summary>
     sealed class PropSpinnerThrustReverser : IThrustReverser
     {
-        readonly global::PartModule module;
+        readonly Part part;
+        ModuleRef reference;
 
-        internal PropSpinnerThrustReverser (global::PartModule module)
+        internal PropSpinnerThrustReverser (Part part, global::PartModule module)
         {
-            this.module = module;
+            this.part = part;
+            reference = ModuleRef.ForModule (module);
+        }
+
+        global::PartModule InternalModule {
+            get { return (global::PartModule)reference.Get (part.InternalPart); }
         }
 
         public bool Reversed {
-            get { return (bool)module.Fields ["reverseThrust"].GetValue (module); }
+            get { return (bool)InternalModule.Fields ["reverseThrust"].GetValue (InternalModule); }
             // The module only exposes a toggle, so set the desired state by toggling
             // when it differs from the current one.
             set { if (value != Reversed) Toggle (); }
@@ -191,7 +210,7 @@ namespace KRPC.SpaceCenter.Services.Parts
 
         public void Toggle ()
         {
-            module.Events ["ToggleThrustTransform"].Invoke ();
+            InternalModule.Events ["ToggleThrustTransform"].Invoke ();
         }
     }
 }

--- a/service/SpaceCenter/src/Services/Parts/Thruster.cs
+++ b/service/SpaceCenter/src/Services/Parts/Thruster.cs
@@ -18,27 +18,56 @@ namespace KRPC.SpaceCenter.Services.Parts
     /// four thrusters.
     /// </remarks>
     [KRPCClass (Service = "SpaceCenter", GameScene = GameScene.Flight)]
-    public class Thruster : Equatable<Thruster>
+    public class Thruster : Equatable<Thruster>, IGameObjectState
     {
         readonly Part part;
-        readonly ModuleEngines engine;
-        readonly ModuleRCS rcs;
-        readonly ModuleGimbal gimbal;
+        // A thruster belongs either to an engine or to a set of RCS thrusters, so one of
+        // these two references stands for nothing.
+        ModuleRef engineRef;
+        ModuleRef rcsRef;
+        ModuleRef gimbalRef;
         readonly int transformIndex;
 
         internal Thruster (Part thrusterPart, ModuleEngines thrusterEngine, ModuleGimbal thrusterGimbal, int thrusterTransformIndex)
         {
             part = thrusterPart;
-            engine = thrusterEngine;
-            gimbal = thrusterGimbal;
+            var internalPart = thrusterPart.InternalPart;
+            engineRef = ModuleRef.ForModule (thrusterEngine);
+            rcsRef = ModuleRef.None;
+            gimbalRef = thrusterGimbal == null
+                ? ModuleRef.None
+                : ModuleRef.ForModule (thrusterGimbal);
             transformIndex = thrusterTransformIndex;
         }
 
         internal Thruster (Part thrusterPart, ModuleRCS thrusterRCS, int thrusterTransformIndex)
         {
             part = thrusterPart;
-            rcs = thrusterRCS;
+            engineRef = ModuleRef.None;
+            rcsRef = ModuleRef.ForModule (thrusterRCS);
+            gimbalRef = ModuleRef.None;
             transformIndex = thrusterTransformIndex;
+        }
+
+        ModuleEngines InternalEngine {
+            get { return (ModuleEngines)engineRef.Find (part.InternalPart); }
+        }
+
+        ModuleRCS InternalRCS {
+            get { return (ModuleRCS)rcsRef.Find (part.InternalPart); }
+        }
+
+        ModuleGimbal InternalGimbal {
+            get { return (ModuleGimbal)gimbalRef.Find (part.InternalPart); }
+        }
+
+        /// <summary>
+        /// What the game holds for the engine or RCS module the thruster is part of.
+        /// Either is enough for the thruster, so it is as alive as the more alive of
+        /// them.
+        /// </summary>
+        public GameObjectState GameObjectState {
+            get { return engineRef.StateOn (part).MostAlive (rcsRef.StateOn (part)); }
         }
 
         /// <summary>
@@ -156,7 +185,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         [KRPCProperty]
         public bool Gimballed {
-            get { return gimbal != null; }
+            get { return InternalGimbal != null; }
         }
 
         void CheckGimballed ()
@@ -175,7 +204,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         public Tuple3 GimbalPosition (ReferenceFrame referenceFrame)
         {
             CheckGimballed ();
-            return referenceFrame.PositionFromWorldSpace (gimbal.gimbalTransforms [transformIndex].position).ToTuple ();
+            return referenceFrame.PositionFromWorldSpace (InternalGimbal.gimbalTransforms [transformIndex].position).ToTuple ();
         }
 
         /// <summary>
@@ -185,7 +214,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         public Tuple3 GimbalAngle {
             get {
                 CheckGimballed ();
-                return gimbal.actuation.ToTuple ();
+                return InternalGimbal.actuation.ToTuple ();
             }
         }
 
@@ -193,7 +222,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// Transform of the thrust vector in world space.
         /// </summary>
         internal Transform WorldTransform {
-            get { return (engine != null ? engine.thrustTransforms : rcs.thrusterTransforms) [transformIndex]; }
+            get { return (InternalEngine != null ? InternalEngine.thrustTransforms : InternalRCS.thrusterTransforms) [transformIndex]; }
         }
 
         /// <summary>
@@ -202,7 +231,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         internal Vector3d WorldThrustDirection {
             get {
                 var transform = WorldTransform;
-                return (rcs != null && !rcs.useZaxis) ? -transform.up : -transform.forward;
+                return (InternalRCS != null && !InternalRCS.useZaxis) ? -transform.up : -transform.forward;
             }
         }
 
@@ -220,8 +249,8 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         void StashGimbalRotation ()
         {
-            savedRotation = gimbal.gimbalTransforms [transformIndex].localRotation;
-            gimbal.gimbalTransforms [transformIndex].localRotation = gimbal.initRots [transformIndex];
+            savedRotation = InternalGimbal.gimbalTransforms [transformIndex].localRotation;
+            InternalGimbal.gimbalTransforms [transformIndex].localRotation = InternalGimbal.initRots [transformIndex];
         }
 
         /// <summary>
@@ -229,7 +258,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         void RestoreGimbalRotation ()
         {
-            gimbal.gimbalTransforms [transformIndex].localRotation = savedRotation;
+            InternalGimbal.gimbalTransforms [transformIndex].localRotation = savedRotation;
         }
     }
 }

--- a/service/SpaceCenter/src/Services/Parts/Wheel.cs
+++ b/service/SpaceCenter/src/Services/Parts/Wheel.cs
@@ -12,15 +12,15 @@ namespace KRPC.SpaceCenter.Services.Parts
     /// Can be used to control the motors, steering and deployment of wheels, among other things.
     /// </summary>
     [KRPCClass(Service = "SpaceCenter")]
-    public class Wheel : Equatable<Wheel>
+    public class Wheel : Equatable<Wheel>, IGameObjectState
     {
-        readonly ModuleWheelBase wheel;
-        readonly ModuleWheels.ModuleWheelBrakes brakes;
-        readonly ModuleWheels.ModuleWheelDamage damage;
-        readonly ModuleWheels.ModuleWheelDeployment deployment;
-        readonly ModuleWheels.ModuleWheelMotor motor;
-        readonly ModuleWheels.ModuleWheelSteering steering;
-        readonly ModuleWheels.ModuleWheelSuspension suspension;
+        ModuleRef wheelRef;
+        ModuleRef brakesRef;
+        ModuleRef damageRef;
+        ModuleRef deploymentRef;
+        ModuleRef motorRef;
+        ModuleRef steeringRef;
+        ModuleRef suspensionRef;
 
         internal static bool Is(Part part)
         {
@@ -35,14 +35,50 @@ namespace KRPC.SpaceCenter.Services.Parts
                 throw new ArgumentException("Part is not a wheel");
             Part = part;
             var internalPart = part.InternalPart;
-            wheel = internalPart.Module<ModuleWheelBase>();
-            brakes = internalPart.Module<ModuleWheels.ModuleWheelBrakes>();
-            damage = internalPart.Module<ModuleWheels.ModuleWheelDamage>();
-            deployment = internalPart.Module<ModuleWheels.ModuleWheelDeployment>();
-            motor = internalPart.Module<ModuleWheels.ModuleWheelMotor> ();
-            steering = internalPart.Module<ModuleWheels.ModuleWheelSteering>();
-            suspension = internalPart.Module<ModuleWheels.ModuleWheelSuspension>();
+            wheelRef = ModuleRef.ForType<ModuleWheelBase> (internalPart);
+            brakesRef = ModuleRef.ForType<ModuleWheels.ModuleWheelBrakes> (internalPart);
+            damageRef = ModuleRef.ForType<ModuleWheels.ModuleWheelDamage> (internalPart);
+            deploymentRef = ModuleRef.ForType<ModuleWheels.ModuleWheelDeployment> (internalPart);
+            motorRef = ModuleRef.ForType<ModuleWheels.ModuleWheelMotor> (internalPart);
+            steeringRef = ModuleRef.ForType<ModuleWheels.ModuleWheelSteering> (internalPart);
+            suspensionRef = ModuleRef.ForType<ModuleWheels.ModuleWheelSuspension> (internalPart);
 
+        }
+
+        ModuleWheelBase InternalWheel {
+            get { return (ModuleWheelBase)wheelRef.Get (Part.InternalPart); }
+        }
+
+        ModuleWheels.ModuleWheelBrakes InternalBrakes {
+            get { return (ModuleWheels.ModuleWheelBrakes)brakesRef.Find (Part.InternalPart); }
+        }
+
+        ModuleWheels.ModuleWheelDamage InternalDamage {
+            get { return (ModuleWheels.ModuleWheelDamage)damageRef.Find (Part.InternalPart); }
+        }
+
+        ModuleWheels.ModuleWheelDeployment InternalDeployment {
+            get { return (ModuleWheels.ModuleWheelDeployment)deploymentRef.Find (Part.InternalPart); }
+        }
+
+        ModuleWheels.ModuleWheelMotor InternalMotor {
+            get { return (ModuleWheels.ModuleWheelMotor)motorRef.Find (Part.InternalPart); }
+        }
+
+        ModuleWheels.ModuleWheelSteering InternalSteering {
+            get { return (ModuleWheels.ModuleWheelSteering)steeringRef.Find (Part.InternalPart); }
+        }
+
+        ModuleWheels.ModuleWheelSuspension InternalSuspension {
+            get { return (ModuleWheels.ModuleWheelSuspension)suspensionRef.Find (Part.InternalPart); }
+        }
+
+        /// <summary>
+        /// What the game holds for the wheel: the state of the part
+        /// carrying it, or destroyed once that part no longer has the module.
+        /// </summary>
+        public GameObjectState GameObjectState {
+            get { return wheelRef.StateOn (Part); }
         }
 
         /// <summary>
@@ -50,7 +86,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         public override bool Equals(Wheel other)
         {
-            return !ReferenceEquals(other, null) && Part == other.Part && wheel == other.wheel;
+            return !ReferenceEquals(other, null) && Part == other.Part && wheelRef == other.wheelRef;
         }
 
         /// <summary>
@@ -58,42 +94,42 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         public override int GetHashCode()
         {
-            return Part.GetHashCode() ^ wheel.GetHashCode();
+            return Part.GetHashCode() ^ wheelRef.GetHashCode();
         }
 
         void CheckBrakes()
         {
-            if (brakes == null)
+            if (InternalBrakes == null)
                 throw new InvalidOperationException("Wheel does not have brakes");
         }
 
         void CheckDeployment()
         {
-            if (deployment == null)
+            if (InternalDeployment == null)
                 throw new InvalidOperationException("Wheel is not deployable");
         }
 
         void CheckMotor()
         {
-            if (motor == null)
+            if (InternalMotor == null)
                 throw new InvalidOperationException("Wheel is not powered");
         }
 
         void CheckSteering()
         {
-            if (steering == null)
+            if (InternalSteering == null)
                 throw new InvalidOperationException("Wheel is not steerable");
         }
 
         void CheckSuspension()
         {
-            if (suspension == null)
+            if (InternalSuspension == null)
                 throw new InvalidOperationException("Wheel does not have suspension");
         }
 
         void CheckDamage()
         {
-            if (damage == null)
+            if (InternalDamage == null)
                 throw new InvalidOperationException("Wheel is not breakable");
         }
 
@@ -108,7 +144,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         [KRPCProperty]
         public DeployableState State {
-            get { return deployment.ToDeployableState (damage); }
+            get { return InternalDeployment.ToDeployableState (InternalDamage); }
         }
 
         /// <summary>
@@ -116,7 +152,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         [KRPCProperty]
         public float Radius {
-            get { return wheel.radius; }
+            get { return InternalWheel.radius; }
         }
 
         /// <summary>
@@ -124,7 +160,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         [KRPCProperty]
         public bool Grounded {
-            get { return wheel.isGrounded; }
+            get { return InternalWheel.isGrounded; }
         }
 
         /// <summary>
@@ -132,7 +168,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         [KRPCProperty]
         public bool HasBrakes {
-            get { return brakes != null; }
+            get { return InternalBrakes != null; }
         }
 
         /// <summary>
@@ -142,11 +178,11 @@ namespace KRPC.SpaceCenter.Services.Parts
         public float Brakes {
             get {
                 CheckBrakes();
-                return brakes.brakeTweakable;
+                return InternalBrakes.brakeTweakable;
             }
             set {
                 CheckBrakes();
-                brakes.brakeTweakable = value;
+                InternalBrakes.brakeTweakable = value;
             }
         }
 
@@ -155,8 +191,8 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         [KRPCProperty]
         public bool AutoFrictionControl {
-            get { return wheel.autoFriction; }
-            set { wheel.autoFriction = value; }
+            get { return InternalWheel.autoFriction; }
+            set { InternalWheel.autoFriction = value; }
         }
 
         /// <summary>
@@ -165,8 +201,8 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         [KRPCProperty]
         public float ManualFrictionControl {
-            get { return wheel.frictionMultiplier; }
-            set { wheel.frictionMultiplier = value.Clamp(0, 5); }
+            get { return InternalWheel.frictionMultiplier; }
+            set { InternalWheel.frictionMultiplier = value.Clamp(0, 5); }
         }
 
         /// <summary>
@@ -174,7 +210,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         [KRPCProperty]
         public bool Deployable {
-            get { return deployment != null; }
+            get { return InternalDeployment != null; }
         }
 
         /// <summary>
@@ -185,7 +221,7 @@ namespace KRPC.SpaceCenter.Services.Parts
             get { return State == DeployableState.Deployed; }
             set {
                 CheckDeployment();
-                deployment.ActionToggle(new KSPActionParam(0, value ? KSPActionType.Activate : KSPActionType.Deactivate));
+                InternalDeployment.ActionToggle(new KSPActionParam(0, value ? KSPActionType.Activate : KSPActionType.Deactivate));
             }
         }
 
@@ -194,7 +230,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         [KRPCProperty]
         public bool Powered {
-            get { return motor != null; }
+            get { return InternalMotor != null; }
         }
 
         /// <summary>
@@ -204,11 +240,11 @@ namespace KRPC.SpaceCenter.Services.Parts
         public bool MotorEnabled {
             get {
                 CheckMotor();
-                return motor.motorEnabled;
+                return InternalMotor.motorEnabled;
             }
             set {
                 CheckMotor();
-                motor.motorEnabled = value;
+                InternalMotor.motorEnabled = value;
             }
         }
 
@@ -219,11 +255,11 @@ namespace KRPC.SpaceCenter.Services.Parts
         public bool MotorInverted {
             get {
                 CheckMotor();
-                return motor.motorInverted;
+                return InternalMotor.motorInverted;
             }
             set {
                 CheckMotor();
-                motor.motorInverted = value;
+                InternalMotor.motorInverted = value;
             }
         }
 
@@ -234,7 +270,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         public MotorState MotorState {
             get {
                 CheckMotor();
-                return motor.state.ToMotorState();
+                return InternalMotor.state.ToMotorState();
             }
         }
 
@@ -245,7 +281,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         public float MotorOutput {
             get {
                 CheckMotor();
-                return motor.driveOutput;
+                return InternalMotor.driveOutput;
             }
         }
 
@@ -257,11 +293,11 @@ namespace KRPC.SpaceCenter.Services.Parts
         public bool TractionControlEnabled {
             get {
                 CheckMotor();
-                return motor.autoTorque;
+                return InternalMotor.autoTorque;
             }
             set {
                 CheckMotor();
-                motor.autoTorque = value;
+                InternalMotor.autoTorque = value;
             }
         }
 
@@ -274,11 +310,11 @@ namespace KRPC.SpaceCenter.Services.Parts
         public float TractionControl {
             get {
                 CheckMotor();
-                return motor.tractionControlScale;
+                return InternalMotor.tractionControlScale;
             }
             set {
                 CheckMotor();
-                motor.tractionControlScale = value.Clamp(0, 5);
+                InternalMotor.tractionControlScale = value.Clamp(0, 5);
             }
         }
 
@@ -291,11 +327,11 @@ namespace KRPC.SpaceCenter.Services.Parts
         public float DriveLimiter {
             get {
                 CheckMotor();
-                return motor.driveLimiter;
+                return InternalMotor.driveLimiter;
             }
             set {
                 CheckMotor();
-                motor.driveLimiter = value.Clamp(0, 100);
+                InternalMotor.driveLimiter = value.Clamp(0, 100);
             }
         }
 
@@ -304,7 +340,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         [KRPCProperty]
         public bool Steerable {
-            get { return steering != null; }
+            get { return InternalSteering != null; }
         }
 
         /// <summary>
@@ -314,11 +350,11 @@ namespace KRPC.SpaceCenter.Services.Parts
         public bool SteeringEnabled {
             get {
                 CheckSteering();
-                return steering.steeringEnabled;
+                return InternalSteering.steeringEnabled;
             }
             set {
                 CheckSteering();
-                steering.steeringEnabled = value;
+                InternalSteering.steeringEnabled = value;
             }
         }
 
@@ -329,11 +365,11 @@ namespace KRPC.SpaceCenter.Services.Parts
         public bool SteeringInverted {
             get {
                 CheckSteering();
-                return steering.steeringInvert;
+                return InternalSteering.steeringInvert;
             }
             set {
                 CheckSteering();
-                steering.steeringInvert = value;
+                InternalSteering.steeringInvert = value;
             }
         }
 
@@ -346,11 +382,11 @@ namespace KRPC.SpaceCenter.Services.Parts
         public bool SteeringAngleAuto {
             get {
                 CheckSteering();
-                return steering.autoSteeringAdjust;
+                return InternalSteering.autoSteeringAdjust;
             }
             set {
                 CheckSteering();
-                steering.autoSteeringAdjust = value;
+                InternalSteering.autoSteeringAdjust = value;
             }
         }
 
@@ -363,12 +399,12 @@ namespace KRPC.SpaceCenter.Services.Parts
             get
             {
                 CheckSteering();
-                return steering.angleTweakable;
+                return InternalSteering.angleTweakable;
             }
             set
             {
                 CheckSteering();
-                steering.angleTweakable = value;
+                InternalSteering.angleTweakable = value;
             }
         }
 
@@ -381,12 +417,12 @@ namespace KRPC.SpaceCenter.Services.Parts
             get
             {
                 CheckSteering();
-                return steering.responseTweakable;
+                return InternalSteering.responseTweakable;
             }
             set
             {
                 CheckSteering();
-                steering.responseTweakable = value;
+                InternalSteering.responseTweakable = value;
             }
         }
 
@@ -395,7 +431,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         [KRPCProperty]
         public bool HasSuspension {
-            get { return suspension != null; }
+            get { return InternalSuspension != null; }
         }
 
         /// <summary>
@@ -405,7 +441,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         public float SuspensionSpringStrength {
             get {
                 CheckSuspension();
-                return suspension.springTweakable;
+                return InternalSuspension.springTweakable;
             }
         }
 
@@ -416,7 +452,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         public float SuspensionDamperStrength {
             get {
                 CheckSuspension();
-                return suspension.damperTweakable;
+                return InternalSuspension.damperTweakable;
             }
         }
 
@@ -425,7 +461,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         [KRPCProperty]
         public bool Broken {
-            get { return damage != null && damage.isDamaged; }
+            get { return InternalDamage != null && InternalDamage.isDamaged; }
         }
 
         /// <summary>
@@ -433,7 +469,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         [KRPCProperty]
         public bool Repairable {
-            get { return damage != null && damage.isRepairable; }
+            get { return InternalDamage != null && InternalDamage.isRepairable; }
         }
 
         /// <summary>
@@ -443,7 +479,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         public float Stress {
             get {
                 CheckDamage();
-                return damage.totalStress;
+                return InternalDamage.totalStress;
             }
         }
 
@@ -454,7 +490,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         public float StressTolerance {
             get {
                 CheckDamage();
-                return damage.stressTolerance;
+                return InternalDamage.stressTolerance;
             }
         }
 
@@ -465,7 +501,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         public float StressPercentage {
             get {
                 CheckDamage();
-                return damage.stressPercent;
+                return InternalDamage.stressPercent;
             }
         }
 
@@ -476,7 +512,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         public float Deflection {
             get {
                 CheckDamage();
-                return damage.currentDeflection;
+                return InternalDamage.currentDeflection;
             }
         }
 
@@ -487,7 +523,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         public float Slip {
             get {
                 CheckDamage();
-                return damage.currentSlip;
+                return InternalDamage.currentSlip;
             }
         }
     }

--- a/service/SpaceCenter/src/Services/ReferenceFrame.cs
+++ b/service/SpaceCenter/src/Services/ReferenceFrame.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Runtime.CompilerServices;
 using KRPC.Service.Attributes;
 using KRPC.SpaceCenter.ExtensionMethods;
 using KRPC.SpaceCenter.Services.Parts;
@@ -24,14 +25,17 @@ namespace KRPC.SpaceCenter.Services
     /// used as a parameter to other functions.
     /// </remarks>
     [KRPCClass (Service = "SpaceCenter")]
-    public class ReferenceFrame : Equatable<ReferenceFrame>
+    public class ReferenceFrame : Equatable<ReferenceFrame>, IGameObjectState
     {
         readonly ReferenceFrameType type;
         readonly global::CelestialBody body;
         readonly Guid vesselId;
         readonly ManeuverNode node;
         readonly uint partId;
-        readonly ModuleDockingNode dockingPort;
+        // The part object is what finds the KSP part again and says whether it is still
+        // there; the identifier beside it is what the frame is identified by.
+        readonly Parts.Part servicePart;
+        ModuleRef dockingPortRef;
         readonly Thruster thruster;
         readonly Orbit orbit;
         readonly ReferenceFrame parent;
@@ -55,9 +59,16 @@ namespace KRPC.SpaceCenter.Services
             this.body = body;
             vesselId = vessel != null ? vessel.id : Guid.Empty;
             this.node = node;
-            if (part != null)
+            if (part != null) {
                 partId = part.flightID;
-            this.dockingPort = dockingPort;
+                servicePart = new Parts.Part (part);
+            }
+            if (dockingPort != null) {
+                var dockingPortPart = dockingPort.part;
+                partId = dockingPortPart.flightID;
+                servicePart = new Parts.Part (dockingPortPart);
+                dockingPortRef = ModuleRef.ForModule (dockingPort);
+            }
             this.thruster = thruster;
             this.orbit = orbit;
             this.parent = parent;
@@ -89,7 +100,7 @@ namespace KRPC.SpaceCenter.Services
             vesselId == other.vesselId &&
             node == other.node &&
             partId == other.partId &&
-            dockingPort == other.dockingPort &&
+            dockingPortRef == other.dockingPortRef &&
             thruster == other.thruster &&
             orbit == other.orbit &&
             parent == other.parent &&
@@ -115,10 +126,9 @@ namespace KRPC.SpaceCenter.Services
                 hash ^= body.name.GetHashCode ();
             hash ^= vesselId.GetHashCode ();
             if (node != null)
-                hash ^= node.GetHashCode ();
+                hash ^= RuntimeHelpers.GetHashCode (node);
             hash ^= partId.GetHashCode ();
-            if (dockingPort != null)
-                hash ^= dockingPort.GetHashCode ();
+            hash ^= dockingPortRef.GetHashCode ();
             if (thruster != null)
                 hash ^= thruster.GetHashCode ();
             if (orbit != null)
@@ -188,9 +198,9 @@ namespace KRPC.SpaceCenter.Services
         /// </summary>
         public DockingPort DockingPort {
             get {
-                if (dockingPort == null)
+                if (type != ReferenceFrameType.DockingPort)
                     throw new InvalidOperationException ("Reference frame has no docking port");
-                return new DockingPort (new Parts.Part (dockingPort.part));
+                return new DockingPort (servicePart);
             }
         }
 
@@ -233,7 +243,7 @@ namespace KRPC.SpaceCenter.Services
                 case ReferenceFrameType.PartCenterOfMass:
                     return InternalPart.transform;
                 case ReferenceFrameType.DockingPort:
-                    return dockingPort.nodeTransform;
+                    return InternalDockingPort.nodeTransform;
                 case ReferenceFrameType.Thrust:
                     return thruster.WorldTransform;
                 case ReferenceFrameType.Relative:
@@ -255,9 +265,47 @@ namespace KRPC.SpaceCenter.Services
 
         Part InternalPart {
             get {
-                if (partId == 0)
+                if (servicePart == null)
                     throw new InvalidOperationException ("Reference frame has no part");
-                return FlightGlobals.FindPartByID (partId);
+                return servicePart.InternalPart;
+            }
+        }
+
+        /// <summary>
+        /// The KSP docking port, found again on its part.
+        /// </summary>
+        ModuleDockingNode InternalDockingPort {
+            get { return (ModuleDockingNode)dockingPortRef.Get (InternalPart); }
+        }
+
+        /// <summary>
+        /// What the game holds for everything the frame is built from. A frame needs each
+        /// of the vessel, part, maneuver node, thruster, orbit and other frames it is
+        /// defined against, so it is as alive as the least alive of them; one defined
+        /// against a celestial body alone never dies.
+        /// </summary>
+        public GameObjectState GameObjectState {
+            get {
+                var state = GameObjectState.Live;
+                if (vesselId != Guid.Empty)
+                    state = node == null
+                        ? FlightGlobalsExtensions.VesselState (vesselId)
+                        : new Node (vesselId, node).GameObjectState;
+                if (servicePart != null)
+                    state = state.LeastAlive (servicePart.GameObjectState);
+                if (thruster != null)
+                    state = state.LeastAlive (thruster.GameObjectState);
+                if (orbit != null)
+                    state = state.LeastAlive (orbit.GameObjectState);
+                if (parent != null)
+                    state = state.LeastAlive (parent.GameObjectState);
+                if (type == ReferenceFrameType.Hybrid)
+                    state = state
+                        .LeastAlive (hybridPosition.GameObjectState)
+                        .LeastAlive (hybridRotation.GameObjectState)
+                        .LeastAlive (hybridVelocity.GameObjectState)
+                        .LeastAlive (hybridAngularVelocity.GameObjectState);
+                return state;
             }
         }
 
@@ -496,7 +544,7 @@ namespace KRPC.SpaceCenter.Services
                 case ReferenceFrameType.PartCenterOfMass:
                     return InternalPart.CenterOfMass ();
                 case ReferenceFrameType.DockingPort:
-                    return dockingPort.nodeTransform.position;
+                    return InternalDockingPort.nodeTransform.position;
                 case ReferenceFrameType.Thrust:
                     return thruster.WorldTransform.position;
                 case ReferenceFrameType.Relative:
@@ -640,7 +688,7 @@ namespace KRPC.SpaceCenter.Services
                 case ReferenceFrameType.PartCenterOfMass:
                     return InternalPart.transform.up;
                 case ReferenceFrameType.DockingPort:
-                    return dockingPort.nodeTransform.forward;
+                    return InternalDockingPort.nodeTransform.forward;
                 case ReferenceFrameType.Thrust:
                     return thruster.WorldThrustDirection;
                 case ReferenceFrameType.Relative:
@@ -720,7 +768,7 @@ namespace KRPC.SpaceCenter.Services
                 case ReferenceFrameType.PartCenterOfMass:
                     return InternalPart.transform.forward;
                 case ReferenceFrameType.DockingPort:
-                    return -dockingPort.nodeTransform.up;
+                    return -InternalDockingPort.nodeTransform.up;
                 case ReferenceFrameType.Thrust:
                     return thruster.WorldThrustPerpendicularDirection;
                 case ReferenceFrameType.Relative:
@@ -777,7 +825,7 @@ namespace KRPC.SpaceCenter.Services
                     // by the tangential contribution of the vessel's spin.
                     return InternalPart.vessel.GetOrbit ().GetVel ();
                 case ReferenceFrameType.DockingPort:
-                    return dockingPort.vessel.GetOrbit ().GetVel ();
+                    return InternalDockingPort.vessel.GetOrbit ().GetVel ();
                 case ReferenceFrameType.Relative:
                     return parent.VelocityToWorldSpace (relativePosition, relativeVelocity);
                 case ReferenceFrameType.Hybrid:
@@ -904,7 +952,7 @@ namespace KRPC.SpaceCenter.Services
                 case ReferenceFrameType.PartCenterOfMass:
                     return InternalPart.vessel.WorldAngularVelocity ();
                 case ReferenceFrameType.DockingPort:
-                    return dockingPort.vessel.WorldAngularVelocity ();
+                    return InternalDockingPort.vessel.WorldAngularVelocity ();
                 case ReferenceFrameType.Thrust:
                     return InternalPart.vessel.WorldAngularVelocity ();
                 case ReferenceFrameType.Relative:

--- a/service/SpaceCenter/src/Services/Resource.cs
+++ b/service/SpaceCenter/src/Services/Resource.cs
@@ -9,7 +9,7 @@ namespace KRPC.SpaceCenter.Services
     /// Created using methods in the <see cref="Resources"/> class.
     /// </summary>
     [KRPCClass (Service = "SpaceCenter", GameScene = GameScene.Flight | GameScene.Editor)]
-    public class Resource : Equatable<Resource>
+    public class Resource : Equatable<Resource>, IGameObjectState
     {
         readonly PartId partId;
         readonly int resourceId;
@@ -18,6 +18,13 @@ namespace KRPC.SpaceCenter.Services
         {
             partId = new PartId (resource.part);
             resourceId = resource.info.id;
+        }
+
+        /// <summary>
+        /// What the game holds for the part this belongs to.
+        /// </summary>
+        public GameObjectState GameObjectState {
+            get { return partId.GameObjectState; }
         }
 
         /// <summary>

--- a/service/SpaceCenter/src/Services/ResourceTransfer.cs
+++ b/service/SpaceCenter/src/Services/ResourceTransfer.cs
@@ -1,5 +1,6 @@
 using System;
 using KRPC.Service.Attributes;
+using KRPC.Utils;
 
 namespace KRPC.SpaceCenter.Services
 {
@@ -7,17 +8,15 @@ namespace KRPC.SpaceCenter.Services
     /// Transfer resources between parts.
     /// </summary>
     [KRPCClass (Service = "SpaceCenter")]
-    public class ResourceTransfer
+    public class ResourceTransfer : IGameObjectState
     {
-        readonly Part internalFromPart;
-        readonly Part internalToPart;
+        // The resource's definition comes from the game's part database rather than from any
+        // craft, so unlike the parts it is not something the game tears down.
         readonly PartResourceDefinition internalResource;
         readonly float transferRate;
 
         ResourceTransfer (Part fromPart, Part toPart, PartResourceDefinition resource, float amount)
         {
-            internalFromPart = fromPart;
-            internalToPart = toPart;
             internalResource = resource;
             FromPart = new Parts.Part (fromPart);
             ToPart = new Parts.Part (toPart);
@@ -27,6 +26,14 @@ namespace KRPC.SpaceCenter.Services
             var totalStorage = (float)toPart.Resources.Get (resource.id).maxAmount;
             transferRate = 0.1f * totalStorage;
             ResourceTransferAddon.AddTransfer (this);
+        }
+
+        /// <summary>
+        /// What the game holds for the transfer, which needs both of the parts it runs
+        /// between and so is as alive as the less alive of them.
+        /// </summary>
+        public GameObjectState GameObjectState {
+            get { return FromPart.GameObjectState.LeastAlive (ToPart.GameObjectState); }
         }
 
         /// <summary>
@@ -126,13 +133,28 @@ namespace KRPC.SpaceCenter.Services
         {
             if (Complete)
                 return;
-            var resourceAvailable = (float)internalFromPart.Resources.Get (internalResource.id).amount;
-            var storage = internalToPart.Resources.Get (internalResource.id);
+            // A transfer runs from the game's fixed update, so it has to decide for itself
+            // what to do about a part it can no longer reach rather than raise the error a
+            // call would get. A destroyed part ends the transfer, as nothing can move into
+            // or out of it again. A part whose vessel the game has unloaded is not gone and
+            // is not being simulated either, so the transfer waits for it to come back.
+            var fromState = FromPart.GameObjectState;
+            var toState = ToPart.GameObjectState;
+            if (fromState == GameObjectState.Destroyed || toState == GameObjectState.Destroyed) {
+                Cancel ();
+                return;
+            }
+            if (fromState != GameObjectState.Live || toState != GameObjectState.Live)
+                return;
+            var fromPart = FromPart.InternalPart;
+            var toPart = ToPart.InternalPart;
+            var resourceAvailable = (float)fromPart.Resources.Get (internalResource.id).amount;
+            var storage = toPart.Resources.Get (internalResource.id);
             var storageAvailable = (float)(storage.maxAmount - storage.amount);
             var available = Math.Min (resourceAvailable, storageAvailable);
             var amountToTransfer = Math.Min (available, Math.Min (TotalAmount - Amount, transferRate * deltaTime));
-            internalFromPart.TransferResource (internalResource.id, -amountToTransfer);
-            internalToPart.TransferResource (internalResource.id, amountToTransfer);
+            fromPart.TransferResource (internalResource.id, -amountToTransfer);
+            toPart.TransferResource (internalResource.id, amountToTransfer);
             Amount += amountToTransfer;
             Complete |= amountToTransfer < 0.0001f;
         }

--- a/service/SpaceCenter/src/Services/Resources.cs
+++ b/service/SpaceCenter/src/Services/Resources.cs
@@ -15,7 +15,7 @@ namespace KRPC.SpaceCenter.Services
     /// or <see cref="Parts.Part.Resources"/>.
     /// </summary>
     [KRPCClass (Service = "SpaceCenter", GameScene = GameScene.Flight | GameScene.Editor)]
-    public class Resources : Equatable<Resources>
+    public class Resources : Equatable<Resources>, IGameObjectState
     {
         /// <summary>
         /// The id of the vessel the resources belong to, or <c>Guid.Empty</c> when they
@@ -62,6 +62,19 @@ namespace KRPC.SpaceCenter.Services
             decoupleStage = true;
             partId = new PartId (part);
             hasPart = true;
+        }
+
+        /// <summary>
+        /// What the game holds for the vessel or part these are the resources of.
+        /// </summary>
+        public GameObjectState GameObjectState {
+            get {
+                if (hasPart)
+                    return partId.GameObjectState;
+                return editorVessel
+                    ? EditorExtensions.ShipState
+                    : FlightGlobalsExtensions.VesselState (vesselId);
+            }
         }
 
         /// <summary>

--- a/service/SpaceCenter/src/Services/Resources.cs
+++ b/service/SpaceCenter/src/Services/Resources.cs
@@ -119,13 +119,7 @@ namespace KRPC.SpaceCenter.Services
         /// </summary>
         IShipconstruct InternalShipConstruct {
             get {
-                if (!editorVessel)
-                    return InternalVessel;
-                var logic = EditorLogic.fetch;
-                var construct = ReferenceEquals (logic, null) ? null : logic.ship;
-                if (ReferenceEquals (construct, null))
-                    throw new InvalidOperationException ("The editor does not contain a vessel.");
-                return construct;
+                return editorVessel ? (IShipconstruct)EditorExtensions.GetShip () : InternalVessel;
             }
         }
 
@@ -136,9 +130,9 @@ namespace KRPC.SpaceCenter.Services
         /// </summary>
         VesselDeltaV InternalDeltaV {
             get {
-                if (!editorVessel)
-                    return InternalVessel.VesselDeltaV;
-                return ((ShipConstruct)InternalShipConstruct).vesselDeltaV;
+                return editorVessel
+                    ? EditorExtensions.GetShip ().vesselDeltaV
+                    : InternalVessel.VesselDeltaV;
             }
         }
 

--- a/service/SpaceCenter/src/Services/Stage.cs
+++ b/service/SpaceCenter/src/Services/Stage.cs
@@ -22,7 +22,7 @@ namespace KRPC.SpaceCenter.Services
     /// are converted from kilonewtons and tonnes).
     /// </remarks>
     [KRPCClass (Service = "SpaceCenter")]
-    public class Stage : Equatable<Stage>
+    public class Stage : Equatable<Stage>, IGameObjectState
     {
         /// <summary>
         /// The id of the vessel the stage belongs to. Unused when the stage belongs to
@@ -67,6 +67,17 @@ namespace KRPC.SpaceCenter.Services
             editorVessel = true;
             stageNumber = number;
             decoupleStage = decouple;
+        }
+
+        /// <summary>
+        /// What the game holds for the vessel the stage belongs to.
+        /// </summary>
+        public GameObjectState GameObjectState {
+            get {
+                return editorVessel
+                    ? EditorExtensions.ShipState
+                    : FlightGlobalsExtensions.VesselState (vesselId);
+            }
         }
 
         /// <summary>

--- a/service/SpaceCenter/src/Services/Stage.cs
+++ b/service/SpaceCenter/src/Services/Stage.cs
@@ -120,13 +120,9 @@ namespace KRPC.SpaceCenter.Services
         /// </summary>
         VesselDeltaV InternalDeltaV {
             get {
-                if (!editorVessel)
-                    return InternalVessel.VesselDeltaV;
-                var logic = EditorLogic.fetch;
-                var construct = logic == null ? null : logic.ship;
-                if (ReferenceEquals (construct, null))
-                    throw new InvalidOperationException ("The editor does not contain a vessel.");
-                return construct.vesselDeltaV;
+                return editorVessel
+                    ? EditorExtensions.GetShip ().vesselDeltaV
+                    : InternalVessel.VesselDeltaV;
             }
         }
 

--- a/service/SpaceCenter/src/Services/Vessel.cs
+++ b/service/SpaceCenter/src/Services/Vessel.cs
@@ -22,6 +22,8 @@ namespace KRPC.SpaceCenter.Services
     [KRPCClass (Service = "SpaceCenter")]
     public class Vessel : Equatable<Vessel>
     {
+        CachedObject<global::Vessel> cache;
+
         /// <summary>
         /// Construct from a KSP vessel object.
         /// </summary>
@@ -65,7 +67,14 @@ namespace KRPC.SpaceCenter.Services
         /// The KSP vessel object.
         /// </summary>
         public global::Vessel InternalVessel {
-            get { return FlightGlobalsExtensions.GetVesselById (Id); }
+            get {
+                var vessel = cache.Get ();
+                if (vessel != null)
+                    return vessel;
+                vessel = FlightGlobalsExtensions.GetVesselById (Id);
+                cache.Set (vessel);
+                return vessel;
+            }
         }
 
         /// <summary>

--- a/service/SpaceCenter/src/Services/Vessel.cs
+++ b/service/SpaceCenter/src/Services/Vessel.cs
@@ -20,7 +20,7 @@ namespace KRPC.SpaceCenter.Services
     /// Created using <see cref="SpaceCenter.ActiveVessel"/> or <see cref="SpaceCenter.Vessels"/>.
     /// </summary>
     [KRPCClass (Service = "SpaceCenter")]
-    public class Vessel : Equatable<Vessel>
+    public class Vessel : Equatable<Vessel>, IGameObjectState
     {
         CachedObject<global::Vessel> cache;
 
@@ -75,6 +75,15 @@ namespace KRPC.SpaceCenter.Services
                 cache.Set (vessel);
                 return vessel;
             }
+        }
+
+        /// <summary>
+        /// What the game holds for the vessel. A vessel is either there to be
+        /// found, loaded or not, or it is gone for good; it has no unloaded form that
+        /// the game can bring back.
+        /// </summary>
+        public GameObjectState GameObjectState {
+            get { return FlightGlobalsExtensions.VesselState (Id); }
         }
 
         /// <summary>

--- a/service/SpaceCenter/src/Services/Waypoint.cs
+++ b/service/SpaceCenter/src/Services/Waypoint.cs
@@ -2,6 +2,7 @@ using System;
 using KRPC.Service;
 using KRPC.Service.Attributes;
 using KRPC.Utils;
+using ObjectDestroyedException = KRPC.Service.KRPC.ObjectDestroyedException;
 
 namespace KRPC.SpaceCenter.Services
 {
@@ -9,23 +10,36 @@ namespace KRPC.SpaceCenter.Services
     /// Represents a waypoint. Can be created using <see cref="WaypointManager.AddWaypoint"/>.
     /// </summary>
     [KRPCClass (Service = "SpaceCenter", GameScene = GameScene.Flight)]
-    public class Waypoint : Equatable<Waypoint>
+    public class Waypoint : Equatable<Waypoint>, IGameObjectState
     {
+        // The identifier the game gives a waypoint when it builds one. Nothing else names
+        // a waypoint: its name is neither unique nor fixed, and its seed and index only
+        // pick out the waypoints of a contract.
+        readonly Guid navigationId;
+
         /// <summary>
         /// Create a waypoint object.
         /// </summary>
         internal Waypoint (double latitude, double longitude, double altitude, CelestialBody body, string name)
         {
-            InternalWaypoint = new FinePrint.Waypoint ();
-            Name = name;
-            Body = body;
-            Icon = "report";
-            Color = 1115;
-            Latitude = latitude;
-            Longitude = longitude;
-            MeanAltitude = altitude;
-            InternalWaypoint.isNavigatable = true;
-            FinePrint.WaypointManager.AddWaypoint (InternalWaypoint);
+            if (ReferenceEquals (body, null))
+                throw new ArgumentNullException (nameof (body));
+            // The waypoint is set up before the game is given it, so this works on it
+            // directly: until the game has it, there is nothing for this object to find.
+            // What each line does is what the property of the same name does.
+            var waypoint = new FinePrint.Waypoint ();
+            waypoint.name = name;
+            waypoint.celestialName = body.Name;
+            waypoint.id = "report";
+            waypoint.seed = 1115;
+            waypoint.latitude = latitude;
+            waypoint.longitude = longitude;
+            waypoint.altitude = altitude - body.BedrockHeight (latitude, longitude);
+            waypoint.isOnSurface =
+                Math.Abs (body.SurfaceHeight (latitude, longitude) - altitude) < 10;
+            waypoint.isNavigatable = true;
+            navigationId = waypoint.navigationId;
+            FinePrint.WaypointManager.AddWaypoint (waypoint);
         }
 
         /// <summary>
@@ -33,20 +47,78 @@ namespace KRPC.SpaceCenter.Services
         /// </summary>
         public Waypoint (FinePrint.Waypoint wp)
         {
-            InternalWaypoint = wp;
+            if (wp == null)
+                throw new ArgumentNullException (nameof (wp));
+            navigationId = wp.navigationId;
         }
 
         /// <summary>
-        /// The KSP Waypoint.
+        /// The KSP Waypoint, found again from the identifier that names it. The game builds
+        /// its waypoints again whenever it loads a game state, so the waypoint this stands
+        /// for is whichever one now carries the identifier.
         /// </summary>
-        public FinePrint.Waypoint InternalWaypoint { get; private set; }
+        public FinePrint.Waypoint InternalWaypoint {
+            get {
+                var waypoint = Find ();
+                if (waypoint == null)
+                    throw NotResolvable ();
+                return waypoint;
+            }
+        }
+
+        /// <summary>
+        /// What the game holds for the waypoint. It is live while the game's waypoint
+        /// manager lists it, and destroyed once the manager is there to ask and does not, as
+        /// a waypoint that leaves the list is gone for good. A game with no waypoint manager
+        /// has no waypoints to look through, which says nothing about this one.
+        /// </summary>
+        public GameObjectState GameObjectState {
+            get {
+                if (FinePrint.WaypointManager.Instance () == null)
+                    return GameObjectState.Dormant;
+                return Find () != null ? GameObjectState.Live : GameObjectState.Destroyed;
+            }
+        }
+
+        /// <summary>
+        /// The waypoint the game currently has under the identifier, or null if it has none.
+        /// </summary>
+        FinePrint.Waypoint Find ()
+        {
+            var manager = FinePrint.WaypointManager.Instance ();
+            if (manager == null)
+                return null;
+            var waypoints = manager.Waypoints;
+            if (waypoints == null)
+                return null;
+            for (var i = 0; i < waypoints.Count; i++) {
+                var waypoint = waypoints [i];
+                if (waypoint != null && waypoint.navigationId == navigationId)
+                    return waypoint;
+            }
+            return null;
+        }
+
+        /// <summary>
+        /// The error to raise when no waypoint answers to the identifier, which
+        /// <see cref="GameObjectState" /> decides between.
+        /// </summary>
+        Exception NotResolvable ()
+        {
+            if (GameObjectState == GameObjectState.Destroyed)
+                return new ObjectDestroyedException (
+                    "The waypoint no longer exists, as the game no longer has a waypoint with its id.");
+            return new InvalidOperationException (
+                "The waypoint is not loaded, as the game has no waypoint manager running. " +
+                "It can be used again once the game does.");
+        }
 
         /// <summary>
         /// Returns true if the objects are equal.
         /// </summary>
         public override bool Equals (Waypoint other)
         {
-            return !ReferenceEquals (other, null) && InternalWaypoint == other.InternalWaypoint;
+            return !ReferenceEquals (other, null) && navigationId == other.navigationId;
         }
 
         /// <summary>
@@ -54,8 +126,7 @@ namespace KRPC.SpaceCenter.Services
         /// </summary>
         public override int GetHashCode ()
         {
-            // Note: InternalNode could be set to null by Remove
-            return InternalWaypoint.GetHashCode ();
+            return navigationId.GetHashCode ();
         }
 
         /// <summary>
@@ -230,12 +301,16 @@ namespace KRPC.SpaceCenter.Services
         /// <summary>
         /// Removes the waypoint.
         /// </summary>
+        /// <remarks>
+        /// Any further use of this object throws an exception.
+        /// </remarks>
         [KRPCMethod]
         public void Remove ()
         {
-            if (HasContract)
+            var waypoint = InternalWaypoint;
+            if (waypoint.contractReference != null)
                 throw new InvalidOperationException ("Cannot remove waypoint attached to a contract.");
-            FinePrint.WaypointManager.RemoveWaypoint (InternalWaypoint);
+            FinePrint.WaypointManager.RemoveWaypoint (waypoint);
         }
     }
 }

--- a/service/SpaceCenter/test/test_alarm.py
+++ b/service/SpaceCenter/test/test_alarm.py
@@ -7,8 +7,10 @@ class TestAlarm(krpctest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.new_save()
-        cls.space_center = cls.connect().space_center
+        cls.conn = cls.connect()
+        cls.space_center = cls.conn.space_center
         cls.alarm_manager = cls.space_center.alarm_manager
+        cls.destroyed = cls.conn.krpc.ObjectDestroyedException
 
     def tearDown(self):
         for alarm in list(self.alarm_manager.alarms):
@@ -23,14 +25,27 @@ class TestAlarm(krpctest.TestCase):
     def test_access_after_remove_raises(self):
         alarm = self.alarm_manager.add_alarm(3600, "test_access_after_remove", "")
         alarm.remove()
-        with self.assertRaises(RuntimeError):
+        # The game no longer has an alarm with the id, so the object says the alarm is
+        # gone rather than that the call was invalid.
+        with self.assertRaises(self.destroyed):
             _ = alarm.title
 
     def test_remove_twice_raises(self):
         alarm = self.alarm_manager.add_alarm(3600, "test_remove_twice", "")
         alarm.remove()
-        with self.assertRaises(RuntimeError):
+        with self.assertRaises(self.destroyed):
             alarm.remove()
+
+    def test_alarm_survives_a_quickload(self):
+        alarm = self.alarm_manager.add_alarm(3600, "test_quickload", "notes")
+        self.space_center.quicksave()
+        self.wait(1)
+        self.space_center.quickload()
+        self.wait(1)
+        # Loading a game state builds its alarms again. The object names the alarm by
+        # the id the game writes into the save, so it reads the one that was built.
+        self.assertEqual("test_quickload", alarm.title)
+        self.assertEqual("notes", alarm.description)
 
     def test_alarm_with_name_after_remove(self):
         alarm = self.alarm_manager.add_alarm(

--- a/service/SpaceCenter/test/test_editor_object_lifetime.py
+++ b/service/SpaceCenter/test/test_editor_object_lifetime.py
@@ -1,0 +1,203 @@
+import krpctest
+
+
+class EditorObjectLifetimeTest(krpctest.TestCase):
+    """Shared setup for the editor object lifetime tests.
+
+    A vessel is launched before the editor is entered so that the tests that leave
+    the editor are checked against a game that has something in flight, which is what
+    decides whether the object store is swept once the editor has been left.
+    """
+
+    craft = "Parts"
+    other_craft = "Basic"
+
+    @classmethod
+    def setUpClass(cls):
+        cls.new_save()
+        cls.launch_vessel_from_vab("Basic")
+        cls.enter_editor("VAB", craft=cls.craft)
+        cls.conn = cls.connect()
+        cls.space_center = cls.conn.space_center
+        cls.editor = cls.space_center.editor
+        cls.destroyed = cls.conn.krpc.ObjectDestroyedException
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.leave_editor()
+
+    def a_part(self, name):
+        return self.editor.vessel.parts.with_name(name)[0]
+
+    def swept(self, before):
+        """Wait for the object store to drop something, and fail if it does not.
+
+        The sweep runs on the game's own schedule rather than on demand, so a test
+        that needs one to have happened has to wait for the store to shrink.
+        """
+        self.wait_until(
+            lambda: self.conn.testing_tools.object_store_size < before,
+            message="the object store was not swept",
+        )
+
+
+class TestEditorObjectLifetime(EditorObjectLifetimeTest):
+    """What a client's editor objects do as the vessel under construction changes.
+
+    A part in the editor is named by its craft id, which is only unique within one
+    vessel: a craft file saved from another carries its craft ids over, so two
+    vessels routinely give the same id to different parts. A part object therefore
+    also records which loaded vessel it was taken from, and a part of any earlier one
+    is gone rather than whatever answers to its id now.
+
+    The editor holds exactly one vessel, so a part that is not in it is gone rather
+    than merely out of reach, as a part of an unloaded vessel in flight would be.
+    Loading another craft is what makes a part leave the vessel here: the game's own
+    delete refreshes the editor's attach node icons before it removes anything, which
+    fails when the call did not come from the editor UI, so it never gets as far as
+    deleting the part.
+    """
+
+    def setUp(self):
+        # Tests here replace the vessel, so each starts from the craft the class was
+        # entered with.
+        self.editor.load_vessel("VAB", self.craft)
+
+    def test_a_part_survives_an_undo(self):
+        # An undo hands back a vessel object of its own, built from the game's backup,
+        # so the vessel the editor has is a different object afterwards. The parts it
+        # builds carry the craft ids they had, so a part the undo did not touch is the
+        # same part and its object goes on working. Only the vessel being replaced by
+        # one loaded as a new vessel makes a part of the old one gone.
+        part = self.a_part("sensorThermometer")
+        module = part.modules[0]
+        name = part.name
+        module_name = module.name
+
+        # Two states with no change between them, so the undo restores a vessel with
+        # the same parts; nothing here can add or remove one to be affected by it.
+        self.conn.testing_tools.editor_set_backup()
+        self.wait(0.5)
+        self.conn.testing_tools.editor_set_backup()
+        self.wait(0.5)
+        self.conn.testing_tools.editor_undo()
+        self.wait(1)
+
+        self.assertEqual(name, part.name)
+        self.assertEqual(module_name, module.name)
+        # And the sweep that the undo asks for must not have taken them either.
+        self.assertGreater(len(self.editor.vessel.parts.all), 0)
+
+    def test_a_part_of_a_reloaded_vessel_is_destroyed(self):
+        part = self.a_part("sensorThermometer")
+        module = part.modules[0]
+
+        self.editor.load_vessel("VAB", self.craft)
+
+        # Loading a craft starts a new vessel, whether or not it is the one the editor
+        # already had. Nothing tells the two apart: a craft file saved from this one
+        # would carry the same craft ids, so a part that answered to the old id could
+        # be a different part. Rather than guess, the old vessel's parts are gone.
+        self.assertRaises(self.destroyed, getattr, part, "name")
+        self.assertRaises(self.destroyed, getattr, module, "name")
+
+    def test_a_part_of_a_replaced_vessel_is_destroyed(self):
+        part = self.a_part("liquidEngineMainsail.v2")
+        module = part.modules[0]
+        # A typed part-module object as well as the generic one. Only the members of
+        # these that describe the design are available in the editor, so the object is
+        # asked for one of those rather than for anything a vessel in flight has.
+        engine = part.engine
+        self.assertEqual("liquidEngineMainsail.v2", part.name)
+        self.assertGreater(engine.thrust_limit, 0)
+
+        self.editor.load_vessel("VAB", self.other_craft)
+
+        # The part is not in the vessel any more, and the editor has no other vessel
+        # it could be in, so it is gone rather than waiting to be loaded.
+        self.assertRaises(self.destroyed, getattr, part, "name")
+        self.assertRaises(self.destroyed, getattr, module, "name")
+        self.assertRaises(self.destroyed, getattr, engine, "thrust_limit")
+
+    def test_the_store_drops_a_part_of_a_replaced_vessel(self):
+        part = self.a_part("liquidEngineMainsail.v2")
+        self.assertEqual("liquidEngineMainsail.v2", part.name)
+        before = self.conn.testing_tools.object_store_size
+
+        self.editor.load_vessel("VAB", self.other_craft)
+        self.swept(before)
+
+        # The server no longer has the object at all, and says so in the same terms
+        # as an object it still has whose part is gone.
+        self.assertRaises(self.destroyed, getattr, part, "name")
+
+    def test_the_vessels_objects_outlive_a_sweep(self):
+        # Everything named against the vessel in the editor rather than against a
+        # vessel in flight. None of it has a vessel id, so a sweep that judged it by
+        # one would find no such vessel and drop the lot.
+        parts = self.editor.vessel.parts
+        resources = self.editor.vessel.resources
+        stages = self.editor.vessel.decouple_stages
+        self.assertGreater(len(stages), 0)
+        stage = stages[0]
+
+        # Replacing the vessel is what makes the sweep run and find something to
+        # drop, so the assertions below are made against a store that has been swept.
+        doomed = self.a_part("liquidEngineMainsail.v2")
+        before = self.conn.testing_tools.object_store_size
+        self.editor.load_vessel("VAB", self.other_craft)
+        self.swept(before)
+        self.assertRaises(self.destroyed, getattr, doomed, "name")
+
+        # The editor still has a vessel, so everything named against it still works,
+        # and reports the vessel that is there now.
+        self.assertGreater(len(parts.all), 0)
+        self.assertGreater(len(resources.all), 0)
+        self.assertGreater(len(stage.parts), 0)
+
+
+class TestEditorObjectLifetimeOnLeaving(EditorObjectLifetimeTest):
+    """The editor takes its vessel with it, and everything named against it."""
+
+    @classmethod
+    def tearDownClass(cls):
+        pass
+
+    def test_leaving_the_editor_destroys_the_vessels_objects(self):
+        parts = self.editor.vessel.parts
+        part = self.a_part("mk1-3pod")
+        self.assertEqual("mk1-3pod", part.name)
+        before = self.conn.testing_tools.object_store_size
+
+        self.leave_editor()
+        self.swept(before)
+
+        # There is no vessel in an editor that is not open, and nothing will build
+        # one again, so the objects are gone rather than dormant.
+        self.assertRaises(self.destroyed, getattr, part, "name")
+        self.assertRaises(self.destroyed, getattr, parts, "all")
+
+
+class TestEditorPartIdCollision(EditorObjectLifetimeTest):
+    """A part is not confused with the part of another vessel that shares its id.
+
+    ActionGroups.craft was saved from Basic.craft, so it carries every one of its
+    craft ids while being a vessel of its own, which is what any craft saved from
+    another looks like. Resolving by craft id alone hands back the part of the new
+    vessel that answers to the old id, with no error and nothing to say the answer
+    came from a vessel the client never asked about.
+    """
+
+    craft = "Basic"
+    other_craft = "ActionGroups"
+
+    def test_a_part_is_not_confused_with_one_of_another_vessel(self):
+        part = self.a_part("mk1pod.v2")
+        self.assertEqual("mk1pod.v2", part.name)
+
+        self.editor.load_vessel("VAB", self.other_craft)
+
+        # The new vessel has a part with exactly this craft id, and it is not this part.
+        self.assertRaises(self.destroyed, getattr, part, "name")
+        # The vessel that is there now is readable, through parts obtained from it.
+        self.assertEqual("mk1pod.v2", self.a_part("mk1pod.v2").name)

--- a/service/SpaceCenter/test/test_node.py
+++ b/service/SpaceCenter/test/test_node.py
@@ -9,9 +9,11 @@ class TestNode(krpctest.TestCase):
     def setUpClass(cls):
         cls.new_save()
         cls.set_circular_orbit("Kerbin", 100000)
-        cls.space_center = cls.connect().space_center
+        cls.conn = cls.connect()
+        cls.space_center = cls.conn.space_center
         cls.vessel = cls.space_center.active_vessel
         cls.control = cls.vessel.control
+        cls.destroyed = cls.conn.krpc.ObjectDestroyedException
 
     def tearDown(self):
         self.control.remove_nodes()
@@ -54,7 +56,7 @@ class TestNode(krpctest.TestCase):
     def test_remove_node(self):
         node = self.control.add_node(self.space_center.ut, 0, 0, 0)
         node.remove()
-        with self.assertRaises(RuntimeError):
+        with self.assertRaises(self.destroyed):
             node.prograde = 0
 
     def test_remove_nodes(self):
@@ -63,7 +65,7 @@ class TestNode(krpctest.TestCase):
         node2 = self.control.add_node(self.space_center.ut + 60, 0, 4, 0)
         self.control.remove_nodes()
         for node in (node0, node1, node2):
-            with self.assertRaises(RuntimeError):
+            with self.assertRaises(self.destroyed):
                 node.prograde = 0
 
     def test_get_nodes(self):

--- a/service/SpaceCenter/test/test_object_lifetime.py
+++ b/service/SpaceCenter/test/test_object_lifetime.py
@@ -130,6 +130,39 @@ class TestObjectLifetime(krpctest.TestCase):
         # as an object it still has whose part is gone.
         self.assertRaises(self.destroyed, getattr, part, "name")
 
+    def test_the_store_drops_a_force_on_a_destroyed_part(self):
+        # A force is applied by the game's own update rather than by a client call, so
+        # there is nobody to raise an error at when its part goes; it is dropped instead.
+        part = self.a_part("longAntenna")
+        force = part.add_force((1, 2, 3), (0, 0, 0), part.reference_frame)
+        self.assertEqual((1, 2, 3), force.force_vector)
+        before = self.conn.testing_tools.object_store_size
+        self.conn.testing_tools.destroy_part(part)
+        self.wait_until(
+            lambda: self.conn.testing_tools.object_store_size < before,
+            message="the force on the destroyed part was not dropped from the store",
+        )
+        self.assertRaises(self.destroyed, getattr, force, "force_vector")
+
+    def test_removing_a_force(self):
+        # The command pod, which nothing here destroys: the tests run in name order and
+        # the thermometer and the strut have both been destroyed by this point.
+        part = self.a_part("mk1-3pod")
+        force = part.add_force((1, 2, 3), (0, 0, 0), part.reference_frame)
+        self.assertEqual((1, 2, 3), force.force_vector)
+        before = self.conn.testing_tools.object_store_size
+        force.remove()
+        # Nothing applies the force again, so the object stands for nothing as soon as
+        # it is taken off the part, rather than once the part itself goes.
+        self.assertRaises(self.destroyed, getattr, force, "force_vector")
+        self.assertRaises(self.destroyed, force.remove)
+        # Taking a force off a part destroys nothing the game raises an event for, so
+        # the removal is what has to get the object out of the store.
+        self.wait_until(
+            lambda: self.conn.testing_tools.object_store_size < before,
+            message="the removed force was not dropped from the object store",
+        )
+
     def test_the_store_drops_dead_objects_on_a_load(self):
         # A maneuver node is what a load definitively kills. The game builds the vessel's
         # parts again under the ids their objects name them by, so those survive a load

--- a/service/SpaceCenter/test/test_object_lifetime.py
+++ b/service/SpaceCenter/test/test_object_lifetime.py
@@ -199,6 +199,38 @@ class TestObjectLifetime(krpctest.TestCase):
         self.assertEqual("Kerbin", orbit.body.name)
         self.assertEqual(vessel.orbit, orbit)
 
+    def test_the_store_drops_a_constructed_orbit_when_its_client_goes(self):
+        # An orbit a client constructs stands for nothing in the game, so nothing the
+        # game destroys ever says it is finished with. The client that asked for it
+        # going is the only thing that can.
+        conn = self.connect(use_cached=False)
+        constructed = conn.space_center.Orbit.create_from_orbital_elements(
+            conn.space_center.bodies["Kerbin"],
+            800000,
+            0.1,
+            0,
+            0,
+            0,
+            0,
+            conn.space_center.ut,
+        )
+        # The two reference frames the orbit hands out are objects in their own right,
+        # and are defined against nothing else, so they go with the orbit.
+        self.assertIsNotNone(constructed.reference_frame)
+        self.assertIsNotNone(constructed.orbital_reference_frame)
+        # The orbit of a vessel is named by the vessel rather than by the client that
+        # asked for it, so both connections have the one object and it must not go
+        # anywhere when one of them does.
+        vessel_orbit = self.space_center.active_vessel.orbit
+        self.assertEqual("Kerbin", conn.space_center.active_vessel.orbit.body.name)
+        before = self.conn.testing_tools.object_store_size
+        conn.close()
+        self.wait_until(
+            lambda: self.conn.testing_tools.object_store_size <= before - 3,
+            message="the constructed orbit and its frames were not dropped from the store",
+        )
+        self.assertEqual("Kerbin", vessel_orbit.body.name)
+
 
 class TestObjectLifetimeUnloaded(krpctest.TestCase):
     """A part of a vessel the game has unloaded is not a destroyed part.

--- a/service/SpaceCenter/test/test_object_lifetime.py
+++ b/service/SpaceCenter/test/test_object_lifetime.py
@@ -32,15 +32,22 @@ class TestObjectLifetime(krpctest.TestCase):
 
     def test_reading_a_module_of_a_destroyed_part(self):
         part = self.a_part("sensorThermometer")
-        module = part.modules[0]
+        module = next(m for m in part.modules if m.field_list)
+        field = module.field_list[0]
         sensor = part.sensor
         self.assertNotEqual("", module.name)
+        self.assertNotEqual("", field.name)
         self.conn.testing_tools.destroy_part(part)
         self.wait(0.5)
         # The module belongs to the part's game object, so it goes when the part does,
         # and says so rather than failing with a null reference.
         self.assertRaises(self.destroyed, getattr, module, "name")
         self.assertRaises(self.destroyed, getattr, sensor, "active")
+        # A field is found on its module on each access, so it goes the same way. The
+        # store has let the object go by now, so even the members that read nothing
+        # raise, which is what makes the two cases indistinguishable to a client.
+        self.assertRaises(self.destroyed, getattr, field, "value")
+        self.assertRaises(self.destroyed, getattr, field, "name")
 
     def test_modules_survive_a_quickload(self):
         part = self.a_part("longAntenna")
@@ -73,6 +80,28 @@ class TestObjectLifetime(krpctest.TestCase):
         self.wait(1)
         self.assertEqual(name, module.name)
         self.assertEqual(power, antenna.power)
+
+    def test_module_members_survive_a_quickload(self):
+        part = self.a_part("mk1-3pod")
+        module = next(m for m in part.modules if m.name == "ModuleCommand")
+        field = next(f for f in module.field_list if f.name == "controlSrcStatusText")
+        event = next(e for e in module.event_list if e.name == "MakeReference")
+        action = next(a for a in module.action_list if a.name == "MakeReferenceToggle")
+        value = field.value
+        self.space_center.quicksave()
+        self.wait(1)
+        self.space_center.quickload()
+        self.wait(1)
+        # A field, event or action is found by name on whichever module the object's
+        # part carries now, so it reads the module the load built rather than the one
+        # it replaced. Reading one is what proves it: the game rebuilt the module, so
+        # anything held from before the load would be reading a replaced game state.
+        self.assertEqual(value, field.value)
+        self.assertEqual(module, field.module)
+        self.assertTrue(event.visible)
+        action.enabled = True
+        self.assertTrue(action.enabled)
+        action.enabled = False
 
     def test_objects_survive_a_quickload(self):
         vessel = self.space_center.active_vessel

--- a/service/SpaceCenter/test/test_object_lifetime.py
+++ b/service/SpaceCenter/test/test_object_lifetime.py
@@ -116,6 +116,20 @@ class TestObjectLifetime(krpctest.TestCase):
         self.assertEqual(name, vessel.name)
         self.assertEqual("sensorThermometer", part.name)
 
+    def test_the_store_drops_a_destroyed_part(self):
+        part = self.a_part("strutConnector")
+        self.assertEqual("strutConnector", part.name)
+        before = self.conn.testing_tools.object_store_size
+        self.conn.testing_tools.destroy_part(part)
+        # The game says the part died, so the object goes without waiting for a load.
+        self.wait_until(
+            lambda: self.conn.testing_tools.object_store_size < before,
+            message="destroyed part was not dropped from the object store",
+        )
+        # The server no longer has the object at all, and says so in the same terms
+        # as an object it still has whose part is gone.
+        self.assertRaises(self.destroyed, getattr, part, "name")
+
     def test_the_store_drops_dead_objects_on_a_load(self):
         # A maneuver node is what a load definitively kills. The game builds the vessel's
         # parts again under the ids their objects name them by, so those survive a load

--- a/service/SpaceCenter/test/test_object_lifetime.py
+++ b/service/SpaceCenter/test/test_object_lifetime.py
@@ -1,0 +1,138 @@
+import krpctest
+
+
+class TestObjectLifetime(krpctest.TestCase):
+    """What a client's objects do when the game objects behind them go away.
+
+    A client object names something in the game and looks it up on each access, so
+    the interesting cases are the ones where that lookup fails: the thing was
+    destroyed, or a game state was loaded on top of it.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.new_save()
+        cls.launch_vessel_from_vab("Parts")
+        cls.remove_other_vessels()
+        cls.conn = cls.connect()
+        cls.space_center = cls.conn.space_center
+        cls.destroyed = cls.conn.krpc.ObjectDestroyedException
+
+    @classmethod
+    def a_part(cls, name):
+        return cls.space_center.active_vessel.parts.with_name(name)[0]
+
+    def test_reading_a_destroyed_part(self):
+        part = self.a_part("strutConnector")
+        self.assertEqual("strutConnector", part.name)
+        self.conn.testing_tools.destroy_part(part)
+        self.wait(0.5)
+        self.assertRaises(self.destroyed, getattr, part, "name")
+        self.assertRaises(self.destroyed, getattr, part, "mass")
+
+    def test_objects_survive_a_quickload(self):
+        vessel = self.space_center.active_vessel
+        part = self.a_part("sensorThermometer")
+        name = vessel.name
+        self.space_center.quicksave()
+        self.wait(1)
+        self.space_center.quickload()
+        self.wait(1)
+        # The game built a new vessel and new parts, and the objects the client
+        # already holds name the same things, so they find them again.
+        self.assertEqual(name, vessel.name)
+        self.assertEqual("sensorThermometer", part.name)
+
+
+class TestObjectLifetimeUnloaded(krpctest.TestCase):
+    """A part of a vessel the game has unloaded is not a destroyed part.
+
+    The game keeps an unloaded vessel as a snapshot and builds its parts again when it
+    comes back into range, so a part object for one of them has to say the part is not
+    loaded, and has to survive being swept for as long as the snapshot is there.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.new_save()
+        cls.launch_vessel_from_vab("Multi")
+        cls.remove_other_vessels()
+        cls.set_circular_orbit("Kerbin", 100000)
+        cls.conn = cls.connect()
+        cls.space_center = cls.conn.space_center
+        cls.destroyed = cls.conn.krpc.ObjectDestroyedException
+        next(iter(cls.space_center.active_vessel.parts.docking_ports)).undock()
+        cls.wait(1)
+        cls.vessel = cls.space_center.active_vessel
+        cls.other = next(v for v in cls.space_center.vessels if v != cls.vessel)
+
+    def assert_not_loaded(self, obj, attribute):
+        """Assert that reading the attribute says the object is not loaded.
+
+        Not loaded and destroyed have to be told apart, and asserting on RuntimeError
+        cannot do it: the client builds ObjectDestroyedException as a subclass of
+        RuntimeError, and the not-loaded error is a RuntimeError itself, so either one
+        satisfies an assertion made against the base class.
+        """
+        with self.assertRaises(RuntimeError) as raised:
+            getattr(obj, attribute)
+        self.assertNotIsInstance(raised.exception, self.destroyed)
+        self.assertIn("not loaded", str(raised.exception))
+
+    def test_parts_of_an_unloaded_vessel(self):
+        part = self.other.parts.all[0]
+        name = part.name
+        other_name = self.other.name
+
+        # Put the other vessel far enough away that the game unloads it.
+        self.set_circular_orbit("Kerbin", 200000)
+        self.wait(2)
+        self.wait_while(lambda: self.other.loaded, message="vessel did not unload")
+
+        # The vessel is still there to be found, and the part is not, but it is not
+        # gone either: it is waiting for its vessel to be loaded again.
+        self.assertEqual(other_name, self.other.name)
+        self.assert_not_loaded(part, "name")
+
+        # A load boundary sweeps the store, and must not take the part with it.
+        self.space_center.quicksave()
+        self.wait(1)
+        self.space_center.quickload()
+        self.wait(1)
+        self.assert_not_loaded(part, "name")
+
+        # Loading the vessel gives the part back, rather than a new object for it.
+        self.space_center.active_vessel = self.other
+        self.wait(2)
+        self.assertEqual(name, part.name)
+
+
+class TestObjectLifetimeDestroyedVessel(krpctest.TestCase):
+    """A vessel the game destroys takes with it every object reached through it."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.new_save()
+        cls.launch_vessel_from_vab("Multi")
+        cls.remove_other_vessels()
+        cls.set_circular_orbit("Kerbin", 100000)
+        cls.conn = cls.connect()
+        cls.space_center = cls.conn.space_center
+        cls.destroyed = cls.conn.krpc.ObjectDestroyedException
+
+    def test_using_a_destroyed_vessel(self):
+        vessel = self.space_center.active_vessel
+        next(iter(vessel.parts.docking_ports)).undock()
+        self.wait(1)
+        other = next(v for v in self.space_center.vessels if v != vessel)
+        control = other.control
+        part = other.parts.all[0]
+        self.assertNotEqual("", other.name)
+
+        # The game destroys the vessel, which is the end of it: it was not merely put out
+        # of range, and there is nothing left to build it again from.
+        self.remove_other_vessels()
+        self.wait(1)
+        self.assertRaises(self.destroyed, getattr, other, "name")
+        self.assertRaises(self.destroyed, getattr, control, "sas")
+        self.assertRaises(self.destroyed, getattr, part, "name")

--- a/service/SpaceCenter/test/test_object_lifetime.py
+++ b/service/SpaceCenter/test/test_object_lifetime.py
@@ -30,6 +30,50 @@ class TestObjectLifetime(krpctest.TestCase):
         self.assertRaises(self.destroyed, getattr, part, "name")
         self.assertRaises(self.destroyed, getattr, part, "mass")
 
+    def test_reading_a_module_of_a_destroyed_part(self):
+        part = self.a_part("sensorThermometer")
+        module = part.modules[0]
+        sensor = part.sensor
+        self.assertNotEqual("", module.name)
+        self.conn.testing_tools.destroy_part(part)
+        self.wait(0.5)
+        # The module belongs to the part's game object, so it goes when the part does,
+        # and says so rather than failing with a null reference.
+        self.assertRaises(self.destroyed, getattr, module, "name")
+        self.assertRaises(self.destroyed, getattr, sensor, "active")
+
+    def test_modules_survive_a_quickload(self):
+        part = self.a_part("longAntenna")
+        module = part.modules[0]
+        antenna = part.antenna
+        name = module.name
+        power = antenna.power
+        self.space_center.quicksave()
+        self.wait(1)
+        self.space_center.quickload()
+        self.wait(1)
+        # The game built new part modules, and the objects the client holds name the
+        # same ones, so they read the new modules rather than the replaced ones.
+        self.assertEqual(name, module.name)
+        self.assertEqual(power, antenna.power)
+
+    def test_modules_survive_a_load_of_a_save_that_predates_them(self):
+        # The game names a part module only when something asks it to, and writes out only
+        # the names it has already given, so a save taken before the client named a module
+        # holds nothing that says which module was meant. Loading one still has to give the
+        # client back the module it named.
+        self.space_center.quicksave()
+        self.wait(1)
+        part = self.a_part("longAntenna")
+        module = part.modules[0]
+        antenna = part.antenna
+        name = module.name
+        power = antenna.power
+        self.space_center.quickload()
+        self.wait(1)
+        self.assertEqual(name, module.name)
+        self.assertEqual(power, antenna.power)
+
     def test_objects_survive_a_quickload(self):
         vessel = self.space_center.active_vessel
         part = self.a_part("sensorThermometer")

--- a/service/SpaceCenter/test/test_object_lifetime.py
+++ b/service/SpaceCenter/test/test_object_lifetime.py
@@ -116,6 +116,42 @@ class TestObjectLifetime(krpctest.TestCase):
         self.assertEqual(name, vessel.name)
         self.assertEqual("sensorThermometer", part.name)
 
+    def test_the_store_drops_dead_objects_on_a_load(self):
+        # A maneuver node is what a load definitively kills. The game builds the vessel's
+        # parts again under the ids their objects name them by, so those survive a load
+        # and show nothing, but it offers nothing to find a node by and the flight plan it
+        # loads is a new one. Nothing raises a destruction event for a node either, so the
+        # sweep at the load boundary is the only thing that can drop the object.
+        vessel = self.space_center.active_vessel
+        node = vessel.control.add_node(self.space_center.ut + 60, 100, 0, 0)
+        self.assertAlmostEqual(100, node.prograde, places=3)
+        before = self.conn.testing_tools.object_store_size
+        self.space_center.quicksave()
+        self.wait(1)
+        self.space_center.quickload()
+        self.wait(1)
+        self.assertEqual("Parts", vessel.name)
+        self.wait_until(
+            lambda: self.conn.testing_tools.object_store_size < before,
+            message="the load did not drop the maneuver node from the object store",
+        )
+        self.assertRaises(self.destroyed, getattr, node, "prograde")
+
+    def test_an_orbit_survives_a_quickload(self):
+        vessel = self.space_center.active_vessel
+        orbit = vessel.orbit
+        self.assertEqual("Kerbin", orbit.body.name)
+        self.space_center.quicksave()
+        self.wait(1)
+        self.space_center.quickload()
+        self.wait(1)
+        # The game built a new orbit along with the vessel it rebuilt. The object names
+        # the vessel whose orbit it is rather than the orbit it was made from, so it
+        # reads the new one, and asking the vessel again gives back the same object
+        # rather than a second one for the orbit that replaced it.
+        self.assertEqual("Kerbin", orbit.body.name)
+        self.assertEqual(vessel.orbit, orbit)
+
 
 class TestObjectLifetimeUnloaded(krpctest.TestCase):
     """A part of a vessel the game has unloaded is not a destroyed part.

--- a/service/SpaceCenter/test/test_parts_decoupler.py
+++ b/service/SpaceCenter/test/test_parts_decoupler.py
@@ -9,7 +9,8 @@ class TestPartsDecoupler(krpctest.TestCase):
         cls.new_save()
         cls.launch_vessel_from_vab("PartsDecoupler")
         cls.remove_other_vessels()
-        cls.vessel = cls.connect().space_center.active_vessel
+        cls.space_center = cls.connect().space_center
+        cls.vessel = cls.space_center.active_vessel
         # Look parts up by language-independent internal name (part.name), not the
         # localized title. Decoupler.1 = "TD-12 Decoupler" (was "TR-18A Stack
         # Decoupler"), Separator.1 = "TS-12 Stack Separator" (was "TR-18D Stack
@@ -19,6 +20,29 @@ class TestPartsDecoupler(krpctest.TestCase):
             0
         ].decoupler
         cls.disabled_decoupler = cls.vessel.parts.with_name("Separator.1")[0].decoupler
+
+    def test_a_decoupler_survives_a_quickload(self):
+        decoupler = self.stack_decoupler
+        part = decoupler.part
+        impulse = decoupler.impulse
+        self.assertFalse(decoupler.decoupled)
+        self.space_center.quicksave()
+        self.wait(1)
+        self.space_center.quickload()
+        self.wait(1)
+        # The game rebuilt the part's modules, and the object names the decoupler of
+        # its part rather than the module it was made from, so it reads the new one.
+        self.assertEqual(impulse, decoupler.impulse)
+        self.assertFalse(decoupler.decoupled)
+        # And asking the part again gives that object back rather than a second one.
+        self.assertEqual(decoupler, part.decoupler)
+
+    def test_asking_twice_gives_the_same_decoupler(self):
+        # Two objects for one decoupler are equal, so the server hands the object it
+        # already has back rather than adding another one for every call.
+        part = self.stack_decoupler.part
+        self.assertEqual(self.stack_decoupler, part.decoupler)
+        self.assertEqual(part.decoupler, part.decoupler)
 
     def test_stack_decoupler(self):
         # impulse = ejectionForce (kN) * 10. TD-12 Decoupler has ejectionForce

--- a/service/SpaceCenter/test/test_waypoints.py
+++ b/service/SpaceCenter/test/test_waypoints.py
@@ -7,9 +7,24 @@ class TestWaypoints(krpctest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.new_save()
-        cls.space_center = cls.connect().space_center
+        cls.conn = cls.connect()
+        cls.space_center = cls.conn.space_center
         cls.wpm = cls.space_center.waypoint_manager
         cls.body = cls.space_center.bodies["Kerbin"]
+        cls.destroyed = cls.conn.krpc.ObjectDestroyedException
+
+    def test_access_after_remove_raises(self):
+        waypoint = self.wpm.add_waypoint(0, 0, self.body, "test_access_after_remove")
+        self.assertEqual("test_access_after_remove", waypoint.name)
+        waypoint.remove()
+        # The game no longer has the waypoint, so reading or writing it says so rather
+        # than changing a waypoint that is not in the game.
+        with self.assertRaises(self.destroyed):
+            _ = waypoint.name
+        with self.assertRaises(self.destroyed):
+            waypoint.latitude = 10
+        with self.assertRaises(self.destroyed):
+            waypoint.remove()
 
     def test_manager(self):
         # On a fresh save KSP creates a waypoint for each launch site. The three

--- a/service/UI/CHANGELOG.md
+++ b/service/UI/CHANGELOG.md
@@ -59,6 +59,16 @@
 - Fix `Text.Font` making a font of its own every time it is set, and leaving it behind when
   the label went. A font of a given name is made once and shared by the labels using it
   (#1040)
+- A user interface object raises `KRPC.ObjectDestroyedException` once the element it
+  stands for is gone, which removing it, `UI.Clear`, the client that made it disconnecting
+  and changing scene all do. They previously failed on a destroyed game object, and were
+  kept for the rest of the session (#1051)
+- `RectTransform`, `Layout`, `LayoutElement` and `SizeFitter` do the same once the element
+  they were taken from is gone, and are dropped with it rather than being kept for the rest
+  of the session (#1051)
+- Fix `RectTransform` objects accumulating for the rest of the session, one for every read
+  of any object's `RectTransform`. Reading the same one twice now gives the same object
+  (#1051)
 
 ## [v0.6.0]
 - Fix locale issues with `UI.Message` (#993)

--- a/service/UI/src/Addon.cs
+++ b/service/UI/src/Addon.cs
@@ -46,11 +46,13 @@ namespace KRPC.UI
         }
 
         /// <summary>
-        /// Update the addon: destroy the objects of clients that have disconnected.
+        /// Update the addon: destroy the objects of clients that have disconnected, and
+        /// drop the ones the game no longer has.
         /// </summary>
         public void Update ()
         {
             Sweep ();
+            objects.RemoveDestroyed ();
         }
     }
 }

--- a/service/UI/src/Button.cs
+++ b/service/UI/src/Button.cs
@@ -66,7 +66,10 @@ namespace KRPC.UI
         /// </remarks>
         [KRPCProperty]
         public bool Pressed {
-            get { return press.Pressed; }
+            get {
+                CheckExists ();
+                return press.Pressed;
+            }
         }
     }
 }

--- a/service/UI/src/Container.cs
+++ b/service/UI/src/Container.cs
@@ -37,7 +37,7 @@ namespace KRPC.UI
         [KRPCMethod]
         public Panel AddPanel (bool visible = true)
         {
-            return new Panel (GameObject, visible);
+            return new Panel (CheckedGameObject, visible);
         }
 
         /// <summary>
@@ -48,7 +48,7 @@ namespace KRPC.UI
         [KRPCMethod]
         public Text AddText (string content, bool visible = true)
         {
-            return new Text (GameObject, content, visible);
+            return new Text (CheckedGameObject, content, visible);
         }
 
         /// <summary>
@@ -58,7 +58,7 @@ namespace KRPC.UI
         [KRPCMethod]
         public InputField AddInputField (bool visible = true)
         {
-            return new InputField (GameObject, visible);
+            return new InputField (CheckedGameObject, visible);
         }
 
         /// <summary>
@@ -71,7 +71,7 @@ namespace KRPC.UI
         [KRPCMethod]
         public Slider AddSlider (bool vertical = false, bool visible = true)
         {
-            return new Slider (GameObject, vertical, visible);
+            return new Slider (CheckedGameObject, vertical, visible);
         }
 
         /// <summary>
@@ -81,7 +81,7 @@ namespace KRPC.UI
         [KRPCMethod]
         public Dropdown AddDropdown (bool visible = true)
         {
-            return new Dropdown (GameObject, visible);
+            return new Dropdown (CheckedGameObject, visible);
         }
 
         /// <summary>
@@ -91,7 +91,7 @@ namespace KRPC.UI
         [KRPCMethod]
         public Image AddImage (bool visible = true)
         {
-            return new Image (GameObject, visible);
+            return new Image (CheckedGameObject, visible);
         }
 
         /// <summary>
@@ -101,7 +101,7 @@ namespace KRPC.UI
         [KRPCMethod]
         public ScrollView AddScrollView (bool visible = true)
         {
-            return new ScrollView (GameObject, visible);
+            return new ScrollView (CheckedGameObject, visible);
         }
 
         /// <summary>
@@ -112,7 +112,7 @@ namespace KRPC.UI
         [KRPCMethod]
         public Toggle AddToggle (string content, bool visible = true)
         {
-            return new Toggle (GameObject, content, visible);
+            return new Toggle (CheckedGameObject, content, visible);
         }
 
         /// <summary>
@@ -125,7 +125,7 @@ namespace KRPC.UI
         [KRPCMethod]
         public ToggleGroup AddToggleGroup ()
         {
-            return new ToggleGroup (GameObject);
+            return new ToggleGroup (CheckedGameObject);
         }
 
         /// <summary>
@@ -136,7 +136,7 @@ namespace KRPC.UI
         [KRPCMethod]
         public Button AddButton (string content, bool visible = true)
         {
-            return new Button (GameObject, content, visible);
+            return new Button (CheckedGameObject, content, visible);
         }
     }
 }

--- a/service/UI/src/Control.cs
+++ b/service/UI/src/Control.cs
@@ -24,6 +24,19 @@ namespace KRPC.UI
         protected abstract UnityEngine.UI.Selectable Selectable { get; }
 
         /// <summary>
+        /// The component that handles interaction, checked to still exist. Every member
+        /// that reaches into the game goes through this, or through
+        /// <see cref="Object.CheckedGameObject" />, so that a control the game no longer
+        /// has says so rather than failing on a torn down object.
+        /// </summary>
+        protected UnityEngine.UI.Selectable CheckedSelectable {
+            get {
+                CheckExists ();
+                return Selectable;
+            }
+        }
+
+        /// <summary>
         /// Whether the control responds to the user.
         /// </summary>
         /// <remarks>
@@ -32,8 +45,8 @@ namespace KRPC.UI
         /// </remarks>
         [KRPCProperty]
         public bool Interactable {
-            get { return Selectable.interactable; }
-            set { Selectable.interactable = value; }
+            get { return CheckedSelectable.interactable; }
+            set { CheckedSelectable.interactable = value; }
         }
 
         /// <summary>
@@ -51,8 +64,8 @@ namespace KRPC.UI
         /// </remarks>
         [KRPCProperty]
         public Tuple4 Color {
-            get { return Selectable.targetGraphic.color.ToRgbaTuple (); }
-            set { Selectable.targetGraphic.color = value.ToColor (); }
+            get { return CheckedSelectable.targetGraphic.color.ToRgbaTuple (); }
+            set { CheckedSelectable.targetGraphic.color = value.ToColor (); }
         }
 
         /// <summary>
@@ -62,16 +75,17 @@ namespace KRPC.UI
         [KRPCProperty]
         public string Tooltip {
             get {
-                var handler = GameObject.GetComponent<TooltipHandler> ();
+                var handler = CheckedGameObject.GetComponent<TooltipHandler> ();
                 return handler == null || handler.Text == null
                     ? string.Empty : handler.Text;
             }
             set {
-                var handler = GameObject.GetComponent<TooltipHandler> ();
+                var gameObject = CheckedGameObject;
+                var handler = gameObject.GetComponent<TooltipHandler> ();
                 if (handler == null) {
                     if (string.IsNullOrEmpty (value))
                         return;
-                    handler = GameObject.AddComponent<TooltipHandler> ();
+                    handler = gameObject.AddComponent<TooltipHandler> ();
                 }
                 handler.Text = value;
             }

--- a/service/UI/src/Dropdown.cs
+++ b/service/UI/src/Dropdown.cs
@@ -109,6 +109,14 @@ namespace KRPC.UI
             get { return dropdown; }
         }
 
+        // The game's dropdown, checked to still exist.
+        UnityEngine.UI.Dropdown Internal {
+            get {
+                CheckExists ();
+                return dropdown;
+            }
+        }
+
         /// <summary>
         /// The options that the dropdown offers.
         /// </summary>
@@ -118,15 +126,15 @@ namespace KRPC.UI
         /// </remarks>
         [KRPCProperty]
         public IList<string> Options {
-            get { return dropdown.options.Select (option => option.text).ToList (); }
+            get { return Internal.options.Select (option => option.text).ToList (); }
             set {
                 // The selection is reset while the old options are still in place, as Unity
                 // ignores a selection made when there is nothing to select.
-                dropdown.SetValueWithoutNotify (0);
-                dropdown.ClearOptions ();
+                Internal.SetValueWithoutNotify (0);
+                Internal.ClearOptions ();
                 if (value != null)
-                    dropdown.AddOptions (value.ToList ());
-                dropdown.RefreshShownValue ();
+                    Internal.AddOptions (value.ToList ());
+                Internal.RefreshShownValue ();
             }
         }
 
@@ -138,17 +146,17 @@ namespace KRPC.UI
         /// </remarks>
         [KRPCProperty]
         public int SelectedIndex {
-            get { return dropdown.value; }
+            get { return Internal.value; }
             set {
                 // Unity moves a position outside the list to the nearest one that is in
                 // it, so a client that asked for the wrong one would be left reading back
                 // a value it did not set and no way to tell that it had happened.
-                if (value < 0 || value >= dropdown.options.Count)
+                if (value < 0 || value >= Internal.options.Count)
                     throw new ArgumentOutOfRangeException (
                         nameof (value), "The dropdown does not have that option");
                 // Unity notifies its listeners of an option chosen by a client just as it
                 // does one chosen by the user, so the option is chosen without notifying them.
-                dropdown.SetValueWithoutNotify (value);
+                Internal.SetValueWithoutNotify (value);
             }
         }
 

--- a/service/UI/src/Image.cs
+++ b/service/UI/src/Image.cs
@@ -31,6 +31,14 @@ namespace KRPC.UI
             image = Widgets.AddImage (GameObject, null);
         }
 
+        // The game's image, checked to still exist.
+        UnityEngine.UI.Image Internal {
+            get {
+                CheckExists ();
+                return image;
+            }
+        }
+
         /// <summary>
         /// The picture to show, as the contents of a PNG or JPEG file. Set it to an empty
         /// array to show a plain rectangle instead.
@@ -45,7 +53,7 @@ namespace KRPC.UI
             get { return content; }
             set {
                 if (value == null || value.Length == 0) {
-                    image.sprite = null;
+                    Internal.sprite = null;
                     DestroyContent ();
                     return;
                 }
@@ -61,8 +69,8 @@ namespace KRPC.UI
                     new Vector2 (0.5f, 0.5f));
                 // The image is pointed at the new picture before the old one is freed, so
                 // that it is never left drawing something that has been destroyed.
-                image.sprite = loadedSprite;
-                image.type = UnityEngine.UI.Image.Type.Simple;
+                Internal.sprite = loadedSprite;
+                Internal.type = UnityEngine.UI.Image.Type.Simple;
                 DestroyContent ();
                 content = value;
                 texture = loaded;
@@ -112,8 +120,8 @@ namespace KRPC.UI
                 loaded, new Rect (0, 0, width, height), new Vector2 (0.5f, 0.5f));
             // The image is pointed at the new picture before the old one is freed, so
             // that it is never left drawing something that has been destroyed.
-            image.sprite = loadedSprite;
-            image.type = UnityEngine.UI.Image.Type.Simple;
+            Internal.sprite = loadedSprite;
+            Internal.type = UnityEngine.UI.Image.Type.Simple;
             DestroyContent ();
             texture = loaded;
             sprite = loadedSprite;
@@ -151,6 +159,10 @@ namespace KRPC.UI
             if (data.LongLength != (long)width * height * 4)
                 throw new ArgumentException (
                     "The block needs width * height * 4 bytes, 4 bytes per pixel");
+            // The block is drawn into the texture rather than through the image component,
+            // so the check that the other members get from Internal is made here, before
+            // anything is concluded from what an image the game no longer has is holding.
+            CheckExists ();
             if (!rawPixels || texture == null)
                 throw new InvalidOperationException (
                     "The image is not showing a picture drawn from raw pixels");
@@ -244,8 +256,8 @@ namespace KRPC.UI
         /// </summary>
         [KRPCProperty]
         public Tuple4 Color {
-            get { return image.color.ToRgbaTuple (); }
-            set { image.color = value.ToColor (); }
+            get { return Internal.color.ToRgbaTuple (); }
+            set { Internal.color = value.ToColor (); }
         }
     }
 }

--- a/service/UI/src/InputField.cs
+++ b/service/UI/src/InputField.cs
@@ -51,15 +51,23 @@ namespace KRPC.UI
             get { return inputField; }
         }
 
+        // The game's input field, checked to still exist.
+        UnityEngine.UI.InputField Internal {
+            get {
+                CheckExists ();
+                return inputField;
+            }
+        }
+
         /// <summary>
         /// The value of the input field.
         /// </summary>
         [KRPCProperty]
         public string Value {
-            get { return inputField.text; }
+            get { return Internal.text; }
             // Unity notifies its listeners of a value set by a client just as it does one
             // typed by the user, so the value is set without notifying them.
-            set { inputField.SetTextWithoutNotify (value); }
+            set { Internal.SetTextWithoutNotify (value); }
         }
 
         /// <summary>
@@ -97,8 +105,8 @@ namespace KRPC.UI
         /// </remarks>
         [KRPCProperty]
         public InputContentType ContentType {
-            get { return inputField.contentType.ToInputContentType (); }
-            set { inputField.contentType = value.FromInputContentType (); }
+            get { return Internal.contentType.ToInputContentType (); }
+            set { Internal.contentType = value.FromInputContentType (); }
         }
 
         /// <summary>
@@ -106,12 +114,12 @@ namespace KRPC.UI
         /// </summary>
         [KRPCProperty]
         public int CharacterLimit {
-            get { return inputField.characterLimit; }
+            get { return Internal.characterLimit; }
             set {
                 if (value < 0)
                     throw new ArgumentOutOfRangeException (
                         nameof (value), "The character limit must not be negative");
-                inputField.characterLimit = value;
+                Internal.characterLimit = value;
             }
         }
 
@@ -125,8 +133,8 @@ namespace KRPC.UI
         /// </remarks>
         [KRPCProperty]
         public bool ReadOnly {
-            get { return inputField.readOnly; }
-            set { inputField.readOnly = value; }
+            get { return Internal.readOnly; }
+            set { Internal.readOnly = value; }
         }
 
         /// <summary>

--- a/service/UI/src/Layout.cs
+++ b/service/UI/src/Layout.cs
@@ -1,8 +1,10 @@
 using System;
+using System.Runtime.CompilerServices;
 using KRPC.Service.Attributes;
 using KRPC.SpaceCenter.ExtensionMethods;
 using KRPC.UI.ExtensionMethods;
 using KRPC.Utils;
+using ObjectDestroyedException = KRPC.Service.KRPC.ObjectDestroyedException;
 using UnityEngine;
 using Tuple2 = System.Tuple<double, double>;
 using Tuple4Int = System.Tuple<int, int, int, int>;
@@ -15,8 +17,11 @@ namespace KRPC.UI
     /// <see cref="Panel.AddVerticalLayout" /> and <see cref="Panel.AddGridLayout" />.
     /// </summary>
     [KRPCClass (Service = "UI")]
-    public class Layout : Equatable<Layout>
+    public class Layout : Equatable<Layout>, IGameObjectState
     {
+        // The game's layout group, which is what this stands for: it belongs to the
+        // interface element it was taken from and lives exactly as long as that
+        // element, and the game gives it nothing else to be named by.
         readonly UnityEngine.UI.LayoutGroup layout;
 
         internal Layout (UnityEngine.UI.LayoutGroup innerLayout)
@@ -29,7 +34,8 @@ namespace KRPC.UI
         /// </summary>
         public override bool Equals (Layout other)
         {
-            return !ReferenceEquals (other, null) && layout == other.layout;
+            return !ReferenceEquals (other, null) &&
+            ReferenceEquals (layout, other.layout);
         }
 
         /// <summary>
@@ -37,12 +43,37 @@ namespace KRPC.UI
         /// </summary>
         public override int GetHashCode ()
         {
-            return layout.GetHashCode ();
+            // The layout's identity hash rather than its own, so that nothing the game
+            // does to it can change it while a client holds this object.
+            return RuntimeHelpers.GetHashCode (layout);
+        }
+
+        /// <summary>
+        /// What the game holds for the layout. It belongs to the interface element it was
+        /// taken from, and the game destroys it with that element, which nothing builds
+        /// again.
+        /// </summary>
+        public GameObjectState GameObjectState {
+            get {
+                return layout == null
+                    ? GameObjectState.Destroyed : GameObjectState.Live;
+            }
+        }
+
+        // The game's layout, checked to still exist.
+        UnityEngine.UI.LayoutGroup Internal {
+            get {
+                if (GameObjectState == GameObjectState.Destroyed)
+                    throw new ObjectDestroyedException (
+                        "The layout no longer exists, as the user interface object " +
+                        "it belongs to has been removed.");
+                return layout;
+            }
         }
 
         UnityEngine.UI.GridLayoutGroup Grid {
             get {
-                var grid = layout as UnityEngine.UI.GridLayoutGroup;
+                var grid = Internal as UnityEngine.UI.GridLayoutGroup;
                 if (grid == null)
                     throw new InvalidOperationException ("The layout is not a grid layout");
                 return grid;
@@ -51,7 +82,7 @@ namespace KRPC.UI
 
         UnityEngine.UI.HorizontalOrVerticalLayoutGroup Line {
             get {
-                var line = layout as UnityEngine.UI.HorizontalOrVerticalLayoutGroup;
+                var line = Internal as UnityEngine.UI.HorizontalOrVerticalLayoutGroup;
                 if (line == null)
                     throw new InvalidOperationException (
                         "The layout is not a horizontal or vertical layout");
@@ -66,11 +97,11 @@ namespace KRPC.UI
         [KRPCProperty]
         public float Spacing {
             get {
-                var grid = layout as UnityEngine.UI.GridLayoutGroup;
+                var grid = Internal as UnityEngine.UI.GridLayoutGroup;
                 return grid != null ? grid.spacing.x : Line.spacing;
             }
             set {
-                var grid = layout as UnityEngine.UI.GridLayoutGroup;
+                var grid = Internal as UnityEngine.UI.GridLayoutGroup;
                 if (grid != null)
                     grid.spacing = new Vector2 (value, value);
                 else
@@ -85,14 +116,14 @@ namespace KRPC.UI
         [KRPCProperty]
         public Tuple4Int Padding {
             get {
-                var padding = layout.padding;
+                var padding = Internal.padding;
                 return new Tuple4Int (
                     padding.left, padding.right, padding.top, padding.bottom);
             }
             set {
                 if (value == null)
                     throw new ArgumentNullException (nameof (value));
-                layout.padding = new RectOffset (
+                Internal.padding = new RectOffset (
                     value.Item1, value.Item2, value.Item3, value.Item4);
             }
         }
@@ -102,8 +133,8 @@ namespace KRPC.UI
         /// </summary>
         [KRPCProperty]
         public TextAnchor ChildAlignment {
-            get { return layout.childAlignment.ToTextAnchor (); }
-            set { layout.childAlignment = value.FromTextAnchor (); }
+            get { return Internal.childAlignment.ToTextAnchor (); }
+            set { Internal.childAlignment = value.FromTextAnchor (); }
         }
 
         /// <summary>

--- a/service/UI/src/LayoutElement.cs
+++ b/service/UI/src/LayoutElement.cs
@@ -1,7 +1,9 @@
 using System;
+using System.Runtime.CompilerServices;
 using KRPC.Service.Attributes;
 using KRPC.SpaceCenter.ExtensionMethods;
 using KRPC.Utils;
+using ObjectDestroyedException = KRPC.Service.KRPC.ObjectDestroyedException;
 using Tuple2 = System.Tuple<double, double>;
 
 namespace KRPC.UI
@@ -15,8 +17,11 @@ namespace KRPC.UI
     /// shared between the elements with a flexible size, in proportion to it.
     /// </remarks>
     [KRPCClass (Service = "UI")]
-    public class LayoutElement : Equatable<LayoutElement>
+    public class LayoutElement : Equatable<LayoutElement>, IGameObjectState
     {
+        // The game's layout element, which is what this stands for: it belongs to the
+        // interface element it was taken from and lives exactly as long as that element,
+        // and the game gives it nothing else to be named by.
         readonly UnityEngine.UI.LayoutElement element;
 
         internal LayoutElement (UnityEngine.UI.LayoutElement innerElement)
@@ -29,7 +34,8 @@ namespace KRPC.UI
         /// </summary>
         public override bool Equals (LayoutElement other)
         {
-            return !ReferenceEquals (other, null) && element == other.element;
+            return !ReferenceEquals (other, null) &&
+            ReferenceEquals (element, other.element);
         }
 
         /// <summary>
@@ -37,7 +43,32 @@ namespace KRPC.UI
         /// </summary>
         public override int GetHashCode ()
         {
-            return element.GetHashCode ();
+            // The element's identity hash rather than its own, so that nothing the game
+            // does to it can change it while a client holds this object.
+            return RuntimeHelpers.GetHashCode (element);
+        }
+
+        /// <summary>
+        /// What the game holds for the layout element. It belongs to the interface element
+        /// it was taken from, and the game destroys it with that element, which nothing
+        /// builds again.
+        /// </summary>
+        public GameObjectState GameObjectState {
+            get {
+                return element == null
+                    ? GameObjectState.Destroyed : GameObjectState.Live;
+            }
+        }
+
+        // The game's layout element, checked to still exist.
+        UnityEngine.UI.LayoutElement Internal {
+            get {
+                if (GameObjectState == GameObjectState.Destroyed)
+                    throw new ObjectDestroyedException (
+                        "The layout element no longer exists, as the user interface object " +
+                        "it belongs to has been removed.");
+                return element;
+            }
         }
 
         /// <summary>
@@ -46,11 +77,11 @@ namespace KRPC.UI
         /// </summary>
         [KRPCProperty]
         public Tuple2 MinSize {
-            get { return new Tuple2 (element.minWidth, element.minHeight); }
+            get { return new Tuple2 (Internal.minWidth, Internal.minHeight); }
             set {
                 var size = value.ToVector ();
-                element.minWidth = size.x;
-                element.minHeight = size.y;
+                Internal.minWidth = size.x;
+                Internal.minHeight = size.y;
             }
         }
 
@@ -60,11 +91,11 @@ namespace KRPC.UI
         /// </summary>
         [KRPCProperty]
         public Tuple2 PreferredSize {
-            get { return new Tuple2 (element.preferredWidth, element.preferredHeight); }
+            get { return new Tuple2 (Internal.preferredWidth, Internal.preferredHeight); }
             set {
                 var size = value.ToVector ();
-                element.preferredWidth = size.x;
-                element.preferredHeight = size.y;
+                Internal.preferredWidth = size.x;
+                Internal.preferredHeight = size.y;
             }
         }
 
@@ -74,11 +105,11 @@ namespace KRPC.UI
         /// </summary>
         [KRPCProperty]
         public Tuple2 FlexibleSize {
-            get { return new Tuple2 (element.flexibleWidth, element.flexibleHeight); }
+            get { return new Tuple2 (Internal.flexibleWidth, Internal.flexibleHeight); }
             set {
                 var size = value.ToVector ();
-                element.flexibleWidth = size.x;
-                element.flexibleHeight = size.y;
+                Internal.flexibleWidth = size.x;
+                Internal.flexibleHeight = size.y;
             }
         }
 
@@ -87,8 +118,8 @@ namespace KRPC.UI
         /// </summary>
         [KRPCProperty]
         public bool IgnoreLayout {
-            get { return element.ignoreLayout; }
-            set { element.ignoreLayout = value; }
+            get { return Internal.ignoreLayout; }
+            set { Internal.ignoreLayout = value; }
         }
     }
 }

--- a/service/UI/src/Object.cs
+++ b/service/UI/src/Object.cs
@@ -1,14 +1,16 @@
 using System;
+using System.Runtime.CompilerServices;
 using KRPC.Service.Attributes;
 using KRPC.Utils;
 using UnityEngine;
+using ObjectDestroyedException = KRPC.Service.KRPC.ObjectDestroyedException;
 
 namespace KRPC.UI
 {
     /// <summary>
     /// Abstract base class for all UI objects.
     /// </summary>
-    public abstract class Object : Equatable<Object>
+    public abstract class Object : Equatable<Object>, IGameObjectState
     {
         /// <summary>
         /// Whether a client can remove the object. Only the objects a client owns can be
@@ -16,19 +18,52 @@ namespace KRPC.UI
         /// with what they belong to.
         /// </summary>
         readonly bool removable;
-
-        /// <summary>
-        /// Whether the object has been destroyed. Unity carries out a destroy at the end
-        /// of the frame it was asked for in, and the server answers more than one call in
-        /// a frame, so the game object is still there to be asked afterwards and cannot be
-        /// used on its own to tell whether the object is gone.
-        /// </summary>
-        bool destroyed;
+        // Whether the element has been taken out of the interface. The game tears a game
+        // object down at the end of the frame, so this records that it is on its way out,
+        // and an element removed and read again in the same frame reports it gone.
+        bool removed;
 
         /// <summary>
         /// Unity game object for the UI element.
         /// </summary>
         protected GameObject GameObject { get; private set; }
+
+        /// <summary>
+        /// What the game holds for the element. The element is the game object it was made
+        /// with, so it is live while the game still has that object, and destroyed once it
+        /// does not, which is what removing it, clearing the interface elements,
+        /// disconnecting the client that made it and leaving the scene all do. Nothing
+        /// builds a client's element again, so there is no dormant state.
+        /// </summary>
+        public GameObjectState GameObjectState {
+            get {
+                return removed || GameObject == null
+                    ? GameObjectState.Destroyed : GameObjectState.Live;
+            }
+        }
+
+        /// <summary>
+        /// The game object for the element, checked to still exist. Every member that
+        /// reaches into the game goes through this, or through a component the element
+        /// found on it, so that an element the game no longer has says so rather than
+        /// failing on a torn down object.
+        /// </summary>
+        protected GameObject CheckedGameObject {
+            get {
+                CheckExists ();
+                return GameObject;
+            }
+        }
+
+        /// <summary>
+        /// Raise if the game no longer has the element.
+        /// </summary>
+        protected void CheckExists ()
+        {
+            if (GameObjectState == GameObjectState.Destroyed)
+                throw new ObjectDestroyedException (
+                    "The user interface object no longer exists, as it has been removed.");
+        }
 
         /// <summary>
         /// Create a UI object.
@@ -58,12 +93,16 @@ namespace KRPC.UI
         /// that a client is handed the same object identifier however it reaches the
         /// element, and asking for the same element repeatedly does not accumulate
         /// identifiers.
+        ///
+        /// The game objects are compared by reference rather than with Unity's own
+        /// equality, which reports a destroyed object as equal to null and so would make
+        /// two objects standing for different destroyed elements equal to each other.
         /// </remarks>
         public override bool Equals (Object other)
         {
             return !ReferenceEquals (other, null) &&
                 GetType () == other.GetType () &&
-                GameObject == other.GameObject;
+                ReferenceEquals (GameObject, other.GameObject);
         }
 
         /// <summary>
@@ -71,7 +110,9 @@ namespace KRPC.UI
         /// </summary>
         public override int GetHashCode ()
         {
-            return GameObject.GetHashCode ();
+            // The game object's identity hash rather than its own, so that nothing the
+            // game does to it can change it while a client holds this object.
+            return RuntimeHelpers.GetHashCode (GameObject);
         }
 
         /// <summary>
@@ -79,7 +120,7 @@ namespace KRPC.UI
         /// game object behind it has been destroyed by a scene change.
         /// </summary>
         internal bool Exists {
-            get { return !destroyed && GameObject != null; }
+            get { return GameObjectState != GameObjectState.Destroyed; }
         }
 
         /// <summary>
@@ -87,7 +128,10 @@ namespace KRPC.UI
         /// </summary>
         [KRPCProperty]
         public RectTransform RectTransform {
-            get { return new RectTransform (GameObject.GetComponent<UnityEngine.RectTransform> ()); }
+            get {
+                return new RectTransform (
+                    CheckedGameObject.GetComponent<UnityEngine.RectTransform> ());
+            }
         }
 
         /// <summary>
@@ -115,9 +159,10 @@ namespace KRPC.UI
                 if (!CanHaveLayoutElement)
                     throw new InvalidOperationException (
                         "A canvas is not inside a layout, so it has no layout element");
-                var element = GameObject.GetComponent<UnityEngine.UI.LayoutElement> ();
+                var gameObject = CheckedGameObject;
+                var element = gameObject.GetComponent<UnityEngine.UI.LayoutElement> ();
                 if (element == null)
-                    element = GameObject.AddComponent<UnityEngine.UI.LayoutElement> ();
+                    element = gameObject.AddComponent<UnityEngine.UI.LayoutElement> ();
                 return new LayoutElement (element);
             }
         }
@@ -133,8 +178,8 @@ namespace KRPC.UI
         /// </remarks>
         [KRPCProperty]
         public bool Visible {
-            get { return GameObject.activeSelf; }
-            set { GameObject.SetActive (value); }
+            get { return CheckedGameObject.activeSelf; }
+            set { CheckedGameObject.SetActive (value); }
         }
 
         /// <summary>
@@ -149,8 +194,8 @@ namespace KRPC.UI
         /// </remarks>
         public virtual void Destroy ()
         {
+            removed = true;
             UnityEngine.Object.Destroy (GameObject);
-            destroyed = true;
         }
 
         /// <summary>
@@ -159,9 +204,15 @@ namespace KRPC.UI
         [KRPCMethod]
         public void Remove ()
         {
+            CheckExists ();
+            CheckNotRemovable ();
+            Addon.Remove (this);
+        }
+
+        void CheckNotRemovable ()
+        {
             if (!removable)
                 throw new InvalidOperationException ("UI object is not removable");
-            Addon.Remove (this);
         }
     }
 }

--- a/service/UI/src/Panel.cs
+++ b/service/UI/src/Panel.cs
@@ -37,7 +37,7 @@ namespace KRPC.UI
         /// </summary>
         UnityEngine.UI.Image Background {
             get {
-                var image = GameObject.GetComponent<UnityEngine.UI.Image> ();
+                var image = CheckedGameObject.GetComponent<UnityEngine.UI.Image> ();
                 if (image == null) {
                     image = Widgets.AddImage (GameObject, null);
                     // It has no sprite yet, and Unity draws an image that has no sprite
@@ -105,15 +105,16 @@ namespace KRPC.UI
         [KRPCProperty]
         public bool Draggable {
             get {
-                var handler = GameObject.GetComponent<DragHandler> ();
+                var handler = CheckedGameObject.GetComponent<DragHandler> ();
                 return handler != null && handler.enabled;
             }
             set {
-                var handler = GameObject.GetComponent<DragHandler> ();
+                var gameObject = CheckedGameObject;
+                var handler = gameObject.GetComponent<DragHandler> ();
                 if (handler == null) {
                     if (!value)
                         return;
-                    handler = GameObject.AddComponent<DragHandler> ();
+                    handler = gameObject.AddComponent<DragHandler> ();
                 }
                 handler.enabled = value;
             }
@@ -126,7 +127,7 @@ namespace KRPC.UI
         [KRPCProperty (Nullable = true)]
         public Layout Layout {
             get {
-                var layout = GameObject.GetComponent<UnityEngine.UI.LayoutGroup> ();
+                var layout = CheckedGameObject.GetComponent<UnityEngine.UI.LayoutGroup> ();
                 return layout == null ? null : new Layout (layout);
             }
         }
@@ -166,9 +167,10 @@ namespace KRPC.UI
         {
             // Unity applies every layout group on an object, and two of them fight over
             // where the elements go, so a panel is allowed only one.
-            if (GameObject.GetComponent<UnityEngine.UI.LayoutGroup> () != null)
+            var gameObject = CheckedGameObject;
+            if (gameObject.GetComponent<UnityEngine.UI.LayoutGroup> () != null)
                 throw new InvalidOperationException ("The panel already has a layout");
-            return new Layout (GameObject.AddComponent<T> ());
+            return new Layout (gameObject.AddComponent<T> ());
         }
 
         /// <summary>
@@ -183,7 +185,7 @@ namespace KRPC.UI
         [KRPCMethod]
         public void BringToFront ()
         {
-            GameObject.transform.SetAsLastSibling ();
+            CheckedGameObject.transform.SetAsLastSibling ();
         }
 
         /// <summary>
@@ -196,9 +198,10 @@ namespace KRPC.UI
         [KRPCProperty]
         public SizeFitter SizeFitter {
             get {
-                var fitter = GameObject.GetComponent<UnityEngine.UI.ContentSizeFitter> ();
+                var gameObject = CheckedGameObject;
+                var fitter = gameObject.GetComponent<UnityEngine.UI.ContentSizeFitter> ();
                 if (fitter == null)
-                    fitter = GameObject.AddComponent<UnityEngine.UI.ContentSizeFitter> ();
+                    fitter = gameObject.AddComponent<UnityEngine.UI.ContentSizeFitter> ();
                 return new SizeFitter (fitter);
             }
         }

--- a/service/UI/src/RectTransform.cs
+++ b/service/UI/src/RectTransform.cs
@@ -1,7 +1,9 @@
 using System;
+using System.Runtime.CompilerServices;
 using KRPC.Service.Attributes;
 using KRPC.SpaceCenter.ExtensionMethods;
 using KRPC.Utils;
+using ObjectDestroyedException = KRPC.Service.KRPC.ObjectDestroyedException;
 using Tuple2 = System.Tuple<double, double>;
 using Tuple3 = System.Tuple<double, double, double>;
 using Tuple4 = System.Tuple<double, double, double, double>;
@@ -13,12 +15,17 @@ namespace KRPC.UI
     /// See the <a href="https://docs.unity3d.com/Manual/class-RectTransform.html">Unity manual</a> for more details.
     /// </summary>
     [KRPCClass (Service = "UI")]
-    public class RectTransform : Equatable<RectTransform>
+    public class RectTransform : Equatable<RectTransform>, IGameObjectState
     {
+        // The game's rect transform, which is what this stands for: it belongs to the
+        // interface element it was taken from and lives exactly as long as that element,
+        // and the game gives it nothing else to be named by.
         readonly UnityEngine.RectTransform rectTransform;
 
         internal RectTransform (UnityEngine.RectTransform innerRectTransform)
         {
+            if (ReferenceEquals (innerRectTransform, null))
+                throw new ArgumentNullException (nameof (innerRectTransform));
             rectTransform = innerRectTransform;
         }
 
@@ -27,7 +34,8 @@ namespace KRPC.UI
         /// </summary>
         public override bool Equals (RectTransform other)
         {
-            return !ReferenceEquals (other, null) && rectTransform == other.rectTransform;
+            return !ReferenceEquals (other, null) &&
+            ReferenceEquals (rectTransform, other.rectTransform);
         }
 
         /// <summary>
@@ -35,7 +43,32 @@ namespace KRPC.UI
         /// </summary>
         public override int GetHashCode ()
         {
-            return rectTransform.GetHashCode ();
+            // The transform's identity hash rather than its own, so that nothing the game
+            // does to it can change it while a client holds this object.
+            return RuntimeHelpers.GetHashCode (rectTransform);
+        }
+
+        /// <summary>
+        /// What the game holds for the rect transform. It belongs to the interface element
+        /// it was taken from, and the game destroys it with that element, which nothing
+        /// builds again.
+        /// </summary>
+        public GameObjectState GameObjectState {
+            get {
+                return rectTransform == null
+                    ? GameObjectState.Destroyed : GameObjectState.Live;
+            }
+        }
+
+        // The game's rect transform, checked to still exist.
+        UnityEngine.RectTransform Internal {
+            get {
+                if (GameObjectState == GameObjectState.Destroyed)
+                    throw new ObjectDestroyedException (
+                        "The rect transform no longer exists, as the user interface object " +
+                        "it belongs to has been removed.");
+                return rectTransform;
+            }
         }
 
         /// <summary>
@@ -43,8 +76,8 @@ namespace KRPC.UI
         /// </summary>
         [KRPCProperty]
         public Tuple2 Position {
-            get { return rectTransform.anchoredPosition.ToTuple (); }
-            set { rectTransform.anchoredPosition = value.ToVector (); }
+            get { return Internal.anchoredPosition.ToTuple (); }
+            set { Internal.anchoredPosition = value.ToVector (); }
         }
 
         /// <summary>
@@ -52,8 +85,8 @@ namespace KRPC.UI
         /// </summary>
         [KRPCProperty]
         public Tuple3 LocalPosition {
-            get { return rectTransform.localPosition.ToTuple (); }
-            set { rectTransform.localPosition = value.ToVector (); }
+            get { return Internal.localPosition.ToTuple (); }
+            set { Internal.localPosition = value.ToVector (); }
         }
 
         /// <summary>
@@ -61,8 +94,8 @@ namespace KRPC.UI
         /// </summary>
         [KRPCProperty]
         public Tuple2 Size {
-            get { return rectTransform.sizeDelta.ToTuple (); }
-            set { rectTransform.sizeDelta = value.ToVector (); }
+            get { return Internal.sizeDelta.ToTuple (); }
+            set { Internal.sizeDelta = value.ToVector (); }
         }
 
         /// <summary>
@@ -70,8 +103,8 @@ namespace KRPC.UI
         /// </summary>
         [KRPCProperty]
         public Tuple2 UpperRight {
-            get { return rectTransform.offsetMax.ToTuple (); }
-            set { rectTransform.offsetMax = value.ToVector (); }
+            get { return Internal.offsetMax.ToTuple (); }
+            set { Internal.offsetMax = value.ToVector (); }
         }
 
         /// <summary>
@@ -79,8 +112,8 @@ namespace KRPC.UI
         /// </summary>
         [KRPCProperty]
         public Tuple2 LowerLeft {
-            get { return rectTransform.offsetMin.ToTuple (); }
-            set { rectTransform.offsetMin = value.ToVector (); }
+            get { return Internal.offsetMin.ToTuple (); }
+            set { Internal.offsetMin = value.ToVector (); }
         }
 
         /// <summary>
@@ -89,8 +122,8 @@ namespace KRPC.UI
         [KRPCProperty]
         public Tuple2 Anchor {
             set {
-                rectTransform.anchorMax = value.ToVector ();
-                rectTransform.anchorMin = value.ToVector ();
+                Internal.anchorMax = value.ToVector ();
+                Internal.anchorMin = value.ToVector ();
             }
         }
 
@@ -99,8 +132,8 @@ namespace KRPC.UI
         /// </summary>
         [KRPCProperty]
         public Tuple2 AnchorMax {
-            get { return rectTransform.anchorMax.ToTuple (); }
-            set { rectTransform.anchorMax = value.ToVector (); }
+            get { return Internal.anchorMax.ToTuple (); }
+            set { Internal.anchorMax = value.ToVector (); }
         }
 
         /// <summary>
@@ -108,8 +141,8 @@ namespace KRPC.UI
         /// </summary>
         [KRPCProperty]
         public Tuple2 AnchorMin {
-            get { return rectTransform.anchorMin.ToTuple (); }
-            set { rectTransform.anchorMin = value.ToVector (); }
+            get { return Internal.anchorMin.ToTuple (); }
+            set { Internal.anchorMin = value.ToVector (); }
         }
 
         /// <summary>
@@ -117,8 +150,8 @@ namespace KRPC.UI
         /// </summary>
         [KRPCProperty]
         public Tuple2 Pivot {
-            get { return rectTransform.pivot.ToTuple (); }
-            set { rectTransform.pivot = value.ToVector (); }
+            get { return Internal.pivot.ToTuple (); }
+            set { Internal.pivot = value.ToVector (); }
         }
 
         /// <summary>
@@ -126,8 +159,8 @@ namespace KRPC.UI
         /// </summary>
         [KRPCProperty]
         public Tuple4 Rotation {
-            get { return rectTransform.localRotation.ToTuple (); }
-            set { rectTransform.localRotation = value.ToQuaternion (); }
+            get { return Internal.localRotation.ToTuple (); }
+            set { Internal.localRotation = value.ToQuaternion (); }
         }
 
         /// <summary>
@@ -135,8 +168,8 @@ namespace KRPC.UI
         /// </summary>
         [KRPCProperty]
         public Tuple3 Scale {
-            get { return rectTransform.localScale.ToTuple (); }
-            set { rectTransform.localScale = value.ToVector (); }
+            get { return Internal.localScale.ToTuple (); }
+            set { Internal.localScale = value.ToVector (); }
         }
     }
 }

--- a/service/UI/src/ScrollView.cs
+++ b/service/UI/src/ScrollView.cs
@@ -54,6 +54,14 @@ namespace KRPC.UI
                 UnityEngine.UI.ScrollRect.ScrollbarVisibility.AutoHideAndExpandViewport;
         }
 
+        // The game's scroll rect, checked to still exist.
+        UnityEngine.UI.ScrollRect Internal {
+            get {
+                CheckExists ();
+                return scrollRect;
+            }
+        }
+
         /// <summary>
         /// The panel that is scrolled, which the elements to show are added to.
         /// </summary>
@@ -67,8 +75,8 @@ namespace KRPC.UI
         /// </summary>
         [KRPCProperty]
         public bool Horizontal {
-            get { return scrollRect.horizontal; }
-            set { scrollRect.horizontal = value; }
+            get { return Internal.horizontal; }
+            set { Internal.horizontal = value; }
         }
 
         /// <summary>
@@ -76,8 +84,8 @@ namespace KRPC.UI
         /// </summary>
         [KRPCProperty]
         public bool Vertical {
-            get { return scrollRect.vertical; }
-            set { scrollRect.vertical = value; }
+            get { return Internal.vertical; }
+            set { Internal.vertical = value; }
         }
     }
 }

--- a/service/UI/src/SizeFitter.cs
+++ b/service/UI/src/SizeFitter.cs
@@ -1,7 +1,9 @@
 using System;
+using System.Runtime.CompilerServices;
 using KRPC.Service.Attributes;
 using KRPC.UI.ExtensionMethods;
 using KRPC.Utils;
+using ObjectDestroyedException = KRPC.Service.KRPC.ObjectDestroyedException;
 
 namespace KRPC.UI
 {
@@ -10,8 +12,11 @@ namespace KRPC.UI
     /// See <see cref="Panel.SizeFitter" />.
     /// </summary>
     [KRPCClass (Service = "UI")]
-    public class SizeFitter : Equatable<SizeFitter>
+    public class SizeFitter : Equatable<SizeFitter>, IGameObjectState
     {
+        // The game's size fitter, which is what this stands for: it belongs to the
+        // interface element it was taken from and lives exactly as long as that
+        // element, and the game gives it nothing else to be named by.
         readonly UnityEngine.UI.ContentSizeFitter fitter;
 
         internal SizeFitter (UnityEngine.UI.ContentSizeFitter innerFitter)
@@ -24,7 +29,8 @@ namespace KRPC.UI
         /// </summary>
         public override bool Equals (SizeFitter other)
         {
-            return !ReferenceEquals (other, null) && fitter == other.fitter;
+            return !ReferenceEquals (other, null) &&
+            ReferenceEquals (fitter, other.fitter);
         }
 
         /// <summary>
@@ -32,7 +38,32 @@ namespace KRPC.UI
         /// </summary>
         public override int GetHashCode ()
         {
-            return fitter.GetHashCode ();
+            // The size fitter's identity hash rather than its own, so that nothing the game
+            // does to it can change it while a client holds this object.
+            return RuntimeHelpers.GetHashCode (fitter);
+        }
+
+        /// <summary>
+        /// What the game holds for the size fitter. It belongs to the interface element it was
+        /// taken from, and the game destroys it with that element, which nothing builds
+        /// again.
+        /// </summary>
+        public GameObjectState GameObjectState {
+            get {
+                return fitter == null
+                    ? GameObjectState.Destroyed : GameObjectState.Live;
+            }
+        }
+
+        // The game's size fitter, checked to still exist.
+        UnityEngine.UI.ContentSizeFitter Internal {
+            get {
+                if (GameObjectState == GameObjectState.Destroyed)
+                    throw new ObjectDestroyedException (
+                        "The size fitter no longer exists, as the user interface object " +
+                        "it belongs to has been removed.");
+                return fitter;
+            }
         }
 
         /// <summary>
@@ -40,8 +71,8 @@ namespace KRPC.UI
         /// </summary>
         [KRPCProperty]
         public ContentSizeFit HorizontalFit {
-            get { return fitter.horizontalFit.ToContentSizeFit (); }
-            set { fitter.horizontalFit = value.FromContentSizeFit (); }
+            get { return Internal.horizontalFit.ToContentSizeFit (); }
+            set { Internal.horizontalFit = value.FromContentSizeFit (); }
         }
 
         /// <summary>
@@ -49,8 +80,8 @@ namespace KRPC.UI
         /// </summary>
         [KRPCProperty]
         public ContentSizeFit VerticalFit {
-            get { return fitter.verticalFit.ToContentSizeFit (); }
-            set { fitter.verticalFit = value.FromContentSizeFit (); }
+            get { return Internal.verticalFit.ToContentSizeFit (); }
+            set { Internal.verticalFit = value.FromContentSizeFit (); }
         }
     }
 }

--- a/service/UI/src/Slider.cs
+++ b/service/UI/src/Slider.cs
@@ -76,23 +76,31 @@ namespace KRPC.UI
             get { return slider; }
         }
 
+        // The game's slider, checked to still exist.
+        UnityEngine.UI.Slider Internal {
+            get {
+                CheckExists ();
+                return slider;
+            }
+        }
+
         /// <summary>
         /// The value of the slider, between <see cref="Min" /> and <see cref="Max" />.
         /// Setting a value outside the range is refused.
         /// </summary>
         [KRPCProperty]
         public float Value {
-            get { return slider.value; }
+            get { return Internal.value; }
             set {
                 // Unity moves a value outside the range to the nearest end of it, so a
                 // client that set the wrong value would be left reading back one it did
                 // not set and no way to tell that it had happened.
-                if (value < slider.minValue || value > slider.maxValue)
+                if (value < Internal.minValue || value > Internal.maxValue)
                     throw new ArgumentOutOfRangeException (
                         nameof (value), "The value is outside the range of the slider");
                 // Unity notifies its listeners of a value set by a client just as it does
                 // one the user chose, so the value is set without notifying them.
-                slider.SetValueWithoutNotify (value);
+                Internal.SetValueWithoutNotify (value);
             }
         }
 
@@ -102,8 +110,8 @@ namespace KRPC.UI
         /// </summary>
         [KRPCProperty]
         public float Min {
-            get { return slider.minValue; }
-            set { SetRange (value, slider.maxValue); }
+            get { return Internal.minValue; }
+            set { SetRange (value, Internal.maxValue); }
         }
 
         /// <summary>
@@ -112,8 +120,8 @@ namespace KRPC.UI
         /// </summary>
         [KRPCProperty]
         public float Max {
-            get { return slider.maxValue; }
-            set { SetRange (slider.minValue, value); }
+            get { return Internal.maxValue; }
+            set { SetRange (Internal.minValue, value); }
         }
 
         /// <summary>
@@ -130,8 +138,8 @@ namespace KRPC.UI
                     "The minimum of the range must not be greater than the maximum");
             settingRange = true;
             try {
-                slider.minValue = min;
-                slider.maxValue = max;
+                Internal.minValue = min;
+                Internal.maxValue = max;
             } finally {
                 settingRange = false;
             }

--- a/service/UI/src/Text.cs
+++ b/service/UI/src/Text.cs
@@ -31,6 +31,14 @@ namespace KRPC.UI
             text = obj.GetComponent<UnityEngine.UI.Text> ();
         }
 
+        // The game's text component, checked to still exist.
+        UnityEngine.UI.Text Internal {
+            get {
+                CheckExists ();
+                return text;
+            }
+        }
+
         /// <summary>
         /// A list of all available fonts.
         /// </summary>
@@ -44,8 +52,8 @@ namespace KRPC.UI
         /// </summary>
         [KRPCProperty]
         public string Content {
-            get { return text.text; }
-            set { text.text = value; }
+            get { return Internal.text; }
+            set { Internal.text = value; }
         }
 
         /// <summary>
@@ -57,11 +65,14 @@ namespace KRPC.UI
         /// </remarks>
         [KRPCProperty]
         public string Font {
-            get { return text.font == null ? string.Empty : text.font.name; }
+            get {
+                var font = Internal.font;
+                return font == null ? string.Empty : font.name;
+            }
             set {
                 if (!AvailableFonts.Contains (value))
                     throw new ArgumentException ("Font does not exist");
-                text.font = Widgets.OSFont (value);
+                Internal.font = Widgets.OSFont (value);
             }
         }
 
@@ -70,8 +81,8 @@ namespace KRPC.UI
         /// </summary>
         [KRPCProperty]
         public int Size {
-            get { return text.fontSize; }
-            set { text.fontSize = value; }
+            get { return Internal.fontSize; }
+            set { Internal.fontSize = value; }
         }
 
         /// <summary>
@@ -79,8 +90,8 @@ namespace KRPC.UI
         /// </summary>
         [KRPCProperty]
         public FontStyle Style {
-            get { return text.fontStyle.ToFontStyle (); }
-            set { text.fontStyle = value.FromFontStyle (); }
+            get { return Internal.fontStyle.ToFontStyle (); }
+            set { Internal.fontStyle = value.FromFontStyle (); }
         }
 
         /// <summary>
@@ -88,8 +99,8 @@ namespace KRPC.UI
         /// </summary>
         [KRPCProperty]
         public TextAnchor Alignment {
-            get { return text.alignment.ToTextAnchor (); }
-            set { text.alignment = value.FromTextAnchor (); }
+            get { return Internal.alignment.ToTextAnchor (); }
+            set { Internal.alignment = value.FromTextAnchor (); }
         }
 
         /// <summary>
@@ -97,8 +108,8 @@ namespace KRPC.UI
         /// </summary>
         [KRPCProperty]
         public float LineSpacing {
-            get { return text.lineSpacing; }
-            set { text.lineSpacing = value; }
+            get { return Internal.lineSpacing; }
+            set { Internal.lineSpacing = value; }
         }
 
         /// <summary>
@@ -109,9 +120,9 @@ namespace KRPC.UI
         /// </summary>
         [KRPCProperty]
         public bool WordWrap {
-            get { return text.horizontalOverflow == HorizontalWrapMode.Wrap; }
+            get { return Internal.horizontalOverflow == HorizontalWrapMode.Wrap; }
             set {
-                text.horizontalOverflow = value
+                Internal.horizontalOverflow = value
                     ? HorizontalWrapMode.Wrap : HorizontalWrapMode.Overflow;
             }
         }
@@ -122,8 +133,8 @@ namespace KRPC.UI
         /// </summary>
         [KRPCProperty]
         public Tuple4 Color {
-            get { return text.color.ToRgbaTuple (); }
-            set { text.color = value.ToColor (); }
+            get { return Internal.color.ToRgbaTuple (); }
+            set { Internal.color = value.ToColor (); }
         }
     }
 }

--- a/service/UI/src/Toggle.cs
+++ b/service/UI/src/Toggle.cs
@@ -57,6 +57,14 @@ namespace KRPC.UI
             get { return toggle; }
         }
 
+        // The game's toggle, checked to still exist.
+        UnityEngine.UI.Toggle Internal {
+            get {
+                CheckExists ();
+                return toggle;
+            }
+        }
+
         /// <summary>
         /// The text for the toggle.
         /// </summary>
@@ -74,7 +82,7 @@ namespace KRPC.UI
         /// </remarks>
         [KRPCProperty]
         public bool Checked {
-            get { return toggle.isOn; }
+            get { return Internal.isOn; }
             set {
                 var toggleGroup = Group;
                 if (toggleGroup == null)
@@ -91,7 +99,7 @@ namespace KRPC.UI
         /// </summary>
         internal void SetChecked (bool value)
         {
-            toggle.SetIsOnWithoutNotify (value);
+            Internal.SetIsOnWithoutNotify (value);
         }
 
         /// <summary>
@@ -123,7 +131,7 @@ namespace KRPC.UI
                 if (current != null)
                     current.RemoveMember (this);
                 group = value;
-                toggle.group = value == null ? null : value.InnerGroup;
+                Internal.group = value == null ? null : value.InnerGroup;
                 if (value != null)
                     value.AddMember (this);
                 Checked = wasChecked;

--- a/service/UI/src/ToggleGroup.cs
+++ b/service/UI/src/ToggleGroup.cs
@@ -31,7 +31,17 @@ namespace KRPC.UI
         }
 
         internal UnityEngine.UI.ToggleGroup InnerGroup {
-            get { return group; }
+            // Checked, so that a toggle joining a group the game no longer has says so
+            // rather than being tied to a torn down one.
+            get { return Internal; }
+        }
+
+        // The game's toggle group, checked to still exist.
+        UnityEngine.UI.ToggleGroup Internal {
+            get {
+                CheckExists ();
+                return group;
+            }
         }
 
         internal void AddMember (Toggle toggle)
@@ -77,8 +87,8 @@ namespace KRPC.UI
             // Unity refuses to uncheck the last checked toggle of a group that does not
             // allow being switched off. That rule is for the user, who can only check a
             // different toggle; a client saying what a toggle is set to is obeyed.
-            var switchOff = group.allowSwitchOff;
-            group.allowSwitchOff = true;
+            var switchOff = Internal.allowSwitchOff;
+            Internal.allowSwitchOff = true;
             try {
                 toggle.SetChecked (value);
                 if (!value)
@@ -88,7 +98,7 @@ namespace KRPC.UI
                         member.SetChecked (false);
                 }
             } finally {
-                group.allowSwitchOff = switchOff;
+                Internal.allowSwitchOff = switchOff;
             }
         }
 
@@ -117,8 +127,8 @@ namespace KRPC.UI
         /// </remarks>
         [KRPCProperty]
         public bool AllowSwitchOff {
-            get { return group.allowSwitchOff; }
-            set { group.allowSwitchOff = value; }
+            get { return Internal.allowSwitchOff; }
+            set { Internal.allowSwitchOff = value; }
         }
     }
 }

--- a/service/UI/test/test_button.py
+++ b/service/UI/test/test_button.py
@@ -7,6 +7,8 @@ class TestButton(krpctest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.new_save()
+        cls.conn = cls.connect()
+        cls.destroyed = cls.conn.krpc.ObjectDestroyedException
         cls.canvas = cls.connect().ui.stock_canvas
 
     def test_button(self):
@@ -17,7 +19,7 @@ class TestButton(krpctest.TestCase):
         self.assertEqual("Foo", button.text.content)
         self.assertFalse(button.clicked)
         button.remove()
-        self.assertRaises(ValueError, button.remove)
+        self.assertRaises(self.destroyed, button.remove)
 
     def test_the_label_cannot_be_removed_on_its_own(self):
         # The label is part of the button, so it goes when the button goes.

--- a/service/UI/test/test_canvas.py
+++ b/service/UI/test/test_canvas.py
@@ -54,6 +54,11 @@ class TestCanvas(krpctest.TestCase):
         self.assertFalse(panel.visible)
         panel.remove()
 
+    def test_rect_transform_is_one_object(self):
+        # A rect transform is named by the one the game holds, so reading it twice gives
+        # the same object rather than adding another to the server's object store.
+        self.assertEqual(self.canvas.rect_transform, self.canvas.rect_transform)
+
     def test_rect_transform(self):
         rect = self.canvas.rect_transform
         width, height = rect.size

--- a/service/UI/test/test_dropdown.py
+++ b/service/UI/test/test_dropdown.py
@@ -7,7 +7,9 @@ class TestDropdown(krpctest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.new_save()
-        cls.canvas = cls.connect().ui.stock_canvas
+        cls.conn = cls.connect()
+        cls.destroyed = cls.conn.krpc.ObjectDestroyedException
+        cls.canvas = cls.conn.ui.stock_canvas
 
     def test_dropdown(self):
         dropdown = self.canvas.add_dropdown()
@@ -17,7 +19,7 @@ class TestDropdown(krpctest.TestCase):
         self.assertEqual(0, dropdown.selected_index)
         self.assertFalse(dropdown.changed)
         dropdown.remove()
-        self.assertRaises(ValueError, dropdown.remove)
+        self.assertRaises(self.destroyed, dropdown.remove)
 
     def test_options(self):
         dropdown = self.canvas.add_dropdown()

--- a/service/UI/test/test_game_scenes.py
+++ b/service/UI/test/test_game_scenes.py
@@ -11,6 +11,7 @@ class TestGameScenes(krpctest.TestCase):
         cls.new_save()
         conn = cls.connect()
         cls.krpc = conn.krpc
+        cls.destroyed = conn.krpc.ObjectDestroyedException
         cls.ui = conn.ui
         cls.scenes = conn.krpc.GameScene
 
@@ -92,7 +93,7 @@ class TestGameScenes(krpctest.TestCase):
 
         self.wait_until(gone, timeout=30, message="the elements to be taken away")
         self.assertRaises(RuntimeError, getattr, text, "visible")
-        self.assertRaises(ValueError, panel.remove)
+        self.assertRaises(self.destroyed, panel.remove)
 
     def test_an_element_added_after_a_scene_change_is_kept(self):
         # Sweeping up after the previous scene must not take away what a client adds to

--- a/service/UI/test/test_image.py
+++ b/service/UI/test/test_image.py
@@ -84,6 +84,16 @@ class TestImage(krpctest.TestCase):
         self.assertRaises(RuntimeError, image.update_pixels, pixel, 0, 0, 1, 1)
         image.remove()
 
+    def test_update_pixels_on_a_removed_image(self):
+        image = self.canvas.add_image()
+        image.set_pixels(b"\xff\x00\x00\xff" * 4, 2, 2)
+        image.remove()
+        # Redrawing a block draws into the texture rather than through the image
+        # component, so it has to say the image is gone in its own right rather than
+        # answering from what the removed image is still holding.
+        pixel = b"\x00\xff\x00\xff"
+        self.assertRaises(self.destroyed, image.update_pixels, pixel, 0, 0, 1, 1)
+
     def test_update_pixels_must_fit_inside_the_picture(self):
         image = self.canvas.add_image()
         image.set_pixels(b"\xff\x00\x00\xff" * 16, 4, 4)

--- a/service/UI/test/test_image.py
+++ b/service/UI/test/test_image.py
@@ -14,7 +14,9 @@ class TestImage(krpctest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.new_save()
-        cls.canvas = cls.connect().ui.stock_canvas
+        cls.conn = cls.connect()
+        cls.destroyed = cls.conn.krpc.ObjectDestroyedException
+        cls.canvas = cls.conn.ui.stock_canvas
 
     def test_image(self):
         image = self.canvas.add_image()
@@ -22,7 +24,7 @@ class TestImage(krpctest.TestCase):
         self.assertTrue(image.visible)
         self.assertEqual(b"", image.content)
         image.remove()
-        self.assertRaises(ValueError, image.remove)
+        self.assertRaises(self.destroyed, image.remove)
 
     def test_color(self):
         image = self.canvas.add_image()

--- a/service/UI/test/test_input_field.py
+++ b/service/UI/test/test_input_field.py
@@ -7,7 +7,9 @@ class TestInputField(krpctest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.new_save()
-        ui = cls.connect().ui
+        cls.conn = cls.connect()
+        cls.destroyed = cls.conn.krpc.ObjectDestroyedException
+        ui = cls.conn.ui
         cls.canvas = ui.stock_canvas
         cls.content_types = ui.InputContentType
 
@@ -19,7 +21,7 @@ class TestInputField(krpctest.TestCase):
         self.assertIsNotNone(input_field.text)
         self.assertFalse(input_field.changed)
         input_field.remove()
-        self.assertRaises(ValueError, input_field.remove)
+        self.assertRaises(self.destroyed, input_field.remove)
 
     def test_value(self):
         input_field = self.canvas.add_input_field()

--- a/service/UI/test/test_panel.py
+++ b/service/UI/test/test_panel.py
@@ -7,7 +7,9 @@ class TestPanel(krpctest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.new_save()
-        ui = cls.connect().ui
+        cls.conn = cls.connect()
+        cls.destroyed = cls.conn.krpc.ObjectDestroyedException
+        ui = cls.conn.ui
         cls.canvas = ui.stock_canvas
         cls.panel_style = ui.PanelStyle
 
@@ -18,7 +20,7 @@ class TestPanel(krpctest.TestCase):
         self.assertEqual(self.panel_style.window, panel.style)
         self.assertFalse(panel.draggable)
         panel.remove()
-        self.assertRaises(ValueError, panel.remove)
+        self.assertRaises(self.destroyed, panel.remove)
 
     def test_visible_is_the_elements_own_setting(self):
         # An element is only drawn when everything it is inside is visible as well, so

--- a/service/UI/test/test_scroll_view.py
+++ b/service/UI/test/test_scroll_view.py
@@ -7,7 +7,9 @@ class TestScrollView(krpctest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.new_save()
-        ui = cls.connect().ui
+        cls.conn = cls.connect()
+        cls.destroyed = cls.conn.krpc.ObjectDestroyedException
+        ui = cls.conn.ui
         cls.canvas = ui.stock_canvas
         cls.constraint = ui.GridConstraint
         cls.fit = ui.ContentSizeFit
@@ -20,7 +22,7 @@ class TestScrollView(krpctest.TestCase):
         self.assertTrue(view.horizontal)
         self.assertTrue(view.vertical)
         view.remove()
-        self.assertRaises(ValueError, view.remove)
+        self.assertRaises(self.destroyed, view.remove)
 
     def test_directions(self):
         view = self.canvas.add_scroll_view()

--- a/service/UI/test/test_slider.py
+++ b/service/UI/test/test_slider.py
@@ -7,7 +7,9 @@ class TestSlider(krpctest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.new_save()
-        cls.canvas = cls.connect().ui.stock_canvas
+        cls.conn = cls.connect()
+        cls.destroyed = cls.conn.krpc.ObjectDestroyedException
+        cls.canvas = cls.conn.ui.stock_canvas
 
     def test_slider(self):
         slider = self.canvas.add_slider()
@@ -18,7 +20,7 @@ class TestSlider(krpctest.TestCase):
         self.assertEqual(0, slider.value)
         self.assertFalse(slider.changed)
         slider.remove()
-        self.assertRaises(ValueError, slider.remove)
+        self.assertRaises(self.destroyed, slider.remove)
 
     def test_value(self):
         slider = self.canvas.add_slider()

--- a/service/UI/test/test_text.py
+++ b/service/UI/test/test_text.py
@@ -7,6 +7,8 @@ class TestText(krpctest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.new_save()
+        cls.conn = cls.connect()
+        cls.destroyed = cls.conn.krpc.ObjectDestroyedException
         ui = cls.connect().ui
         cls.canvas = ui.stock_canvas
         cls.style = ui.FontStyle
@@ -27,7 +29,7 @@ class TestText(krpctest.TestCase):
         self.assertEqual(self.anchor.upper_left, text.alignment)
         self.assertEqual(1, text.line_spacing)
         text.remove()
-        self.assertRaises(ValueError, text.remove)
+        self.assertRaises(self.destroyed, text.remove)
 
     def test_properties(self):
         text = self.canvas.add_text("Jebediah Kerman")
@@ -45,6 +47,7 @@ class TestText(krpctest.TestCase):
         self.assertEqual(self.anchor.upper_right, text.alignment)
         self.assertEqual(2, text.line_spacing)
         text.remove()
+        self.assertRaises(self.destroyed, text.remove)
 
     def test_word_wrap(self):
         text = self.canvas.add_text("Jebediah Kerman")
@@ -56,7 +59,7 @@ class TestText(krpctest.TestCase):
         text.word_wrap = True
         self.assertTrue(text.word_wrap)
         text.remove()
-        self.assertRaises(ValueError, text.remove)
+        self.assertRaises(self.destroyed, text.remove)
 
 
 if __name__ == "__main__":

--- a/service/UI/test/test_toggle.py
+++ b/service/UI/test/test_toggle.py
@@ -7,7 +7,9 @@ class TestToggle(krpctest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.new_save()
-        cls.canvas = cls.connect().ui.stock_canvas
+        cls.conn = cls.connect()
+        cls.destroyed = cls.conn.krpc.ObjectDestroyedException
+        cls.canvas = cls.conn.ui.stock_canvas
 
     def test_toggle(self):
         toggle = self.canvas.add_toggle("Foo")
@@ -19,7 +21,7 @@ class TestToggle(krpctest.TestCase):
         self.assertFalse(toggle.changed)
         self.assertIsNone(toggle.group)
         toggle.remove()
-        self.assertRaises(ValueError, toggle.remove)
+        self.assertRaises(self.destroyed, toggle.remove)
 
     def test_checked(self):
         toggle = self.canvas.add_toggle("Foo")

--- a/tools/TestingTools/src/TestingTools.cs
+++ b/tools/TestingTools/src/TestingTools.cs
@@ -147,6 +147,37 @@ namespace TestingTools
         }
 
         /// <summary>
+        /// Record the vessel in the editor as a state an undo can return to, as the game
+        /// does after each change the player makes to it.
+        /// </summary>
+        [KRPCProcedure]
+        public static void EditorSetBackup ()
+        {
+            EditorLogic.fetch.SetBackup ();
+        }
+
+        /// <summary>
+        /// Undo, restoring the vessel in the editor from the state recorded before the
+        /// last one. Used by tests that check what an undo does to a client's objects.
+        /// </summary>
+        /// <remarks>
+        /// The game drives this from the editor's own input handling, and the method that
+        /// does it is private, so there is nothing else to call.
+        /// </remarks>
+        [KRPCProcedure]
+        public static void EditorUndo ()
+        {
+            var method = typeof (EditorLogic).GetMethod (
+                "RestoreState",
+                System.Reflection.BindingFlags.Instance |
+                System.Reflection.BindingFlags.NonPublic);
+            if (method == null)
+                throw new InvalidOperationException (
+                    "EditorLogic.RestoreState not found; the game's undo has moved");
+            method.Invoke (EditorLogic.fetch, new object[] { -1 });
+        }
+
+        /// <summary>
         /// The number of objects the server is holding on behalf of its clients. Used by tests
         /// that check the server reclaims the objects whose game objects are gone.
         /// </summary>

--- a/tools/TestingTools/src/TestingTools.cs
+++ b/tools/TestingTools/src/TestingTools.cs
@@ -133,6 +133,28 @@ namespace TestingTools
                 vessel.Die ();
         }
 
+        /// <summary>
+        /// Destroy a part, the way the game does when it is blown up or overheats.
+        /// Used by tests that need a part to stop existing under a client's part object.
+        /// </summary>
+        /// <param name="part">The part to destroy.</param>
+        [KRPCProcedure]
+        public static void DestroyPart (KRPC.SpaceCenter.Services.Parts.Part part)
+        {
+            if (part == null)
+                throw new ArgumentNullException (nameof (part));
+            part.InternalPart.Die ();
+        }
+
+        /// <summary>
+        /// The number of objects the server is holding on behalf of its clients. Used by tests
+        /// that check the server reclaims the objects whose game objects are gone.
+        /// </summary>
+        [KRPCProperty]
+        public static int ObjectStoreSize {
+            get { return ObjectStore.Instance.Count; }
+        }
+
         static Quaternion ZeroRotation {
             get {
                 var vessel = FlightGlobals.ActiveVessel;


### PR DESCRIPTION
A "proxy" object handed to a client would previously hold onto a direct reference to a Unity game object. The game replaces these objects in many scenarios: on quickload, reverting to launch, or when a vessel leaves and reenters physics range. This means an object obtained by a client beforehand went on reading invalid game state, or failed with a null reference exception.

The proxy objects live on the server in an "object store" and they were never removed from there. The object store kept every object it had handed out until the game was restarted. Additionally, some RPCs made a new object on every access, so a script that polls in a loop grew the store without bound.

A proxy object now names what it stands for, via a persistent identifier: vessel id, part id, a module's part and index, a kerbal's name, an alarm's id and so on. That name is resolved against the game on every call (with caching to make it fast). This allows a proxy object to follow the game state across a quickload/revert.

An object is also now classified as alive, dormant or destroyed: this clearly separates game state that is gone (e.g. a part that exploded) from something temporary (e.g. a part was unloaded as the vessel went out of range). Using an object that is gone now raises the new `KRPC.ObjectDestroyedException`, while objects that are temporarily gone report themselves as unavailable and may work again at a later point.

The object store is periodically swept to remove unnecessary objects from the store and free memory. Therefore, objects no longer accumulate. This is done during events such as quickloads, so that the game does not lock up noticeably when doing a sweep.

The behaviour is written up in a new tutorial: `doc/src/tutorials/object-lifetime.rst`.

A detailed design doc for these changes can be found here: https://github.com/krpc/krpc-docs/blob/main/design/object-lifetime.md

**Testing.** Two new in-game suites, `service/SpaceCenter/test/test_object_lifetime.py` and `service/SpaceCenter/test/test_editor_object_lifetime.py`, exercise what objects do across a quickload, a part being destroyed, a vessel being unloaded or destroyed, and an editor loading, undoing and leaving a vessel, and check that the store gives up what it no longer needs. `TestingTools` gained ways to destroy a part and to report how many objects the server holds, which those tests need and cannot get otherwise. The suites of the services that were touched cover the rest.

Fixes #764
Fixes #771
Related to #877
Superceeds PR #894 (it includes this work, and builds on top of it)