### PR TITLE
Keep the target roll when the autopilot's target direction is set

### DIFF
--- a/service/SpaceCenter/CHANGELOG.md
+++ b/service/SpaceCenter/CHANGELOG.md
@@ -99,6 +99,13 @@
     not been calculated for the vessel. Stages requested after the revert were affected
     too, so the game had to be restarted to get working stages back (#1023)
 
+- Autopilot
+  - Setting `AutoPilot.TargetDirection` keeps the target roll, rather than clearing it. It
+    re-aims the nose and nothing else, holding the commanded roll relative to
+    `AutoPilot.UpReference` as the scalar `TargetPitch` and `TargetHeading` setters do, so
+    tracking a moving direction such as prograde no longer drops the roll on every
+    update (#1054)
+
 - Orbits, nodes and bodies
   - An `Orbit` reads the orbit of the vessel, celestial body or maneuver node it belongs to as
     it is now, rather than the one the game had when it was obtained, so it keeps working

--- a/service/SpaceCenter/src/AutoPilot/AttitudeController.cs
+++ b/service/SpaceCenter/src/AutoPilot/AttitudeController.cs
@@ -262,15 +262,15 @@ namespace KRPC.SpaceCenter.AutoPilot
         // Demoted convenience scalars (heading-singular near the vertical). The getters read the
         // surface-frame Euler decomposition; the setters re-aim the nose by (pitch, heading) while
         // preserving the current roll relative to the up reference (so a pitch/heading change no
-        // longer perturbs roll near the vertical). See AimNose.
+        // longer perturbs roll near the vertical). See SetTargetDirection.
         public double TargetPitch {
             get { return targetRotation.PitchHeadingRoll ().x; }
-            set { AimNose (DirectionFromPitchHeading (value, targetRotation.PitchHeadingRoll ().y)); }
+            set { SetTargetDirection (DirectionFromPitchHeading (value, targetRotation.PitchHeadingRoll ().y)); }
         }
 
         public double TargetHeading {
             get { return targetRotation.PitchHeadingRoll ().y; }
-            set { AimNose (DirectionFromPitchHeading (targetRotation.PitchHeadingRoll ().x, value)); }
+            set { SetTargetDirection (DirectionFromPitchHeading (targetRotation.PitchHeadingRoll ().x, value)); }
         }
 
         // Roll about the nose measured relative to the up reference (roof aligned to the reference =
@@ -352,10 +352,18 @@ namespace KRPC.SpaceCenter.AutoPilot
             BeginSlew ();
         }
 
+        // Re-aim the nose to a new direction through the shared primitive, preserving roll relative
+        // to the up reference. When roll is controlled the current roll is kept, so re-aiming the
+        // nose never silently drops a commanded roll; when it is suppressed the target is built
+        // wings-level (roll 0 vs the reference) — matching the historical pitch/heading target and,
+        // crucially, giving consecutive targets a consistent roll so a smoothed slew between them
+        // stays a clean pure-pitch/heading path (FromToRotation's minimal-arc roll varies with
+        // direction and wanders the heading through the slerp). The rollControlled flag is left
+        // unchanged. Backs TargetDirection and the demoted TargetPitch/TargetHeading setters.
         public void SetTargetDirection (Vector3d direction)
         {
-            targetRotation = GeometryExtensions.FromToRotation (Vector3d.up, direction.normalized);
-            rollControlled = false;
+            var roll = rollControlled ? RollRelativeTo (targetRotation, upReference) : 0.0;
+            targetRotation = RotationFromDirectionUpRoll (direction, upReference, roll);
             BeginSlew ();
         }
 
@@ -379,20 +387,6 @@ namespace KRPC.SpaceCenter.AutoPilot
             upReference = up;
             targetRotation = RotationFromDirectionUpRoll (direction, up, roll);
             rollControlled = true;
-            BeginSlew ();
-        }
-
-        // Re-aim the nose to a new direction through the shared primitive, preserving roll relative
-        // to the up reference. When roll is controlled the current roll is kept; when it is suppressed
-        // the target is built wings-level (roll 0 vs the reference) — matching the historical
-        // pitch/heading target and, crucially, giving consecutive pitch/heading targets a consistent
-        // roll so a smoothed slew between them stays a clean pure-pitch/heading path (FromToRotation's
-        // minimal-arc roll varies with direction and wanders the heading through the slerp). The
-        // rollControlled flag is left unchanged. Backs the demoted TargetPitch/TargetHeading setters.
-        void AimNose (Vector3d direction)
-        {
-            var roll = rollControlled ? RollRelativeTo (targetRotation, upReference) : 0.0;
-            targetRotation = RotationFromDirectionUpRoll (direction, upReference, roll);
             BeginSlew ();
         }
 

--- a/service/SpaceCenter/src/Services/AutoPilot.cs
+++ b/service/SpaceCenter/src/Services/AutoPilot.cs
@@ -229,6 +229,11 @@ namespace KRPC.SpaceCenter.Services
         /// An error will be thrown if this property is set to a reference frame that rotates with
         /// the vessel being controlled, as it is impossible to rotate the vessel in such a
         /// reference frame.
+        ///
+        /// The target and the <see cref="UpReference"/> are held as vectors in this frame, so
+        /// changing it re-interprets them in the new frame rather than converting them: the
+        /// orientation the vessel is held in, and what a given <see cref="TargetRoll"/> means,
+        /// both change. Set the frame first, then the target.
         /// </remarks>
         [KRPCProperty]
         public ReferenceFrame ReferenceFrame {
@@ -318,6 +323,11 @@ namespace KRPC.SpaceCenter.Services
         /// effect of <see cref="SetDirectionAndUp"/>. Setting the target rotation, target direction,
         /// or the scalar pitch/heading leaves it unchanged. Choosing a reference off the flight path
         /// keeps roll well-defined through the vertical.
+        ///
+        /// Because roll is measured against this reference, changing it changes the angle that
+        /// <see cref="TargetRoll"/> and <see cref="CurrentTargetRoll"/> report, even though the
+        /// vessel is still being held in exactly the same orientation. Set the reference first and
+        /// the roll afterwards, or set both at once with <see cref="SetDirectionAndUp"/>.
         /// </remarks>
         [KRPCProperty]
         public Tuple3 UpReference {
@@ -376,6 +386,12 @@ namespace KRPC.SpaceCenter.Services
         /// Direction vector corresponding to the target pitch and heading.
         /// This is in the reference frame specified by <see cref="ReferenceFrame"/>.
         /// </summary>
+        /// <remarks>
+        /// The setter re-aims the nose and nothing else: it preserves the current
+        /// <see cref="TargetRoll"/> relative to <see cref="UpReference"/>, and leaves roll
+        /// suppressed if no target roll is set. Point the nose repeatedly and a commanded roll is
+        /// held throughout.
+        /// </remarks>
         [KRPCProperty]
         public Tuple3 TargetDirection {
             get { return Controller.TargetDirection.ToTuple (); }

--- a/service/SpaceCenter/test/test_autopilot.py
+++ b/service/SpaceCenter/test/test_autopilot.py
@@ -470,6 +470,29 @@ def _make_autopilot_test_class(
                 self.ap.target_heading = 200
                 self.assertAlmostEqual(self.ap.target_roll, roll, delta=1e-2)
 
+        def test_target_direction_preserves_roll(self):
+            # Setting target_direction re-aims the nose and nothing else: the commanded
+            # roll relative to the up reference is preserved, as it is for the scalar
+            # pitch/heading setters, including through the vertical. A suppressed roll
+            # stays suppressed.
+            self.ap.reset()
+            self.ap.reference_frame = self.vessel.surface_reference_frame
+            north = (0, 1, 0)
+            east = (0, 0, 1)
+            zenith = (1, 0, 0)
+            for roll in (0, 35, -60, 120):
+                self.ap.set_direction_and_up(east, north, roll)
+                for direction in (normalize((1, 0, 1)), zenith, normalize((0, -1, 1))):
+                    self.ap.target_direction = direction
+                    self.assertAlmostEqual(
+                        self.ap.target_direction, direction, delta=1e-3
+                    )
+                    self.assertAlmostEqual(self.ap.target_roll, roll, delta=1e-2)
+
+            self.ap.target_roll = float("nan")
+            self.ap.target_direction = east
+            self.assertTrue(math.isnan(self.ap.target_roll))
+
         def test_up_parallel_direction_suppresses_roll(self):
             # up parallel to the direction has no roll anchor (the roof cannot point where
             # the nose already does); it falls back to direction-only rather than


### PR DESCRIPTION
**Problem.** Setting `AutoPilot.TargetDirection` cleared the target roll. The setter built the target with a minimal-arc rotation and suppressed roll, so a commanded roll was dropped every time the nose was re-aimed, and tracking a moving direction such as prograde meant setting the roll again after every update. The scalar `TargetPitch` and `TargetHeading` setters already preserved it, so the two ways of aiming the nose disagreed.

**Fix.** `TargetDirection` now goes through the same primitive those setters use: it re-aims the nose while holding the roll relative to `UpReference`, and leaves the roll-suppressed mode alone when no target roll is set.

**Docs.** The roll side effects of the neighboring properties are now stated. `UpReference` is the reference the roll angle is measured against, so changing it changes what `TargetRoll` and `CurrentTargetRoll` report even though the vessel is held in exactly the same orientation. `ReferenceFrame` holds the target and the up reference as vectors in that frame and reinterprets rather than converts them when it changes, so both the held orientation and the meaning of a given roll change with it.

**Testing.** Added `test_target_direction_preserves_roll`, which re-aims the nose through several directions including the vertical and checks the commanded roll reads back unchanged, and that a suppressed roll stays suppressed. It and the rest of the autopilot orientation tests pass in game across all six craft variants.