### PR TITLE
Cnano client TCP/IP support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,10 +147,14 @@ jobs:
         with:
           path: ${{ env.CCACHE_DIR }}
           key: ccache-${{ steps.cache-key.outputs.hash }}
-      - name: build-system
-        run: client/cnano/test-cmake-linux.sh krpc-cnano-*.zip system
-      - name: build-fetch
-        run: client/cnano/test-cmake-linux.sh krpc-cnano-*.zip fetch
+      - name: build-system-serialio
+        run: client/cnano/test-cmake-linux.sh krpc-cnano-*.zip system-serialio
+      - name: build-system-tcpip
+        run: client/cnano/test-cmake-linux.sh krpc-cnano-*.zip system-tcpip
+      - name: build-fetch-serialio
+        run: client/cnano/test-cmake-linux.sh krpc-cnano-*.zip fetch-serialio
+      - name: build-fetch-tcpip
+        run: client/cnano/test-cmake-linux.sh krpc-cnano-*.zip fetch-tcpip
 
   build-client-cnano-cmake-windows:
     needs: test-client-cnano
@@ -166,9 +170,18 @@ jobs:
         uses: ./.github/actions/vcpkg-windows
         with:
           packages: nanopb:x64-windows
-      - name: test-build
+      - name: build-system-serialio
         shell: bash
-        run: client/cnano/test-cmake-windows.sh
+        run: client/cnano/test-cmake-windows.sh system-serialio
+      - name: build-system-tcpip
+        shell: bash
+        run: client/cnano/test-cmake-windows.sh system-tcpip
+      - name: build-fetch-serialio
+        shell: bash
+        run: client/cnano/test-cmake-windows.sh fetch-serialio
+      - name: build-fetch-tcpip
+        shell: bash
+        run: client/cnano/test-cmake-windows.sh fetch-tcpip
 
   build-client-cnano-vcpkg-linux:
     needs: test-client-cnano

--- a/Development-Guide.md
+++ b/Development-Guide.md
@@ -247,7 +247,7 @@ and tools for A/B testing to compare performance.
 ```
 bazel run //tools/benchmarks:testserver              # server, game-less
 bazel run //tools/benchmarks:python                  # a client, against TestServer
-bazel run //tools/benchmarks:cpp                     #   "  (also: java, csharp, lua)
+bazel run //tools/benchmarks:cpp                     #   "  (also: java, csharp, lua, cnano)
 bazel run //tools/benchmarks:clients                 # every client, one table
 bazel run //tools/benchmarks:server                  # server, in game, launches KSP
 ```
@@ -269,10 +269,15 @@ What each one measures:
  * **`:testserver`** — what the server pays per remote procedure call: argument decode, dispatch,
    the procedure, result encode. It runs against `TestServer`, which is the server without the
    game, so a change to `core/` or `server/` can be measured without launching the game.
- * **`:python`, `:cpp`, `:java`, `:csharp`, `:lua`** — what a client pays: the round trip for a
-   call, and what a call carrying a collection of values costs, against the same `TestServer`.
-   Measuring a client means timing it from inside that client, so each is its own program in its
-   own language, printing results for `run_client.py` to turn into the usual table.
+ * **`:python`, `:cpp`, `:java`, `:csharp`, `:lua`, `:cnano`** — what a client pays: the round
+   trip for a call, and what a call carrying a collection of values costs, against the same
+   `TestServer`. Measuring a client means timing it from inside that client, so each is its own
+   program in its own language, printing results for `run_client.py` to turn into the usual table.
+
+   `:cnano` measures the client built for TCP/IP rather than for the serial port it is usually
+   built for. The server reads a serial port on a poll whose interval is longer than everything
+   these cases measure put together, so over a serial port the figures would be that poll rather
+   than the client.
 
    They run against a server started with `--no-frame-pacing`, which runs its update loop as
    fast as it will go: paced, a round trip is inflated by the part of each update that does not

--- a/client/cnano/BUILD.bazel
+++ b/client/cnano/BUILD.bazel
@@ -187,7 +187,8 @@ cog_test(
 
 # The library built for each of the transports that can be tested here. Both enable server error
 # messages, so that the tests cover decoding them and a failure says what the server objected to;
-# the default build, with them disabled, is covered by the krpc_cnano library itself.
+# the default build, with them disabled, is covered by the krpc_cnano library itself. The TCP/IP
+# one is not testonly, as the benchmark program is built on it too.
 cc_library(
     name = "krpc_cnano_serialio",
     testonly = True,
@@ -336,6 +337,18 @@ cc_binary(
     ],
 )
 
+# The benchmark program, run by //tools/benchmarks:cnano. Not a test: it measures.
+cc_binary(
+    name = "benchmark",
+    srcs = [
+        "benchmark/benchmark.c",
+        ":services-test-service",
+    ],
+    includes = ["test"],
+    visibility = ["//tools/benchmarks:__pkg__"],
+    deps = [":krpc_cnano_tcpip"],
+)
+
 test_suite(
     name = "lint",
     tests = [
@@ -356,6 +369,7 @@ clang_format_test(
     name = "clangformat",
     size = "small",
     srcs = glob([
+        "benchmark/*.c",
         "src/*.c",
         "include/**/*.h",
         "test/**/*.cpp",

--- a/client/cnano/BUILD.bazel
+++ b/client/cnano/BUILD.bazel
@@ -161,10 +161,12 @@ cc_library(
 test_suite(
     name = "test",
     tests = [
-        ":arduino",
-        ":client",
+        ":client-serialio",
         ":cog",
+        ":communication-arduino",
+        ":communication-serialio",
         ":lint",
+        ":unit",
     ],
 )
 
@@ -181,12 +183,60 @@ cog_test(
     ],
 )
 
+# The library the tests are built against, with server error messages enabled so that they cover
+# decoding them and a failure says what the server objected to. The default build, with them
+# disabled, is covered by the krpc_cnano library itself.
+cc_library(
+    name = "krpc_cnano_serialio",
+    testonly = True,
+    srcs = srcs + [":protobuf"],
+    hdrs = hdrs + [":protobuf"],
+    defines = ["KRPC_ERROR_MESSAGES"],
+    includes = ["include"],
+    deps = ["@c_nanopb//:nanopb"],
+)
+
+# What the client does regardless of the transport it talks over: encoding and decoding values
+# and messages. It needs no server, so it runs on its own rather than under the harness that
+# starts one.
+cc_test(
+    name = "unit",
+    size = "small",
+    srcs = [
+        "test/test_decoder.cpp",
+        "test/test_encode_decode.cpp",
+        "test/test_encoder.cpp",
+        "test/test_utils.cpp",
+        "test/testing_tools.hpp",
+        ":services-test-service",
+    ],
+    includes = ["test"],
+    deps = [
+        ":krpc_cnano_serialio",
+        "@cpp_googletest//:gmock",
+        "@cpp_googletest//:gtest",
+    ],
+)
+
+# The communication backends, one test each. Every one of them runs against something that
+# behaves as the thing it talks to does, so none needs the hardware, port or server it is
+# written for.
+cc_test(
+    name = "communication-serialio",
+    size = "small",
+    srcs = ["test/test_communication_posix.cpp"],
+    deps = [
+        ":krpc_cnano_serialio",
+        "@cpp_googletest//:gtest",
+    ],
+)
+
 # Builds the Arduino communication backend for the host, against a stand-in for the Arduino
 # HardwareSerial class, so it can be tested without hardware. It deliberately does not depend
 # on krpc_cnano, whose copy of communication.c is built for the host platform instead and
 # defines the same functions.
 cc_test(
-    name = "arduino",
+    name = "communication-arduino",
     size = "small",
     srcs = [
         "include/krpc_cnano/communication.h",
@@ -204,8 +254,9 @@ cc_test(
     deps = ["@cpp_googletest//:gtest"],
 )
 
+# The client end to end against a TestServer, over the transport it is built for.
 client_test(
-    name = "client",
+    name = "client-serialio",
     size = "small",
     server_executable = "//tools/TestServer",
     server_type = "serialio",
@@ -213,33 +264,22 @@ client_test(
         "local",
         "requires-network",
     ],
-    test_executable = ":cnanotest",
+    test_executable = ":cnanotest-serialio",
 )
 
-test_srcs = glob([
-    "test/test_*.cpp",
-    "test/*.hpp",
-]) + [":services-test-service"]
-
-# The tests are built with server error messages enabled, so that they cover decoding them. The
-# default build, with them disabled, is covered by the krpc_cnano library itself.
-cc_library(
-    name = "krpc_cnano_error_messages",
-    testonly = True,
-    srcs = srcs + [":protobuf"],
-    hdrs = hdrs + [":protobuf"],
-    defines = ["KRPC_ERROR_MESSAGES"],
-    includes = ["include"],
-    deps = ["@c_nanopb//:nanopb"],
-)
+client_test_srcs = [
+    "test/server_test.hpp",
+    "test/test_client.cpp",
+    ":services-test-service",
+]
 
 cc_binary(
-    name = "cnanotest",
+    name = "cnanotest-serialio",
     testonly = True,
-    srcs = test_srcs,
+    srcs = client_test_srcs,
     includes = ["test"],
     deps = [
-        ":krpc_cnano_error_messages",
+        ":krpc_cnano_serialio",
         "@cpp_googletest//:gmock",
         "@cpp_googletest//:gtest",
     ],

--- a/client/cnano/BUILD.bazel
+++ b/client/cnano/BUILD.bazel
@@ -162,9 +162,11 @@ test_suite(
     name = "test",
     tests = [
         ":client-serialio",
+        ":client-tcpip",
         ":cog",
         ":communication-arduino",
         ":communication-serialio",
+        ":communication-tcpip",
         ":lint",
         ":unit",
     ],
@@ -183,9 +185,9 @@ cog_test(
     ],
 )
 
-# The library the tests are built against, with server error messages enabled so that they cover
-# decoding them and a failure says what the server objected to. The default build, with them
-# disabled, is covered by the krpc_cnano library itself.
+# The library built for each of the transports that can be tested here. Both enable server error
+# messages, so that the tests cover decoding them and a failure says what the server objected to;
+# the default build, with them disabled, is covered by the krpc_cnano library itself.
 cc_library(
     name = "krpc_cnano_serialio",
     testonly = True,
@@ -196,9 +198,21 @@ cc_library(
     deps = ["@c_nanopb//:nanopb"],
 )
 
+cc_library(
+    name = "krpc_cnano_tcpip",
+    srcs = srcs + [":protobuf"],
+    hdrs = hdrs + [":protobuf"],
+    defines = [
+        "KRPC_COMMUNICATION_TCP",
+        "KRPC_ERROR_MESSAGES",
+    ],
+    includes = ["include"],
+    deps = ["@c_nanopb//:nanopb"],
+)
+
 # What the client does regardless of the transport it talks over: encoding and decoding values
 # and messages. It needs no server, so it runs on its own rather than under the harness that
-# starts one.
+# starts one, and it is built for one transport rather than every one of them.
 cc_test(
     name = "unit",
     size = "small",
@@ -231,6 +245,16 @@ cc_test(
     ],
 )
 
+cc_test(
+    name = "communication-tcpip",
+    size = "small",
+    srcs = ["test/test_communication_tcp.cpp"],
+    deps = [
+        ":krpc_cnano_tcpip",
+        "@cpp_googletest//:gtest",
+    ],
+)
+
 # Builds the Arduino communication backend for the host, against a stand-in for the Arduino
 # HardwareSerial class, so it can be tested without hardware. It deliberately does not depend
 # on krpc_cnano, whose copy of communication.c is built for the host platform instead and
@@ -254,7 +278,10 @@ cc_test(
     deps = ["@cpp_googletest//:gtest"],
 )
 
-# The client end to end against a TestServer, over the transport it is built for.
+# The client end to end against a TestServer, once per transport. The two differ in more than
+# the socket: a serial port carries both of the connections to a server over the one link, so
+# its messages are wrapped in a multiplexed message saying which they belong to, where a
+# transport that opens a connection per server sends the messages themselves.
 client_test(
     name = "client-serialio",
     size = "small",
@@ -265,6 +292,18 @@ client_test(
         "requires-network",
     ],
     test_executable = ":cnanotest-serialio",
+)
+
+client_test(
+    name = "client-tcpip",
+    size = "small",
+    server_executable = "//tools/TestServer",
+    server_type = "protobuf",
+    tags = [
+        "local",
+        "requires-network",
+    ],
+    test_executable = ":cnanotest-tcpip",
 )
 
 client_test_srcs = [
@@ -280,6 +319,18 @@ cc_binary(
     includes = ["test"],
     deps = [
         ":krpc_cnano_serialio",
+        "@cpp_googletest//:gmock",
+        "@cpp_googletest//:gtest",
+    ],
+)
+
+cc_binary(
+    name = "cnanotest-tcpip",
+    testonly = True,
+    srcs = client_test_srcs,
+    includes = ["test"],
+    deps = [
+        ":krpc_cnano_tcpip",
         "@cpp_googletest//:gmock",
         "@cpp_googletest//:gtest",
     ],

--- a/client/cnano/CHANGELOG.md
+++ b/client/cnano/CHANGELOG.md
@@ -1,6 +1,18 @@
 ## [v0.7.0] - unreleased
 - **Breaking:** Support null for any nullable type; a nullable non-class return adds a `bool*
   returnValueIsNull` out-parameter and a nullable argument is a pointer (#1017)
+- Add `KRPC_COMMUNICATION_TCP`, which builds the library to communicate with a server over
+  TCP/IP rather than over a serial port, leaving the server on its default protocol. A
+  connection is opened with the address and port the server is listening on, held in a
+  `krpc_connection_config_t`, in place of the name of a port. CMake builds of the library ask
+  for it with `-DKRPC_COMMUNICATION_TCP=ON`, which also links the winsock library it needs on
+  Windows (#1055)
+- Add a `tcp` feature to the vcpkg port, which installs the library built to communicate over
+  TCP/IP; `vcpkg install "krpc-cnano[tcp]"` (#1055)
+- Add `KRPC_SINGLE_CONNECTION`, for a `KRPC_COMMUNICATION_CUSTOM` communication mechanism that
+  opens a connection of its own to each server. Messages are then sent as they are, rather than
+  wrapped in the multiplexed message a serial port needs to say which of the connections it
+  carries a message belongs to (#1055)
 
 ## [v0.6.0]
 - Distribute via vcpkg (#874)

--- a/client/cnano/CMakeLists.txt.tmpl
+++ b/client/cnano/CMakeLists.txt.tmpl
@@ -11,6 +11,7 @@ option(KRPC_FETCH_NANOPB     "Use FetchContent for nanopb"                      
 option(KRPC_FETCH_PROTOBUF   "Use FetchContent for protobuf (for protoc; only used with KRPC_REGENERATE_PROTO=ON)" OFF)
 option(KRPC_FETCH_ABSL       "Use FetchContent for abseil (only relevant when KRPC_FETCH_PROTOBUF=ON)"             OFF)
 option(KRPC_REGENERATE_PROTO "Re-run protoc+nanopb to regenerate proto sources (requires Python protobuf package)" OFF)
+option(KRPC_COMMUNICATION_TCP "Communicate with the server over TCP/IP instead of a serial port" OFF)
 
 if(KRPC_FETCH_DEPS)
   set(KRPC_FETCH_NANOPB ON)
@@ -137,6 +138,15 @@ target_include_directories(krpc_cnano PUBLIC
 target_link_libraries(krpc_cnano PUBLIC
   "$<BUILD_INTERFACE:nanopb::protobuf-nanopb-static>"
   "$<INSTALL_INTERFACE:nanopb::protobuf-nanopb-static>")
+
+# Which transport the library talks to the server over. The headers pick a serial port for the
+# platform on their own; TCP/IP has to be asked for, and on Windows brings in winsock. The
+# definition is public so that a program using the library is built for the same transport it is,
+# which decides the type of the connection and of the argument that opens it.
+if(KRPC_COMMUNICATION_TCP)
+  target_compile_definitions(krpc_cnano PUBLIC KRPC_COMMUNICATION_TCP)
+  target_link_libraries(krpc_cnano PUBLIC "$<$<PLATFORM_ID:Windows>:ws2_32>")
+endif()
 
 set_target_properties(krpc_cnano PROPERTIES
   VERSION   ${PROJECT_VERSION}

--- a/client/cnano/INSTALL.txt
+++ b/client/cnano/INSTALL.txt
@@ -4,16 +4,16 @@ Installing the kRPC C-nano client library
 Via vcpkg
 ---------
 
-The library can be installed using the bundled vcpkg overlay port. Extract this
-archive and run:
+The library is published to the vcpkg registry, so it can be installed without
+this archive:
 
 On Linux:
 
-    vcpkg install krpc-cnano --overlay-ports=vcpkg-port
+    vcpkg install krpc-cnano
 
 On Windows:
 
-    vcpkg install krpc-cnano:x64-windows --overlay-ports=vcpkg-port
+    vcpkg install krpc-cnano:x64-windows
 
 Then pass the vcpkg toolchain file when configuring your CMake project:
 

--- a/client/cnano/INSTALL.txt
+++ b/client/cnano/INSTALL.txt
@@ -15,6 +15,12 @@ On Windows:
 
     vcpkg install krpc-cnano:x64-windows
 
+The library communicates over a serial port unless the "tcp" feature is asked
+for, which builds it to communicate over TCP/IP instead:
+
+    vcpkg install "krpc-cnano[tcp]"
+    vcpkg install "krpc-cnano[tcp]:x64-windows"
+
 Then pass the vcpkg toolchain file when configuring your CMake project:
 
     cmake -B build -DCMAKE_TOOLCHAIN_FILE=/path/to/vcpkg/scripts/buildsystems/vcpkg.cmake
@@ -69,6 +75,24 @@ package, pass KRPC_FETCH_DEPS=ON:
 The fine-grained option KRPC_FETCH_NANOPB=ON is also accepted. When an option
 is OFF (the default), the system package is required and CMake will error if it
 cannot be found.
+
+
+Choosing the transport
+----------------------
+
+By default the library communicates with the server over a serial port, using
+the API of the platform it is built for. To communicate over TCP/IP with a
+server reachable over the network, pass KRPC_COMMUNICATION_TCP=ON:
+
+    cmake -B build -DKRPC_COMMUNICATION_TCP=ON
+    cmake --build build
+    sudo cmake --install build
+
+Ask for it this way rather than by defining KRPC_COMMUNICATION_TCP directly, so
+that programs linking the library are built for the same transport and, on
+Windows, are linked against winsock along with it. A connection is then opened
+with the address and port the server is listening on, in place of the name of a
+port.
 
 
 Using the installed library

--- a/client/cnano/benchmark/benchmark.c
+++ b/client/cnano/benchmark/benchmark.c
@@ -1,0 +1,220 @@
+/* Benchmarks for the C-nano client, run by //tools/benchmarks:cnano.
+ *
+ * Measures what this client costs from inside it: the round trip for a procedure call, and what
+ * a call carrying a collection of values costs. The runner starts a TestServer, passes the ports
+ * in the environment and reads the JSON printed here; see tools/benchmarks/run_client.py for the
+ * contract and for what happens to these numbers afterwards.
+ *
+ * The client is built for TCP/IP here rather than for a serial port, which is the only way the
+ * figures mean anything next to the other clients': the server reads a serial port on a poll
+ * whose interval is longer than everything measured here put together.
+ */
+
+/* clock_gettime is POSIX rather than C. See the same note in src/communication.c. */
+#if !defined(_POSIX_C_SOURCE)
+#define _POSIX_C_SOURCE 199309L
+#endif
+
+#include <krpc_cnano.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <time.h>
+
+#include "services/test_service.h"
+
+/* How long one timed loop should run for. Long enough that the clock and a stray scheduling
+   delay do not decide the answer, short enough that a whole run stays in seconds. */
+#define TARGET_SECONDS 0.2
+
+/* How many timed loops to take. A round trip crosses a socket and a scheduler as well as the
+   server, and every one of those can only make a sample slower. */
+#define SAMPLES 9
+
+/* How long one discarded chunk of calls runs for while a case is being settled, how many of
+   them at a time are asked whether it has stopped getting faster, and how much better the last
+   few have to be than everything before them for it to count as still improving. */
+#define SETTLE_CHUNK_SECONDS 0.1
+#define SETTLE_CHUNKS 3
+#define SETTLE_TOLERANCE 0.02
+
+/* How long to keep settling one case before measuring it anyway, and room for the chunks that
+   takes. A chunk runs for at least SETTLE_CHUNK_SECONDS, so the timeout bounds how many there
+   can be; the array is sized above that bound rather than grown. */
+#define SETTLE_TIMEOUT_SECONDS 10.0
+#define SETTLE_CHUNKS_MAX 128
+
+/* How many values the collection case sends and gets back. A call carries a value at a time, so
+   what one costs to encode and decode is lost in the round trip it arrives in; a list makes
+   that per-value cost most of what the case measures. The same count for every client, so that
+   the figures can be read against each other. */
+#define LIST_VALUES 100
+
+/* The number of cases this program can report, which is every round trip it measures. */
+#define CASES 3
+
+struct benchmark_case {
+  const char *name;
+  double samples[SAMPLES];
+  /* Whether the case had stopped getting faster before any of it was measured. */
+  int settled;
+};
+
+/* What every case is measured against, and the list the collection case sends. Held here rather
+   than passed through the settling and timing code, which only ever needs to make the call. */
+static krpc_connection_t connection;
+static krpc_list_int32_t list_argument = KRPC_NULL_LIST;
+
+static void check(krpc_error_t error, const char *what) {
+  if (error == KRPC_OK) return;
+  fprintf(stderr, "%s: %s\n", what, krpc_get_error(error));
+#ifdef KRPC_ERROR_MESSAGES
+  fprintf(stderr, "%s\n", krpc_get_error_message());
+#endif
+  exit(1);
+}
+
+static double now(void) {
+  struct timespec time;
+  clock_gettime(CLOCK_MONOTONIC, &time);
+  return (double)time.tv_sec + (double)time.tv_nsec * 1e-9;
+}
+
+/* The calls the cases measure. A returned string is left to the client to allocate and then
+   freed, rather than decoded into a buffer held across calls, because every other client
+   allocates one per call and these figures are read against theirs. */
+
+static void call_float_to_string(void) {
+  char *result = NULL;
+  check(krpc_TestService_FloatToString(connection, &result, 3.14159f), "FloatToString");
+  krpc_free(result);
+}
+
+static void call_add_multiple_values(void) {
+  char *result = NULL;
+  check(krpc_TestService_AddMultipleValues(connection, &result, 3.14159f, 1, 2),
+        "AddMultipleValues");
+  krpc_free(result);
+}
+
+static void call_increment_list(void) {
+  krpc_list_int32_t result = KRPC_NULL_LIST;
+  check(krpc_TestService_IncrementList(connection, &result, &list_argument), "IncrementList");
+  KRPC_FREE_LIST(result);
+}
+
+/* Call for a short while and return the milliseconds one call took. */
+static double chunk(void (*call)(void)) {
+  double start = now();
+  long calls = 0;
+  double elapsed;
+  do {
+    call();
+    calls++;
+    elapsed = now() - start;
+  } while (elapsed < SETTLE_CHUNK_SECONDS);
+  return elapsed * 1e3 / (double)calls;
+}
+
+static double smallest(const double *values, int count) {
+  double result = values[0];
+  int i;
+  for (i = 1; i < count; i++)
+    if (values[i] < result) result = values[i];
+  return result;
+}
+
+/* Make discarded calls until they stop getting faster, and return what one costs along with
+   whether it got there. A fixed warmup cannot know when it is done: both ends of a round trip
+   get faster under load for a while, and a case measured before that finishes returns a curve
+   rather than a cost. Every case is settled on its own, since one already warmed by the case
+   before it says so within a few chunks. The cost of a call also falls out of the last chunks,
+   which is what sizes the timed loops. */
+static double settle(void (*call)(void), int *settled) {
+  double chunks[SETTLE_CHUNKS_MAX];
+  int count = 1;
+  double start;
+  chunks[0] = chunk(call);
+  start = now();
+  while (now() - start < SETTLE_TIMEOUT_SECONDS && count < SETTLE_CHUNKS_MAX) {
+    chunks[count++] = chunk(call);
+    if (count > SETTLE_CHUNKS) {
+      int split = count - SETTLE_CHUNKS;
+      double recent = smallest(chunks + split, SETTLE_CHUNKS);
+      double earlier = smallest(chunks, split);
+      if (recent >= earlier * (1 - SETTLE_TOLERANCE)) {
+        *settled = 1;
+        return recent;
+      }
+    }
+  }
+  *settled = 0;
+  return count < SETTLE_CHUNKS ? smallest(chunks, count)
+                               : smallest(chunks + count - SETTLE_CHUNKS, SETTLE_CHUNKS);
+}
+
+/* Time the call in a loop, several times over, filling in the milliseconds one call took. */
+static struct benchmark_case round_trip(const char *name, void (*call)(void)) {
+  struct benchmark_case result;
+  double per_call = settle(call, &result.settled);
+  long iterations = (long)(TARGET_SECONDS * 1e3 / per_call);
+  int sample;
+  if (iterations < 1) iterations = 1;
+  result.name = name;
+  for (sample = 0; sample < SAMPLES; sample++) {
+    long i;
+    double start = now();
+    for (i = 0; i < iterations; i++) call();
+    result.samples[sample] = (now() - start) * 1e3 / (double)iterations;
+  }
+  return result;
+}
+
+static void emit(const struct benchmark_case *cases, int count) {
+  int i;
+  printf("{\"results\": [");
+  for (i = 0; i < count; i++) {
+    int sample;
+    printf("%s{\"case\": \"%s\", \"unit\": \"ms\", \"rate\": \"calls/s\", \"samples\": [",
+           i == 0 ? "" : ", ", cases[i].name);
+    for (sample = 0; sample < SAMPLES; sample++)
+      printf("%s%.9g", sample == 0 ? "" : ", ", cases[i].samples[sample]);
+    printf("]");
+    if (!cases[i].settled) printf(", \"settled\": false");
+    printf("}");
+  }
+  printf("]}\n");
+}
+
+static uint16_t port(const char *name, uint16_t fallback) {
+  const char *value = getenv(name);
+  return value == NULL ? fallback : (uint16_t)atoi(value);
+}
+
+int main(void) {
+  krpc_connection_config_t config;
+  struct benchmark_case cases[CASES];
+  char list_name[64];
+  int count = 0;
+  int i;
+
+  config.address = "127.0.0.1";
+  config.port = port("RPC_PORT", 50000);
+  check(krpc_open(&connection, &config), "open");
+  check(krpc_connect(connection, "cnano_client_benchmark"), "connect");
+
+  list_argument.size = LIST_VALUES;
+  list_argument.items = (int32_t *)krpc_calloc(LIST_VALUES, sizeof(int32_t));
+  for (i = 0; i < LIST_VALUES; i++) list_argument.items[i] = i;
+  snprintf(list_name, sizeof(list_name), "round trip, list of %d values", LIST_VALUES);
+
+  cases[count++] = round_trip("round trip", &call_float_to_string);
+  cases[count++] = round_trip("round trip, 3 arguments", &call_add_multiple_values);
+  cases[count++] = round_trip(list_name, &call_increment_list);
+
+  KRPC_FREE_LIST(list_argument);
+
+  emit(cases, count);
+  check(krpc_close(connection), "close");
+  return 0;
+}

--- a/client/cnano/include/krpc_cnano/communication.h
+++ b/client/cnano/include/krpc_cnano/communication.h
@@ -4,7 +4,7 @@
 #include <stddef.h>
 #include <stdint.h>
 
-#if !defined(KRPC_COMMUNICATION_CUSTOM)
+#if !defined(KRPC_COMMUNICATION_CUSTOM) && !defined(KRPC_COMMUNICATION_TCP)
 #if defined(ARDUINO)
 #define KRPC_COMMUNICATION_ARDUINO
 #ifndef __cplusplus
@@ -50,6 +50,19 @@ typedef HardwareSerial* krpc_connection_t;
 typedef struct {
   uint32_t speed;
   uint8_t config;
+} krpc_connection_config_t;
+#endif
+
+/* A TCP/IP connection to a server reached over a network. The connection is a socket, held as an
+   integer wide enough for both a POSIX file descriptor and a Windows SOCKET so that the winsock
+   headers stay out of this one. An endpoint is a host and a port rather than a name, so this is
+   the one transport whose configuration is a structure on every platform. */
+#ifdef KRPC_COMMUNICATION_TCP
+typedef uintptr_t krpc_connection_t;
+
+typedef struct {
+  const char* address;
+  uint16_t port;
 } krpc_connection_config_t;
 #endif
 

--- a/client/cnano/include/krpc_cnano/communication.h
+++ b/client/cnano/include/krpc_cnano/communication.h
@@ -18,6 +18,18 @@
 #endif
 #endif
 
+/* A serial link carries the RPC and stream connections over the one link, so each message sent
+   over it is wrapped in a multiplexed message saying which connection it belongs to. A transport
+   that opens a connection of its own per server sends the messages themselves.
+
+   A custom transport is taken to carry both connections over one link, as a serial port does;
+   one that opens a connection per server is built with KRPC_SINGLE_CONNECTION. */
+#if defined(KRPC_COMMUNICATION_POSIX) || defined(KRPC_COMMUNICATION_WINDOWS) || \
+    defined(KRPC_COMMUNICATION_ARDUINO) ||                                      \
+    (defined(KRPC_COMMUNICATION_CUSTOM) && !defined(KRPC_SINGLE_CONNECTION))
+#define KRPC_MULTIPLEXED
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/client/cnano/src/communication.c
+++ b/client/cnano/src/communication.c
@@ -1,3 +1,10 @@
+/* The sockets API is POSIX rather than C, and a compiler asked for strict C hides it unless the
+ * file says which POSIX it expects. A feature test macro only has any effect before the first
+ * header is included, which is why this comes ahead of them. */
+#if defined(KRPC_COMMUNICATION_TCP) && !defined(_WIN32) && !defined(_POSIX_C_SOURCE)
+#define _POSIX_C_SOURCE 200112L
+#endif
+
 #include <krpc_cnano/communication.h>
 #include <krpc_cnano/error.h>
 
@@ -80,6 +87,144 @@ krpc_error_t krpc_write(krpc_connection_t connection, const uint8_t* buf, size_t
   if (!WriteFile((HANDLE)connection, buf, (DWORD)count, &bytes_written, NULL) ||
       bytes_written != (DWORD)count)
     KRPC_RETURN_ERROR(IO, "write failed");
+  return KRPC_OK;
+}
+
+#endif
+
+#if defined(KRPC_COMMUNICATION_TCP)
+
+#include <stdio.h>
+#include <string.h>
+
+#ifdef _WIN32
+#include <winsock2.h>
+#include <ws2tcpip.h>
+#else
+#include <errno.h>
+#include <netdb.h>
+#include <netinet/in.h>
+#include <netinet/tcp.h>
+#include <sys/socket.h>
+#include <unistd.h>
+/* The winsock spellings, so that the code below is the same on both platforms */
+typedef int SOCKET;
+#define INVALID_SOCKET (-1)
+#define closesocket close
+#endif
+
+/* Sending to a socket whose peer has gone raises SIGPIPE, which by default takes the program
+   down, in place of the error the caller is waiting to be told about. Where there is a send flag
+   that suppresses it, it is passed on every send; where there is only a socket option, that is
+   set on the socket when it is opened. Winsock raises no such signal. */
+#if defined(MSG_NOSIGNAL)
+#define KRPC_SEND_FLAGS MSG_NOSIGNAL
+#else
+#define KRPC_SEND_FLAGS 0
+#endif
+
+/* A read or write interrupted by a signal the program handles has not failed, and is resumed
+   from where it stopped. Treating it as a failure would leave part of a message on the socket,
+   which every call after it would then read in place of its own. Winsock does not interrupt
+   calls this way, and reports through WSAGetLastError rather than errno. */
+#ifdef _WIN32
+#define KRPC_INTERRUPTED() 0
+#else
+#define KRPC_INTERRUPTED() (errno == EINTR)
+#endif
+
+/* The longest a port number and its terminator can be, as getaddrinfo takes the service to
+ * connect to as a string */
+#define KRPC_PORT_LENGTH 6
+
+#ifdef _WIN32
+/* Winsock has to be started before any socket call, and counts starts against stops. It is
+   started once for the process and left started, so that the count does not depend on how many
+   connections have been opened and closed, or on the caller balancing its own use of winsock
+   against this one. The system releases it when the process exits. */
+static krpc_error_t krpc_start_winsock(void) {
+  static int started = 0;
+  WSADATA winsock;
+  if (started) return KRPC_OK;
+  if (WSAStartup(MAKEWORD(2, 2), &winsock) != 0) KRPC_RETURN_ERROR(IO, "failed to start winsock");
+  started = 1;
+  return KRPC_OK;
+}
+#endif
+
+krpc_error_t krpc_open(krpc_connection_t* connection, const krpc_connection_config_t* arg) {
+  struct addrinfo hints;
+  struct addrinfo* addresses;
+  struct addrinfo* address;
+  char port[KRPC_PORT_LENGTH];
+  SOCKET result = INVALID_SOCKET;
+  int nodelay = 1;
+#if !defined(MSG_NOSIGNAL) && defined(SO_NOSIGPIPE)
+  int nosigpipe = 1;
+#endif
+  if (arg == NULL || arg->address == NULL) KRPC_RETURN_ERROR(IO, "no server address to connect to");
+#ifdef _WIN32
+  KRPC_RETURN_ON_ERROR(krpc_start_winsock());
+#endif
+  snprintf(port, sizeof(port), "%u", (unsigned int)arg->port);
+  memset(&hints, 0, sizeof(hints));
+  hints.ai_family = AF_UNSPEC;
+  hints.ai_socktype = SOCK_STREAM;
+  if (getaddrinfo(arg->address, port, &hints, &addresses) != 0)
+    KRPC_RETURN_ERROR(IO, "failed to resolve server address");
+  /* The address may resolve to several endpoints, IPv6 and IPv4 among them, and only one of them
+     need be listening. Try each until one connects. */
+  for (address = addresses; address != NULL; address = address->ai_next) {
+    result = socket(address->ai_family, address->ai_socktype, address->ai_protocol);
+    if (result == INVALID_SOCKET) continue;
+    if (connect(result, address->ai_addr, (int)address->ai_addrlen) == 0) break;
+    closesocket(result);
+    result = INVALID_SOCKET;
+  }
+  freeaddrinfo(addresses);
+  if (result == INVALID_SOCKET) KRPC_RETURN_ERROR(IO, "failed to connect to server");
+  /* A request is written in full and then waited on, so holding one back in the hope of more to
+     send with it only adds that wait to every call. */
+  setsockopt(result, IPPROTO_TCP, TCP_NODELAY, (const char*)&nodelay, sizeof(nodelay));
+#if !defined(MSG_NOSIGNAL) && defined(SO_NOSIGPIPE)
+  setsockopt(result, SOL_SOCKET, SO_NOSIGPIPE, (const char*)&nosigpipe, sizeof(nosigpipe));
+#endif
+  *connection = (krpc_connection_t)result;
+  return KRPC_OK;
+}
+
+krpc_error_t krpc_close(krpc_connection_t connection) {
+  closesocket((SOCKET)connection);
+  return KRPC_OK;
+}
+
+krpc_error_t krpc_read(krpc_connection_t connection, uint8_t* buf, size_t count) {
+  size_t total = 0;
+  while (total < count) {
+    int result = recv((SOCKET)connection, (char*)(buf + total), (int)(count - total), 0);
+    if (result < 0) {
+      if (KRPC_INTERRUPTED()) continue;
+      KRPC_RETURN_ERROR(IO, "read failed");
+    } else if (result == 0) {
+      KRPC_RETURN_ERROR(EOF, "eof received");
+    } else {
+      total += (size_t)result;
+    }
+  }
+  return KRPC_OK;
+}
+
+krpc_error_t krpc_write(krpc_connection_t connection, const uint8_t* buf, size_t count) {
+  size_t total = 0;
+  while (total < count) {
+    int result =
+        send((SOCKET)connection, (const char*)(buf + total), (int)(count - total), KRPC_SEND_FLAGS);
+    if (result <= 0) {
+      if (result < 0 && KRPC_INTERRUPTED()) continue;
+      KRPC_RETURN_ERROR(IO, "write failed");
+    }
+    total += (size_t)result;
+  }
   return KRPC_OK;
 }
 

--- a/client/cnano/src/krpc.c
+++ b/client/cnano/src/krpc.c
@@ -18,13 +18,21 @@ static pb_istream_t krpc_pb_istream_from_connection(krpc_connection_t connection
 krpc_error_t krpc_connect(krpc_connection_t connection, const char *client_name) {
   {
     // Send connection request message
-    krpc_schema_MultiplexedRequest request = krpc_schema_MultiplexedRequest_init_default;
-    request.has_connection_request = true;
-    request.connection_request.type = krpc_schema_ConnectionRequest_Type_RPC;
-    request.connection_request.client_name.funcs.encode = &krpc_encode_callback_cstring;
-    request.connection_request.client_name.arg = (void *)client_name;
+#ifdef KRPC_MULTIPLEXED
+    krpc_schema_MultiplexedRequest message = krpc_schema_MultiplexedRequest_init_default;
+    const pb_msgdesc_t *fields = krpc_schema_MultiplexedRequest_fields;
+    krpc_schema_ConnectionRequest *request = &message.connection_request;
+    message.has_connection_request = true;
+#else
+    krpc_schema_ConnectionRequest message = krpc_schema_ConnectionRequest_init_default;
+    const pb_msgdesc_t *fields = krpc_schema_ConnectionRequest_fields;
+    krpc_schema_ConnectionRequest *request = &message;
+#endif
+    request->type = krpc_schema_ConnectionRequest_Type_RPC;
+    request->client_name.funcs.encode = &krpc_encode_callback_cstring;
+    request->client_name.arg = (void *)client_name;
     pb_ostream_t stream = krpc_pb_ostream_from_connection(connection);
-    if (!pb_encode_delimited(&stream, krpc_schema_MultiplexedRequest_fields, &request)) {
+    if (!pb_encode_delimited(&stream, fields, &message)) {
       krpc_close(connection);
       KRPC_RETURN_STREAM_ERROR(ENCODING_FAILED, "failed to encode connection request", &stream);
     }
@@ -113,13 +121,21 @@ krpc_error_t krpc_invoke(krpc_connection_t connection, krpc_schema_ProcedureResu
     pb_ostream_t ostream = krpc_pb_ostream_from_connection(connection);
 
     // Create request message containing the procedure call
-    krpc_schema_MultiplexedRequest m_request = krpc_schema_MultiplexedRequest_init_default;
-    m_request.has_request = true;
-    m_request.request.calls[0] = *call;
-    m_request.request.calls_count = 1;
+#ifdef KRPC_MULTIPLEXED
+    krpc_schema_MultiplexedRequest message = krpc_schema_MultiplexedRequest_init_default;
+    const pb_msgdesc_t *fields = krpc_schema_MultiplexedRequest_fields;
+    krpc_schema_Request *request = &message.request;
+    message.has_request = true;
+#else
+    krpc_schema_Request message = krpc_schema_Request_init_default;
+    const pb_msgdesc_t *fields = krpc_schema_Request_fields;
+    krpc_schema_Request *request = &message;
+#endif
+    request->calls[0] = *call;
+    request->calls_count = 1;
 
     // Send request message
-    if (!pb_encode_delimited(&ostream, krpc_schema_MultiplexedRequest_fields, &m_request))
+    if (!pb_encode_delimited(&ostream, fields, &message))
       KRPC_RETURN_STREAM_ERROR(ENCODING_FAILED, "failed to encode request message", &ostream);
   }
 
@@ -127,17 +143,25 @@ krpc_error_t krpc_invoke(krpc_connection_t connection, krpc_schema_ProcedureResu
     pb_istream_t istream = krpc_pb_istream_from_connection(connection);
 
     // Receive response message
-    krpc_schema_MultiplexedResponse m_response = krpc_schema_MultiplexedResponse_init_default;
+#ifdef KRPC_MULTIPLEXED
+    krpc_schema_MultiplexedResponse message = krpc_schema_MultiplexedResponse_init_default;
+    const pb_msgdesc_t *fields = krpc_schema_MultiplexedResponse_fields;
+    krpc_schema_Response *response = &message.response;
+#else
+    krpc_schema_Response message = krpc_schema_Response_init_default;
+    const pb_msgdesc_t *fields = krpc_schema_Response_fields;
+    krpc_schema_Response *response = &message;
+#endif
 
-    m_response.response.results[0] = *result;
+    response->results[0] = *result;
 
     krpc_error_t rpc_error = KRPC_OK;
-    m_response.response.error.funcs.decode = &krpc_decode_callback_error;
-    m_response.response.error.arg = &rpc_error;
-    m_response.response.results[0].error.funcs.decode = &krpc_decode_callback_error;
-    m_response.response.results[0].error.arg = &rpc_error;
+    response->error.funcs.decode = &krpc_decode_callback_error;
+    response->error.arg = &rpc_error;
+    response->results[0].error.funcs.decode = &krpc_decode_callback_error;
+    response->results[0].error.arg = &rpc_error;
 
-    if (!pb_decode_delimited(&istream, krpc_schema_MultiplexedResponse_fields, &m_response))
+    if (!pb_decode_delimited(&istream, fields, &message))
       KRPC_RETURN_STREAM_ERROR(DECODING_FAILED, "failed to decode response message", &istream);
 
     if (rpc_error != KRPC_OK) {
@@ -149,7 +173,6 @@ krpc_error_t krpc_invoke(krpc_connection_t connection, krpc_schema_ProcedureResu
     }
 
     // Extract the procedure result message from the response
-    krpc_schema_Response *response = &m_response.response;
     if (response->results_count != 1)
       KRPC_RETURN_ERROR(NO_RESULTS, "response message does not contain a single result");
     *result = response->results[0];

--- a/client/cnano/test-cmake-linux.sh
+++ b/client/cnano/test-cmake-linux.sh
@@ -1,18 +1,23 @@
 #!/bin/bash
 # Test building the C-nano client using CMake.
 # Accepts the release archive as the first argument.
-# Runs CMake build scenario(s):
-#   system) system-installed nanopb
-#   fetch)  nanopb fetched via FetchContent (KRPC_FETCH_DEPS=ON)
+# Covers the two things a build chooses between, crossed with each other:
+#   how nanopb is provided) system) a system-installed nanopb
+#                           fetch)  nanopb fetched via FetchContent (KRPC_FETCH_DEPS=ON)
+#   which transport)        serialio) a serial port, the default
+#                           tcpip)    TCP/IP (KRPC_COMMUNICATION_TCP=ON)
 # Each is followed by a consumer test using find_package(krpc_cnano CONFIG REQUIRED).
-# Usage: test-cmake-linux.sh ARCHIVE [system|fetch]  (default: run both)
+# Usage: test-cmake-linux.sh ARCHIVE [system-serialio|system-tcpip|fetch-serialio|fetch-tcpip]
+#        (default: run all)
 set -e
 set -o pipefail
 set -x
 set -o functrace
 
-archive="$(realpath "${1:?Usage: test-cmake-linux.sh ARCHIVE [system|fetch]}")"
-mode="${2:-all}"
+scenarios="system-serialio system-tcpip fetch-serialio fetch-tcpip"
+
+archive="$(realpath "${1:?Usage: test-cmake-linux.sh ARCHIVE [$(echo $scenarios | tr ' ' '|')]}")"
+scenario="${2:-all}"
 
 scriptroot="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 cd "$scriptroot/../.."
@@ -72,53 +77,58 @@ function check_absent {
   fi
 }
 
-# Build a small consumer project that uses find_package(krpc_cnano CONFIG REQUIRED)
-# to verify the installed package config and targets work end-to-end.
+# Build the consumer project against the installed package, to verify the package config and
+# targets work end-to-end. Where the library is built for TCP/IP the program opens a connection,
+# which is what proves the transport reaches it through the package.
 function consumer_test {
   local install_dir=$1
-  local test_dir=$2
-  mkdir -p "$test_dir"
-
-  cat > "$test_dir/main.c" << 'EOF'
-#include <stdio.h>
-#include <krpc_cnano.h>
-#include <krpc_cnano/services/krpc.h>
-int main(void) {
-    /* Compile+link test only — no server connection. */
-    printf("krpc_cnano library linked OK\n");
-    return 0;
-}
-EOF
-
-  cat > "$test_dir/CMakeLists.txt" << 'EOF'
-cmake_minimum_required(VERSION 3.15)
-project(krpc_cnano_consumer_test LANGUAGES C)
-set(CMAKE_C_STANDARD 99)
-find_package(krpc_cnano CONFIG REQUIRED)
-add_executable(test_app main.c)
-target_link_libraries(test_app PRIVATE krpc_cnano::krpc_cnano)
-EOF
-
-  mkdir -p "$test_dir/build"
-  cmake -S "$test_dir" -B "$test_dir/build" \
+  local build_dir=$2
+  cmake -S "$scriptroot/test-consumer" -B "$build_dir" \
     -DCMAKE_PREFIX_PATH="$install_dir" \
     -DCMAKE_BUILD_TYPE=Release
-  cmake --build "$test_dir/build" --parallel $(nproc)
+  cmake --build "$build_dir" --parallel $(nproc)
 }
 
-# 1) System-installed nanopb
-if [[ "$mode" == "system" || "$mode" == "all" ]]; then
-  build_install "$out/system/build" "$out/system/install" "$out/system/configure.log"
-  check_present "$out/system/configure.log" "Found nanopb"
-  check_absent  "$out/system/configure.log" "Fetching nanopb via FetchContent"
-  consumer_test "$out/system/install" "$out/system/consumer"
-fi
+# Build, install and consume the library for one scenario, named for how nanopb is provided and
+# which transport the library talks over.
+function run_scenario {
+  local name=$1
+  local dir="$out/$name"
+  local log="$dir/configure.log"
+  local options=()
 
-# 2) FetchContent nanopb via global option
-if [[ "$mode" == "fetch" || "$mode" == "all" ]]; then
-  build_install "$out/fetch/build" "$out/fetch/install" "$out/fetch/configure.log" \
-    -DKRPC_FETCH_DEPS=ON
-  check_present "$out/fetch/configure.log" "Fetching nanopb via FetchContent"
-  check_absent  "$out/fetch/configure.log" "Found nanopb"
-  consumer_test "$out/fetch/install" "$out/fetch/consumer"
+  case "$name" in
+    fetch-*)  options+=(-DKRPC_FETCH_DEPS=ON) ;;
+    system-*) ;;
+    *) echo "unknown scenario '$name'"; exit 1 ;;
+  esac
+  case "$name" in
+    *-tcpip)    options+=(-DKRPC_COMMUNICATION_TCP=ON) ;;
+    *-serialio) ;;
+    *) echo "unknown scenario '$name'"; exit 1 ;;
+  esac
+
+  build_install "$dir/build" "$dir/install" "$log" "${options[@]}"
+
+  # Which of the two ways of providing nanopb the configure step actually took
+  case "$name" in
+    fetch-*)
+      check_present "$log" "Fetching nanopb via FetchContent"
+      check_absent  "$log" "Found nanopb"
+      ;;
+    system-*)
+      check_present "$log" "Found nanopb"
+      check_absent  "$log" "Fetching nanopb via FetchContent"
+      ;;
+  esac
+
+  consumer_test "$dir/install" "$dir/consumer"
+}
+
+if [[ "$scenario" == "all" ]]; then
+  for name in $scenarios; do
+    run_scenario "$name"
+  done
+else
+  run_scenario "$scenario"
 fi

--- a/client/cnano/test-cmake-windows.sh
+++ b/client/cnano/test-cmake-windows.sh
@@ -1,50 +1,107 @@
 #!/bin/bash
 # Test building the C-nano client on Windows using CMake with vcpkg.
 # Expects the release archive (krpc-cnano-*.zip) in the current directory.
-# Usage: test-build-windows.sh
+# Covers the two things a build chooses between, crossed with each other:
+#   how nanopb is provided) system) the nanopb vcpkg installs
+#                           fetch)  nanopb fetched via FetchContent (KRPC_FETCH_DEPS=ON)
+#   which transport)        serialio) a serial port, reached through the Windows file API
+#                           tcpip)    TCP/IP, reached through winsock (KRPC_COMMUNICATION_TCP=ON)
+# Each is followed by a consumer test using find_package(krpc_cnano CONFIG REQUIRED).
+# Usage: test-cmake-windows.sh [system-serialio|system-tcpip|fetch-serialio|fetch-tcpip]
+#        (default: run all)
 set -eo pipefail
 set -x
 
-# Extract the release archive
-unzip -q krpc-cnano-*.zip
+scenarios="system-serialio system-tcpip fetch-serialio fetch-tcpip"
+scenario="${1:-all}"
+
+scriptroot="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+# Extract the release archive, over any tree an earlier scenario left behind
+unzip -o -q krpc-cnano-*.zip
 src=$(ls -d krpc-cnano-*/)
 
-# Configure
-cmake -S "$src" -B build \
-  -DCMAKE_INSTALL_PREFIX=install \
-  -DCMAKE_BUILD_TYPE=Release \
-  "-DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake" \
-  -DVCPKG_TARGET_TRIPLET=x64-windows \
-  2>&1 | tee configure.log
-grep -q "Found nanopb" configure.log
-! grep -q "Fetching nanopb via FetchContent" configure.log
+root=$(pwd)
+toolchain="C:/vcpkg/scripts/buildsystems/vcpkg.cmake"
 
-# Build and install
-cmake --build build --config Release --parallel
-cmake --install build --config Release
-
-# Consumer test
-mkdir -p consumer
-cat > consumer/main.c << 'EOF'
-#include <stdio.h>
-#include <krpc_cnano.h>
-#include <krpc_cnano/services/krpc.h>
-int main(void) {
-    printf("krpc_cnano library linked OK\n");
-    return 0;
+# Verify a pattern appears in the cmake configure log.
+function check_present {
+  local log=$1
+  local pattern=$2
+  if ! grep -q "$pattern" "$log"; then
+    echo "FAIL: expected '${pattern}' in cmake configure output but not found"
+    exit 1
+  fi
 }
-EOF
-cat > consumer/CMakeLists.txt << 'EOF'
-cmake_minimum_required(VERSION 3.15)
-project(krpc_cnano_consumer_test LANGUAGES C)
-set(CMAKE_C_STANDARD 99)
-find_package(krpc_cnano CONFIG REQUIRED)
-add_executable(test_app main.c)
-target_link_libraries(test_app PRIVATE krpc_cnano::krpc_cnano)
-EOF
-cmake -S consumer -B consumer/build \
-  "-DCMAKE_PREFIX_PATH=$(pwd)/install" \
-  -DCMAKE_BUILD_TYPE=Release \
-  "-DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake" \
-  -DVCPKG_TARGET_TRIPLET=x64-windows
-cmake --build consumer/build --config Release --parallel
+
+# Verify a pattern does not appear in the cmake configure log.
+function check_absent {
+  local log=$1
+  local pattern=$2
+  if grep -q "$pattern" "$log"; then
+    echo "FAIL: '${pattern}' should not appear in cmake configure output"
+    exit 1
+  fi
+}
+
+# Build and install the library, then build the consumer project against the installed package
+# with find_package(krpc_cnano CONFIG REQUIRED), to verify the package config and targets work
+# end-to-end. Where the library is built for TCP/IP the program opens a connection, which is what
+# proves the transport, and the winsock library it needs, reach it through the package.
+function run_scenario {
+  local name=$1
+  local out="$root/$name"
+  local log="$out/configure.log"
+  local options=()
+  mkdir -p "$out"
+
+  case "$name" in
+    fetch-*)  options+=(-DKRPC_FETCH_DEPS=ON) ;;
+    system-*) ;;
+    *) echo "unknown scenario '$name'"; exit 1 ;;
+  esac
+  case "$name" in
+    *-tcpip)    options+=(-DKRPC_COMMUNICATION_TCP=ON) ;;
+    *-serialio) ;;
+    *) echo "unknown scenario '$name'"; exit 1 ;;
+  esac
+
+  # Configure, build and install the library
+  cmake -S "$src" -B "$out/build" \
+    -DCMAKE_INSTALL_PREFIX="$out/install" \
+    -DCMAKE_BUILD_TYPE=Release \
+    "-DCMAKE_TOOLCHAIN_FILE=$toolchain" \
+    -DVCPKG_TARGET_TRIPLET=x64-windows \
+    "${options[@]}" 2>&1 | tee "$log"
+
+  # Which of the two ways of providing nanopb the configure step actually took
+  case "$name" in
+    fetch-*)
+      check_present "$log" "Fetching nanopb via FetchContent"
+      check_absent  "$log" "Found nanopb"
+      ;;
+    system-*)
+      check_present "$log" "Found nanopb"
+      check_absent  "$log" "Fetching nanopb via FetchContent"
+      ;;
+  esac
+
+  cmake --build "$out/build" --config Release --parallel
+  cmake --install "$out/build" --config Release
+
+  # Consumer test
+  cmake -S "$scriptroot/test-consumer" -B "$out/consumer" \
+    "-DCMAKE_PREFIX_PATH=$out/install" \
+    -DCMAKE_BUILD_TYPE=Release \
+    "-DCMAKE_TOOLCHAIN_FILE=$toolchain" \
+    -DVCPKG_TARGET_TRIPLET=x64-windows
+  cmake --build "$out/consumer" --config Release --parallel
+}
+
+if [[ "$scenario" == "all" ]]; then
+  for name in $scenarios; do
+    run_scenario "$name"
+  done
+else
+  run_scenario "$scenario"
+fi

--- a/client/cnano/test-consumer/CMakeLists.txt
+++ b/client/cnano/test-consumer/CMakeLists.txt
@@ -1,0 +1,9 @@
+# A program built against the installed krpc_cnano package, to verify that the package config and
+# its targets work end-to-end. The build-test scripts point cmake at this directory once per
+# scenario they cover, so that every one of them is checked the same way.
+cmake_minimum_required(VERSION 3.15)
+project(krpc_cnano_consumer_test LANGUAGES C)
+set(CMAKE_C_STANDARD 99)
+find_package(krpc_cnano CONFIG REQUIRED)
+add_executable(test_app main.c)
+target_link_libraries(test_app PRIVATE krpc_cnano::krpc_cnano)

--- a/client/cnano/test-consumer/main.c
+++ b/client/cnano/test-consumer/main.c
@@ -1,0 +1,24 @@
+#include <stdio.h>
+
+#include <krpc_cnano.h>
+#include <krpc_cnano/services/krpc.h>
+
+int main(void) {
+    /* Compiles and links against the installed package; there is no server to talk to. */
+#ifdef KRPC_COMMUNICATION_TCP
+    /* Which transport the library was built for reaches a program using it through the package,
+       so this is compiled only when that transport is TCP/IP. Opening a connection is what pulls
+       in the socket code, and with it the libraries the transport needs; nothing is listening on
+       the port, so it fails. */
+    krpc_connection_t connection;
+    krpc_connection_config_t config;
+    config.address = "127.0.0.1";
+    config.port = 1;
+    if (krpc_open(&connection, &config) == KRPC_OK) {
+        printf("opened a connection to a port nothing should be listening on\n");
+        return 1;
+    }
+#endif
+    printf("krpc_cnano library linked OK\n");
+    return 0;
+}

--- a/client/cnano/test-vcpkg-linux.sh
+++ b/client/cnano/test-vcpkg-linux.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Test installing the kRPC C-nano client via vcpkg overlay port.
+# Test installing the kRPC C-nano client via vcpkg overlay port, once per transport it offers.
 # Builds the release archive with Bazel, or uses a provided archive.
 # Usage: test-vcpkg.sh [/path/to/krpc-cnano-VERSION.zip]
 # Requires: VCPKG_ROOT environment variable pointing to a vcpkg installation.
@@ -47,38 +47,26 @@ sed -i \
   "$tmpport/portfile.cmake"
 sed -i "s/\"version\": \"[^\"]*\"/\"version\": \"$version_semver\"/" "$tmpport/vcpkg.json"
 
-# Install via the overlay port into a local directory
+# Install via the overlay port and build the consumer project against it, once per transport the
+# port offers. Where the library is built for TCP/IP the consumer opens a connection, which is
+# what proves the transport reaches a program through the package vcpkg installed.
 out=$(pwd)/bazel-bin/client/cnano/test-vcpkg
 rm -rf "$out"
 mkdir -p "$out"
-"$vcpkg_bin" install krpc-cnano --overlay-ports="$tmpport" --x-install-root="$out/vcpkg_installed"
 
-# Consumer test: a small project that uses find_package(krpc_cnano CONFIG REQUIRED)
-mkdir -p "$out/consumer"
-
-cat > "$out/consumer/main.c" << 'EOF'
-#include <stdio.h>
-#include <krpc_cnano.h>
-#include <krpc_cnano/services/krpc.h>
-int main(void) {
-    /* Compile+link test only — no server connection. */
-    printf("krpc_cnano library linked OK\n");
-    return 0;
+function run_scenario {
+  local name=$1
+  local package=$2
+  local dir="$out/$name"
+  mkdir -p "$dir"
+  "$vcpkg_bin" install "$package" --overlay-ports="$tmpport" \
+    --x-install-root="$dir/vcpkg_installed"
+  cmake -S "$scriptroot/test-consumer" -B "$dir/consumer" \
+    "-DCMAKE_TOOLCHAIN_FILE=$toolchain" \
+    "-DVCPKG_INSTALLED_DIR=$dir/vcpkg_installed" \
+    -DCMAKE_BUILD_TYPE=Release
+  cmake --build "$dir/consumer" --parallel "$(nproc)"
 }
-EOF
 
-cat > "$out/consumer/CMakeLists.txt" << 'EOF'
-cmake_minimum_required(VERSION 3.15)
-project(krpc_cnano_consumer_test LANGUAGES C)
-set(CMAKE_C_STANDARD 99)
-find_package(krpc_cnano CONFIG REQUIRED)
-add_executable(test_app main.c)
-target_link_libraries(test_app PRIVATE krpc_cnano::krpc_cnano)
-EOF
-
-mkdir -p "$out/consumer/build"
-cmake -S "$out/consumer" -B "$out/consumer/build" \
-  "-DCMAKE_TOOLCHAIN_FILE=$toolchain" \
-  "-DVCPKG_INSTALLED_DIR=$out/vcpkg_installed" \
-  -DCMAKE_BUILD_TYPE=Release
-cmake --build "$out/consumer/build" --parallel "$(nproc)"
+run_scenario serialio "krpc-cnano"
+run_scenario tcpip "krpc-cnano[tcp]"

--- a/client/cnano/test-vcpkg-windows.sh
+++ b/client/cnano/test-vcpkg-windows.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-# Test installing the kRPC C-nano client via vcpkg overlay port on Windows.
+# Test installing the kRPC C-nano client via vcpkg overlay port on Windows, once per
+# transport it offers.
 # Expects the release archive (krpc-cnano-*.zip) in the current directory.
 # Usage: test-vcpkg-windows.sh
 set -eo pipefail
@@ -31,32 +32,23 @@ sed -i \
   "$tmpport/portfile.cmake"
 sed -i "s/\"version\": \"[^\"]*\"/\"version\": \"$version_semver\"/" "$tmpport/vcpkg.json"
 
-# Install via the overlay port into a local directory
-"$vcpkg_bin" install krpc-cnano:x64-windows --overlay-ports="$tmpport" --x-install-root=vcpkg_installed
-
-# Consumer test
-mkdir -p consumer
-cat > consumer/main.c << 'EOF'
-#include <stdio.h>
-#include <krpc_cnano.h>
-#include <krpc_cnano/services/krpc.h>
-int main(void) {
-    /* Compile+link test only — no server connection. */
-    printf("krpc_cnano library linked OK\n");
-    return 0;
+# Install via the overlay port and build the consumer project against it, once per transport the
+# port offers. Where the library is built for TCP/IP the consumer opens a connection, which is
+# what proves the transport, and the winsock library it needs, reach a program through the
+# package vcpkg installed.
+function run_scenario {
+  local name=$1
+  local package=$2
+  mkdir -p "$name"
+  "$vcpkg_bin" install "$package" --overlay-ports="$tmpport" \
+    --x-install-root="$name/vcpkg_installed"
+  cmake -S "$scriptroot/test-consumer" -B "$name/consumer" \
+    "-DCMAKE_TOOLCHAIN_FILE=$toolchain" \
+    "-DVCPKG_INSTALLED_DIR=$(pwd)/$name/vcpkg_installed" \
+    -DVCPKG_TARGET_TRIPLET=x64-windows \
+    -DCMAKE_BUILD_TYPE=Release
+  cmake --build "$name/consumer" --config Release --parallel
 }
-EOF
-cat > consumer/CMakeLists.txt << 'EOF'
-cmake_minimum_required(VERSION 3.15)
-project(krpc_cnano_consumer_test LANGUAGES C)
-set(CMAKE_C_STANDARD 99)
-find_package(krpc_cnano CONFIG REQUIRED)
-add_executable(test_app main.c)
-target_link_libraries(test_app PRIVATE krpc_cnano::krpc_cnano)
-EOF
-cmake -S consumer -B consumer/build \
-  "-DCMAKE_TOOLCHAIN_FILE=$toolchain" \
-  "-DVCPKG_INSTALLED_DIR=$(pwd)/vcpkg_installed" \
-  -DVCPKG_TARGET_TRIPLET=x64-windows \
-  -DCMAKE_BUILD_TYPE=Release
-cmake --build consumer/build --config Release --parallel
+
+run_scenario serialio "krpc-cnano:x64-windows"
+run_scenario tcpip "krpc-cnano[tcp]:x64-windows"

--- a/client/cnano/test/server_test.hpp
+++ b/client/cnano/test/server_test.hpp
@@ -3,6 +3,9 @@
 #include <gmock/gmock.h>
 #include <krpc_cnano.h>
 
+#include <cstdint>
+#include <cstdlib>
+
 // Check the message for the last error returned by the server, when the client is built with
 // support for them. Only the start of the message is compared, as the server also sends a stack
 // trace, which is truncated to fit the message buffer.
@@ -20,7 +23,6 @@ class server_test : public ::testing::Test {
   server_test();
   ~server_test();
   krpc_connection_t connect();
-  const char* get_port() const;
   krpc_connection_t conn;
 };
 
@@ -30,11 +32,29 @@ inline server_test::~server_test() {
   if (KRPC_OK != krpc_close(conn)) exit(1);
 }
 
+// Where the server the test harness started is listening, in whatever form the transport this
+// build uses opens a connection from.
+#ifdef KRPC_COMMUNICATION_TCP
+inline krpc_connection_config_t server_address() {
+  // The port the test harness passes in, or the server's default when the binary is run directly
+  const char* port = std::getenv("RPC_PORT");
+  krpc_connection_config_t config;
+  config.address = "127.0.0.1";
+  config.port = port == nullptr ? 50000 : static_cast<uint16_t>(std::atoi(port));
+  return config;
+}
+#else
+inline const char* server_address() { return std::getenv("PORT"); }
+#endif
+
 inline krpc_connection_t server_test::connect() {
   krpc_connection_t result;
-  if (KRPC_OK != krpc_open(&result, get_port())) exit(1);
+#ifdef KRPC_COMMUNICATION_TCP
+  krpc_connection_config_t config = server_address();
+  if (KRPC_OK != krpc_open(&result, &config)) exit(1);
+#else
+  if (KRPC_OK != krpc_open(&result, server_address())) exit(1);
+#endif
   if (KRPC_OK != krpc_connect(result, "TestClientCNano")) exit(1);
   return result;
 }
-
-inline const char* server_test::get_port() const { return std::getenv("PORT"); }

--- a/client/cnano/test/test_communication_posix.cpp
+++ b/client/cnano/test/test_communication_posix.cpp
@@ -2,6 +2,8 @@
 
 #include "gtest/gtest.h"
 
+// The serial transport reads and writes its port through the file API, which a pipe answers to
+// in the same way, so these need no serial port to run against.
 #if defined(KRPC_COMMUNICATION_POSIX)
 
 #include <unistd.h>

--- a/client/cnano/test/test_communication_tcp.cpp
+++ b/client/cnano/test/test_communication_tcp.cpp
@@ -1,0 +1,133 @@
+#include <krpc_cnano/communication.h>
+
+#include "gtest/gtest.h"
+
+// The TCP transport is exercised over a socket pair, which behaves as a connected socket does
+// without needing a server to connect to. Winsock has no equivalent, so these are POSIX only.
+#if defined(KRPC_COMMUNICATION_TCP) && !defined(_WIN32)
+
+#include <pthread.h>
+#include <signal.h>
+#include <sys/socket.h>
+#include <sys/time.h>
+#include <unistd.h>
+
+#include <chrono>
+#include <cstring>
+#include <thread>
+
+namespace {
+
+volatile sig_atomic_t alarms = 0;
+
+void count_alarm(int) { alarms++; }
+
+}  // namespace
+
+// A read that returns fewer bytes than requested must resume at the point the previous one
+// finished, rather than restarting at the beginning of the buffer. A large response arrives in
+// as many segments as the network chose to split it into, so this is the usual case rather than
+// an unusual one.
+TEST(test_communication, test_socket_read_partial) {
+  int fds[2];
+  ASSERT_EQ(0, socketpair(AF_UNIX, SOCK_STREAM, 0, fds));
+
+  const uint8_t data[] = {1, 2, 3, 4, 5, 6, 7, 8};
+  ASSERT_EQ(3, send(fds[1], data, 3, 0));
+
+  // Supply the remainder only once the reader is blocked, so that the first read is short
+  std::thread writer([&fds, &data]() {
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    EXPECT_EQ(5, send(fds[1], data + 3, 5, 0));
+  });
+
+  uint8_t buf[8] = {0};
+  krpc_error_t error = krpc_read(fds[0], buf, sizeof(buf));
+  writer.join();
+  close(fds[0]);
+  close(fds[1]);
+
+  ASSERT_EQ(KRPC_OK, error);
+  for (size_t i = 0; i < sizeof(buf); i++) ASSERT_EQ(data[i], buf[i]);
+}
+
+TEST(test_communication, test_socket_read_eof) {
+  int fds[2];
+  ASSERT_EQ(0, socketpair(AF_UNIX, SOCK_STREAM, 0, fds));
+  close(fds[1]);
+
+  uint8_t buf[4] = {0};
+  krpc_error_t error = krpc_read(fds[0], buf, sizeof(buf));
+  close(fds[0]);
+
+  ASSERT_EQ(KRPC_ERROR_EOF, error);
+}
+
+// Writing to a socket whose peer has gone must report the failure. Left to itself it raises
+// SIGPIPE, whose default action ends the program before the caller is told anything, so this
+// test crashes rather than fails when the signal is not suppressed.
+TEST(test_communication, test_socket_write_peer_closed) {
+  int fds[2];
+  ASSERT_EQ(0, socketpair(AF_UNIX, SOCK_STREAM, 0, fds));
+  ASSERT_EQ(0, close(fds[1]));
+
+  const uint8_t data[] = {1, 2, 3, 4};
+  krpc_error_t error = krpc_write(fds[0], data, sizeof(data));
+  close(fds[0]);
+
+  ASSERT_EQ(KRPC_ERROR_IO, error);
+}
+
+// A signal delivered while a read is blocked interrupts it, and the read has to carry on from
+// where it stopped: reporting a failure would leave the rest of the message on the socket for
+// the next call to read as its own.
+TEST(test_communication, test_socket_read_interrupted) {
+  int fds[2];
+  ASSERT_EQ(0, socketpair(AF_UNIX, SOCK_STREAM, 0, fds));
+
+  const uint8_t data[] = {1, 2, 3, 4, 5, 6, 7, 8};
+  ASSERT_EQ(3, send(fds[1], data, 3, 0));
+
+  // A handler with no SA_RESTART, which is what leaves an interrupted read to be resumed by the
+  // program rather than by the system
+  struct sigaction action;
+  struct sigaction previous_action;
+  std::memset(&action, 0, sizeof(action));
+  action.sa_handler = &count_alarm;
+  sigemptyset(&action.sa_mask);
+  action.sa_flags = 0;
+  alarms = 0;
+  ASSERT_EQ(0, sigaction(SIGALRM, &action, &previous_action));
+
+  // The signal goes to a thread that is not blocking it, so it is blocked here for as long as it
+  // takes to start the writer, leaving this thread, the one that blocks in the read, to take it
+  sigset_t alarm_signal;
+  sigset_t previous_mask;
+  sigemptyset(&alarm_signal);
+  sigaddset(&alarm_signal, SIGALRM);
+  ASSERT_EQ(0, pthread_sigmask(SIG_BLOCK, &alarm_signal, &previous_mask));
+  std::thread writer([&fds, &data]() {
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+    EXPECT_EQ(5, send(fds[1], data + 3, 5, 0));
+  });
+  ASSERT_EQ(0, pthread_sigmask(SIG_SETMASK, &previous_mask, nullptr));
+
+  // Well before the writer supplies the rest, so that the read is interrupted while blocked
+  struct itimerval timer;
+  std::memset(&timer, 0, sizeof(timer));
+  timer.it_value.tv_usec = 50000;
+  ASSERT_EQ(0, setitimer(ITIMER_REAL, &timer, nullptr));
+
+  uint8_t buf[8] = {0};
+  krpc_error_t error = krpc_read(fds[0], buf, sizeof(buf));
+  writer.join();
+  sigaction(SIGALRM, &previous_action, nullptr);
+  close(fds[0]);
+  close(fds[1]);
+
+  ASSERT_EQ(KRPC_OK, error);
+  ASSERT_GT(alarms, 0);
+  for (size_t i = 0; i < sizeof(buf); i++) ASSERT_EQ(data[i], buf[i]);
+}
+
+#endif

--- a/client/cnano/vcpkg-port/portfile.cmake
+++ b/client/cnano/vcpkg-port/portfile.cmake
@@ -9,11 +9,20 @@ vcpkg_extract_source_archive(SOURCE_PATH
     SOURCE_BASE "krpc-cnano-${VERSION}"
 )
 
+# Which transport the library talks to the server over. It is a feature rather than the default
+# because a program using the library is built for the same transport it is, so asking for it is
+# what tells vcpkg to hand out a library that speaks TCP/IP.
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        tcp KRPC_COMMUNICATION_TCP
+)
+
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         -DKRPC_FETCH_NANOPB=OFF
         -DKRPC_REGENERATE_PROTO=OFF
+        ${FEATURE_OPTIONS}
 )
 
 vcpkg_cmake_install()

--- a/client/cnano/vcpkg-port/vcpkg.json
+++ b/client/cnano/vcpkg-port/vcpkg.json
@@ -8,5 +8,10 @@
     "nanopb",
     { "name": "vcpkg-cmake", "host": true },
     { "name": "vcpkg-cmake-config", "host": true }
-  ]
+  ],
+  "features": {
+    "tcp": {
+      "description": "Communicate with the server over TCP/IP rather than a serial port"
+    }
+  }
 }

--- a/doc/src/cnano/client.rst
+++ b/doc/src/cnano/client.rst
@@ -112,8 +112,19 @@ argument to the compiler.
   * ``KRPC_COMMUNICATION_ARDUINO`` -- Specifies that the library should be built using Arduino
     serial communication mechanisms. The Arduino platform will be auto-detected so you do not need
     to specify this manually.
+  * ``KRPC_COMMUNICATION_TCP`` -- Specifies that the library should be built to communicate over
+    TCP/IP with a server reachable over the network. A serial port remains the usual choice for the
+    devices this client is written for, so this is never auto-detected and has to be specified.
+    CMake builds of the library should ask for it with ``-DKRPC_COMMUNICATION_TCP=ON`` rather than
+    by defining it directly, so that programs linking the library are built for the same transport
+    and, on Windows, are linked against winsock along with it.
   * ``KRPC_COMMUNICATION_CUSTOM`` -- Allows you to provide your own implementation for the
     communication mechanism.
+  * ``KRPC_SINGLE_CONNECTION`` -- Only meaningful alongside ``KRPC_COMMUNICATION_CUSTOM``. A serial
+    port carries the RPC and stream connections over the one link, so every message sent over it is
+    wrapped in a multiplexed message saying which connection it belongs to. A custom communication
+    mechanism is assumed to work the same way; define this if yours instead opens a connection of
+    its own to each server, as a socket does, and the messages are sent unwrapped.
 
 * Memory allocation
 
@@ -138,18 +149,22 @@ Getting Started
 Configuring the Server
 ^^^^^^^^^^^^^^^^^^^^^^
 
-The C-nano client library communicates with the server over a serial port using `protobuf messages
-<https://github.com/nanopb/nanopb>`_. The kRPC server, which runs in the game, needs to be
-configured to use the serial port protocol (instead of the default TCP/IP protocol). This can be
-done from the in-game server configuration window, which also allows settings such as
-the port name, baud rate and parity settings.
+The C-nano client library communicates with the server using `protobuf messages
+<https://github.com/nanopb/nanopb>`_, over a serial port by default. The kRPC server, which runs in
+the game, needs to be configured to use the serial port protocol (instead of the default TCP/IP
+protocol). This can be done from the in-game server configuration window, which also allows settings
+such as the port name, baud rate and parity settings.
+
+Building the library with ``KRPC_COMMUNICATION_TCP`` instead has it communicate over TCP/IP, with a
+server left on its default protocol. A connection is then opened with the address and port the
+server is listening on rather than the name of a port.
 
 .. note:: A serial port carries data far more slowly than the game produces it, and the server
           drops a connection that produces more data than the port can carry for a sustained
           period. See :ref:`communication-protocol-serialio-buffering` for the limits and how to
-          stay within them. The client blocks while waiting for data from the server, with no
-          timeout, so a call that is never answered, for example because the connection was
-          dropped, never returns.
+          stay within them. This does not apply over TCP/IP. The client blocks while waiting for
+          data from the server, with no timeout, so a call that is never answered, for example
+          because the connection was dropped, never returns.
 
 Linking
 ^^^^^^^
@@ -236,6 +251,20 @@ Client API Reference
    When the library is built using ``KRPC_COMMUNICATION_WINDOWS`` (auto-detected on Windows)
    calling this function opens the serial port named by *arg* using the Windows API, for example
    ``krpc_open(&conn, "COM1")``.
+
+   When the library is built using ``KRPC_COMMUNICATION_TCP`` calling this function connects to the
+   server over TCP/IP. *arg* is a pointer to a structure of type ``krpc_connection_config_t``
+   holding the address of the machine the server is running on and the port its RPC server is
+   listening on. The address may be a host name or an address literal, and every endpoint it
+   resolves to is tried until one accepts the connection. For example:
+
+   .. code-block:: c
+
+     krpc_connection_t conn;
+     krpc_connection_config_t config;
+     config.address = "127.0.0.1";
+     config.port = 50000;
+     krpc_open(&conn, &config);
 
    When the library is built using ``KRPC_COMMUNICATION_ARDUINO``, *connection* must be a pointer to
    a ``HardwareSerial`` object. *arg* is optionally used to pass additional configuration options

--- a/doc/src/cnano/client.rst
+++ b/doc/src/cnano/client.rst
@@ -48,6 +48,23 @@ The C-nano client is available from `vcpkg <https://vcpkg.io>`_. It can be insta
 
          vcpkg install krpc-cnano:x64-windows
 
+The library communicates over a serial port unless the ``tcp`` feature is asked for, which builds
+it to communicate over TCP/IP instead:
+
+.. tabs::
+
+   .. tab:: Linux
+
+      .. code-block:: bash
+
+         vcpkg install "krpc-cnano[tcp]"
+
+   .. tab:: Windows
+
+      .. code-block:: bash
+
+         vcpkg install "krpc-cnano[tcp]:x64-windows"
+
 CMake
 ^^^^^
 
@@ -115,9 +132,10 @@ argument to the compiler.
   * ``KRPC_COMMUNICATION_TCP`` -- Specifies that the library should be built to communicate over
     TCP/IP with a server reachable over the network. A serial port remains the usual choice for the
     devices this client is written for, so this is never auto-detected and has to be specified.
-    CMake builds of the library should ask for it with ``-DKRPC_COMMUNICATION_TCP=ON`` rather than
-    by defining it directly, so that programs linking the library are built for the same transport
-    and, on Windows, are linked against winsock along with it.
+    CMake builds of the library should ask for it with ``-DKRPC_COMMUNICATION_TCP=ON``, and vcpkg
+    installs with the ``tcp`` feature, rather than by defining it directly, so that programs
+    linking the library are built for the same transport and, on Windows, are linked against
+    winsock along with it.
   * ``KRPC_COMMUNICATION_CUSTOM`` -- Allows you to provide your own implementation for the
     communication mechanism.
   * ``KRPC_SINGLE_CONNECTION`` -- Only meaningful alongside ``KRPC_COMMUNICATION_CUSTOM``. A serial

--- a/doc/src/dictionary.txt
+++ b/doc/src/dictionary.txt
@@ -199,3 +199,4 @@ virtualenv
 waypoint
 waypoints
 websockets
+winsock

--- a/tools/benchmarks/BUILD.bazel
+++ b/tools/benchmarks/BUILD.bazel
@@ -196,6 +196,31 @@ py_binary(
     deps = [":benchmarks_lib"],
 )
 
+# Measured over TCP/IP rather than the serial port this client is usually built for, since the
+# server reads a serial port on a poll whose interval is longer than everything this measures
+# put together.
+optimized_binary(
+    name = "cnano_client",
+    binary = "//client/cnano:benchmark",
+)
+
+py_binary(
+    name = "cnano",
+    srcs = ["run_client.py"],
+    args = [
+        "--name=cnano",
+        "--server=$(rootpath //tools/TestServer)",
+        "--client=$(rootpath :cnano_client)",
+    ],
+    data = [
+        ":cnano_client",
+        "//tools/TestServer",
+    ],
+    main = "run_client.py",
+    visibility = ["//visibility:public"],
+    deps = [":benchmarks_lib"],
+)
+
 # Every client at once, as one table: `bazel run //tools/benchmarks:clients`. Runs what the
 # targets above run, one language after another, so the columns are the same measurements those
 # targets report rather than a second way of taking them.
@@ -212,8 +237,10 @@ py_binary(
         "--client=java=$(rootpath //client/java:benchmark)",
         "--client=csharp=$(rootpath //client/csharp:benchmark)",
         "--client=lua=$(rootpath //client/lua:benchmark)",
+        "--client=cnano=$(rootpath :cnano_client)",
     ],
     data = [
+        ":cnano_client",
         ":cpp_client",
         "//client/csharp:benchmark",
         "//client/java:benchmark",


### PR DESCRIPTION
Add TCP/IP connection support to the Cnano client.

Enabled by defining `KRPC_COMMUNICATION_TCP` or enabling the `tcp` feature in vcpkg via `krpc-cnano[tcp]`

Split the Cnano tests: serverless unit tests and end to end client tests are run separately, and against each of serial IO and TCP/IP communication protocols. The CMake build tests cover all combinations of communication protocol and third party dependency fetching. The client is also now benchmarked, over TCP/IP, in the same way as the other clients.
