### PR TITLE
Client optimization

### DIFF
--- a/client/cnano/CHANGELOG.md
+++ b/client/cnano/CHANGELOG.md
@@ -13,6 +13,14 @@
   opens a connection of its own to each server. Messages are then sent as they are, rather than
   wrapped in the multiplexed message a serial port needs to say which of the connections it
   carries a message belongs to (#1055)
+- Reduce the cost of a remote procedure call. A message is sent and received through a buffer
+  rather than a piece at a time, taking a call from tens of reads and writes down to one write
+  and two reads, and a message is measured as it is encoded rather than by a pass over it
+  first (#1056)
+- Add `KRPC_BUFFER_SIZE`, how much of a message to hold in memory while it is written to or
+  read from the connection. It bounds the memory a call costs and never the size of a message,
+  but a message that fits is cheaper to send, so it is worth setting above the largest call a
+  program makes. Defaults to 1024 bytes, and to 128 on Arduino (#1056)
 
 ## [v0.6.0]
 - Distribute via vcpkg (#874)

--- a/client/cnano/include/krpc_cnano.h
+++ b/client/cnano/include/krpc_cnano.h
@@ -4,6 +4,15 @@
 #include "krpc_cnano/error.h"
 #include "krpc_cnano/krpc.pb.h"
 
+/* How much of a message to hold in memory while it is written to or read from the connection.
+ * A message larger than this is carried in as many passes as it takes, so this bounds the
+ * memory a call costs and never the size of a message it can carry. Two buffers of this size
+ * are used, one for a message being sent and one for a message being received, and neither
+ * outlives the call it is made for. */
+#ifndef KRPC_BUFFER_SIZE
+#define KRPC_BUFFER_SIZE 256
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/client/cnano/include/krpc_cnano.h
+++ b/client/cnano/include/krpc_cnano.h
@@ -8,9 +8,24 @@
  * A message larger than this is carried in as many passes as it takes, so this bounds the
  * memory a call costs and never the size of a message it can carry. Two buffers of this size
  * are used, one for a message being sent and one for a message being received, and neither
- * outlives the call it is made for. */
+ * outlives the call it is made for.
+ *
+ * A message that fits is also cheaper to send, as its size can be written in front of it
+ * rather than measured by a pass over it first, so this is worth setting above the largest
+ * call a program makes. The default is small on Arduino, where a kilobyte is a large share of
+ * the memory there is, and where calls tend to be small ones. */
 #ifndef KRPC_BUFFER_SIZE
-#define KRPC_BUFFER_SIZE 256
+#ifdef KRPC_COMMUNICATION_ARDUINO
+#define KRPC_BUFFER_SIZE 128
+#else
+#define KRPC_BUFFER_SIZE 1024
+#endif
+#endif
+
+/* A message is sent with the room its size needs left in front of it, which is up to five
+   bytes, so a buffer has to be larger than that to hold any of the message at all. */
+#if KRPC_BUFFER_SIZE < 16
+#error KRPC_BUFFER_SIZE must be at least 16
 #endif
 
 #ifdef __cplusplus

--- a/client/cnano/src/encoder.c
+++ b/client/cnano/src/encoder.c
@@ -81,6 +81,25 @@ krpc_error_t krpc_encode_double(pb_ostream_t* stream, double value) {
   return KRPC_OK;
 }
 
+/* How many bytes a value takes to write as a variable length integer. Counting the seven bit
+   groups costs a fraction of encoding the value into a sizing stream to find out. */
+static size_t krpc_varint_size(uint64_t value) {
+  size_t size = 1;
+  while (value >= 0x80) {
+    value >>= 7;
+    size++;
+  }
+  return size;
+}
+
+/* A signed value as the unsigned one a variable length integer carries, matching what the
+   protocol buffer encoder does with it. */
+static uint64_t krpc_zigzag(int64_t value) {
+  const uint64_t mask = ((uint64_t)-1) >> 1;
+  if (value < 0) return ~(((uint64_t)value & mask) << 1);
+  return (uint64_t)value << 1;
+}
+
 /*[[[cog
 types = [
   ('double', 'double',   None,      '&', 8),
@@ -112,12 +131,12 @@ krpc_error_t krpc_encode_size_""" + typ + """(size_t * size, """ + ctyp + """ va
   return KRPC_OK;
 }""")
   else:
+    # Every argument of every call is measured before it is written, so counting the seven bit
+    # groups a value takes beats encoding it into a sizing stream to find out.
+    zigzag = 'krpc_zigzag(value)' if enc == 'svarint' else '(uint64_t)value'
     cog.outl("""
 krpc_error_t krpc_encode_size_""" + typ + """(size_t * size, """ + ctyp + """ value) {
-  pb_ostream_t stream = PB_OSTREAM_SIZING;
-  if (!pb_encode_""" + enc + """(&stream, value))
-    KRPC_RETURN_STREAM_ERROR(ENCODING_FAILED, "failed to get size of """ + typ + """", &stream);
-  *size = stream.bytes_written;
+  *size = krpc_varint_size(""" + zigzag + """);
   return KRPC_OK;
 }""")
 
@@ -209,58 +228,37 @@ krpc_error_t krpc_encode_size_float(size_t* size, float value) {
 }
 
 krpc_error_t krpc_encode_size_int32(size_t* size, int32_t value) {
-  pb_ostream_t stream = PB_OSTREAM_SIZING;
-  if (!pb_encode_svarint(&stream, value))
-    KRPC_RETURN_STREAM_ERROR(ENCODING_FAILED, "failed to get size of int32", &stream);
-  *size = stream.bytes_written;
+  *size = krpc_varint_size(krpc_zigzag(value));
   return KRPC_OK;
 }
 
 krpc_error_t krpc_encode_size_int64(size_t* size, int64_t value) {
-  pb_ostream_t stream = PB_OSTREAM_SIZING;
-  if (!pb_encode_svarint(&stream, value))
-    KRPC_RETURN_STREAM_ERROR(ENCODING_FAILED, "failed to get size of int64", &stream);
-  *size = stream.bytes_written;
+  *size = krpc_varint_size(krpc_zigzag(value));
   return KRPC_OK;
 }
 
 krpc_error_t krpc_encode_size_uint32(size_t* size, uint32_t value) {
-  pb_ostream_t stream = PB_OSTREAM_SIZING;
-  if (!pb_encode_varint(&stream, value))
-    KRPC_RETURN_STREAM_ERROR(ENCODING_FAILED, "failed to get size of uint32", &stream);
-  *size = stream.bytes_written;
+  *size = krpc_varint_size((uint64_t)value);
   return KRPC_OK;
 }
 
 krpc_error_t krpc_encode_size_uint64(size_t* size, uint64_t value) {
-  pb_ostream_t stream = PB_OSTREAM_SIZING;
-  if (!pb_encode_varint(&stream, value))
-    KRPC_RETURN_STREAM_ERROR(ENCODING_FAILED, "failed to get size of uint64", &stream);
-  *size = stream.bytes_written;
+  *size = krpc_varint_size((uint64_t)value);
   return KRPC_OK;
 }
 
 krpc_error_t krpc_encode_size_bool(size_t* size, bool value) {
-  pb_ostream_t stream = PB_OSTREAM_SIZING;
-  if (!pb_encode_varint(&stream, value))
-    KRPC_RETURN_STREAM_ERROR(ENCODING_FAILED, "failed to get size of bool", &stream);
-  *size = stream.bytes_written;
+  *size = krpc_varint_size((uint64_t)value);
   return KRPC_OK;
 }
 
 krpc_error_t krpc_encode_size_object(size_t* size, krpc_object_t value) {
-  pb_ostream_t stream = PB_OSTREAM_SIZING;
-  if (!pb_encode_varint(&stream, value))
-    KRPC_RETURN_STREAM_ERROR(ENCODING_FAILED, "failed to get size of object", &stream);
-  *size = stream.bytes_written;
+  *size = krpc_varint_size((uint64_t)value);
   return KRPC_OK;
 }
 
 krpc_error_t krpc_encode_size_enum(size_t* size, krpc_enum_t value) {
-  pb_ostream_t stream = PB_OSTREAM_SIZING;
-  if (!pb_encode_svarint(&stream, value))
-    KRPC_RETURN_STREAM_ERROR(ENCODING_FAILED, "failed to get size of enum", &stream);
-  *size = stream.bytes_written;
+  *size = krpc_varint_size(krpc_zigzag(value));
   return KRPC_OK;
 }
 

--- a/client/cnano/src/krpc.c
+++ b/client/cnano/src/krpc.c
@@ -6,14 +6,38 @@
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
-#ifdef KRPC_ERROR_MESSAGES
 #include <string.h>
-#endif
+
+/* A message is written to the connection through a buffer, rather than in the pieces the
+   protocol buffer encoder works in. A piece is a field tag, a length or a single value, so a
+   call handed straight to the connection costs tens of writes, each of which is a system call
+   and - with the transport asked not to hold data back - a packet of its own.
+
+   The buffer bounds how much is written at a time, never the size of a message: one larger
+   than the buffer is written in as many passes as it takes. */
+typedef struct {
+  krpc_connection_t connection;
+  size_t used;
+  uint8_t buffer[KRPC_BUFFER_SIZE];
+} krpc_writer_t;
+
+/* The same for reading, with one difference: the connection is only ever asked for bytes the
+   message being read still has to come, so a read never waits on a message that has not been
+   asked for. That is what remaining counts. */
+typedef struct {
+  krpc_connection_t connection;
+  size_t remaining;
+  size_t position;
+  size_t available;
+  uint8_t buffer[KRPC_BUFFER_SIZE];
+} krpc_reader_t;
 
 static bool write_callback(pb_ostream_t *stream, const uint8_t *buf, size_t count);
 static bool read_callback(pb_istream_t *stream, uint8_t *buf, size_t count);
-static pb_ostream_t krpc_pb_ostream_from_connection(krpc_connection_t connection);
-static pb_istream_t krpc_pb_istream_from_connection(krpc_connection_t connection);
+static krpc_error_t krpc_send_message(krpc_connection_t connection, const pb_msgdesc_t *fields,
+                                      const void *message);
+static krpc_error_t krpc_receive_message(krpc_connection_t connection, const pb_msgdesc_t *fields,
+                                         void *message);
 
 krpc_error_t krpc_connect(krpc_connection_t connection, const char *client_name) {
   {
@@ -31,20 +55,19 @@ krpc_error_t krpc_connect(krpc_connection_t connection, const char *client_name)
     request->type = krpc_schema_ConnectionRequest_Type_RPC;
     request->client_name.funcs.encode = &krpc_encode_callback_cstring;
     request->client_name.arg = (void *)client_name;
-    pb_ostream_t stream = krpc_pb_ostream_from_connection(connection);
-    if (!pb_encode_delimited(&stream, fields, &message)) {
+    if (krpc_send_message(connection, fields, &message) != KRPC_OK) {
       krpc_close(connection);
-      KRPC_RETURN_STREAM_ERROR(ENCODING_FAILED, "failed to encode connection request", &stream);
+      KRPC_RETURN_ERROR(ENCODING_FAILED, "failed to send connection request");
     }
   }
 
   {
     // Receive connection response message
-    pb_istream_t stream = krpc_pb_istream_from_connection(connection);
     krpc_schema_ConnectionResponse response = krpc_schema_ConnectionResponse_init_default;
-    if (!pb_decode_delimited(&stream, krpc_schema_ConnectionResponse_fields, &response)) {
+    if (krpc_receive_message(connection, krpc_schema_ConnectionResponse_fields, &response) !=
+        KRPC_OK) {
       krpc_close(connection);
-      KRPC_RETURN_STREAM_ERROR(DECODING_FAILED, "failed to decode connection response", &stream);
+      KRPC_RETURN_ERROR(DECODING_FAILED, "failed to receive connection response");
     }
 
     // Check the connection status
@@ -118,8 +141,6 @@ static bool krpc_decode_callback_error(pb_istream_t *stream, const pb_field_t *f
 krpc_error_t krpc_invoke(krpc_connection_t connection, krpc_schema_ProcedureResult *result,
                          krpc_schema_ProcedureCall *call) {
   {
-    pb_ostream_t ostream = krpc_pb_ostream_from_connection(connection);
-
     // Create request message containing the procedure call
 #ifdef KRPC_MULTIPLEXED
     krpc_schema_MultiplexedRequest message = krpc_schema_MultiplexedRequest_init_default;
@@ -135,13 +156,10 @@ krpc_error_t krpc_invoke(krpc_connection_t connection, krpc_schema_ProcedureResu
     request->calls_count = 1;
 
     // Send request message
-    if (!pb_encode_delimited(&ostream, fields, &message))
-      KRPC_RETURN_STREAM_ERROR(ENCODING_FAILED, "failed to encode request message", &ostream);
+    KRPC_RETURN_ON_ERROR(krpc_send_message(connection, fields, &message));
   }
 
   {
-    pb_istream_t istream = krpc_pb_istream_from_connection(connection);
-
     // Receive response message
 #ifdef KRPC_MULTIPLEXED
     krpc_schema_MultiplexedResponse message = krpc_schema_MultiplexedResponse_init_default;
@@ -161,8 +179,7 @@ krpc_error_t krpc_invoke(krpc_connection_t connection, krpc_schema_ProcedureResu
     response->results[0].error.funcs.decode = &krpc_decode_callback_error;
     response->results[0].error.arg = &rpc_error;
 
-    if (!pb_decode_delimited(&istream, fields, &message))
-      KRPC_RETURN_STREAM_ERROR(DECODING_FAILED, "failed to decode response message", &istream);
+    KRPC_RETURN_ON_ERROR(krpc_receive_message(connection, fields, &message));
 
     if (rpc_error != KRPC_OK) {
 #ifdef KRPC_ERROR_MESSAGES
@@ -180,26 +197,104 @@ krpc_error_t krpc_invoke(krpc_connection_t connection, krpc_schema_ProcedureResu
   return KRPC_OK;
 }
 
+/* Hand what has been buffered to the connection */
+static krpc_error_t krpc_writer_flush(krpc_writer_t *writer) {
+  size_t used = writer->used;
+  writer->used = 0;
+  if (used == 0) return KRPC_OK;
+  return krpc_write(writer->connection, writer->buffer, used);
+}
+
 static bool write_callback(pb_ostream_t *stream, const uint8_t *buf, size_t count) {
-  krpc_connection_t connection = (krpc_connection_t)(intptr_t)stream->state;
-  KRPC_CALLBACK_RETURN_ON_ERROR(krpc_write(connection, buf, count))
+  krpc_writer_t *writer = (krpc_writer_t *)stream->state;
+  while (count > 0) {
+    size_t space;
+    size_t take;
+    if (writer->used == sizeof(writer->buffer))
+      KRPC_CALLBACK_RETURN_ON_ERROR(krpc_writer_flush(writer));
+    space = sizeof(writer->buffer) - writer->used;
+    take = count < space ? count : space;
+    memcpy(writer->buffer + writer->used, buf, take);
+    writer->used += take;
+    buf += take;
+    count -= take;
+  }
   return true;
+}
+
+/* Ask the connection for as much of what the message has left to come as the buffer will hold */
+static krpc_error_t krpc_reader_fill(krpc_reader_t *reader) {
+  size_t wanted = reader->remaining;
+  if (wanted == 0) KRPC_RETURN_ERROR(EOF, "read past the end of the message");
+  if (wanted > sizeof(reader->buffer)) wanted = sizeof(reader->buffer);
+  KRPC_RETURN_ON_ERROR(krpc_read(reader->connection, reader->buffer, wanted));
+  reader->position = 0;
+  reader->available = wanted;
+  reader->remaining -= wanted;
+  return KRPC_OK;
 }
 
 static bool read_callback(pb_istream_t *stream, uint8_t *buf, size_t count) {
-  krpc_connection_t connection = (krpc_connection_t)(intptr_t)stream->state;
-  krpc_error_t result = krpc_read(connection, buf, count);
-  if (result == KRPC_ERROR_EOF) stream->bytes_left = 0;
-  KRPC_CALLBACK_RETURN_ON_ERROR(result);
+  krpc_reader_t *reader = (krpc_reader_t *)stream->state;
+  while (count > 0) {
+    size_t take;
+    if (reader->position == reader->available) {
+      krpc_error_t error = krpc_reader_fill(reader);
+      if (error == KRPC_ERROR_EOF) stream->bytes_left = 0;
+      KRPC_CALLBACK_RETURN_ON_ERROR(error);
+    }
+    take = reader->available - reader->position;
+    if (take > count) take = count;
+    memcpy(buf, reader->buffer + reader->position, take);
+    reader->position += take;
+    buf += take;
+    count -= take;
+  }
   return true;
 }
 
-static pb_ostream_t krpc_pb_ostream_from_connection(krpc_connection_t connection) {
-  pb_ostream_t stream = {&write_callback, (void *)(intptr_t)connection, SIZE_MAX, 0};
-  return stream;
+/* The size a message is prefixed with, read a byte at a time as it is the only part of a
+   message whose length is not known before it has been read. Knowing the size is what lets
+   the rest of the message be read in whole buffers. */
+static krpc_error_t krpc_read_size(krpc_connection_t connection, size_t *size) {
+  uint8_t byte;
+  size_t result = 0;
+  unsigned int shift = 0;
+  do {
+    if (shift > sizeof(size_t) * 8 - 7) KRPC_RETURN_ERROR(DECODING_FAILED, "message size too big");
+    KRPC_RETURN_ON_ERROR(krpc_read(connection, &byte, 1));
+    result |= (size_t)(byte & 0x7F) << shift;
+    shift += 7;
+  } while (byte & 0x80);
+  *size = result;
+  return KRPC_OK;
 }
 
-static pb_istream_t krpc_pb_istream_from_connection(krpc_connection_t connection) {
-  pb_istream_t stream = {&read_callback, (void *)(intptr_t)connection, SIZE_MAX};
-  return stream;
+static krpc_error_t krpc_send_message(krpc_connection_t connection, const pb_msgdesc_t *fields,
+                                      const void *message) {
+  krpc_writer_t writer;
+  pb_ostream_t stream = {&write_callback, NULL, SIZE_MAX, 0};
+  writer.connection = connection;
+  writer.used = 0;
+  stream.state = &writer;
+  if (!pb_encode_delimited(&stream, fields, message))
+    KRPC_RETURN_STREAM_ERROR(ENCODING_FAILED, "failed to encode message", &stream);
+  return krpc_writer_flush(&writer);
+}
+
+static krpc_error_t krpc_receive_message(krpc_connection_t connection, const pb_msgdesc_t *fields,
+                                         void *message) {
+  krpc_reader_t reader;
+  pb_istream_t stream = {&read_callback, NULL, 0};
+  size_t size;
+  KRPC_RETURN_ON_ERROR(krpc_read_size(connection, &size));
+  reader.connection = connection;
+  reader.remaining = size;
+  reader.position = 0;
+  reader.available = 0;
+  stream.state = &reader;
+  stream.bytes_left = size;
+  if (!pb_decode(&stream, fields, message))
+    KRPC_RETURN_STREAM_ERROR(DECODING_FAILED, "failed to decode message", &stream);
+  return KRPC_OK;
 }

--- a/client/cnano/src/krpc.c
+++ b/client/cnano/src/krpc.c
@@ -14,12 +14,28 @@
    and - with the transport asked not to hold data back - a packet of its own.
 
    The buffer bounds how much is written at a time, never the size of a message: one larger
-   than the buffer is written in as many passes as it takes. */
+   than the buffer is written in as many passes as it takes. It is lent by the caller rather
+   than held here, so that sending a message costs one buffer whichever way it is written. */
 typedef struct {
   krpc_connection_t connection;
+  uint8_t *data;
+  size_t size;
   size_t used;
-  uint8_t buffer[KRPC_BUFFER_SIZE];
 } krpc_writer_t;
+
+/* The most room the size a message is prefixed with can need in front of it */
+#define KRPC_SIZE_PREFIX_MAX 5
+
+/* Where a message is encoded before it is sent, for the common case of one that fits. Written
+   to through a callback of its own rather than by pb_ostream_from_buffer, so that a message too
+   big for the buffer is told apart from one that failed to encode: only the first is worth
+   encoding a second time to write it a bufferful at a time. */
+typedef struct {
+  uint8_t *data;
+  size_t size;
+  size_t used;
+  bool overflowed;
+} krpc_buffer_t;
 
 /* The same for reading, with one difference: the connection is only ever asked for bytes the
    message being read still has to come, so a read never waits on a message that has not been
@@ -32,6 +48,7 @@ typedef struct {
   uint8_t buffer[KRPC_BUFFER_SIZE];
 } krpc_reader_t;
 
+static bool buffer_write_callback(pb_ostream_t *stream, const uint8_t *buf, size_t count);
 static bool write_callback(pb_ostream_t *stream, const uint8_t *buf, size_t count);
 static bool read_callback(pb_istream_t *stream, uint8_t *buf, size_t count);
 static krpc_error_t krpc_send_message(krpc_connection_t connection, const pb_msgdesc_t *fields,
@@ -197,12 +214,23 @@ krpc_error_t krpc_invoke(krpc_connection_t connection, krpc_schema_ProcedureResu
   return KRPC_OK;
 }
 
+static bool buffer_write_callback(pb_ostream_t *stream, const uint8_t *buf, size_t count) {
+  krpc_buffer_t *buffer = (krpc_buffer_t *)stream->state;
+  if (count > buffer->size - buffer->used) {
+    buffer->overflowed = true;
+    return false;
+  }
+  memcpy(buffer->data + buffer->used, buf, count);
+  buffer->used += count;
+  return true;
+}
+
 /* Hand what has been buffered to the connection */
 static krpc_error_t krpc_writer_flush(krpc_writer_t *writer) {
   size_t used = writer->used;
   writer->used = 0;
   if (used == 0) return KRPC_OK;
-  return krpc_write(writer->connection, writer->buffer, used);
+  return krpc_write(writer->connection, writer->data, used);
 }
 
 static bool write_callback(pb_ostream_t *stream, const uint8_t *buf, size_t count) {
@@ -210,11 +238,10 @@ static bool write_callback(pb_ostream_t *stream, const uint8_t *buf, size_t coun
   while (count > 0) {
     size_t space;
     size_t take;
-    if (writer->used == sizeof(writer->buffer))
-      KRPC_CALLBACK_RETURN_ON_ERROR(krpc_writer_flush(writer));
-    space = sizeof(writer->buffer) - writer->used;
+    if (writer->used == writer->size) KRPC_CALLBACK_RETURN_ON_ERROR(krpc_writer_flush(writer));
+    space = writer->size - writer->used;
     take = count < space ? count : space;
-    memcpy(writer->buffer + writer->used, buf, take);
+    memcpy(writer->data + writer->used, buf, take);
     writer->used += take;
     buf += take;
     count -= take;
@@ -270,16 +297,60 @@ static krpc_error_t krpc_read_size(krpc_connection_t connection, size_t *size) {
   return KRPC_OK;
 }
 
+/* How many bytes the size a message is prefixed with takes to write */
+static size_t krpc_size_prefix_length(size_t size) {
+  size_t length = 1;
+  while (size >= 0x80) {
+    size >>= 7;
+    length++;
+  }
+  return length;
+}
+
 static krpc_error_t krpc_send_message(krpc_connection_t connection, const pb_msgdesc_t *fields,
                                       const void *message) {
-  krpc_writer_t writer;
-  pb_ostream_t stream = {&write_callback, NULL, SIZE_MAX, 0};
-  writer.connection = connection;
-  writer.used = 0;
-  stream.state = &writer;
-  if (!pb_encode_delimited(&stream, fields, message))
+  uint8_t data[KRPC_BUFFER_SIZE];
+  krpc_buffer_t buffer;
+  pb_ostream_t stream = {&buffer_write_callback, NULL, SIZE_MAX, 0};
+  buffer.data = data + KRPC_SIZE_PREFIX_MAX;
+  buffer.size = sizeof(data) - KRPC_SIZE_PREFIX_MAX;
+  buffer.used = 0;
+  buffer.overflowed = false;
+  stream.state = &buffer;
+  /* A message is prefixed with its size, so writing one in order means knowing how long it is
+     before it has been encoded, which costs a pass over it to measure. Encoding it into the
+     buffer with room left in front instead means the size is known once it is there, and can
+     be written into the room left for it. That halves what encoding a message costs. */
+  if (pb_encode(&stream, fields, message)) {
+    size_t size = buffer.used;
+    size_t length = krpc_size_prefix_length(size);
+    uint8_t *at = buffer.data - length;
+    uint8_t *start = at;
+    while (size >= 0x80) {
+      *at++ = (uint8_t)(size | 0x80);
+      size >>= 7;
+    }
+    *at = (uint8_t)size;
+    return krpc_write(connection, start, length + buffer.used);
+  }
+  /* A message that failed to encode for any other reason would only fail the same way again,
+     so it is reported here rather than encoded a second time. */
+  if (!buffer.overflowed)
     KRPC_RETURN_STREAM_ERROR(ENCODING_FAILED, "failed to encode message", &stream);
-  return krpc_writer_flush(&writer);
+  /* Larger than the buffer, so it is measured and then written a bufferful at a time, through
+     the same buffer the message did not fit in. */
+  {
+    krpc_writer_t writer;
+    pb_ostream_t streamed = {&write_callback, NULL, SIZE_MAX, 0};
+    writer.connection = connection;
+    writer.data = data;
+    writer.size = sizeof(data);
+    writer.used = 0;
+    streamed.state = &writer;
+    if (!pb_encode_delimited(&streamed, fields, message))
+      KRPC_RETURN_STREAM_ERROR(ENCODING_FAILED, "failed to encode message", &streamed);
+    return krpc_writer_flush(&writer);
+  }
 }
 
 static krpc_error_t krpc_receive_message(krpc_connection_t connection, const pb_msgdesc_t *fields,

--- a/client/cpp/CHANGELOG.md
+++ b/client/cpp/CHANGELOG.md
@@ -3,6 +3,16 @@
   `std::optional`, changing generated signatures (#1017)
 - Fix a service with a collection of enumerations in a procedure signature failing to
   compile (#1044)
+- Reduce the cost of a remote procedure call. A response is read a block at a time and
+  parsed straight out of the read buffer, the request a call is built into and the response
+  it is answered by are kept from one call to the next, the arguments of a call are sized up
+  front, and the client connections disable Nagle's algorithm. `Client::invoke`,
+  `Client::build_request` and `Client::build_call` name a service and a procedure with
+  `std::string_view`, so a call no longer builds a string for either (#1056)
+- Reduce the cost of a call that carries a collection. A value is read without setting up a
+  protobuf stream for it, the message a collection is carried in is kept from one call to the
+  next rather than allocated and freed for each, and a list is given room for its values up
+  front (#1056)
 
 ## [v0.6.0]
 - Update to protobuf v35.1 (#850)

--- a/client/cpp/include/krpc/client.hpp
+++ b/client/cpp/include/krpc/client.hpp
@@ -43,6 +43,8 @@ class Client {
  private:
   friend class StreamManager;
   void throw_exception(const schema::Error& error) const;
+  schema::ProcedureResult send_request(const schema::Request& request);
+  static void add_arguments(schema::ProcedureCall* call, const std::vector<encoder::Value>& args);
 
  public:
   std::shared_ptr<StreamImpl> add_stream(const schema::ProcedureCall& call);
@@ -80,6 +82,13 @@ class Client {
   std::shared_ptr<Connection> rpc_connection;
   std::shared_ptr<StreamManager> stream_manager;
   std::shared_ptr<std::mutex> lock;
+  // The request a call is built into, the bytes it is written as, and the response it is
+  // answered by. Kept from one call to the next and guarded by lock, so that a call reuses
+  // what the one before it allocated: clearing a protobuf message keeps the storage its fields
+  // have, and the buffer keeps its capacity.
+  schema::Request request_buffer;
+  std::string request_data;
+  schema::Response response_buffer;
   std::map<std::pair<std::string, std::string>, std::function<void(std::string)>>
       exception_throwers;
   // Guards exception_throwers. Services register their throwers as they are constructed,

--- a/client/cpp/include/krpc/client.hpp
+++ b/client/cpp/include/krpc/client.hpp
@@ -7,6 +7,7 @@
 #include <memory>
 #include <mutex>  // NOLINT(build/c++11)
 #include <string>
+#include <string_view>
 #include <utility>
 #include <vector>
 
@@ -28,14 +29,14 @@ class Client {
   schema::ProcedureResult invoke(const schema::Request& request);
   schema::ProcedureResult invoke(const schema::ProcedureCall& call);
   schema::ProcedureResult invoke(
-      const std::string& service, const std::string& procedure,
+      std::string_view service, std::string_view procedure,
       const std::vector<encoder::Value>& args = std::vector<encoder::Value>());
 
   schema::Request build_request(
-      const std::string& service, const std::string& procedure,
+      std::string_view service, std::string_view procedure,
       const std::vector<encoder::Value>& args = std::vector<encoder::Value>());
   schema::ProcedureCall build_call(
-      const std::string& service, const std::string& procedure,
+      std::string_view service, std::string_view procedure,
       const std::vector<encoder::Value>& args = std::vector<encoder::Value>());
   void add_exception_thrower(const std::string& service, const std::string& name,
                              const std::function<void(std::string)>& thrower);

--- a/client/cpp/include/krpc/connection.hpp
+++ b/client/cpp/include/krpc/connection.hpp
@@ -3,12 +3,20 @@
 #include <chrono>  // NOLINT(build/c++11)
 #include <cstddef>
 #include <string>
+#include <utility>
+#include <vector>
 
 #ifndef ASIO_STANDALONE
 #define ASIO_STANDALONE
 #endif
 #include <asio/io_context.hpp>
 #include <asio/ip/tcp.hpp>
+
+namespace google {
+namespace protobuf {
+class MessageLite;
+}
+}  // namespace google
 
 namespace krpc {
 
@@ -22,6 +30,9 @@ class Connection {
   void send(const std::string& data);
   /** Receive data from the connection for a message. Blocks until a message has been received. */
   std::string receive_message();
+  /** Receive a message from the connection and parse it. Blocks until a message has been
+      received. Parses it out of the read buffer, so nothing is copied on the way. */
+  void receive_message(google::protobuf::MessageLite& message);
   /** Receive data from the connection. Blocks until length bytes have been received. */
   std::string receive(size_t length);
   /** Receive up to length bytes of data from the connection. */
@@ -29,11 +40,30 @@ class Connection {
                               std::chrono::milliseconds timeout = std::chrono::milliseconds(10));
 
  private:
+  /** How much is read from the socket at a time. */
+  static const size_t READ_SIZE = 8192;
+
+  /** Wait for the buffer to hold a whole message, consume it, and return where it starts and
+      how long it is. Valid until the next read. */
+  std::pair<const char*, size_t> buffered_message();
+  /** Read a block from the socket into the buffer. Blocks until at least one byte arrives. */
+  void fill();
+  /** Take length bytes of what has been read but not consumed yet. */
+  void take(char* data, size_t length);
+  /** How much has been read but not consumed yet. */
+  size_t available() const { return filled - consumed; }
+
   asio::io_context io_context;
   asio::ip::tcp::socket socket;
   const std::string address;
   const unsigned int port;
   asio::ip::tcp::resolver resolver;
+  // Data read from the socket, how much of it there is and how much has been consumed. Reads
+  // are made a block at a time rather than exactly the bytes wanted, so that a message costs
+  // one read rather than one per byte of its size prefix plus one for its body.
+  std::vector<char> buffer;
+  size_t filled = 0;
+  size_t consumed = 0;
 };
 
 }  // namespace krpc

--- a/client/cpp/include/krpc/decoder.hpp
+++ b/client/cpp/include/krpc/decoder.hpp
@@ -60,6 +60,10 @@ void decode(std::map<K, V>& dictionary, const std::string& data, Client* client 
 
 uint32_t decode_size(const std::string& data);
 
+/** Read the size prefix a message is preceded by out of a buffer. Returns false if the buffer
+    does not hold a complete prefix yet, leaving size and prefix_length untouched. */
+bool decode_size_prefix(const char* data, size_t length, uint32_t* size, size_t* prefix_length);
+
 template <typename T>
 inline void decode(Object<T>& object, const std::string& data, Client* client) {
   uint64_t id;

--- a/client/cpp/include/krpc/decoder.hpp
+++ b/client/cpp/include/krpc/decoder.hpp
@@ -7,6 +7,7 @@
 #include <set>
 #include <string>
 #include <tuple>
+#include <utility>
 #include <vector>
 
 #include "krpc/error.hpp"
@@ -74,7 +75,8 @@ inline void decode(Object<T>& object, const std::string& data, Client* client) {
 
 template <typename... Ts>
 inline void decode(std::tuple<Ts...>& tuple, const std::string& data, Client* client) {
-  krpc::schema::Tuple tupleMessage;
+  // See the note on the list below for why the message this arrives in is kept between calls.
+  static thread_local krpc::schema::Tuple tupleMessage;
   if (!tupleMessage.ParseFromString(data)) throw EncodingError("Failed to decode message");
   int index = 0;
   std::apply([&](Ts&... args) { (decode(args, tupleMessage.items(index++), client), ...); }, tuple);
@@ -89,42 +91,52 @@ inline void decode(std::optional<T>& value, const std::string& data, Client* cli
   value = inner;
 }
 
+// A collection arrives as a message holding its items, one encoded value each. That message is
+// kept between calls rather than made for one: parsing into it reuses the storage the items it
+// held last time have, where a message made for the call goes to the allocator for every item
+// and gives it all back again. It is one per thread, since the thread that reads stream updates
+// decodes them while the program is decoding what it asked for; and it is one per element type,
+// which is what makes it safe to reuse - reaching this function again while it is running takes
+// a collection of itself, which is not a type that can be written.
 template <typename T>
 inline void decode(std::vector<T>& list, const std::string& data, Client* client) {
-  list.clear();
-  krpc::schema::List listMessage;
+  static thread_local krpc::schema::List listMessage;
   if (!listMessage.ParseFromString(data)) throw EncodingError("Failed to decode message");
+  list.clear();
+  // The number of items is known before any of them are decoded, so the list is given room for
+  // all of them rather than growing as they arrive.
+  list.reserve(listMessage.items_size());
   for (int i = 0; i < listMessage.items_size(); i++) {
     T value;
     decode(value, listMessage.items(i), client);
-    list.push_back(value);
+    list.push_back(std::move(value));
   }
 }
 
 template <typename T>
 inline void decode(std::set<T>& set, const std::string& data, Client* client) {
-  set.clear();
-  krpc::schema::Set setMessage;
+  static thread_local krpc::schema::Set setMessage;
   if (!setMessage.ParseFromString(data)) throw EncodingError("Failed to decode message");
+  set.clear();
   for (int i = 0; i < setMessage.items_size(); i++) {
     T value;
     decode(value, setMessage.items(i), client);
-    set.insert(value);
+    set.insert(std::move(value));
   }
 }
 
 template <typename K, typename V>
 inline void decode(std::map<K, V>& dictionary, const std::string& data, Client* client) {
-  dictionary.clear();
-  krpc::schema::Dictionary dictionaryMessage;
+  static thread_local krpc::schema::Dictionary dictionaryMessage;
   if (!dictionaryMessage.ParseFromString(data)) throw EncodingError("Failed to decode message");
+  dictionary.clear();
   for (int i = 0; i < dictionaryMessage.entries_size(); i++) {
     const schema::DictionaryEntry& entry = dictionaryMessage.entries(i);
     K key;
     V value;
     decode(key, entry.key(), client);
     decode(value, entry.value(), client);
-    dictionary[key] = value;
+    dictionary[std::move(key)] = std::move(value);
   }
 }
 

--- a/client/cpp/include/krpc/encoder.hpp
+++ b/client/cpp/include/krpc/encoder.hpp
@@ -57,9 +57,17 @@ inline std::string encode(const Object<T>& object) {
   return encode(object._id);
 }
 
+// A collection is sent as a message holding its items, one encoded value each. That message is
+// kept between calls rather than made for one: clearing it reuses the storage the items it held
+// last time have, where a message made for the call goes to the allocator for every item and
+// gives it all back again. It is one per thread, since a stream is added from the thread that
+// reads stream updates while the program is making calls of its own; and it is one per element
+// type, which is what makes it safe to reuse - reaching this function again while it is running
+// takes a collection of itself, which is not a type that can be written.
 template <typename T>
 inline std::string encode(const std::vector<T>& list) {
-  krpc::schema::List listMessage;
+  static thread_local krpc::schema::List listMessage;
+  listMessage.Clear();
   for (typename std::vector<T>::const_iterator x = list.begin(); x != list.end(); ++x)
     listMessage.add_items(encode(*x));
   return encode(listMessage);
@@ -67,7 +75,8 @@ inline std::string encode(const std::vector<T>& list) {
 
 template <typename K, typename V>
 inline std::string encode(const std::map<K, V>& dictionary) {
-  krpc::schema::Dictionary dictionaryMessage;
+  static thread_local krpc::schema::Dictionary dictionaryMessage;
+  dictionaryMessage.Clear();
   for (typename std::map<K, V>::const_iterator x = dictionary.begin(); x != dictionary.end(); ++x) {
     schema::DictionaryEntry* entry = dictionaryMessage.add_entries();
     entry->set_key(encode(x->first));
@@ -78,7 +87,8 @@ inline std::string encode(const std::map<K, V>& dictionary) {
 
 template <typename T>
 inline std::string encode(const std::set<T>& set) {
-  krpc::schema::Set setMessage;
+  static thread_local krpc::schema::Set setMessage;
+  setMessage.Clear();
   for (typename std::set<T>::const_iterator x = set.begin(); x != set.end(); ++x)
     setMessage.add_items(encode(*x));
   return encode(setMessage);
@@ -86,9 +96,11 @@ inline std::string encode(const std::set<T>& set) {
 
 template <typename... Ts>
 inline std::string encode(const std::tuple<Ts...>& tuple) {
-  krpc::schema::Tuple tupleMessage;
-  std::apply([&tupleMessage](const Ts&... args) { (tupleMessage.add_items(encode(args)), ...); },
-             tuple);
+  // See the note on the list above for why the message this is sent in is kept between calls.
+  static thread_local krpc::schema::Tuple tupleMessage;
+  tupleMessage.Clear();
+  // The message is not captured: it lives for the thread rather than for this call.
+  std::apply([](const Ts&... args) { (tupleMessage.add_items(encode(args)), ...); }, tuple);
   return encode(tupleMessage);
 }
 

--- a/client/cpp/include/krpc/encoder.hpp
+++ b/client/cpp/include/krpc/encoder.hpp
@@ -48,6 +48,9 @@ template <typename... Ts>
 std::string encode(const std::tuple<Ts...>& tuple);
 
 std::string encode_message_with_size(const google::protobuf::MessageLite& message);
+/** Encode a message, preceded by its size, into data. Reuses whatever data has already
+    allocated, for a caller that encodes one message after another. */
+void encode_message_with_size(const google::protobuf::MessageLite& message, std::string* data);
 
 template <typename T>
 inline std::string encode(const Object<T>& object) {

--- a/client/cpp/src/client.cpp
+++ b/client/cpp/src/client.cpp
@@ -50,39 +50,49 @@ Client::Client(const std::string& name, const std::string& address, unsigned int
 }
 
 schema::ProcedureResult Client::invoke(const schema::Request& request) {
-  schema::Response response;
-  {
-    std::lock_guard<std::mutex> lock_guard(*lock);
-    rpc_connection->send(encoder::encode_message_with_size(request));
-    rpc_connection->receive_message(response);
-  }
-
-  if (response.has_error()) throw_exception(response.error());
-
-  if (response.results(0).has_error()) throw_exception(response.results(0).error());
-
-  return response.results(0);
+  std::lock_guard<std::mutex> lock_guard(*lock);
+  return this->send_request(request);
 }
 
 schema::ProcedureResult Client::invoke(const schema::ProcedureCall& call) {
-  schema::Request request;
+  std::lock_guard<std::mutex> lock_guard(*lock);
+  request_buffer.Clear();
   // Copied because the call is received by const reference and a Request owns its calls, so it
   // cannot be moved in. CopyFrom also stays correct if ProcedureCall gains fields.
-  request.add_calls()->CopyFrom(call);
-  return this->invoke(request);
+  request_buffer.add_calls()->CopyFrom(call);
+  return this->send_request(request_buffer);
 }
 
 schema::ProcedureResult Client::invoke(const std::string& service, const std::string& procedure,
                                        const std::vector<encoder::Value>& args) {
-  return this->invoke(this->build_request(service, procedure, args));
-}
-
-schema::Request Client::build_request(const std::string& service, const std::string& procedure,
-                                      const std::vector<encoder::Value>& args) {
-  schema::Request request;
-  schema::ProcedureCall* call = request.add_calls();
+  std::lock_guard<std::mutex> lock_guard(*lock);
+  request_buffer.Clear();
+  schema::ProcedureCall* call = request_buffer.add_calls();
   call->set_service(service);
   call->set_procedure(procedure);
+  add_arguments(call, args);
+  return this->send_request(request_buffer);
+}
+
+// Send a request and return the result it is answered by. Called with lock held, which is what
+// makes the response and the bytes the request is written as safe to keep from one call to the
+// next.
+schema::ProcedureResult Client::send_request(const schema::Request& request) {
+  encoder::encode_message_with_size(request, &request_data);
+  rpc_connection->send(request_data);
+  rpc_connection->receive_message(response_buffer);
+
+  if (response_buffer.has_error()) throw_exception(response_buffer.error());
+
+  // Moved out of the response, which is about to be reused, rather than copied out of it.
+  schema::ProcedureResult result = std::move(*response_buffer.mutable_results(0));
+
+  if (result.has_error()) throw_exception(result.error());
+
+  return result;
+}
+
+void Client::add_arguments(schema::ProcedureCall* call, const std::vector<encoder::Value>& args) {
   for (unsigned int i = 0; i < args.size(); i++) {
     schema::Argument* arg = call->add_arguments();
     arg->set_position(i);
@@ -92,6 +102,15 @@ schema::Request Client::build_request(const std::string& service, const std::str
     else
       arg->set_value(args[i].value);
   }
+}
+
+schema::Request Client::build_request(const std::string& service, const std::string& procedure,
+                                      const std::vector<encoder::Value>& args) {
+  schema::Request request;
+  schema::ProcedureCall* call = request.add_calls();
+  call->set_service(service);
+  call->set_procedure(procedure);
+  add_arguments(call, args);
   return request;
 }
 
@@ -100,15 +119,7 @@ schema::ProcedureCall Client::build_call(const std::string& service, const std::
   schema::ProcedureCall call;
   call.set_service(service);
   call.set_procedure(procedure);
-  for (unsigned int i = 0; i < args.size(); i++) {
-    schema::Argument* arg = call.add_arguments();
-    arg->set_position(i);
-    // A null argument is signaled by is_null with the value left unset.
-    if (args[i].is_null)
-      arg->set_is_null(true);
-    else
-      arg->set_value(args[i].value);
-  }
+  add_arguments(&call, args);
   return call;
 }
 

--- a/client/cpp/src/client.cpp
+++ b/client/cpp/src/client.cpp
@@ -28,7 +28,7 @@ Client::Client(const std::string& name, const std::string& address, unsigned int
   request.set_client_name(name);
   rpc_connection->send(encoder::encode_message_with_size(request));
   schema::ConnectionResponse response;
-  decoder::decode(response, rpc_connection->receive_message(), nullptr);
+  rpc_connection->receive_message(response);
   if (response.status() != schema::ConnectionResponse::OK)
     throw ConnectionError(response.message());
 
@@ -42,7 +42,7 @@ Client::Client(const std::string& name, const std::string& address, unsigned int
     request.set_client_identifier(response.client_identifier());
     stream_connection->send(encoder::encode_message_with_size(request));
     schema::ConnectionResponse response;
-    decoder::decode(response, stream_connection->receive_message(), nullptr);
+    stream_connection->receive_message(response);
     if (response.status() != schema::ConnectionResponse::OK)
       throw ConnectionError(response.message());
     stream_manager = std::make_shared<StreamManager>(this, stream_connection);
@@ -50,15 +50,12 @@ Client::Client(const std::string& name, const std::string& address, unsigned int
 }
 
 schema::ProcedureResult Client::invoke(const schema::Request& request) {
-  std::string data;
+  schema::Response response;
   {
     std::lock_guard<std::mutex> lock_guard(*lock);
     rpc_connection->send(encoder::encode_message_with_size(request));
-    data = rpc_connection->receive_message();
+    rpc_connection->receive_message(response);
   }
-
-  schema::Response response;
-  decoder::decode(response, data, this);
 
   if (response.has_error()) throw_exception(response.error());
 

--- a/client/cpp/src/client.cpp
+++ b/client/cpp/src/client.cpp
@@ -2,6 +2,7 @@
 
 #include <memory>
 #include <string>
+#include <string_view>
 #include <utility>
 #include <vector>
 
@@ -63,7 +64,7 @@ schema::ProcedureResult Client::invoke(const schema::ProcedureCall& call) {
   return this->send_request(request_buffer);
 }
 
-schema::ProcedureResult Client::invoke(const std::string& service, const std::string& procedure,
+schema::ProcedureResult Client::invoke(std::string_view service, std::string_view procedure,
                                        const std::vector<encoder::Value>& args) {
   std::lock_guard<std::mutex> lock_guard(*lock);
   request_buffer.Clear();
@@ -104,7 +105,7 @@ void Client::add_arguments(schema::ProcedureCall* call, const std::vector<encode
   }
 }
 
-schema::Request Client::build_request(const std::string& service, const std::string& procedure,
+schema::Request Client::build_request(std::string_view service, std::string_view procedure,
                                       const std::vector<encoder::Value>& args) {
   schema::Request request;
   schema::ProcedureCall* call = request.add_calls();
@@ -114,7 +115,7 @@ schema::Request Client::build_request(const std::string& service, const std::str
   return request;
 }
 
-schema::ProcedureCall Client::build_call(const std::string& service, const std::string& procedure,
+schema::ProcedureCall Client::build_call(std::string_view service, std::string_view procedure,
                                          const std::vector<encoder::Value>& args) {
   schema::ProcedureCall call;
   call.set_service(service);

--- a/client/cpp/src/connection.cpp
+++ b/client/cpp/src/connection.cpp
@@ -29,6 +29,9 @@ void Connection::connect() {
   port_str << port;
   auto endpoints = resolver.resolve(asio::ip::tcp::v4(), address, port_str.str());
   asio::connect(socket, endpoints);
+  // The protocol is strictly request and response, so holding a write back to coalesce it with
+  // a later one can only add latency.
+  socket.set_option(asio::ip::tcp::no_delay(true));
 }
 
 void Connection::send(const char* data, size_t length) {

--- a/client/cpp/src/connection.cpp
+++ b/client/cpp/src/connection.cpp
@@ -1,15 +1,20 @@
 #include "krpc/connection.hpp"
 
+#include <google/protobuf/message_lite.h>
+
+#include <algorithm>
 #include <asio/buffer.hpp>
 #include <asio/connect.hpp>  // IWYU pragma: keep
 #include <asio/error_code.hpp>
 #include <asio/read.hpp>  // IWYU pragma: keep
 #include <asio/steady_timer.hpp>
 #include <asio/write.hpp>  // IWYU pragma: keep
+#include <cstring>
 #include <memory>
 #include <new>
 #include <ostream>
 #include <string>
+#include <utility>
 // IWYU pragma: no_include <asio/detail/impl/epoll_reactor.hpp>
 // IWYU pragma: no_include <asio/detail/impl/reactive_socket_service_base.ipp>
 // IWYU pragma: no_include <asio/impl/connect.hpp>
@@ -41,27 +46,70 @@ void Connection::send(const char* data, size_t length) {
 void Connection::send(const std::string& data) { asio::write(socket, asio::buffer(data)); }
 
 std::string Connection::receive_message() {
-  std::string data;
-  size_t size = 0;
-  while (true) {
-    try {
-      data += this->receive(1);
-      size = decoder::decode_size(data);
-      break;
-    } catch (EncodingError&) {  // NOLINT(bugprone-empty-catch): need more bytes
-    }
+  auto [data, size] = this->buffered_message();
+  return std::string(data, size);
+}
+
+void Connection::receive_message(google::protobuf::MessageLite& message) {
+  auto [data, size] = this->buffered_message();
+  if (!message.ParseFromArray(data, static_cast<int>(size)))
+    throw EncodingError("Failed to decode message");
+}
+
+std::pair<const char*, size_t> Connection::buffered_message() {
+  // Read until the buffer holds a size prefix and the whole message it describes. A message
+  // longer than a read is read through the buffer as well: the extra copy costs one memcpy,
+  // where reading its body straight into its own storage costs a system call every time.
+  uint32_t size = 0;
+  size_t prefix_length = 0;
+  while (!decoder::decode_size_prefix(buffer.data() + consumed, available(), &size, &prefix_length))
+    this->fill();
+  while (available() < prefix_length + size) this->fill();
+  consumed += prefix_length;
+  const char* message = buffer.data() + consumed;
+  consumed += size;
+  return {message, size};
+}
+
+void Connection::fill() {
+  // Move what is left to the front rather than reading further along a buffer that only ever
+  // grows. In the ordinary case nothing is left and this moves nothing.
+  if (consumed > 0) {
+    std::memmove(buffer.data(), buffer.data() + consumed, available());
+    filled -= consumed;
+    consumed = 0;
   }
-  return this->receive(size);
+  if (buffer.size() - filled < READ_SIZE) buffer.resize(filled + READ_SIZE);
+  filled += socket.read_some(asio::buffer(&buffer[filled], buffer.size() - filled));
+}
+
+void Connection::take(char* data, size_t length) {
+  std::memcpy(data, buffer.data() + consumed, length);
+  consumed += length;
 }
 
 std::string Connection::receive(size_t length) {
   std::string data;
   data.resize(length);
-  asio::read(socket, asio::buffer(&data[0], length));
+  size_t buffered = std::min(length, available());
+  this->take(&data[0], buffered);
+  // Whatever an earlier read has already brought in is used first, and the rest read into the
+  // caller's own storage: a message this long is one the buffer was never going to hold.
+  if (buffered < length) asio::read(socket, asio::buffer(&data[buffered], length - buffered));
   return data;
 }
 
 std::string Connection::partial_receive(size_t length, std::chrono::milliseconds timeout) {
+  // Data read for an earlier message is data that has arrived, so a caller polling for more
+  // has to be given it before the socket is waited on.
+  if (available() > 0) {
+    length = std::min(length, available());
+    std::string data;
+    data.resize(length);
+    this->take(&data[0], length);
+    return data;
+  }
+
   size_t read = 0;
   std::string data;
   data.resize(length);

--- a/client/cpp/src/decoder.cpp
+++ b/client/cpp/src/decoder.cpp
@@ -95,11 +95,29 @@ void decode(google::protobuf::MessageLite& message, const std::string& data, Cli
 }
 
 uint32_t decode_size(const std::string& data) {
-  uint32_t result;
-  google::protobuf::io::CodedInputStream stream(reinterpret_cast<const uint8_t*>(&data[0]),
-                                                static_cast<int>(data.size()));
-  if (!stream.ReadVarint32(&result)) throw EncodingError("Failed to decode size");
-  return result;
+  uint32_t size = 0;
+  size_t prefix_length = 0;
+  if (!decode_size_prefix(data.data(), data.size(), &size, &prefix_length))
+    throw EncodingError("Failed to decode size");
+  return size;
+}
+
+bool decode_size_prefix(const char* data, size_t length, uint32_t* size, size_t* prefix_length) {
+  // A size is a varint of at most five bytes, each carrying seven bits of it and a top bit
+  // saying whether another byte follows. Read it here rather than through a coded stream, as
+  // this sits between every message and the one after it.
+  uint32_t result = 0;
+  for (size_t i = 0; i < length; i++) {
+    uint8_t byte = static_cast<uint8_t>(data[i]);
+    result |= static_cast<uint32_t>(byte & 0x7f) << (7 * i);
+    if ((byte & 0x80) == 0) {
+      *size = result;
+      *prefix_length = i + 1;
+      return true;
+    }
+    if (i == 4) throw EncodingError("Failed to decode size");
+  }
+  return false;
 }
 
 }  // namespace decoder

--- a/client/cpp/src/decoder.cpp
+++ b/client/cpp/src/decoder.cpp
@@ -4,6 +4,8 @@
 #include <google/protobuf/message_lite.h>
 #include <google/protobuf/wire_format_lite.h>
 
+#include <algorithm>
+#include <cstddef>
 #include <cstdint>
 #include <string>
 
@@ -13,6 +15,46 @@
 
 namespace krpc {
 namespace decoder {
+
+namespace {
+
+const size_t LITTLE_ENDIAN_32_LENGTH = 4;
+const size_t LITTLE_ENDIAN_64_LENGTH = 8;
+
+// The most bytes a varint can take: seven bits of a 64 bit value in each.
+const size_t MAX_VARINT_LENGTH = 10;
+
+// Read a varint out of a buffer, and return how many bytes it took, or zero if the buffer does
+// not hold a whole one yet. A varint carries seven bits of the value in each byte, with the
+// top bit saying whether another byte follows.
+//
+// Read here rather than through a coded stream. A value is a few bytes long, and a collection
+// arrives a value at a time, so setting a stream up to read one costs more than reading it.
+size_t read_varint(const char* data, size_t length, uint64_t* value) {
+  uint64_t result = 0;
+  size_t whole = std::min(length, MAX_VARINT_LENGTH);
+  for (size_t i = 0; i < whole; i++) {
+    uint8_t byte = static_cast<uint8_t>(data[i]);
+    result |= static_cast<uint64_t>(byte & 0x7f) << (7 * i);
+    if ((byte & 0x80) == 0) {
+      *value = result;
+      return i + 1;
+    }
+  }
+  // A varint that has not ended by its last byte is not one, however much data follows it.
+  if (length >= MAX_VARINT_LENGTH) throw EncodingError("Failed to decode a varint");
+  return 0;
+}
+
+// Read a varint that the data has to hold, and return how many bytes it took. What is being
+// decoded is named for the error, which is all the caller could have said about it anyway.
+size_t read_varint(const std::string& data, uint64_t* value, const char* what) {
+  size_t length = read_varint(data.data(), data.size(), value);
+  if (length == 0) throw EncodingError(std::string("Failed to decode ") + what);
+  return length;
+}
+
+}  // namespace
 
 std::string guid(const std::string& data) {
   if (data.size() != 16) throw EncodingError("GUID is not 16 characters");
@@ -24,64 +66,55 @@ std::string guid(const std::string& data) {
 }
 
 void decode(double& value, const std::string& data, Client* client) {
-  google::protobuf::io::CodedInputStream stream(reinterpret_cast<const uint8_t*>(&data[0]),
-                                                static_cast<int>(data.size()));
+  if (data.size() < LITTLE_ENDIAN_64_LENGTH) throw EncodingError("Failed to decode double");
   uint64_t value2 = 0;
-  if (!stream.ReadLittleEndian64(&value2)) throw EncodingError("Failed to decode double");
+  (void)google::protobuf::io::CodedInputStream::ReadLittleEndian64FromArray(
+      reinterpret_cast<const uint8_t*>(data.data()), &value2);
   value = google::protobuf::internal::WireFormatLite::DecodeDouble(value2);
 }
 
 void decode(float& value, const std::string& data, Client* client) {
-  google::protobuf::io::CodedInputStream stream(reinterpret_cast<const uint8_t*>(&data[0]),
-                                                static_cast<int>(data.size()));
-  uint32_t value2;
-  if (!stream.ReadLittleEndian32(&value2)) throw EncodingError("Failed to decode float");
+  if (data.size() < LITTLE_ENDIAN_32_LENGTH) throw EncodingError("Failed to decode float");
+  uint32_t value2 = 0;
+  (void)google::protobuf::io::CodedInputStream::ReadLittleEndian32FromArray(
+      reinterpret_cast<const uint8_t*>(data.data()), &value2);
   value = google::protobuf::internal::WireFormatLite::DecodeFloat(value2);
 }
 
 void decode(int32_t& value, const std::string& data, Client* client) {
-  google::protobuf::io::CodedInputStream stream(reinterpret_cast<const uint8_t*>(&data[0]),
-                                                static_cast<int>(data.size()));
-  uint32_t zigZagValue = 0;
-  if (!stream.ReadVarint32(&zigZagValue)) throw EncodingError("Failed to decode sint32");
-  value = google::protobuf::internal::WireFormatLite::ZigZagDecode32(zigZagValue);
+  uint64_t zigZagValue = 0;
+  read_varint(data, &zigZagValue, "sint32");
+  value = google::protobuf::internal::WireFormatLite::ZigZagDecode32(
+      static_cast<uint32_t>(zigZagValue));
 }
 
 void decode(int64_t& value, const std::string& data, Client* client) {
-  google::protobuf::io::CodedInputStream stream(reinterpret_cast<const uint8_t*>(&data[0]),
-                                                static_cast<int>(data.size()));
   uint64_t zigZagValue = 0;
-  if (!stream.ReadVarint64(&zigZagValue)) throw EncodingError("Failed to decode sint64");
+  read_varint(data, &zigZagValue, "sint64");
   value = google::protobuf::internal::WireFormatLite::ZigZagDecode64(zigZagValue);
 }
 
 void decode(uint32_t& value, const std::string& data, Client* client) {
-  google::protobuf::io::CodedInputStream stream(reinterpret_cast<const uint8_t*>(&data[0]),
-                                                static_cast<int>(data.size()));
-  if (!stream.ReadVarint32(&value)) throw EncodingError("Failed to decode uint32");
+  uint64_t value2 = 0;
+  read_varint(data, &value2, "uint32");
+  value = static_cast<uint32_t>(value2);
 }
 
 void decode(uint64_t& value, const std::string& data, Client* client) {
-  google::protobuf::io::CodedInputStream stream(reinterpret_cast<const uint8_t*>(&data[0]),
-                                                static_cast<int>(data.size()));
-  if (!stream.ReadVarint64(&value)) throw EncodingError("Failed to decode uint64");
+  read_varint(data, &value, "uint64");
 }
 
 void decode(bool& value, const std::string& data, Client* client) {
-  google::protobuf::io::CodedInputStream stream(reinterpret_cast<const uint8_t*>(&data[0]),
-                                                static_cast<int>(data.size()));
   uint64_t value2 = 0;
-  if (!stream.ReadVarint64(&value2)) throw EncodingError("Failed to decode bool");
+  read_varint(data, &value2, "bool");
   value = (value2 != 0);
 }
 
 void decode(std::string& value, const std::string& data, Client* client) {
-  google::protobuf::io::CodedInputStream stream(reinterpret_cast<const uint8_t*>(&data[0]),
-                                                static_cast<int>(data.size()));
-  uint64_t length;
-  if (!stream.ReadVarint64(&length)) throw EncodingError("Failed to decode string (length)");
-  if (!stream.ReadString(&value, static_cast<int>(length)))
-    throw EncodingError("Failed to decode string");
+  uint64_t length = 0;
+  size_t header_length = read_varint(data, &length, "string (length)");
+  if (data.size() - header_length < length) throw EncodingError("Failed to decode string");
+  value.assign(data, header_length, length);
 }
 
 void decode(Event& event, const std::string& data, Client* client) {
@@ -103,21 +136,12 @@ uint32_t decode_size(const std::string& data) {
 }
 
 bool decode_size_prefix(const char* data, size_t length, uint32_t* size, size_t* prefix_length) {
-  // A size is a varint of at most five bytes, each carrying seven bits of it and a top bit
-  // saying whether another byte follows. Read it here rather than through a coded stream, as
-  // this sits between every message and the one after it.
-  uint32_t result = 0;
-  for (size_t i = 0; i < length; i++) {
-    uint8_t byte = static_cast<uint8_t>(data[i]);
-    result |= static_cast<uint32_t>(byte & 0x7f) << (7 * i);
-    if ((byte & 0x80) == 0) {
-      *size = result;
-      *prefix_length = i + 1;
-      return true;
-    }
-    if (i == 4) throw EncodingError("Failed to decode size");
-  }
-  return false;
+  uint64_t value = 0;
+  size_t read = read_varint(data, length, &value);
+  if (read == 0) return false;
+  *size = static_cast<uint32_t>(value);
+  *prefix_length = read;
+  return true;
 }
 
 }  // namespace decoder

--- a/client/cpp/src/encoder.cpp
+++ b/client/cpp/src/encoder.cpp
@@ -95,14 +95,19 @@ std::string encode(const google::protobuf::MessageLite& message) {
 }
 
 std::string encode_message_with_size(const google::protobuf::MessageLite& message) {
+  std::string data;
+  encode_message_with_size(message, &data);
+  return data;
+}
+
+void encode_message_with_size(const google::protobuf::MessageLite& message, std::string* data) {
   size_t length = message.ByteSizeLong();
   size_t header_length = google::protobuf::io::CodedOutputStream::VarintSize64(length);
-  std::string data(header_length + length, 0);
+  data->resize(header_length + length);
   (void)google::protobuf::io::CodedOutputStream::WriteVarint64ToArray(
-      length, reinterpret_cast<uint8_t*>(&data[0]));
-  if (!message.SerializeWithCachedSizesToArray(reinterpret_cast<uint8_t*>(&data[header_length])))
+      length, reinterpret_cast<uint8_t*>(&(*data)[0]));
+  if (!message.SerializeWithCachedSizesToArray(reinterpret_cast<uint8_t*>(&(*data)[header_length])))
     throw EncodingError("Failed to encode message with size");
-  return data;
 }
 
 }  // namespace encoder

--- a/client/csharp/CHANGELOG.md
+++ b/client/csharp/CHANGELOG.md
@@ -1,6 +1,15 @@
 ## [v0.7.0] - unreleased
 - **Breaking:** Support `null` for any nullable type; nullable value types use the nullable
   form (`int?`) (#1017)
+- Reduce the cost of a remote procedure call. A value is encoded and decoded without a
+  protobuf stream of its own, its bytes are written into a buffer of their own rather than one
+  the thread keeps, a response is read a block at a time and parsed straight out of the read
+  buffer, the request a call is built into is kept from one call to the next, and the client
+  connections disable Nagle's algorithm (#1056)
+- Reduce the cost of a call that returns a collection or an object. What kind of value a type
+  carries, and how to build one, is worked out the first time the type is seen rather than for
+  every value encoded or decoded, and a collection works out how to encode and decode its
+  items once for the collection rather than once for every item (#1056)
 
 ## [v0.6.0]
 - **Breaking:** Requires .NET Framework 4.7.2 or later (#948)

--- a/client/csharp/src/Connection.cs
+++ b/client/csharp/src/Connection.cs
@@ -21,7 +21,7 @@ namespace KRPC.Client
         TcpClient streamClient;
         NetworkStream rpcStream;
         CodedOutputStream codedRpcStream;
-        byte[] responseBuffer = new byte [BUFFER_INITIAL_SIZE];
+        MessageReader rpcReader;
 
         internal StreamManager StreamManager {
             get;
@@ -46,14 +46,16 @@ namespace KRPC.Client
             rpcClient.NoDelay = true;
             rpcStream = rpcClient.GetStream ();
             codedRpcStream = new CodedOutputStream (rpcStream, true);
+            rpcReader = new MessageReader (rpcStream);
             var request = new ConnectionRequest ();
             request.Type = Type.Rpc;
             request.ClientName = name;
             codedRpcStream.WriteLength (request.CalculateSize ());
             request.WriteTo (codedRpcStream);
             codedRpcStream.Flush ();
-            int size = ReadMessageData (rpcStream, ref responseBuffer);
-            var response = ConnectionResponse.Parser.ParseFrom (new CodedInputStream (responseBuffer, 0, size));
+            rpcReader.Read ();
+            var response = ConnectionResponse.Parser.ParseFrom (
+                rpcReader.Buffer, rpcReader.Offset, rpcReader.Size);
             if (response.Status != ConnectionResponse.Types.Status.Ok)
                 throw new ConnectionException (response.Message);
 
@@ -69,11 +71,16 @@ namespace KRPC.Client
                 codedStreamStream.WriteLength (request.CalculateSize ());
                 request.WriteTo (codedStreamStream);
                 codedStreamStream.Flush ();
-                size = ReadMessageData (streamStream, ref responseBuffer);
-                response = ConnectionResponse.Parser.ParseFrom (new CodedInputStream (responseBuffer, 0, size));
+                // The reader that reads the reply goes on to read the stream updates that
+                // follow it. It may have taken the first of them along with the reply, so a
+                // second reader on the same socket would never see it.
+                var streamReader = new MessageReader (streamStream);
+                streamReader.Read ();
+                response = ConnectionResponse.Parser.ParseFrom (
+                    streamReader.Buffer, streamReader.Offset, streamReader.Size);
                 if (response.Status != ConnectionResponse.Types.Status.Ok)
                     throw new ConnectionException (response.Message);
-                StreamManager = new StreamManager (this, streamClient);
+                StreamManager = new StreamManager (this, streamReader);
             }
 
             Services.KRPC.Service.AddExceptionTypes (this);
@@ -167,8 +174,9 @@ namespace KRPC.Client
                 request.WriteTo (codedRpcStream);
                 codedRpcStream.Flush ();
                 // Receive response
-                int size = ReadMessageData (rpcStream, ref responseBuffer);
-                response = Response.Parser.ParseFrom (new CodedInputStream (responseBuffer, 0, size));
+                rpcReader.Read ();
+                response = Response.Parser.ParseFrom (
+                    rpcReader.Buffer, rpcReader.Offset, rpcReader.Size);
             }
 
             if (response.Error != null)
@@ -310,56 +318,6 @@ namespace KRPC.Client
             var instanceExpr = Expression.Lambda<Func<object>> (
                 Expression.Convert (instance, typeof(object)));
             return instanceExpr.Compile () ();
-        }
-
-        // Initial buffer size of 1 MB
-        internal const int BUFFER_INITIAL_SIZE = 1 * 1024 * 1024;
-        // Initial increases in increments of 512 KB
-        internal const int BUFFER_INCREASE_SIZE = 512 * 1024;
-
-        /// <summary>
-        /// Read the data from a message from the given stream into the given buffer.
-        /// May reallocate the buffer if it is too small to receive the message.
-        /// Returns the lenght of the message in bytes.
-        /// If a stopEvent is specified, this method will return 0 if the event is triggered.
-        /// </summary>
-        internal static int ReadMessageData (System.IO.Stream stream, ref byte[] buffer, EventWaitHandle stopEvent = null)
-        {
-            bool stop = stopEvent != null && stopEvent.WaitOne (0);
-            int bufferSize = 0;
-            int messageSize = 0;
-
-            // Read the offset and size of the message data
-            while (!stop) {
-                bufferSize += stream.Read (buffer, bufferSize, 1);
-                stop |= stopEvent != null && stopEvent.WaitOne (0);
-                try {
-                    var codedStream = new CodedInputStream (buffer, 0, bufferSize);
-                    messageSize = (int)codedStream.ReadUInt32 ();
-                    stop |= stopEvent != null && stopEvent.WaitOne (0);
-                    break;
-                } catch (InvalidProtocolBufferException) {
-                }
-            }
-            if (stop)
-                return 0;
-
-            // Read the response data
-            bufferSize = 0;
-            while (!stop && bufferSize < messageSize) {
-                // Increase the size of the buffer if the remaining space is low
-                if (buffer.Length - bufferSize < BUFFER_INCREASE_SIZE) {
-                    var newBuffer = new byte [buffer.Length + BUFFER_INCREASE_SIZE];
-                    Array.Copy (buffer, newBuffer, bufferSize);
-                    buffer = newBuffer;
-                }
-                bufferSize += stream.Read (buffer, bufferSize, messageSize - bufferSize);
-                stop |= stopEvent != null && stopEvent.WaitOne (0);
-            }
-            if (stop)
-                return 0;
-
-            return messageSize;
         }
 
         readonly IDictionary<string, System.Type> exceptionTypes = new Dictionary<string, System.Type>();

--- a/client/csharp/src/Connection.cs
+++ b/client/csharp/src/Connection.cs
@@ -40,6 +40,10 @@ namespace KRPC.Client
 
             rpcClient = new TcpClient ();
             rpcClient.Connect (address, rpcPort);
+            // A call writes a request and then waits for its response, so there is never a
+            // second small write for Nagle's algorithm to hold the first one back for. Left on,
+            // it can only delay a request the server is already waiting for.
+            rpcClient.NoDelay = true;
             rpcStream = rpcClient.GetStream ();
             codedRpcStream = new CodedOutputStream (rpcStream, true);
             var request = new ConnectionRequest ();
@@ -56,6 +60,7 @@ namespace KRPC.Client
             if (streamPort != 0) {
                 streamClient = new TcpClient ();
                 streamClient.Connect (address, streamPort);
+                streamClient.NoDelay = true;
                 var streamStream = streamClient.GetStream ();
                 request = new ConnectionRequest ();
                 request.Type = Type.Stream;

--- a/client/csharp/src/Connection.cs
+++ b/client/csharp/src/Connection.cs
@@ -23,6 +23,11 @@ namespace KRPC.Client
         CodedOutputStream codedRpcStream;
         MessageReader rpcReader;
 
+        // The request a call is sent as, and the parts it is built from. See BuildRequest.
+        readonly Request request = new Request ();
+        readonly ProcedureCall call = new ProcedureCall ();
+        readonly List<Argument> callArguments = new List<Argument> ();
+
         internal StreamManager StreamManager {
             get;
             private set;
@@ -38,6 +43,9 @@ namespace KRPC.Client
             if (address == null)
                 address = IPAddress.Loopback;
 
+            // Every request carries the one call, which is filled in for each of them.
+            request.Calls.Add (call);
+
             rpcClient = new TcpClient ();
             rpcClient.Connect (address, rpcPort);
             // A call writes a request and then waits for its response, so there is never a
@@ -47,11 +55,11 @@ namespace KRPC.Client
             rpcStream = rpcClient.GetStream ();
             codedRpcStream = new CodedOutputStream (rpcStream, true);
             rpcReader = new MessageReader (rpcStream);
-            var request = new ConnectionRequest ();
-            request.Type = Type.Rpc;
-            request.ClientName = name;
-            codedRpcStream.WriteLength (request.CalculateSize ());
-            request.WriteTo (codedRpcStream);
+            var connectionRequest = new ConnectionRequest ();
+            connectionRequest.Type = Type.Rpc;
+            connectionRequest.ClientName = name;
+            codedRpcStream.WriteLength (connectionRequest.CalculateSize ());
+            connectionRequest.WriteTo (codedRpcStream);
             codedRpcStream.Flush ();
             rpcReader.Read ();
             var response = ConnectionResponse.Parser.ParseFrom (
@@ -64,12 +72,12 @@ namespace KRPC.Client
                 streamClient.Connect (address, streamPort);
                 streamClient.NoDelay = true;
                 var streamStream = streamClient.GetStream ();
-                request = new ConnectionRequest ();
-                request.Type = Type.Stream;
-                request.ClientIdentifier = response.ClientIdentifier;
+                connectionRequest = new ConnectionRequest ();
+                connectionRequest.Type = Type.Stream;
+                connectionRequest.ClientIdentifier = response.ClientIdentifier;
                 var codedStreamStream = new CodedOutputStream (streamStream, true);
-                codedStreamStream.WriteLength (request.CalculateSize ());
-                request.WriteTo (codedStreamStream);
+                codedStreamStream.WriteLength (connectionRequest.CalculateSize ());
+                connectionRequest.WriteTo (codedStreamStream);
                 codedStreamStream.Flush ();
                 // The reader that reads the reply goes on to read the stream updates that
                 // follow it. It may have taken the first of them along with the reply, so a
@@ -159,16 +167,10 @@ namespace KRPC.Client
         public ProcedureResult Invoke (string service, string procedure, IList<ByteString> arguments = null)
         {
             CheckDisposed ();
-            return Invoke (GetCall (service, procedure, arguments));
-        }
-
-        internal ProcedureResult Invoke (ProcedureCall call)
-        {
-            var request = new Request ();
-            request.Calls.Add (call);
             Response response;
 
             lock (invokeLock) {
+                BuildRequest (service, procedure, arguments);
                 // Send request to server
                 codedRpcStream.WriteLength (request.CalculateSize ());
                 request.WriteTo (codedRpcStream);
@@ -184,6 +186,36 @@ namespace KRPC.Client
             if (response.Results[0].Error != null)
                 throw GetException (response.Results [0].Error);
             return response.Results[0];
+        }
+
+        /// <summary>
+        /// Fill in the request that the next call is sent as.
+        /// </summary>
+        /// <remarks>
+        /// The request, the call it carries and the arguments of that call are kept from one
+        /// call to the next rather than built for each. A protobuf message allocates storage for
+        /// its fields as they are set, and the shape of a request never changes, so a call after
+        /// the first fills in storage it already has. They are guarded by the lock that already
+        /// serializes a call against the response it is waiting for.
+        /// </remarks>
+        void BuildRequest (string service, string procedure, IList<ByteString> values)
+        {
+            call.Service = service;
+            call.Procedure = procedure;
+            call.Arguments.Clear ();
+            if (values == null)
+                return;
+            for (var position = 0; position < values.Count; position++) {
+                while (callArguments.Count <= position)
+                    callArguments.Add (new Argument ());
+                var argument = callArguments [position];
+                argument.Position = (uint)position;
+                // A null encoding signals a null value, carried out-of-band by is_null with
+                // the value field left unset.
+                argument.IsNull = values [position] == null;
+                argument.Value = values [position] ?? ByteString.Empty;
+                call.Arguments.Add (argument);
+            }
         }
 
         internal static ProcedureCall GetCall (string service, string procedure, IList<ByteString> arguments = null)

--- a/client/csharp/src/Encoder.cs
+++ b/client/csharp/src/Encoder.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections;
+using System.Collections.Concurrent;
 using System.Runtime.InteropServices;
 using System.Text;
 using Google.Protobuf;
@@ -32,8 +33,8 @@ namespace KRPC.Client
         /// A number, a string or an object identifier is a handful of bytes on the wire, and its
         /// bytes are written into a buffer of that size. A coded output stream carries a buffer
         /// of several kilobytes of its own, which is far more to allocate for one number than
-        /// writing the number costs. Anything carried by a protobuf message
-        /// is left to protobuf to serialize.
+        /// writing the number costs. Anything carried by a protobuf message is left to protobuf
+        /// to serialize.
         /// </remarks>
         static ByteString EncodeValue (object value, Type type)
         {
@@ -92,6 +93,92 @@ namespace KRPC.Client
             }
         }
 
+        static readonly ConcurrentDictionary<Type, Func<object, ByteString>> encoders =
+            new ConcurrentDictionary<Type, Func<object, ByteString>> ();
+
+        /// <summary>
+        /// A function that encodes one value of the given type.
+        /// </summary>
+        /// <remarks>
+        /// A collection carries many values of the same type, and reaching the code that writes
+        /// one of them means asking the type whether it is an enumeration and which type code it
+        /// carries, and for anything that is not a number or a string, what kind of value it is.
+        /// None of those answers change, so a collection asks once and calls what it gets back
+        /// for each of its items.
+        /// </remarks>
+        static Func<object, ByteString> EncoderFor (Type type)
+        {
+            Func<object, ByteString> encode;
+            if (encoders.TryGetValue (type, out encode))
+                return encode;
+            return encoders.GetOrAdd (type, BuildEncoder (type));
+        }
+
+        /// <remarks>
+        /// A value reached this way is an item of a collection whose type says what its items
+        /// are, so unlike <see cref="EncodeValue"/> this does not ask each one whether it is of
+        /// that type. Asking is a call into the type system, and asking it once per item is what
+        /// made writing a collection cost several times what reading one back costs. A null is
+        /// still rejected, as a collection of a class type can hold one.
+        /// </remarks>
+        static Func<object, ByteString> BuildEncoder (Type type)
+        {
+            Func<object, ByteString> write = WriterFor (type);
+            return value => {
+                if (value == null)
+                    throw new ArgumentException ("null cannot be encoded to type " + type);
+                return write (value);
+            };
+        }
+
+        /// <summary>
+        /// A function that writes one value of the given type, without checking it first.
+        /// </summary>
+        static Func<object, ByteString> WriterFor (Type type)
+        {
+            if (type.IsEnum)
+                return value => Varint (EncodeZigZag ((int)value));
+            switch (Type.GetTypeCode (type)) {
+            case TypeCode.Double:
+                return value => Fixed64 ((ulong)BitConverter.DoubleToInt64Bits ((double)value));
+            case TypeCode.Single:
+                return value => Fixed32 (ToBits ((float)value));
+            case TypeCode.Int32:
+                return value => Varint (EncodeZigZag ((int)value));
+            case TypeCode.Int64:
+                return value => Varint (EncodeZigZag ((long)value));
+            case TypeCode.UInt32:
+                return value => Varint ((uint)value);
+            case TypeCode.UInt64:
+                return value => Varint ((ulong)value);
+            case TypeCode.Boolean:
+                return value => Varint ((bool)value ? 1UL : 0UL);
+            case TypeCode.String:
+                return value => EncodeString ((string)value);
+            default:
+                break;
+            }
+            var info = TypeInfo.For (type);
+            switch (info.Kind) {
+            case TypeKind.Bytes:
+                return value => EncodeBytes ((byte[])value);
+            case TypeKind.Class:
+                return value => Varint (((RemoteObject)value).id);
+            case TypeKind.Tuple:
+                return value => EncodeTuple (value, info).ToByteString ();
+            case TypeKind.List:
+                return value => EncodeList (value, info).ToByteString ();
+            case TypeKind.Set:
+                return value => EncodeSet (value, info).ToByteString ();
+            case TypeKind.Dictionary:
+                return value => EncodeDictionary (value, info).ToByteString ();
+            case TypeKind.Message:
+                return value => ((IMessage)value).ToByteString ();
+            default:
+                throw new ArgumentException (type + " is not a serializable type");
+            }
+        }
+
         static IMessage EncodeTuple (object value, TypeInfo info)
         {
             var encodedTuple = new Schema.KRPC.Tuple ();
@@ -103,30 +190,30 @@ namespace KRPC.Client
         static IMessage EncodeList (object value, TypeInfo info)
         {
             var encodedList = new Schema.KRPC.List ();
-            var valueType = info.Arguments [0];
+            var encodeItem = EncoderFor (info.Arguments [0]);
             foreach (var item in (IList)value)
-                encodedList.Items.Add (EncodeValue (item, valueType));
+                encodedList.Items.Add (encodeItem (item));
             return encodedList;
         }
 
         static IMessage EncodeSet (object value, TypeInfo info)
         {
             var encodedSet = new Schema.KRPC.Set ();
-            var valueType = info.Arguments [0];
+            var encodeItem = EncoderFor (info.Arguments [0]);
             foreach (var item in (IEnumerable)value)
-                encodedSet.Items.Add (EncodeValue (item, valueType));
+                encodedSet.Items.Add (encodeItem (item));
             return encodedSet;
         }
 
         static IMessage EncodeDictionary (object value, TypeInfo info)
         {
-            var keyType = info.Arguments [0];
-            var valueType = info.Arguments [1];
+            var encodeKey = EncoderFor (info.Arguments [0]);
+            var encodeValue = EncoderFor (info.Arguments [1]);
             var encodedDictionary = new Schema.KRPC.Dictionary ();
             foreach (DictionaryEntry entry in (IDictionary)value) {
                 var encodedEntry = new Schema.KRPC.DictionaryEntry ();
-                encodedEntry.Key = EncodeValue (entry.Key, keyType);
-                encodedEntry.Value = EncodeValue (entry.Value, valueType);
+                encodedEntry.Key = encodeKey (entry.Key);
+                encodedEntry.Value = encodeValue (entry.Value);
                 encodedDictionary.Entries.Add (encodedEntry);
             }
             return encodedDictionary;
@@ -209,6 +296,83 @@ namespace KRPC.Client
             }
         }
 
+        static readonly ConcurrentDictionary<Type, Func<ByteString, IConnection, object>> decoders =
+            new ConcurrentDictionary<Type, Func<ByteString, IConnection, object>> ();
+
+        /// <summary>
+        /// A function that decodes one value of the given type. The counterpart of
+        /// <see cref="EncoderFor"/>, and there for the same reason.
+        /// </summary>
+        static Func<ByteString, IConnection, object> DecoderFor (Type type)
+        {
+            Func<ByteString, IConnection, object> decode;
+            if (decoders.TryGetValue (type, out decode))
+                return decode;
+            return decoders.GetOrAdd (type, BuildDecoder (type));
+        }
+
+        static Func<ByteString, IConnection, object> BuildDecoder (Type type)
+        {
+            // A Nullable<T> value decodes as its underlying type T; a null value is
+            // signaled out-of-band by is_null and never reaches here.
+            type = Nullable.GetUnderlyingType (type) ?? type;
+            if (type.IsEnum)
+                return (value, client) => DecodeZigZag32 (ReadVarint (value));
+            switch (Type.GetTypeCode (type)) {
+            case TypeCode.Double:
+                return (value, client) => BitConverter.Int64BitsToDouble ((long)ReadFixed64 (value));
+            case TypeCode.Single:
+                return (value, client) => ToSingle (ReadFixed32 (value));
+            case TypeCode.Int32:
+                return (value, client) => DecodeZigZag32 (ReadVarint (value));
+            case TypeCode.Int64:
+                return (value, client) => DecodeZigZag64 (ReadVarint (value));
+            case TypeCode.UInt32:
+                return (value, client) => (uint)ReadVarint (value);
+            case TypeCode.UInt64:
+                return (value, client) => ReadVarint (value);
+            case TypeCode.Boolean:
+                return (value, client) => ReadVarint (value) != 0;
+            case TypeCode.String:
+                return (value, client) => value.CreateCodedInput ().ReadString ();
+            default:
+                break;
+            }
+            var info = TypeInfo.For (type);
+            switch (info.Kind) {
+            case TypeKind.Bytes:
+                return (value, client) => value.CreateCodedInput ().ReadBytes ().ToByteArray ();
+            case TypeKind.Class:
+                return (value, client) => {
+                    if (client == null)
+                        throw new ArgumentException ("Client not passed when decoding remote object");
+                    return info.NewObject (client, ReadVarint (value));
+                };
+            case TypeKind.Tuple:
+                return (value, client) => DecodeTuple (value, info, client);
+            case TypeKind.List:
+                return (value, client) => DecodeList (value, info, client);
+            case TypeKind.Set:
+                return (value, client) => DecodeSet (value, info, client);
+            case TypeKind.Dictionary:
+                return (value, client) => DecodeDictionary (value, info, client);
+            case TypeKind.Message:
+                return (value, client) => {
+                    var message = (IMessage)Activator.CreateInstance (type);
+                    message.MergeFrom (value);
+                    return message;
+                };
+            case TypeKind.Event:
+                return (value, client) => {
+                    var message = new Schema.KRPC.Event ();
+                    message.MergeFrom (value);
+                    return new Event ((Connection)client, message);
+                };
+            default:
+                throw new ArgumentException (type + " is not a serializable type");
+            }
+        }
+
         static object DecodeTuple (ByteString data, TypeInfo info, IConnection client)
         {
             var encodedTuple = Schema.KRPC.Tuple.Parser.ParseFrom (data);
@@ -221,32 +385,32 @@ namespace KRPC.Client
         static object DecodeList (ByteString data, TypeInfo info, IConnection client)
         {
             var encodedList = Schema.KRPC.List.Parser.ParseFrom (data);
-            var valueType = info.Arguments [0];
+            var decodeItem = DecoderFor (info.Arguments [0]);
             var list = (IList)info.New ();
             foreach (var item in encodedList.Items)
-                list.Add (Decode (item, valueType, client));
+                list.Add (decodeItem (item, client));
             return list;
         }
 
         static object DecodeSet (ByteString data, TypeInfo info, IConnection client)
         {
             var encodedSet = Schema.KRPC.Set.Parser.ParseFrom (data);
-            var valueType = info.Arguments [0];
+            var decodeItem = DecoderFor (info.Arguments [0]);
             var set = info.New ();
             foreach (var item in encodedSet.Items)
-                info.Add (set, Decode (item, valueType, client));
+                info.Add (set, decodeItem (item, client));
             return set;
         }
 
         static object DecodeDictionary (ByteString data, TypeInfo info, IConnection client)
         {
             var encodedDictionary = Schema.KRPC.Dictionary.Parser.ParseFrom (data);
-            var keyType = info.Arguments [0];
-            var valueType = info.Arguments [1];
+            var decodeKey = DecoderFor (info.Arguments [0]);
+            var decodeValue = DecoderFor (info.Arguments [1]);
             var dictionary = (IDictionary)info.New ();
             foreach (var entry in encodedDictionary.Entries) {
-                var key = Decode (entry.Key, keyType, client);
-                var value = Decode (entry.Value, valueType, client);
+                var key = decodeKey (entry.Key, client);
+                var value = decodeValue (entry.Value, client);
                 dictionary [key] = value;
             }
             return dictionary;

--- a/client/csharp/src/Encoder.cs
+++ b/client/csharp/src/Encoder.cs
@@ -2,9 +2,10 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Globalization;
-using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.InteropServices;
+using System.Text;
 using Google.Protobuf;
 
 namespace KRPC.Client
@@ -25,135 +26,118 @@ namespace KRPC.Client
             type = Nullable.GetUnderlyingType (type) ?? type;
             if (value == null)
                 return null;
-            using (var buffer = new MemoryStream ()) {
-                var stream = new CodedOutputStream (buffer, true);
-                return EncodeObject (value, type, buffer, stream);
-            }
+            return EncodeValue (value, type);
         }
 
-        static ByteString EncodeObject (object value, Type type, MemoryStream buffer, CodedOutputStream stream)
+        /// <summary>
+        /// Encode a value of the given type.
+        /// </summary>
+        /// <remarks>
+        /// A number, a string or an object identifier is a handful of bytes on the wire, and its
+        /// bytes are written into a buffer the thread keeps and copied out of it. A coded output
+        /// stream carries a buffer of several kilobytes of its own, which is far more to allocate
+        /// for one number than writing the number costs. Anything carried by a protobuf message
+        /// is left to protobuf to serialize.
+        /// </remarks>
+        static ByteString EncodeValue (object value, Type type)
         {
-            buffer.SetLength (0);
             if (value == null)
                 throw new ArgumentException ("null cannot be encoded to type " + type);
             if (!type.IsInstanceOfType (value))
                 throw new ArgumentException ("Value of type " + value.GetType () + " cannot be encoded to type " + type);
             if (value is Enum)
-                stream.WriteSInt32 ((int)value);
-            else {
-                switch (Type.GetTypeCode (type)) {
-                case TypeCode.Double:
-                    stream.WriteDouble ((double)value);
-                    break;
-                case TypeCode.Single:
-                    stream.WriteFloat ((float)value);
-                    break;
-                case TypeCode.Int32:
-                    stream.WriteSInt32 ((int)value);
-                    break;
-                case TypeCode.Int64:
-                    stream.WriteSInt64 ((long)value);
-                    break;
-                case TypeCode.UInt32:
-                    stream.WriteUInt32 ((uint)value);
-                    break;
-                case TypeCode.UInt64:
-                    stream.WriteUInt64 ((ulong)value);
-                    break;
-                case TypeCode.Boolean:
-                    stream.WriteBool ((bool)value);
-                    break;
-                case TypeCode.String:
-                    stream.WriteString ((string)value);
-                    break;
-                default:
-                    if (type.Equals (typeof(byte[])))
-                        stream.WriteBytes (ByteString.CopyFrom ((byte[])value));
-                    else if (IsAClassType (type))
-                        stream.WriteUInt64 (((RemoteObject)value).id);
-                    else if (IsATupleType (type))
-                        WriteTuple (value, type, buffer);
-                    else if (IsAListType (type))
-                        WriteList (value, type, buffer);
-                    else if (IsASetType (type))
-                        WriteSet (value, type, buffer);
-                    else if (IsADictionaryType (type))
-                        WriteDictionary (value, type, buffer);
-                    else if (IsAMessageType (type))
-                        ((IMessage)value).WriteTo (buffer);
-                    else
-                        throw new ArgumentException (type + " is not a serializable type");
-                    break;
-                }
+                return Varint (EncodeZigZag ((int)value));
+            switch (Type.GetTypeCode (type)) {
+            case TypeCode.Double:
+                return Fixed64 ((ulong)BitConverter.DoubleToInt64Bits ((double)value));
+            case TypeCode.Single:
+                return Fixed32 (ToBits ((float)value));
+            case TypeCode.Int32:
+                return Varint (EncodeZigZag ((int)value));
+            case TypeCode.Int64:
+                return Varint (EncodeZigZag ((long)value));
+            case TypeCode.UInt32:
+                return Varint ((uint)value);
+            case TypeCode.UInt64:
+                return Varint ((ulong)value);
+            case TypeCode.Boolean:
+                return Varint ((bool)value ? 1UL : 0UL);
+            case TypeCode.String:
+                return EncodeString ((string)value);
+            default:
+                if (type.Equals (typeof(byte[])))
+                    return EncodeBytes ((byte[])value);
+                if (IsAClassType (type))
+                    return Varint (((RemoteObject)value).id);
+                if (IsATupleType (type))
+                    return EncodeTuple (value, type).ToByteString ();
+                if (IsAListType (type))
+                    return EncodeList (value, type).ToByteString ();
+                if (IsASetType (type))
+                    return EncodeSet (value, type).ToByteString ();
+                if (IsADictionaryType (type))
+                    return EncodeDictionary (value, type).ToByteString ();
+                if (IsAMessageType (type))
+                    return ((IMessage)value).ToByteString ();
+                throw new ArgumentException (type + " is not a serializable type");
             }
-            stream.Flush ();
-            return ByteString.CopyFrom (buffer.GetBuffer (), 0, (int)buffer.Length);
         }
 
-        static void WriteTuple (object value, Type type, Stream stream)
+        static IMessage EncodeTuple (object value, Type type)
         {
             var encodedTuple = new Schema.KRPC.Tuple ();
-            var valueTypes = type.GetGenericArguments ().ToArray ();
+            var valueTypes = type.GetGenericArguments ();
             var genericType = Type.GetType ("System.Tuple`" + valueTypes.Length.ToString (CultureInfo.InvariantCulture));
             var tupleType = genericType.MakeGenericType (valueTypes);
-            using (var internalBuffer = new MemoryStream ()) {
-                var internalStream = new CodedOutputStream (internalBuffer);
-                for (int i = 0; i < valueTypes.Length; i++) {
-                    var property = tupleType.GetProperty ("Item" + (i + 1).ToString (CultureInfo.InvariantCulture));
-                    var item = property.GetGetMethod ().Invoke (value, null);
-                    encodedTuple.Items.Add (EncodeObject (item, valueTypes [i], internalBuffer, internalStream));
-                }
+            for (int i = 0; i < valueTypes.Length; i++) {
+                var property = tupleType.GetProperty ("Item" + (i + 1).ToString (CultureInfo.InvariantCulture));
+                var item = property.GetGetMethod ().Invoke (value, null);
+                encodedTuple.Items.Add (EncodeValue (item, valueTypes [i]));
             }
-            encodedTuple.WriteTo (stream);
+            return encodedTuple;
         }
 
-        static void WriteList (object value, Type type, Stream stream)
+        static IMessage EncodeList (object value, Type type)
         {
             var encodedList = new Schema.KRPC.List ();
-            var list = (IList)value;
             var valueType = type.GetGenericArguments ().Single ();
-            using (var internalBuffer = new MemoryStream ()) {
-                var internalStream = new CodedOutputStream (internalBuffer);
-                foreach (var item in list)
-                    encodedList.Items.Add (EncodeObject (item, valueType, internalBuffer, internalStream));
-            }
-            encodedList.WriteTo (stream);
+            foreach (var item in (IList)value)
+                encodedList.Items.Add (EncodeValue (item, valueType));
+            return encodedList;
         }
 
-        static void WriteSet (object value, Type type, Stream stream)
+        static IMessage EncodeSet (object value, Type type)
         {
             var encodedSet = new Schema.KRPC.Set ();
-            var set = (IEnumerable)value;
             var valueType = type.GetGenericArguments ().Single ();
-            using (var internalBuffer = new MemoryStream ()) {
-                var internalStream = new CodedOutputStream (internalBuffer);
-                foreach (var item in set)
-                    encodedSet.Items.Add (EncodeObject (item, valueType, internalBuffer, internalStream));
-            }
-            encodedSet.WriteTo (stream);
+            foreach (var item in (IEnumerable)value)
+                encodedSet.Items.Add (EncodeValue (item, valueType));
+            return encodedSet;
         }
 
-        static void WriteDictionary (object value, Type type, Stream stream)
+        static IMessage EncodeDictionary (object value, Type type)
         {
             var keyType = type.GetGenericArguments () [0];
             var valueType = type.GetGenericArguments () [1];
             var encodedDictionary = new Schema.KRPC.Dictionary ();
-            using (var internalBuffer = new MemoryStream ()) {
-                var internalStream = new CodedOutputStream (internalBuffer);
-                foreach (DictionaryEntry entry in (IDictionary) value) {
-                    var encodedEntry = new Schema.KRPC.DictionaryEntry ();
-                    encodedEntry.Key = EncodeObject (entry.Key, keyType, internalBuffer, internalStream);
-                    encodedEntry.Value = EncodeObject (entry.Value, valueType, internalBuffer, internalStream);
-                    encodedDictionary.Entries.Add (encodedEntry);
-                }
+            foreach (DictionaryEntry entry in (IDictionary)value) {
+                var encodedEntry = new Schema.KRPC.DictionaryEntry ();
+                encodedEntry.Key = EncodeValue (entry.Key, keyType);
+                encodedEntry.Value = EncodeValue (entry.Value, valueType);
+                encodedDictionary.Entries.Add (encodedEntry);
             }
-            encodedDictionary.WriteTo (stream);
+            return encodedDictionary;
         }
 
         /// <summary>
         /// Decode a value of the given type.
         /// Should not be called directly. This interface is used by service client stubs.
         /// </summary>
+        /// <remarks>
+        /// The bytes of a number, a string or an object identifier are read where they are, for
+        /// the same reason the encoding writes them there: a coded input stream of its own is
+        /// more to allocate for one value than reading the value costs.
+        /// </remarks>
         public static object Decode (ByteString value, Type type, IConnection client)
         {
             if (ReferenceEquals (type, null))
@@ -161,61 +145,59 @@ namespace KRPC.Client
             // A Nullable<T> value decodes as its underlying type T; a null value is
             // signaled out-of-band by is_null and never reaches this method.
             type = Nullable.GetUnderlyingType (type) ?? type;
-            var stream = value.CreateCodedInput ();
             if (type.IsEnum)
-                return stream.ReadSInt32 ();
+                return DecodeZigZag32 (ReadVarint (value));
             switch (Type.GetTypeCode (type)) {
             case TypeCode.Double:
-                return stream.ReadDouble ();
+                return BitConverter.Int64BitsToDouble ((long)ReadFixed64 (value));
             case TypeCode.Single:
-                return stream.ReadFloat ();
+                return ToSingle (ReadFixed32 (value));
             case TypeCode.Int32:
-                return stream.ReadSInt32 ();
+                return DecodeZigZag32 (ReadVarint (value));
             case TypeCode.Int64:
-                return stream.ReadSInt64 ();
+                return DecodeZigZag64 (ReadVarint (value));
             case TypeCode.UInt32:
-                return stream.ReadUInt32 ();
+                return (uint)ReadVarint (value);
             case TypeCode.UInt64:
-                return stream.ReadUInt64 ();
+                return ReadVarint (value);
             case TypeCode.Boolean:
-                return stream.ReadBool ();
+                return ReadVarint (value) != 0;
             case TypeCode.String:
-                return stream.ReadString ();
+                return value.CreateCodedInput ().ReadString ();
             default:
                 if (type.Equals (typeof(byte[])))
-                    return stream.ReadBytes ().ToByteArray ();
+                    return value.CreateCodedInput ().ReadBytes ().ToByteArray ();
                 if (IsAClassType (type)) {
                     if (client == null)
                         throw new ArgumentException ("Client not passed when decoding remote object");
-                    var id = stream.ReadUInt64 ();
-                    return (RemoteObject)Activator.CreateInstance (type, client, id);
+                    return (RemoteObject)Activator.CreateInstance (type, client, ReadVarint (value));
                 }
                 if (IsATupleType (type))
-                    return DecodeTuple (stream, type, client);
+                    return DecodeTuple (value, type, client);
                 if (IsAListType (type))
-                    return DecodeList (stream, type, client);
+                    return DecodeList (value, type, client);
                 if (IsASetType (type))
-                    return DecodeSet (stream, type, client);
+                    return DecodeSet (value, type, client);
                 if (IsADictionaryType (type))
-                    return DecodeDictionary (stream, type, client);
+                    return DecodeDictionary (value, type, client);
                 if (IsAMessageType (type)) {
                     var message = (IMessage)Activator.CreateInstance (type);
-                    message.MergeFrom (stream);
+                    message.MergeFrom (value);
                     return message;
                 }
                 if (type == typeof (Event)) {
                     var message = new Schema.KRPC.Event ();
-                    message.MergeFrom (stream);
+                    message.MergeFrom (value);
                     return new Event ((Connection)client, message);
                 }
                 throw new ArgumentException (type + " is not a serializable type");
             }
         }
 
-        static object DecodeTuple (CodedInputStream stream, Type type, IConnection client)
+        static object DecodeTuple (ByteString data, Type type, IConnection client)
         {
-            var encodedTuple = Schema.KRPC.Tuple.Parser.ParseFrom (stream);
-            var valueTypes = type.GetGenericArguments ().ToArray ();
+            var encodedTuple = Schema.KRPC.Tuple.Parser.ParseFrom (data);
+            var valueTypes = type.GetGenericArguments ();
             var genericType = Type.GetType ("System.Tuple`" + valueTypes.Length.ToString (CultureInfo.InvariantCulture));
             var values = new object[valueTypes.Length];
             for (int i = 0; i < valueTypes.Length; i++) {
@@ -229,46 +211,206 @@ namespace KRPC.Client
             return tuple;
         }
 
-        static object DecodeList (CodedInputStream stream, Type type, IConnection client)
+        static object DecodeList (ByteString data, Type type, IConnection client)
         {
-            var encodedList = Schema.KRPC.List.Parser.ParseFrom (stream);
+            var encodedList = Schema.KRPC.List.Parser.ParseFrom (data);
+            var valueType = type.GetGenericArguments ().Single ();
             var list = (IList)(typeof(List<>)
-                .MakeGenericType (type.GetGenericArguments ().Single ())
+                .MakeGenericType (valueType)
                 .GetConstructor (Type.EmptyTypes)
                 .Invoke (null));
             foreach (var item in encodedList.Items)
-                list.Add (Decode (item, type.GetGenericArguments ().Single (), client));
+                list.Add (Decode (item, valueType, client));
             return list;
         }
 
-        static object DecodeSet (CodedInputStream stream, Type type, IConnection client)
+        static object DecodeSet (ByteString data, Type type, IConnection client)
         {
-            var encodedSet = Schema.KRPC.Set.Parser.ParseFrom (stream);
+            var encodedSet = Schema.KRPC.Set.Parser.ParseFrom (data);
+            var valueType = type.GetGenericArguments ().Single ();
             var set = (IEnumerable)(typeof(HashSet<>)
-                .MakeGenericType (type.GetGenericArguments ().Single ())
+                .MakeGenericType (valueType)
                 .GetConstructor (Type.EmptyTypes)
                 .Invoke (null));
             MethodInfo methodInfo = type.GetMethod ("Add");
             foreach (var item in encodedSet.Items) {
-                var decodedItem = Decode (item, type.GetGenericArguments ().Single (), client);
+                var decodedItem = Decode (item, valueType, client);
                 methodInfo.Invoke (set, new [] { decodedItem });
             }
             return set;
         }
 
-        static object DecodeDictionary (CodedInputStream stream, Type type, IConnection client)
+        static object DecodeDictionary (ByteString data, Type type, IConnection client)
         {
-            var encodedDictionary = Schema.KRPC.Dictionary.Parser.ParseFrom (stream);
+            var encodedDictionary = Schema.KRPC.Dictionary.Parser.ParseFrom (data);
+            var keyType = type.GetGenericArguments () [0];
+            var valueType = type.GetGenericArguments () [1];
             var dictionary = (IDictionary)(typeof(Dictionary<,>)
-                .MakeGenericType (type.GetGenericArguments () [0], type.GetGenericArguments () [1])
+                .MakeGenericType (keyType, valueType)
                 .GetConstructor (Type.EmptyTypes)
                 .Invoke (null));
             foreach (var entry in encodedDictionary.Entries) {
-                var key = Decode (entry.Key, type.GetGenericArguments () [0], client);
-                var value = Decode (entry.Value, type.GetGenericArguments () [1], client);
+                var key = Decode (entry.Key, keyType, client);
+                var value = Decode (entry.Value, valueType, client);
                 dictionary [key] = value;
             }
             return dictionary;
+        }
+
+        /// <summary>
+        /// A float and the bits it is made of, laid over each other so that one can be had from
+        /// the other. The framework converts a double to its bits and back, and has nothing that
+        /// does the same for a float.
+        /// </summary>
+        [StructLayout (LayoutKind.Explicit)]
+        struct Single32
+        {
+            [FieldOffset (0)]
+            public float Value;
+
+            [FieldOffset (0)]
+            public uint Bits;
+        }
+
+        static uint ToBits (float value)
+        {
+            var single = default (Single32);
+            single.Value = value;
+            return single.Bits;
+        }
+
+        static float ToSingle (uint bits)
+        {
+            var single = default (Single32);
+            single.Bits = bits;
+            return single.Value;
+        }
+
+        // The buffer a value's bytes are written into before being copied out of it, one per
+        // thread. A value too big for it gets a buffer of its own rather than enlarging this one
+        // for the rest of the thread's life.
+        const int ScratchSize = 4096;
+
+        // The longest a varint can be: ten bytes, for a 64 bit value.
+        const int VarintSize = 10;
+
+        [ThreadStatic]
+        static byte[] scratch;
+
+        static byte[] Scratch (int size)
+        {
+            if (size > ScratchSize)
+                return new byte [size];
+            if (scratch == null)
+                scratch = new byte [ScratchSize];
+            return scratch;
+        }
+
+        static ByteString Varint (ulong value)
+        {
+            var buffer = Scratch (VarintSize);
+            return ByteString.CopyFrom (buffer, 0, WriteVarint (value, buffer, 0));
+        }
+
+        static int WriteVarint (ulong value, byte[] buffer, int offset)
+        {
+            var position = offset;
+            while (value > 0x7f) {
+                buffer [position++] = (byte)(value | 0x80);
+                value >>= 7;
+            }
+            buffer [position++] = (byte)value;
+            return position - offset;
+        }
+
+        static ByteString Fixed32 (uint bits)
+        {
+            var buffer = Scratch (4);
+            for (var i = 0; i < 4; i++)
+                buffer [i] = (byte)(bits >> (8 * i));
+            return ByteString.CopyFrom (buffer, 0, 4);
+        }
+
+        static ByteString Fixed64 (ulong bits)
+        {
+            var buffer = Scratch (8);
+            for (var i = 0; i < 8; i++)
+                buffer [i] = (byte)(bits >> (8 * i));
+            return ByteString.CopyFrom (buffer, 0, 8);
+        }
+
+        static ByteString EncodeString (string value)
+        {
+            var count = Encoding.UTF8.GetByteCount (value);
+            var buffer = Scratch (count + VarintSize);
+            var length = WriteVarint ((ulong)count, buffer, 0);
+            Encoding.UTF8.GetBytes (value, 0, value.Length, buffer, length);
+            return ByteString.CopyFrom (buffer, 0, length + count);
+        }
+
+        static ByteString EncodeBytes (byte[] value)
+        {
+            var buffer = Scratch (value.Length + VarintSize);
+            var length = WriteVarint ((ulong)value.Length, buffer, 0);
+            Buffer.BlockCopy (value, 0, buffer, length, value.Length);
+            return ByteString.CopyFrom (buffer, 0, length + value.Length);
+        }
+
+        static ulong ReadVarint (ByteString data)
+        {
+            ulong value = 0;
+            var shift = 0;
+            // A varint that has not ended by the time it has filled a 64 bit value is not one,
+            // and shifting any further would fold its bits back over the ones already read.
+            for (var i = 0; i < data.Length && shift < 64; i++) {
+                var b = data [i];
+                value |= (ulong)(b & 0x7f) << shift;
+                if ((b & 0x80) == 0)
+                    return value;
+                shift += 7;
+            }
+            throw new ArgumentException ("Value is not a varint");
+        }
+
+        static uint ReadFixed32 (ByteString data)
+        {
+            if (data.Length < 4)
+                throw new ArgumentException ("Value is not four bytes long");
+            uint bits = 0;
+            for (var i = 0; i < 4; i++)
+                bits |= (uint)data [i] << (8 * i);
+            return bits;
+        }
+
+        static ulong ReadFixed64 (ByteString data)
+        {
+            if (data.Length < 8)
+                throw new ArgumentException ("Value is not eight bytes long");
+            ulong bits = 0;
+            for (var i = 0; i < 8; i++)
+                bits |= (ulong)data [i] << (8 * i);
+            return bits;
+        }
+
+        static ulong EncodeZigZag (int value)
+        {
+            return (uint)((value << 1) ^ (value >> 31));
+        }
+
+        static ulong EncodeZigZag (long value)
+        {
+            return (ulong)((value << 1) ^ (value >> 63));
+        }
+
+        static int DecodeZigZag32 (ulong value)
+        {
+            var bits = (uint)value;
+            return (int)(bits >> 1) ^ -(int)(bits & 1);
+        }
+
+        static long DecodeZigZag64 (ulong value)
+        {
+            return (long)(value >> 1) ^ -(long)(value & 1);
         }
 
         static bool IsAGenericType (Type type, Type genericType)

--- a/client/csharp/src/Encoder.cs
+++ b/client/csharp/src/Encoder.cs
@@ -1,9 +1,5 @@
 using System;
 using System.Collections;
-using System.Collections.Generic;
-using System.Globalization;
-using System.Linq;
-using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Text;
 using Google.Protobuf;
@@ -65,60 +61,67 @@ namespace KRPC.Client
             case TypeCode.String:
                 return EncodeString ((string)value);
             default:
-                if (type.Equals (typeof(byte[])))
-                    return EncodeBytes ((byte[])value);
-                if (IsAClassType (type))
-                    return Varint (((RemoteObject)value).id);
-                if (IsATupleType (type))
-                    return EncodeTuple (value, type).ToByteString ();
-                if (IsAListType (type))
-                    return EncodeList (value, type).ToByteString ();
-                if (IsASetType (type))
-                    return EncodeSet (value, type).ToByteString ();
-                if (IsADictionaryType (type))
-                    return EncodeDictionary (value, type).ToByteString ();
-                if (IsAMessageType (type))
-                    return ((IMessage)value).ToByteString ();
+                return EncodeObject (value, type);
+            }
+        }
+
+        /// <summary>
+        /// Encode a value that is not a number, a string or an enumeration, from what is known
+        /// about its type.
+        /// </summary>
+        static ByteString EncodeObject (object value, Type type)
+        {
+            var info = TypeInfo.For (type);
+            switch (info.Kind) {
+            case TypeKind.Bytes:
+                return EncodeBytes ((byte[])value);
+            case TypeKind.Class:
+                return Varint (((RemoteObject)value).id);
+            case TypeKind.Tuple:
+                return EncodeTuple (value, info).ToByteString ();
+            case TypeKind.List:
+                return EncodeList (value, info).ToByteString ();
+            case TypeKind.Set:
+                return EncodeSet (value, info).ToByteString ();
+            case TypeKind.Dictionary:
+                return EncodeDictionary (value, info).ToByteString ();
+            case TypeKind.Message:
+                return ((IMessage)value).ToByteString ();
+            default:
                 throw new ArgumentException (type + " is not a serializable type");
             }
         }
 
-        static IMessage EncodeTuple (object value, Type type)
+        static IMessage EncodeTuple (object value, TypeInfo info)
         {
             var encodedTuple = new Schema.KRPC.Tuple ();
-            var valueTypes = type.GetGenericArguments ();
-            var genericType = Type.GetType ("System.Tuple`" + valueTypes.Length.ToString (CultureInfo.InvariantCulture));
-            var tupleType = genericType.MakeGenericType (valueTypes);
-            for (int i = 0; i < valueTypes.Length; i++) {
-                var property = tupleType.GetProperty ("Item" + (i + 1).ToString (CultureInfo.InvariantCulture));
-                var item = property.GetGetMethod ().Invoke (value, null);
-                encodedTuple.Items.Add (EncodeValue (item, valueTypes [i]));
-            }
+            for (int i = 0; i < info.Arguments.Length; i++)
+                encodedTuple.Items.Add (EncodeValue (info.Items [i] (value), info.Arguments [i]));
             return encodedTuple;
         }
 
-        static IMessage EncodeList (object value, Type type)
+        static IMessage EncodeList (object value, TypeInfo info)
         {
             var encodedList = new Schema.KRPC.List ();
-            var valueType = type.GetGenericArguments ().Single ();
+            var valueType = info.Arguments [0];
             foreach (var item in (IList)value)
                 encodedList.Items.Add (EncodeValue (item, valueType));
             return encodedList;
         }
 
-        static IMessage EncodeSet (object value, Type type)
+        static IMessage EncodeSet (object value, TypeInfo info)
         {
             var encodedSet = new Schema.KRPC.Set ();
-            var valueType = type.GetGenericArguments ().Single ();
+            var valueType = info.Arguments [0];
             foreach (var item in (IEnumerable)value)
                 encodedSet.Items.Add (EncodeValue (item, valueType));
             return encodedSet;
         }
 
-        static IMessage EncodeDictionary (object value, Type type)
+        static IMessage EncodeDictionary (object value, TypeInfo info)
         {
-            var keyType = type.GetGenericArguments () [0];
-            var valueType = type.GetGenericArguments () [1];
+            var keyType = info.Arguments [0];
+            var valueType = info.Arguments [1];
             var encodedDictionary = new Schema.KRPC.Dictionary ();
             foreach (DictionaryEntry entry in (IDictionary)value) {
                 var encodedEntry = new Schema.KRPC.DictionaryEntry ();
@@ -165,90 +168,82 @@ namespace KRPC.Client
             case TypeCode.String:
                 return value.CreateCodedInput ().ReadString ();
             default:
-                if (type.Equals (typeof(byte[])))
-                    return value.CreateCodedInput ().ReadBytes ().ToByteArray ();
-                if (IsAClassType (type)) {
-                    if (client == null)
-                        throw new ArgumentException ("Client not passed when decoding remote object");
-                    return (RemoteObject)Activator.CreateInstance (type, client, ReadVarint (value));
-                }
-                if (IsATupleType (type))
-                    return DecodeTuple (value, type, client);
-                if (IsAListType (type))
-                    return DecodeList (value, type, client);
-                if (IsASetType (type))
-                    return DecodeSet (value, type, client);
-                if (IsADictionaryType (type))
-                    return DecodeDictionary (value, type, client);
-                if (IsAMessageType (type)) {
+                return DecodeObject (value, type, client);
+            }
+        }
+
+        /// <summary>
+        /// Decode a value that is not a number, a string or an enumeration, from what is known
+        /// about its type.
+        /// </summary>
+        static object DecodeObject (ByteString value, Type type, IConnection client)
+        {
+            var info = TypeInfo.For (type);
+            switch (info.Kind) {
+            case TypeKind.Bytes:
+                return value.CreateCodedInput ().ReadBytes ().ToByteArray ();
+            case TypeKind.Class:
+                if (client == null)
+                    throw new ArgumentException ("Client not passed when decoding remote object");
+                return info.NewObject (client, ReadVarint (value));
+            case TypeKind.Tuple:
+                return DecodeTuple (value, info, client);
+            case TypeKind.List:
+                return DecodeList (value, info, client);
+            case TypeKind.Set:
+                return DecodeSet (value, info, client);
+            case TypeKind.Dictionary:
+                return DecodeDictionary (value, info, client);
+            case TypeKind.Message: {
                     var message = (IMessage)Activator.CreateInstance (type);
                     message.MergeFrom (value);
                     return message;
                 }
-                if (type == typeof (Event)) {
+            case TypeKind.Event: {
                     var message = new Schema.KRPC.Event ();
                     message.MergeFrom (value);
                     return new Event ((Connection)client, message);
                 }
+            default:
                 throw new ArgumentException (type + " is not a serializable type");
             }
         }
 
-        static object DecodeTuple (ByteString data, Type type, IConnection client)
+        static object DecodeTuple (ByteString data, TypeInfo info, IConnection client)
         {
             var encodedTuple = Schema.KRPC.Tuple.Parser.ParseFrom (data);
-            var valueTypes = type.GetGenericArguments ();
-            var genericType = Type.GetType ("System.Tuple`" + valueTypes.Length.ToString (CultureInfo.InvariantCulture));
-            var values = new object[valueTypes.Length];
-            for (int i = 0; i < valueTypes.Length; i++) {
-                var item = encodedTuple.Items [i];
-                values [i] = Decode (item, valueTypes [i], client);
-            }
-            var tuple = genericType
-                .MakeGenericType (valueTypes)
-                .GetConstructor (valueTypes)
-                .Invoke (values);
-            return tuple;
+            var values = new object [info.Arguments.Length];
+            for (int i = 0; i < values.Length; i++)
+                values [i] = Decode (encodedTuple.Items [i], info.Arguments [i], client);
+            return info.NewTuple (values);
         }
 
-        static object DecodeList (ByteString data, Type type, IConnection client)
+        static object DecodeList (ByteString data, TypeInfo info, IConnection client)
         {
             var encodedList = Schema.KRPC.List.Parser.ParseFrom (data);
-            var valueType = type.GetGenericArguments ().Single ();
-            var list = (IList)(typeof(List<>)
-                .MakeGenericType (valueType)
-                .GetConstructor (Type.EmptyTypes)
-                .Invoke (null));
+            var valueType = info.Arguments [0];
+            var list = (IList)info.New ();
             foreach (var item in encodedList.Items)
                 list.Add (Decode (item, valueType, client));
             return list;
         }
 
-        static object DecodeSet (ByteString data, Type type, IConnection client)
+        static object DecodeSet (ByteString data, TypeInfo info, IConnection client)
         {
             var encodedSet = Schema.KRPC.Set.Parser.ParseFrom (data);
-            var valueType = type.GetGenericArguments ().Single ();
-            var set = (IEnumerable)(typeof(HashSet<>)
-                .MakeGenericType (valueType)
-                .GetConstructor (Type.EmptyTypes)
-                .Invoke (null));
-            MethodInfo methodInfo = type.GetMethod ("Add");
-            foreach (var item in encodedSet.Items) {
-                var decodedItem = Decode (item, valueType, client);
-                methodInfo.Invoke (set, new [] { decodedItem });
-            }
+            var valueType = info.Arguments [0];
+            var set = info.New ();
+            foreach (var item in encodedSet.Items)
+                info.Add (set, Decode (item, valueType, client));
             return set;
         }
 
-        static object DecodeDictionary (ByteString data, Type type, IConnection client)
+        static object DecodeDictionary (ByteString data, TypeInfo info, IConnection client)
         {
             var encodedDictionary = Schema.KRPC.Dictionary.Parser.ParseFrom (data);
-            var keyType = type.GetGenericArguments () [0];
-            var valueType = type.GetGenericArguments () [1];
-            var dictionary = (IDictionary)(typeof(Dictionary<,>)
-                .MakeGenericType (keyType, valueType)
-                .GetConstructor (Type.EmptyTypes)
-                .Invoke (null));
+            var keyType = info.Arguments [0];
+            var valueType = info.Arguments [1];
+            var dictionary = (IDictionary)info.New ();
             foreach (var entry in encodedDictionary.Entries) {
                 var key = Decode (entry.Key, keyType, client);
                 var value = Decode (entry.Value, valueType, client);
@@ -411,62 +406,6 @@ namespace KRPC.Client
         static long DecodeZigZag64 (ulong value)
         {
             return (long)(value >> 1) ^ -(long)(value & 1);
-        }
-
-        static bool IsAGenericType (Type type, Type genericType)
-        {
-            while (!ReferenceEquals (type, null)) {
-                if (type.IsGenericType && type.GetGenericTypeDefinition ().Equals (genericType))
-                    return true;
-                foreach (var intType in type.GetInterfaces())
-                    if (IsAGenericType (intType, genericType))
-                        return true;
-                type = type.BaseType;
-            }
-            return false;
-        }
-
-        static bool IsAClassType (Type type)
-        {
-            return type.IsSubclassOf (typeof(RemoteObject));
-        }
-
-        static bool IsATupleType (Type type)
-        {
-            return
-            IsAGenericType (type, typeof(Tuple<>)) ||
-            IsAGenericType (type, typeof(Tuple<,>)) ||
-            IsAGenericType (type, typeof(Tuple<,,>)) ||
-            IsAGenericType (type, typeof(Tuple<,,,>)) ||
-            IsAGenericType (type, typeof(Tuple<,,,,>)) ||
-            IsAGenericType (type, typeof(Tuple<,,,,,>)) ||
-            IsAGenericType (type, typeof(Tuple<,,,,,,>)) ||
-            IsAGenericType (type, typeof(Tuple<,,,,,,,>));
-        }
-
-        static bool IsACollectionType (Type type)
-        {
-            return IsATupleType (type) || IsAListType (type) || IsASetType (type) || IsADictionaryType (type);
-        }
-
-        static bool IsAListType (Type type)
-        {
-            return IsAGenericType (type, typeof(IList<>));
-        }
-
-        static bool IsASetType (Type type)
-        {
-            return IsAGenericType (type, typeof(ISet<>));
-        }
-
-        static bool IsADictionaryType (Type type)
-        {
-            return IsAGenericType (type, typeof(IDictionary<,>));
-        }
-
-        static bool IsAMessageType (Type type)
-        {
-            return typeof(IMessage).IsAssignableFrom (type);
         }
     }
 }

--- a/client/csharp/src/Encoder.cs
+++ b/client/csharp/src/Encoder.cs
@@ -30,9 +30,9 @@ namespace KRPC.Client
         /// </summary>
         /// <remarks>
         /// A number, a string or an object identifier is a handful of bytes on the wire, and its
-        /// bytes are written into a buffer the thread keeps and copied out of it. A coded output
-        /// stream carries a buffer of several kilobytes of its own, which is far more to allocate
-        /// for one number than writing the number costs. Anything carried by a protobuf message
+        /// bytes are written into a buffer of that size. A coded output stream carries a buffer
+        /// of several kilobytes of its own, which is far more to allocate for one number than
+        /// writing the number costs. Anything carried by a protobuf message
         /// is left to protobuf to serialize.
         /// </remarks>
         static ByteString EncodeValue (object value, Type type)
@@ -281,29 +281,17 @@ namespace KRPC.Client
             return single.Value;
         }
 
-        // The buffer a value's bytes are written into before being copied out of it, one per
-        // thread. A value too big for it gets a buffer of its own rather than enlarging this one
-        // for the rest of the thread's life.
-        const int ScratchSize = 4096;
-
         // The longest a varint can be: ten bytes, for a 64 bit value.
         const int VarintSize = 10;
 
-        [ThreadStatic]
-        static byte[] scratch;
-
-        static byte[] Scratch (int size)
-        {
-            if (size > ScratchSize)
-                return new byte [size];
-            if (scratch == null)
-                scratch = new byte [ScratchSize];
-            return scratch;
-        }
+        // A value's bytes are written into a buffer of their own, made where they are written.
+        // Keeping one buffer per thread instead was measured and is far worse: reaching a
+        // thread's own static costs several times what making a buffer this small costs, and it
+        // is reached once for every value written.
 
         static ByteString Varint (ulong value)
         {
-            var buffer = Scratch (VarintSize);
+            var buffer = new byte [VarintSize];
             return ByteString.CopyFrom (buffer, 0, WriteVarint (value, buffer, 0));
         }
 
@@ -320,7 +308,7 @@ namespace KRPC.Client
 
         static ByteString Fixed32 (uint bits)
         {
-            var buffer = Scratch (4);
+            var buffer = new byte [4];
             for (var i = 0; i < 4; i++)
                 buffer [i] = (byte)(bits >> (8 * i));
             return ByteString.CopyFrom (buffer, 0, 4);
@@ -328,7 +316,7 @@ namespace KRPC.Client
 
         static ByteString Fixed64 (ulong bits)
         {
-            var buffer = Scratch (8);
+            var buffer = new byte [8];
             for (var i = 0; i < 8; i++)
                 buffer [i] = (byte)(bits >> (8 * i));
             return ByteString.CopyFrom (buffer, 0, 8);
@@ -337,7 +325,7 @@ namespace KRPC.Client
         static ByteString EncodeString (string value)
         {
             var count = Encoding.UTF8.GetByteCount (value);
-            var buffer = Scratch (count + VarintSize);
+            var buffer = new byte [count + VarintSize];
             var length = WriteVarint ((ulong)count, buffer, 0);
             Encoding.UTF8.GetBytes (value, 0, value.Length, buffer, length);
             return ByteString.CopyFrom (buffer, 0, length + count);
@@ -345,7 +333,7 @@ namespace KRPC.Client
 
         static ByteString EncodeBytes (byte[] value)
         {
-            var buffer = Scratch (value.Length + VarintSize);
+            var buffer = new byte [value.Length + VarintSize];
             var length = WriteVarint ((ulong)value.Length, buffer, 0);
             Buffer.BlockCopy (value, 0, buffer, length, value.Length);
             return ByteString.CopyFrom (buffer, 0, length + value.Length);

--- a/client/csharp/src/KRPC.Client.csproj
+++ b/client/csharp/src/KRPC.Client.csproj
@@ -37,6 +37,7 @@
     <Compile Include="Event.cs" />
     <Compile Include="ExpressionUtils.cs" />
     <Compile Include="IConnection.cs" />
+    <Compile Include="MessageReader.cs" />
     <Compile Include="RPCException.cs" />
     <Compile Include="RemoteObject.cs" />
     <Compile Include="Stream.cs" />

--- a/client/csharp/src/KRPC.Client.csproj
+++ b/client/csharp/src/KRPC.Client.csproj
@@ -43,6 +43,7 @@
     <Compile Include="Stream.cs" />
     <Compile Include="StreamImpl.cs" />
     <Compile Include="StreamManager.cs" />
+    <Compile Include="TypeInfo.cs" />
     <Compile Include="$(bazel-bin)\protobuf\KRPC.cs">
       <Link>KRPC.cs</Link>
     </Compile>

--- a/client/csharp/src/MessageReader.cs
+++ b/client/csharp/src/MessageReader.cs
@@ -1,0 +1,168 @@
+using System.IO;
+using System.Threading;
+
+namespace KRPC.Client
+{
+    /// <summary>
+    /// Reads length prefixed messages from a stream, a block at a time.
+    /// </summary>
+    /// <remarks>
+    /// The server puts the length of a message in front of it as a varint. Taken straight from
+    /// the stream, finding out how long a message is costs a read for every byte of that prefix
+    /// and the message itself costs another, so a response that has already arrived whole still
+    /// takes several reads to pick up. Buffering the stream instead means a read takes whatever
+    /// has arrived, and messages are then taken out of the buffer; what came along with one is
+    /// already in hand when the next is asked for. A message is parsed where it lies, so nothing
+    /// is copied out of the buffer on the way.
+    /// </remarks>
+    sealed class MessageReader
+    {
+        // Big enough that anything a server sends arrives in one read.
+        const int InitialSize = 1024 * 1024;
+
+        // How much more room to make when a message does not fit in the buffer.
+        const int IncreaseSize = 512 * 1024;
+
+        // A length prefix is a varint, and one that does not end within five bytes cannot be the
+        // uint32 it is meant to be.
+        const int MaximumPrefixLength = 5;
+
+        readonly Stream stream;
+        byte[] buffer = new byte [InitialSize];
+
+        // What has been read but not yet handed out, as the half open range [start, end) of the
+        // buffer.
+        int start;
+        int end;
+
+        public MessageReader (Stream messageStream)
+        {
+            stream = messageStream;
+        }
+
+        /// <summary>
+        /// The buffer holding the message last read, where in it that message starts and how
+        /// long it is. They describe that message until the next one is read.
+        /// </summary>
+        public byte[] Buffer {
+            get { return buffer; }
+        }
+
+        /// <summary>
+        /// See <see cref="Buffer"/>.
+        /// </summary>
+        public int Offset { get; private set; }
+
+        /// <summary>
+        /// See <see cref="Buffer"/>.
+        /// </summary>
+        public int Size { get; private set; }
+
+        /// <summary>
+        /// Read the next message, and return whether one was read. If a stop event is given and
+        /// is signaled while waiting for a message, returns false without having read one.
+        /// </summary>
+        public bool Read (EventWaitHandle stopEvent = null)
+        {
+            int size;
+            int prefix;
+            while (!Prefix (out size, out prefix)) {
+                if (!Fill (stopEvent))
+                    return false;
+            }
+            // The prefix and the message together, so that neither making room for the message
+            // nor reading the rest of it moves the buffer once the message has been found in it.
+            Reserve (prefix + size);
+            while (end - start < prefix + size) {
+                if (!Fill (stopEvent))
+                    return false;
+            }
+            Offset = start + prefix;
+            Size = size;
+            start += prefix + size;
+            return true;
+        }
+
+        /// <summary>
+        /// The length of the next message and of the prefix carrying it, from what has been read
+        /// so far. False if the whole prefix has not arrived yet.
+        /// </summary>
+        bool Prefix (out int size, out int length)
+        {
+            size = 0;
+            length = 0;
+            ulong value = 0;
+            var shift = 0;
+            for (var i = start; i < end; i++) {
+                var b = buffer [i];
+                value |= (ulong)(b & 0x7f) << shift;
+                length++;
+                if ((b & 0x80) == 0) {
+                    // Room is made for the prefix and the message together, so the two have to
+                    // add up to something an array can be indexed by.
+                    if (value > int.MaxValue - MaximumPrefixLength)
+                        throw new InvalidDataException ("Message is longer than can be read");
+                    size = (int)value;
+                    return true;
+                }
+                if (length == MaximumPrefixLength)
+                    throw new InvalidDataException ("Message length prefix is malformed");
+                shift += 7;
+            }
+            return false;
+        }
+
+        /// <summary>
+        /// Read a block from the stream into the buffer, and return whether to carry on. A stop
+        /// event is checked either side of the read, since the read itself does not observe it.
+        /// </summary>
+        bool Fill (EventWaitHandle stopEvent)
+        {
+            if (Stopped (stopEvent))
+                return false;
+            // Room for at least one byte more than is in hand, so that there is somewhere to put
+            // what the read takes.
+            Reserve (end - start + 1);
+            var read = stream.Read (buffer, end, buffer.Length - end);
+            if (read <= 0)
+                throw new EndOfStreamException ("Connection closed by the server");
+            end += read;
+            return !Stopped (stopEvent);
+        }
+
+        /// <summary>
+        /// Make room for the given number of bytes from the start of what has been read, moving
+        /// that down the buffer and growing the buffer as needed.
+        /// </summary>
+        void Reserve (int size)
+        {
+            if (buffer.Length - start >= size)
+                return;
+            if (start > 0) {
+                System.Buffer.BlockCopy (buffer, start, buffer, 0, end - start);
+                end -= start;
+                start = 0;
+            }
+            if (buffer.Length >= size)
+                return;
+            var length = buffer.Length;
+            while (length < size) {
+                // Stepping up past what an array can hold would wrap around to a negative
+                // length, so the last step up is to exactly what is needed.
+                if (length > int.MaxValue - IncreaseSize) {
+                    length = size;
+                    break;
+                }
+                length += IncreaseSize;
+            }
+            var grown = new byte [length];
+            System.Buffer.BlockCopy (buffer, 0, grown, 0, end);
+            buffer = grown;
+        }
+
+        static bool Stopped (EventWaitHandle stopEvent)
+        {
+            return stopEvent != null && stopEvent.WaitOne (0);
+        }
+    }
+}

--- a/client/csharp/src/StreamManager.cs
+++ b/client/csharp/src/StreamManager.cs
@@ -1,9 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Net.Sockets;
 using System.Threading;
-using Google.Protobuf;
 using KRPC.Client.Services.KRPC;
 using KRPC.Schema.KRPC;
 
@@ -17,10 +15,10 @@ namespace KRPC.Client
         readonly UpdateThread updateThreadObject;
         readonly Thread updateThread;
 
-        public StreamManager (Connection serverConnection, TcpClient streamClient)
+        public StreamManager (Connection serverConnection, MessageReader reader)
         {
             connection = serverConnection;
-            updateThreadObject = new UpdateThread (this, streamClient);
+            updateThreadObject = new UpdateThread (this, reader);
             updateThread = new Thread (new ThreadStart (updateThreadObject.Main));
             updateThread.Start ();
         }
@@ -139,15 +137,14 @@ namespace KRPC.Client
         sealed class UpdateThread
         {
             readonly StreamManager manager;
-            readonly NetworkStream stream;
+            readonly MessageReader reader;
             volatile bool stop;
             readonly EventWaitHandle stopEvent = new EventWaitHandle (false, EventResetMode.ManualReset);
-            byte [] buffer = new byte [Connection.BUFFER_INITIAL_SIZE];
 
-            public UpdateThread (StreamManager streamManager, TcpClient streamClient)
+            public UpdateThread (StreamManager streamManager, MessageReader streamReader)
             {
                 manager = streamManager;
-                stream = streamClient.GetStream ();
+                reader = streamReader;
             }
 
             public void Stop ()
@@ -160,10 +157,10 @@ namespace KRPC.Client
             {
                 try {
                     while (!stop) {
-                        var size = Connection.ReadMessageData (stream, ref buffer, stopEvent);
-                        if (size == 0 || stop)
+                        if (!reader.Read (stopEvent) || stop)
                             break;
-                        var update = StreamUpdate.Parser.ParseFrom (new CodedInputStream (buffer, 0, size));
+                        var update = StreamUpdate.Parser.ParseFrom (
+                            reader.Buffer, reader.Offset, reader.Size);
                         if (stop)
                             break;
                         foreach (var result in update.Results) {

--- a/client/csharp/src/TypeInfo.cs
+++ b/client/csharp/src/TypeInfo.cs
@@ -1,0 +1,220 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq.Expressions;
+using Google.Protobuf;
+
+namespace KRPC.Client
+{
+    /// <summary>
+    /// The kinds of value the encoding carries that are not a number, a string or a block of
+    /// bytes. Which one a type is decides how it is encoded and decoded.
+    /// </summary>
+    enum TypeKind
+    {
+        Unsupported,
+        Bytes,
+        Class,
+        Tuple,
+        List,
+        Set,
+        Dictionary,
+        Message,
+        Event
+    }
+
+    /// <summary>
+    /// What the encoding needs to know about a type, worked out once and kept.
+    /// </summary>
+    /// <remarks>
+    /// Deciding which kind a type is means walking its interfaces and its base types, and
+    /// building a value of it means finding a constructor, a property or a method by name.
+    /// Neither answer changes over the life of a program, and both were being worked out again
+    /// for every value encoded or decoded: a call returning a list of parts asked what a part is
+    /// once per part, and a call returning a position asked what a tuple of three doubles is,
+    /// and then which constructor builds one, on every call.
+    ///
+    /// The delegates below are compiled from expression trees, as the client already does to
+    /// turn a call into a procedure to invoke.
+    /// </remarks>
+    sealed class TypeInfo
+    {
+        static readonly ConcurrentDictionary<Type, TypeInfo> cache =
+            new ConcurrentDictionary<Type, TypeInfo> ();
+
+        /// <summary>
+        /// What is known about the given type.
+        /// </summary>
+        public static TypeInfo For (Type type)
+        {
+            TypeInfo info;
+            if (cache.TryGetValue (type, out info))
+                return info;
+            return cache.GetOrAdd (type, new TypeInfo (type));
+        }
+
+        TypeInfo (Type type)
+        {
+            if (type.Equals (typeof(byte[]))) {
+                Kind = TypeKind.Bytes;
+            } else if (type.IsSubclassOf (typeof(RemoteObject))) {
+                Kind = TypeKind.Class;
+                NewObject = ObjectConstructor (type);
+            } else if (IsATupleType (type)) {
+                Kind = TypeKind.Tuple;
+                Arguments = type.GetGenericArguments ();
+                Items = TupleItems (Arguments);
+                NewTuple = TupleConstructor (Arguments);
+            } else if (IsAGenericType (type, typeof(IList<>))) {
+                Kind = TypeKind.List;
+                Arguments = type.GetGenericArguments ();
+                New = Constructor (typeof(List<>).MakeGenericType (Arguments));
+            } else if (IsAGenericType (type, typeof(ISet<>))) {
+                Kind = TypeKind.Set;
+                Arguments = type.GetGenericArguments ();
+                New = Constructor (typeof(HashSet<>).MakeGenericType (Arguments));
+                Add = SetAdder (type, Arguments [0]);
+            } else if (IsAGenericType (type, typeof(IDictionary<,>))) {
+                Kind = TypeKind.Dictionary;
+                Arguments = type.GetGenericArguments ();
+                New = Constructor (typeof(Dictionary<,>).MakeGenericType (Arguments));
+            } else if (typeof(IMessage).IsAssignableFrom (type)) {
+                Kind = TypeKind.Message;
+            } else if (type.Equals (typeof(Event))) {
+                Kind = TypeKind.Event;
+            } else {
+                Kind = TypeKind.Unsupported;
+            }
+        }
+
+        /// <summary>
+        /// Which kind of value the type carries.
+        /// </summary>
+        public TypeKind Kind { get; private set; }
+
+        /// <summary>
+        /// The types of the values a collection holds: the item types of a tuple, the element
+        /// type of a list or a set, or the key and value types of a dictionary.
+        /// </summary>
+        public Type[] Arguments { get; private set; }
+
+        /// <summary>
+        /// Build a remote object of the type, given the connection it lives on and its
+        /// identifier on the server.
+        /// </summary>
+        public Func<IConnection, ulong, RemoteObject> NewObject { get; private set; }
+
+        /// <summary>
+        /// Build an empty collection to decode a list, a set or a dictionary into.
+        /// </summary>
+        public Func<object> New { get; private set; }
+
+        /// <summary>
+        /// Add a value to a set built by <see cref="New"/>.
+        /// </summary>
+        public Action<object, object> Add { get; private set; }
+
+        /// <summary>
+        /// Build a tuple from its items, in the order <see cref="Arguments"/> names them.
+        /// </summary>
+        public Func<object[], object> NewTuple { get; private set; }
+
+        /// <summary>
+        /// Take the items out of a tuple, in the order <see cref="Arguments"/> names them.
+        /// </summary>
+        public Func<object, object>[] Items { get; private set; }
+
+        static Func<IConnection, ulong, RemoteObject> ObjectConstructor (Type type)
+        {
+            var connection = Expression.Parameter (typeof(IConnection));
+            var id = Expression.Parameter (typeof(ulong));
+            var constructor = type.GetConstructor (new [] { typeof(IConnection), typeof(ulong) });
+            return Expression.Lambda<Func<IConnection, ulong, RemoteObject>> (
+                Expression.New (constructor, connection, id), connection, id).Compile ();
+        }
+
+        static Func<object> Constructor (Type type)
+        {
+            return Expression.Lambda<Func<object>> (
+                Expression.Convert (Expression.New (type), typeof(object))).Compile ();
+        }
+
+        static Action<object, object> SetAdder (Type type, Type valueType)
+        {
+            var set = Expression.Parameter (typeof(object));
+            var item = Expression.Parameter (typeof(object));
+            // The result of Add says whether the set already held the value, and is discarded.
+            return Expression.Lambda<Action<object, object>> (
+                Expression.Block (
+                    Expression.Call (Expression.Convert (set, type), type.GetMethod ("Add"),
+                                     Expression.Convert (item, valueType)),
+                    Expression.Empty ()),
+                set, item).Compile ();
+        }
+
+        static Type TupleType (Type[] valueTypes)
+        {
+            var generic = Type.GetType (
+                "System.Tuple`" + valueTypes.Length.ToString (CultureInfo.InvariantCulture));
+            return generic.MakeGenericType (valueTypes);
+        }
+
+        static Func<object[], object> TupleConstructor (Type[] valueTypes)
+        {
+            var values = Expression.Parameter (typeof(object[]));
+            var items = new Expression [valueTypes.Length];
+            for (var i = 0; i < valueTypes.Length; i++)
+                items [i] = Expression.Convert (
+                    Expression.ArrayIndex (values, Expression.Constant (i)), valueTypes [i]);
+            return Expression.Lambda<Func<object[], object>> (
+                Expression.Convert (
+                    Expression.New (TupleType (valueTypes).GetConstructor (valueTypes), items),
+                    typeof(object)),
+                values).Compile ();
+        }
+
+        static Func<object, object>[] TupleItems (Type[] valueTypes)
+        {
+            var tupleType = TupleType (valueTypes);
+            var items = new Func<object, object> [valueTypes.Length];
+            for (var i = 0; i < valueTypes.Length; i++) {
+                var tuple = Expression.Parameter (typeof(object));
+                var name = "Item" + (i + 1).ToString (CultureInfo.InvariantCulture);
+                items [i] = Expression.Lambda<Func<object, object>> (
+                    Expression.Convert (
+                        Expression.Property (Expression.Convert (tuple, tupleType),
+                                             tupleType.GetProperty (name)),
+                        typeof(object)),
+                    tuple).Compile ();
+            }
+            return items;
+        }
+
+        static bool IsATupleType (Type type)
+        {
+            return
+            IsAGenericType (type, typeof(Tuple<>)) ||
+            IsAGenericType (type, typeof(Tuple<,>)) ||
+            IsAGenericType (type, typeof(Tuple<,,>)) ||
+            IsAGenericType (type, typeof(Tuple<,,,>)) ||
+            IsAGenericType (type, typeof(Tuple<,,,,>)) ||
+            IsAGenericType (type, typeof(Tuple<,,,,,>)) ||
+            IsAGenericType (type, typeof(Tuple<,,,,,,>)) ||
+            IsAGenericType (type, typeof(Tuple<,,,,,,,>));
+        }
+
+        static bool IsAGenericType (Type type, Type genericType)
+        {
+            while (!ReferenceEquals (type, null)) {
+                if (type.IsGenericType && type.GetGenericTypeDefinition ().Equals (genericType))
+                    return true;
+                foreach (var intType in type.GetInterfaces())
+                    if (IsAGenericType (intType, genericType))
+                        return true;
+                type = type.BaseType;
+            }
+            return false;
+        }
+    }
+}

--- a/client/lua/CHANGELOG.md
+++ b/client/lua/CHANGELOG.md
@@ -6,6 +6,13 @@
   such as `krpc.limits.SINT32_MAX` and `krpc.limits.DOUBLE_LOWEST`. Lua names none of them
   itself, as `math.maxinteger` and `math.mininteger` need Lua 5.3, and a parameter that
   defaults to one is now documented as the constant rather than the decimal value (#1045)
+- Reduce the cost of a remote procedure call. The request carrying a call is written as the
+  bytes it comes to, rather than built as a protocol buffer message and serialized, and so are
+  the lists, sets, tuples and dictionaries a call carries, which are read back the same way. A
+  value is encoded and decoded by looking up its type code rather than by asking the type what
+  class it is, a float or a double is packed without building a protobuf field encoder for it,
+  the size of a message is read directly rather than by handing each byte to a decoder until it
+  stops raising an error, and the client connection disables Nagle's algorithm (#1056)
 
 ## [v0.6.0]
 - Fix `attributes` module to always return boolean for `is_a_class_member` and `is_a_class_property_accessor` (#850)

--- a/client/lua/krpc/client.lua
+++ b/client/lua/krpc/client.lua
@@ -45,8 +45,8 @@ function Client:_invoke(service, procedure, args, param_types, return_type)
   -- Build the request
   local request = self:_build_request(service, procedure, args, param_types)
 
-  -- Send the request
-  self._rpc_connection:send_message(request)
+  -- Send the request, which is already the bytes to send
+  self._rpc_connection:send(request)
   local response = self._rpc_connection:receive_message(schema.Response)
 
   -- Check for an error response
@@ -70,20 +70,15 @@ function Client:_invoke(service, procedure, args, param_types, return_type)
   return nil
 end
 
---- Build a KRPC.Request object
+--- Build the bytes of the request carrying a procedure call, ready to send
 function Client:_build_request(service, procedure, args, param_types)
-  local request = schema.Request()
-  local call = request.calls:add()
-  call.service = service
-  call.procedure = procedure
+  local arguments = {}
 
   for i,value in ipairs(args) do
     local typ = param_types[i]
-    local arg = call.arguments:add()
-    arg.position = i-1
     if value == Types.none then
       -- A null argument is signaled out-of-band by is_null; the value field is left unset
-      arg.is_null = true
+      arguments[i] = Types.none
     else
       local valid = false
       if type(typ.lua_type) == 'string' then
@@ -100,11 +95,11 @@ function Client:_build_request(service, procedure, args, param_types)
           error(string.format('%s.%s() argument %d must be a %s, got a %s', service, procedure, i, typ.lua_type, type(value)))
         end
       end
-      arg.value = encoder.encode(value, typ)
+      arguments[i] = encoder.encode(value, typ)
     end
   end
 
-  return request
+  return encoder.encode_request(service, procedure, arguments)
 end
 
 --- Construct an error description from a KRPC.Error object

--- a/client/lua/krpc/client.lua
+++ b/client/lua/krpc/client.lua
@@ -18,7 +18,7 @@ function Client:_init(rpc_connection)
   self._rpc_connection = rpc_connection
 
   -- Set up the main KRPC service
-  local services = self:_invoke('KRPC', 'GetServices', nil, nil, nil, self._types:services_type()).services
+  local services = self:_invoke('KRPC', 'GetServices', nil, nil, self._types:services_type()).services
 
   -- Register the types of every service before creating any of them: a service's procedures
   -- are built from types that any service may define, and a default value cannot be decoded
@@ -38,13 +38,12 @@ function Client:close()
 end
 
 --- Execute an RPC
-function Client:_invoke(service, procedure, args, param_names, param_types, return_type)
+function Client:_invoke(service, procedure, args, param_types, return_type)
   args = args or List{}
-  param_names = param_names or List{}
   param_types = param_types or List{}
 
   -- Build the request
-  local request = self:_build_request(service, procedure, args, param_names, param_types, return_type)
+  local request = self:_build_request(service, procedure, args, param_types)
 
   -- Send the request
   self._rpc_connection:send_message(request)
@@ -72,7 +71,7 @@ function Client:_invoke(service, procedure, args, param_names, param_types, retu
 end
 
 --- Build a KRPC.Request object
-function Client:_build_request(service, procedure, args, param_names, param_types, return_type)
+function Client:_build_request(service, procedure, args, param_types)
   local request = schema.Request()
   local call = request.calls:add()
   call.service = service

--- a/client/lua/krpc/connection.lua
+++ b/client/lua/krpc/connection.lua
@@ -60,20 +60,24 @@ function Connection:send_message(message)
 end
 
 function Connection:receive_message(typ)
-  -- Receive a protobuf message.
-  local size
-  local data = ''
-  while true do
-    data = data .. self:receive(1)
-    local ok, result = pcall(decoder.decode_size, data)
-    if ok then
-      size = result
-      break
+  -- Receive a protobuf message. Its size arrives in front of it as a varint, and how long that
+  -- varint is is only known once its last byte has arrived, so it is read a byte at a time.
+  -- Reading the size itself, rather than handing what has arrived so far to a decoder that
+  -- raises an error until the whole of it has, saves a protected call for every one of those
+  -- bytes.
+  local size = 0
+  local shift = 1
+  -- A message size is a 32 bit value, so five bytes carry the whole of it. A varint that has
+  -- not ended by then is not a size, however much more of it arrives.
+  for _ = 1, 5 do
+    local byte = self:receive(1):byte()
+    size = size + (byte % 128) * shift
+    if byte < 128 then
+      return decoder.decode_message(self:receive(size), typ)
     end
+    shift = shift * 128
   end
-
-  data = self:receive(size)
-  return decoder.decode_message(data, typ)
+  error('Failed to decode the size of a message')
 end
 
 return Connection

--- a/client/lua/krpc/connection.lua
+++ b/client/lua/krpc/connection.lua
@@ -17,6 +17,10 @@ function Connection:connect()
   if result == nil then
     error('Socket error: ' .. err)
   end
+  -- A call writes a request and then waits for its response, so there is never a second small
+  -- write for Nagle's algorithm to hold the first one back for. Left on, it can only delay a
+  -- request the server is already waiting for.
+  self._socket:setoption('tcp-nodelay', true)
 end
 
 function Connection:close()

--- a/client/lua/krpc/decoder.lua
+++ b/client/lua/krpc/decoder.lua
@@ -72,6 +72,64 @@ function decoder.guid(data)
   return table.concat(parts, '-')
 end
 
+-- The tag every value of a collection is carried under: field number 1, length delimited, for
+-- the items of a Tuple, a List and a Set and for the entries of a Dictionary. A DictionaryEntry
+-- carries its key under the same tag and its value under field number 2. See the same list in
+-- the encoder, which writes them, and test_decoder, which reads collections written by the
+-- protocol buffer message layer back through these.
+local _ITEMS = 10
+local _ENTRY_KEY = 10
+local _ENTRY_VALUE = 18
+
+--- Read the values a collection carries, each a length delimited field under the given tag.
+--
+-- Read here rather than by parsing a message, for the reason the encoder writes them here: the
+-- protocol buffer library is written in lua, and parsing a message of a hundred values into a
+-- container that type checks each one costs far more than reading the bytes does.
+local function _decode_items(data, tag)
+  local items = {}
+  local count = 0
+  local position = 0
+  local length = data:len()
+  while position < length do
+    if data:byte(position+1) ~= tag then
+      error('Unexpected field in an encoded collection')
+    end
+    local size, after = pb.varint_decoder(data, position+1)
+    items[count+1] = data:sub(after+1, after+size)
+    count = count + 1
+    position = after + size
+  end
+  return items, count
+end
+
+--- Read the key and the value out of one entry of a dictionary.
+--
+-- The two are read by the tag in front of each rather than by the order they are in, as a
+-- message carries its fields in whatever order the writer chose.
+local function _decode_entry(data)
+  -- A key or a value that encodes to nothing, an empty collection or an empty string among
+  -- them, is left out of the entry entirely, and reads back as the nothing it was
+  local key = ''
+  local value = ''
+  local position = 0
+  local length = data:len()
+  while position < length do
+    local tag = data:byte(position+1)
+    local size, after = pb.varint_decoder(data, position+1)
+    local field = data:sub(after+1, after+size)
+    if tag == _ENTRY_KEY then
+      key = field
+    elseif tag == _ENTRY_VALUE then
+      value = field
+    else
+      error('Unexpected field in an encoded dictionary entry')
+    end
+    position = after + size
+  end
+  return key, value
+end
+
 function decoder.decode(data, typ)
   local code = typ.code
   local decode_value = _value_decoders[code]
@@ -79,34 +137,37 @@ function decoder.decode(data, typ)
     return decode_value(data, typ)
   end
   if code == Types.LIST then
-    local msg = decoder.decode_message(data, schema.List)
-    local result = List{}
+    local items, count = _decode_items(data, _ITEMS)
     local value_type = typ.value_type
-    for _,item in ipairs(msg.items) do
-      result:append(decoder.decode(item, value_type))
+    local result = List{}
+    for i = 1, count do
+      result[i] = decoder.decode(items[i], value_type)
     end
     return result
   elseif code == Types.DICTIONARY then
-    local msg = decoder.decode_message(data, schema.Dictionary)
+    local entries, count = _decode_items(data, _ITEMS)
+    local key_type = typ.key_type
+    local value_type = typ.value_type
     local result = Map{}
-    for _,item in ipairs(msg.entries) do
-      result[decoder.decode(item.key, typ.key_type)] =
-        decoder.decode(item.value, typ.value_type)
+    for i = 1, count do
+      local key, value = _decode_entry(entries[i])
+      result[decoder.decode(key, key_type)] = decoder.decode(value, value_type)
     end
     return result
   elseif code == Types.SET then
-    local msg = decoder.decode_message(data, schema.Set)
-    local result = Set{}
+    local items, count = _decode_items(data, _ITEMS)
     local value_type = typ.value_type
-    for _,item in ipairs(msg.items) do
-      result[decoder.decode(item, value_type)] = true
+    local result = Set{}
+    for i = 1, count do
+      result[decoder.decode(items[i], value_type)] = true
     end
     return result
   elseif code == Types.TUPLE then
-    local msg = decoder.decode_message(data, schema.Tuple)
+    local items, count = _decode_items(data, _ITEMS)
+    local value_types = typ.value_types
     local result = List{}
-    for _,item in ipairs(tablex.zip(msg.items, typ.value_types)) do
-      result:append(decoder.decode(item[1], item[2]))
+    for i = 1, count do
+      result[i] = decoder.decode(items[i], value_types[i])
     end
     return result
   elseif typ:is_a(Types.MessageType) then

--- a/client/lua/krpc/decoder.lua
+++ b/client/lua/krpc/decoder.lua
@@ -1,5 +1,4 @@
 local pb = require 'protobuf.pb'
-local pb_decoder = require 'protobuf.decoder'
 local List = require 'pl.List'
 local Set = require 'pl.Set'
 local Map = require 'pl.Map'
@@ -22,20 +21,16 @@ local function _decode_varint(data)
   end
 end
 
+-- What pb.struct_unpack calls a single precision and a double precision number.
+local FLOAT_FORMAT = string.byte('f')
+local DOUBLE_FORMAT = string.byte('d')
+
 local function _decode_float(data)
-  local field_dict = {}
-  local key = 1
-  local decoder = pb_decoder.FloatDecoder(1,False,False,key,nil)
-  local pos = decoder(data, 0, data:len(), nil, field_dict)
-  return field_dict[1]
+  return pb.struct_unpack(FLOAT_FORMAT, data, 0)
 end
 
 local function _decode_double(data)
-  local field_dict = {}
-  local key = 1
-  local decoder = pb_decoder.DoubleDecoder(1,False,False,key,nil)
-  local pos = decoder(data, 0, data:len(), nil, field_dict)
-  return field_dict[1]
+  return pb.struct_unpack(DOUBLE_FORMAT, data, 0)
 end
 
 local function _decode_value(data, typ)

--- a/client/lua/krpc/decoder.lua
+++ b/client/lua/krpc/decoder.lua
@@ -9,16 +9,20 @@ local Types = require 'krpc.types'
 
 local decoder = {}
 
-local _types = Types()
-
 decoder.OK_MESSAGE = '\79\75'
 
 local function _decode_varint(data)
+  -- A varint that fits in one byte is most of the values a call carries, and reading it needs
+  -- neither the C decoder nor the position it hands back alongside the value.
+  local byte = data:byte(1)
+  if byte and byte < 128 then
+    return byte
+  end
   if data == '\255\255\255\255\255\255\255\255\127' then
     return math.huge
-  else
-    return pb.varint_decoder(data, 0)
   end
+  local value = pb.varint_decoder(data, 0)
+  return value
 end
 
 -- What pb.struct_unpack calls a single precision and a double precision number.
@@ -33,27 +37,29 @@ local function _decode_double(data)
   return pb.struct_unpack(DOUBLE_FORMAT, data, 0)
 end
 
-local function _decode_value(data, typ)
-  code = typ.protobuf_type.code
-  if code == Types.DOUBLE then
-    return _decode_double(data)
-  elseif code == Types.FLOAT then
-    return _decode_float(data)
-  elseif code == Types.SINT32 then
-    return pb.zig_zag_decode32(_decode_varint(data))
-  elseif code == Types.SINT64 then
-    return pb.zig_zag_decode64(_decode_varint(data))
-  elseif code == Types.UINT32 or code == Types.UINT64 then
-    return _decode_varint(data)
-  elseif code == Types.BOOL then
-    local x = _decode_varint(data)
-    return x ~= 0
-  elseif code == Types.STRING or code == Types.BYTES then
-    local size, position = pb.varint_decoder(data, 0)
-    return data:sub(position+1, position+size+1)
-  end
-  error('Failed to decode data')
+local function _decode_string(data)
+  local size, position = pb.varint_decoder(data, 0)
+  return data:sub(position+1, position+size+1)
 end
+
+-- How to decode a value, by the code of the type it has. Which of these a type wants is the
+-- first thing decoding a value asks, and a table says so in one lookup where asking a type what
+-- class it is walks its ancestry once per question.
+local _value_decoders = {
+  [Types.DOUBLE] = _decode_double,
+  [Types.FLOAT] = _decode_float,
+  [Types.SINT32] = function(data) return pb.zig_zag_decode32(_decode_varint(data)) end,
+  [Types.SINT64] = function(data) return pb.zig_zag_decode64(_decode_varint(data)) end,
+  [Types.UINT32] = _decode_varint,
+  [Types.UINT64] = _decode_varint,
+  [Types.BOOL] = function(data) return _decode_varint(data) ~= 0 end,
+  [Types.STRING] = _decode_string,
+  [Types.BYTES] = _decode_string,
+  [Types.ENUMERATION] = function(data, typ)
+    return typ.lua_type(pb.zig_zag_decode32(_decode_varint(data)))
+  end,
+  [Types.CLASS] = function(data, typ) return typ.lua_type(_decode_varint(data)) end,
+}
 
 function decoder.guid(data)
   local parts = {
@@ -67,49 +73,46 @@ function decoder.guid(data)
 end
 
 function decoder.decode(data, typ)
-  if typ:is_a(Types.MessageType) then
-    return decoder.decode_message(data, typ.lua_type)
-  elseif typ:is_a(Types.EnumerationType) then
-    return typ.lua_type(_decode_value(data, _types:sint32_type()))
-  elseif typ:is_a(Types.ValueType) then
-    return _decode_value(data, typ)
-  elseif typ:is_a(Types.ClassType) then
-    local object_id_typ = _types:uint64_type()
-    local object_id = _decode_value(data, object_id_typ)
-    return typ.lua_type(object_id)
-  elseif typ:is_a(Types.ListType) then
+  local code = typ.code
+  local decode_value = _value_decoders[code]
+  if decode_value then
+    return decode_value(data, typ)
+  end
+  if code == Types.LIST then
     local msg = decoder.decode_message(data, schema.List)
     local result = List{}
+    local value_type = typ.value_type
     for _,item in ipairs(msg.items) do
-      result:append(decoder.decode(item, typ.value_type))
+      result:append(decoder.decode(item, value_type))
     end
     return result
-  elseif typ:is_a(Types.DictionaryType) then
+  elseif code == Types.DICTIONARY then
     local msg = decoder.decode_message(data, schema.Dictionary)
     local result = Map{}
     for _,item in ipairs(msg.entries) do
-       key = decoder.decode(item.key, typ.key_type)
-       value = decoder.decode(item.value, typ.value_type)
-      result[key] = value
+      result[decoder.decode(item.key, typ.key_type)] =
+        decoder.decode(item.value, typ.value_type)
     end
     return result
-  elseif typ:is_a(Types.SetType) then
+  elseif code == Types.SET then
     local msg = decoder.decode_message(data, schema.Set)
     local result = Set{}
+    local value_type = typ.value_type
     for _,item in ipairs(msg.items) do
-      result[decoder.decode(item, typ.value_type)] = true
+      result[decoder.decode(item, value_type)] = true
     end
     return result
-  elseif typ:is_a(Types.TupleType) then
+  elseif code == Types.TUPLE then
     local msg = decoder.decode_message(data, schema.Tuple)
     local result = List{}
     for _,item in ipairs(tablex.zip(msg.items, typ.value_types)) do
       result:append(decoder.decode(item[1], item[2]))
     end
     return result
-  else
-    error('Cannot decode type ' .. tostring(typ))
+  elseif typ:is_a(Types.MessageType) then
+    return decoder.decode_message(data, typ.lua_type)
   end
+  error('Cannot decode type ' .. tostring(typ))
 end
 
 function decoder.decode_message(data, typ)

--- a/client/lua/krpc/encoder.lua
+++ b/client/lua/krpc/encoder.lua
@@ -111,4 +111,56 @@ function encoder.encode_message_with_size(message)
   return delimiter .. data
 end
 
+-- The tags the request carrying a procedure call is written with, each the field's number and
+-- wire type in one byte. From krpc.proto:
+--
+--   Request.calls           1, length delimited
+--   ProcedureCall.service   1, length delimited
+--   ProcedureCall.procedure 2, length delimited
+--   ProcedureCall.arguments 3, length delimited
+--   Argument.position       1, varint
+--   Argument.value          2, length delimited
+--   Argument.is_null        3, varint
+--
+-- test_encoder builds the same requests through the protocol buffer message layer and compares
+-- the bytes, so a field renumbered in the schema without these following fails there.
+local _REQUEST_CALLS = '\10'
+local _CALL_SERVICE = '\10'
+local _CALL_PROCEDURE = '\18'
+local _CALL_ARGUMENTS = '\26'
+local _ARGUMENT_POSITION = '\8'
+local _ARGUMENT_VALUE = '\18'
+local _ARGUMENT_IS_NULL = '\24'
+
+local _concat = table.concat
+
+local function _delimited(tag, data)
+  return tag .. _encode_varint(data:len()) .. data
+end
+
+--- Encode the request carrying one procedure call, prefixed by its size, ready to send.
+--
+-- The arguments are the already encoded value of each, in order, with Types.none where a call
+-- passes nothing. Written here rather than built as a protocol buffer message and serialized:
+-- the message layer allocates a table of fields and a pair of listeners for each of the three
+-- messages a call needs, and then walks all of them twice, once to size them and once to write
+-- them. That costs an order of magnitude more than the bytes it produces.
+function encoder.encode_request(service, procedure, arguments)
+  local parts = { _delimited(_CALL_SERVICE, service), _delimited(_CALL_PROCEDURE, procedure) }
+  local count = 2
+  for i = 1, #arguments do
+    local value = arguments[i]
+    local argument
+    if value == Types.none then
+      argument = _ARGUMENT_POSITION .. _encode_varint(i-1) .. _ARGUMENT_IS_NULL .. '\1'
+    else
+      argument = _ARGUMENT_POSITION .. _encode_varint(i-1) .. _delimited(_ARGUMENT_VALUE, value)
+    end
+    count = count + 1
+    parts[count] = _delimited(_CALL_ARGUMENTS, argument)
+  end
+  local request = _delimited(_REQUEST_CALLS, _concat(parts))
+  return _encode_varint(request:len()) .. request
+end
+
 return encoder

--- a/client/lua/krpc/encoder.lua
+++ b/client/lua/krpc/encoder.lua
@@ -66,6 +66,44 @@ local _value_encoders = {
   [Types.CLASS] = function(x) return _encode_varint(x._object_id) end,
 }
 
+-- The tags the messages written here are written with, each a field's number and wire type in
+-- one byte. From krpc.proto:
+--
+--   Request.calls             1, length delimited
+--   ProcedureCall.service     1, length delimited
+--   ProcedureCall.procedure   2, length delimited
+--   ProcedureCall.arguments   3, length delimited
+--   Argument.position         1, varint
+--   Argument.value            2, length delimited
+--   Argument.is_null          3, varint
+--   Tuple.items               1, length delimited
+--   List.items                1, length delimited
+--   Set.items                 1, length delimited
+--   Dictionary.entries        1, length delimited
+--   DictionaryEntry.key       1, length delimited
+--   DictionaryEntry.value     2, length delimited
+--
+-- test_encoder reads back what is written with these through the protocol buffer message layer
+-- and checks it arrived intact, so a field renumbered in the schema without these following, or
+-- a tag written wrongly, fails there.
+local _REQUEST_CALLS = '\10'
+local _CALL_SERVICE = '\10'
+local _CALL_PROCEDURE = '\18'
+local _CALL_ARGUMENTS = '\26'
+local _ARGUMENT_POSITION = '\8'
+local _ARGUMENT_VALUE = '\18'
+local _ARGUMENT_IS_NULL = '\24'
+local _ITEMS = '\10'
+local _ENTRIES = '\10'
+local _ENTRY_KEY = '\10'
+local _ENTRY_VALUE = '\18'
+
+local _concat = table.concat
+
+local function _delimited(tag, data)
+  return tag .. _encode_varint(data:len()) .. data
+end
+
 function encoder.encode(x, typ)
   local code = typ.code
   local encode_value = _value_encoders[code]
@@ -73,31 +111,43 @@ function encoder.encode(x, typ)
     return encode_value(x)
   end
   if code == Types.LIST then
-    local msg = schema.List()
+    local value_type = typ.value_type
+    local parts = {}
+    local count = 0
     for item in x:iter() do
-      msg.items:append(encoder.encode(item, typ.value_type))
+      count = count + 1
+      parts[count] = _delimited(_ITEMS, encoder.encode(item, value_type))
     end
-    return msg:SerializeToString()
+    return _concat(parts)
   elseif code == Types.DICTIONARY then
-    local msg = schema.Dictionary()
+    local key_type = typ.key_type
+    local value_type = typ.value_type
+    local parts = {}
+    local count = 0
     for key,value in tablex.sort(x) do
-      local entry = msg.entries:add()
-      entry.key = encoder.encode(key, typ.key_type)
-      entry.value = encoder.encode(value, typ.value_type)
+      local entry = _delimited(_ENTRY_KEY, encoder.encode(key, key_type)) ..
+                    _delimited(_ENTRY_VALUE, encoder.encode(value, value_type))
+      count = count + 1
+      parts[count] = _delimited(_ENTRIES, entry)
     end
-    return msg:SerializeToString()
+    return _concat(parts)
   elseif code == Types.SET then
-    local msg = schema.Set()
+    local value_type = typ.value_type
+    local parts = {}
+    local count = 0
     for item in pairs(x) do
-      msg.items:append(encoder.encode(item, typ.value_type))
+      count = count + 1
+      parts[count] = _delimited(_ITEMS, encoder.encode(item, value_type))
     end
-    return msg:SerializeToString()
+    return _concat(parts)
   elseif code == Types.TUPLE then
-    local msg = schema.Tuple()
+    local parts = {}
+    local count = 0
     for _,item in ipairs(tablex.zip(x, typ.value_types)) do
-      msg.items:append(encoder.encode(item[1], item[2]))
+      count = count + 1
+      parts[count] = _delimited(_ITEMS, encoder.encode(item[1], item[2]))
     end
-    return msg:SerializeToString()
+    return _concat(parts)
   elseif typ:is_a(Types.MessageType) then
     return x:SerializeToString()
   end
@@ -109,33 +159,6 @@ function encoder.encode_message_with_size(message)
   local data = message:SerializeToString()
   local delimiter = _encode_varint(data:len())
   return delimiter .. data
-end
-
--- The tags the request carrying a procedure call is written with, each the field's number and
--- wire type in one byte. From krpc.proto:
---
---   Request.calls           1, length delimited
---   ProcedureCall.service   1, length delimited
---   ProcedureCall.procedure 2, length delimited
---   ProcedureCall.arguments 3, length delimited
---   Argument.position       1, varint
---   Argument.value          2, length delimited
---   Argument.is_null        3, varint
---
--- test_encoder builds the same requests through the protocol buffer message layer and compares
--- the bytes, so a field renumbered in the schema without these following fails there.
-local _REQUEST_CALLS = '\10'
-local _CALL_SERVICE = '\10'
-local _CALL_PROCEDURE = '\18'
-local _CALL_ARGUMENTS = '\26'
-local _ARGUMENT_POSITION = '\8'
-local _ARGUMENT_VALUE = '\18'
-local _ARGUMENT_IS_NULL = '\24'
-
-local _concat = table.concat
-
-local function _delimited(tag, data)
-  return tag .. _encode_varint(data:len()) .. data
 end
 
 --- Encode the request carrying one procedure call, prefixed by its size, ready to send.

--- a/client/lua/krpc/encoder.lua
+++ b/client/lua/krpc/encoder.lua
@@ -1,12 +1,9 @@
 local pb = require 'protobuf.pb'
-local seq = require 'pl.seq'
 local tablex = require 'pl.tablex'
 local schema = require 'krpc.schema.KRPC'
 local Types = require 'krpc.types'
 
 local encoder = {}
-
-local _types = Types()
 
 -- Where the routines below leave the bytes they produce. They are handed to a writer, and one
 -- writer shared by all of them costs nothing per value, where a closure made for the value
@@ -52,69 +49,59 @@ local function _encode_double(value)
   return _written
 end
 
-local function _encode_value(x, typ)
-  code = typ.protobuf_type.code
-  if code == Types.DOUBLE then
-    return _encode_double(x)
-  elseif code == Types.FLOAT then
-    return _encode_float(x)
-  elseif code == Types.SINT32 then
-    return _encode_varint(pb.zig_zag_encode32(x))
-  elseif code == Types.SINT64 then
-    return _encode_varint(pb.zig_zag_encode64(x))
-  elseif code == Types.UINT32 or code == Types.UINT64 then
-    return _encode_varint(x)
-  elseif code == Types.BOOL then
-    if x then
-      return _encode_varint(1)
-    else
-      return _encode_varint(0)
-    end
-  elseif code == Types.STRING or code == Types.BYTES then
-    return _encode_varint(x:len()) .. x
-  end
-  error('Failed to encode data')
-end
+-- How to encode a value, by the code of the type it has. Which of these a type wants is the
+-- first thing encoding a value asks, and a table says so in one lookup where asking a type what
+-- class it is walks its ancestry once per question.
+local _value_encoders = {
+  [Types.DOUBLE] = _encode_double,
+  [Types.FLOAT] = _encode_float,
+  [Types.SINT32] = function(x) return _encode_varint(pb.zig_zag_encode32(x)) end,
+  [Types.SINT64] = function(x) return _encode_varint(pb.zig_zag_encode64(x)) end,
+  [Types.UINT32] = _encode_varint,
+  [Types.UINT64] = _encode_varint,
+  [Types.BOOL] = function(x) return _encode_varint(x and 1 or 0) end,
+  [Types.STRING] = function(x) return _encode_varint(x:len()) .. x end,
+  [Types.BYTES] = function(x) return _encode_varint(x:len()) .. x end,
+  [Types.ENUMERATION] = function(x) return _encode_varint(pb.zig_zag_encode32(x.value)) end,
+  [Types.CLASS] = function(x) return _encode_varint(x._object_id) end,
+}
 
 function encoder.encode(x, typ)
-  if typ:is_a(Types.MessageType) then
-    return x:SerializeToString()
-  elseif typ:is_a(Types.ValueType) then
-    return _encode_value(x, typ)
-  elseif typ:is_a(Types.EnumerationType) then
-    return _encode_value(x.value, _types:sint32_type())
-  elseif typ:is_a(Types.ClassType) then
-    return _encode_value(x._object_id, _types:uint64_type())
-  elseif typ:is_a(Types.ListType) then
+  local code = typ.code
+  local encode_value = _value_encoders[code]
+  if encode_value then
+    return encode_value(x)
+  end
+  if code == Types.LIST then
     local msg = schema.List()
     for item in x:iter() do
       msg.items:append(encoder.encode(item, typ.value_type))
     end
     return msg:SerializeToString()
-  elseif typ:is_a(Types.DictionaryType) then
+  elseif code == Types.DICTIONARY then
     local msg = schema.Dictionary()
-    local entry_type = schema.DictionaryEntry()
     for key,value in tablex.sort(x) do
       local entry = msg.entries:add()
       entry.key = encoder.encode(key, typ.key_type)
       entry.value = encoder.encode(value, typ.value_type)
     end
     return msg:SerializeToString()
-  elseif typ:is_a(Types.SetType) then
+  elseif code == Types.SET then
     local msg = schema.Set()
     for item in pairs(x) do
       msg.items:append(encoder.encode(item, typ.value_type))
     end
     return msg:SerializeToString()
-  elseif typ:is_a(Types.TupleType) then
+  elseif code == Types.TUPLE then
     local msg = schema.Tuple()
     for _,item in ipairs(tablex.zip(x, typ.value_types)) do
       msg.items:append(encoder.encode(item[1], item[2]))
     end
     return msg:SerializeToString()
-  else
-    error('Cannot encode object of type ' .. tostring(typ))
+  elseif typ:is_a(Types.MessageType) then
+    return x:SerializeToString()
   end
+  error('Cannot encode object of type ' .. tostring(typ))
 end
 
 function encoder.encode_message_with_size(message)

--- a/client/lua/krpc/encoder.lua
+++ b/client/lua/krpc/encoder.lua
@@ -1,5 +1,4 @@
 local pb = require 'protobuf.pb'
-local pb_encoder = require 'protobuf.encoder'
 local seq = require 'pl.seq'
 local tablex = require 'pl.tablex'
 local schema = require 'krpc.schema.KRPC'
@@ -9,39 +8,48 @@ local encoder = {}
 
 local _types = Types()
 
+-- Where the routines below leave the bytes they produce. They are handed to a writer, and one
+-- writer shared by all of them costs nothing per value, where a closure made for the value
+-- would be allocated and thrown away again for every one encoded.
+local _written
+local function _write(data)
+  _written = data
+end
+
+-- What pb.struct_pack calls a single precision and a double precision number.
+local FLOAT_FORMAT = string.byte('f')
+local DOUBLE_FORMAT = string.byte('d')
+
+-- The encoding of every varint that fits in one byte, which is most of the values a call
+-- carries: an index, a count, a small identifier or a boolean.
+local _small_varints = {}
+for value = 0, 127 do
+  _small_varints[value] = string.char(value)
+end
+
 local function _encode_varint(x)
+  local small = _small_varints[x]
+  if small then
+    return small
+  end
   if x < 0 then
     error('Value must be non-negative, got ' .. x)
   elseif x == math.huge then
     return '\255\255\255\255\255\255\255\255\127'
   else
-    local data = ''
-    local function write(y)
-      data = y
-    end
-    pb.varint_encoder(write, x)
-    return data
+    pb.varint_encoder(_write, x)
+    return _written
   end
 end
 
 local function _encode_float(value)
-  local data = ''
-  local function write(x)
-    data = data .. x
-  end
-  local encoder = pb_encoder.FloatEncoder(1,False,False)
-  encoder(write, value)
-  return data:sub(2) -- strips the tag value
+  pb.struct_pack(_write, FLOAT_FORMAT, value)
+  return _written
 end
 
 local function _encode_double(value)
-  local data = ''
-  local function write(x)
-    data = data .. x
-  end
-  local encoder = pb_encoder.DoubleEncoder(1,False,False)
-  encoder(write, value)
-  return data:sub(2) -- strips the tag value
+  pb.struct_pack(_write, DOUBLE_FORMAT, value)
+  return _written
 end
 
 local function _encode_value(x, typ)

--- a/client/lua/krpc/service.lua
+++ b/client/lua/krpc/service.lua
@@ -66,16 +66,15 @@ local function _construct_func(invoke, service_name, procedure_name, prefix_para
       {'service_name',
        'procedure_name',
        '{'..stringx.join(',', param_names)..'}',
-       'param_names',
        'param_types',
        'return_type'
       }) ..
     ')'
   local func = 'return function (' .. stringx.join(',', prefix_param_names..param_names) .. ') ' .. body .. ' end'
   local wrapper =
-    'return function (invoke,service_name,procedure_name,param_names,param_types,return_type,Map) ' .. func .. ' end'
+    'return function (invoke,service_name,procedure_name,param_types,return_type,Map) ' .. func .. ' end'
   local callable = assert(loadstring(wrapper, '_construct_func('..service_name..','..procedure_name..')'))()
-  return callable(invoke,service_name,procedure_name,param_names,param_types,return_type,Map)
+  return callable(invoke,service_name,procedure_name,param_types,return_type,Map)
 end
 
 local ServiceBase = class(Types.DynamicType)

--- a/client/lua/krpc/test/test_decoder.lua
+++ b/client/lua/krpc/test/test_decoder.lua
@@ -4,6 +4,8 @@ local decoder = require 'krpc.decoder'
 local platform = require 'krpc.platform'
 local schema = require 'krpc.schema.KRPC'
 local Types = require 'krpc.types'
+local encoder = require 'krpc.encoder'
+local List = require 'pl.List'
 
 local TestDecoder = class()
 
@@ -31,6 +33,69 @@ function TestDecoder:test_decode_size()
   local message = '1c'
   local size = decoder.decode_size(platform.unhexlify(message))
   luaunit.assertEquals(28, size)
+end
+
+-- A collection is read by the tags its values are carried under rather than by parsing a
+-- message, so this hands it collections the protocol buffer message layer wrote and checks the
+-- values come back. A tag read wrongly, or a field renumbered in the schema, fails here.
+function TestDecoder:test_decode_collections_written_by_message_layer()
+  local long = string.rep('x', 300)
+
+  local list_message = schema.List()
+  for _, value in ipairs({'one', 'two', long}) do
+    list_message.items:append(encoder.encode(value, types:string_type()))
+  end
+  local values = decoder.decode(list_message:SerializeToString(),
+                                types:list_type(types:string_type()))
+  luaunit.assertEquals(3, #values)
+  luaunit.assertEquals('one', values[1])
+  luaunit.assertEquals('two', values[2])
+  luaunit.assertEquals(long, values[3])
+
+  local empty = decoder.decode(schema.List():SerializeToString(),
+                               types:list_type(types:string_type()))
+  luaunit.assertEquals(0, #empty)
+
+  local set_message = schema.Set()
+  set_message.items:append(encoder.encode(7, types:uint32_type()))
+  set_message.items:append(encoder.encode(300, types:uint32_type()))
+  local set = decoder.decode(set_message:SerializeToString(),
+                             types:set_type(types:uint32_type()))
+  luaunit.assertEquals(true, set[7])
+  luaunit.assertEquals(true, set[300])
+
+  local tuple_message = schema.Tuple()
+  tuple_message.items:append(encoder.encode(7, types:uint32_type()))
+  tuple_message.items:append(encoder.encode(long, types:string_type()))
+  local tuple = decoder.decode(
+    tuple_message:SerializeToString(),
+    types:tuple_type(List{types:uint32_type(), types:string_type()}))
+  luaunit.assertEquals(2, #tuple)
+  luaunit.assertEquals(7, tuple[1])
+  luaunit.assertEquals(long, tuple[2])
+
+  local dictionary_message = schema.Dictionary()
+  local entry = dictionary_message.entries:add()
+  entry.key = encoder.encode('a', types:string_type())
+  entry.value = encoder.encode(1, types:uint32_type())
+  entry = dictionary_message.entries:add()
+  entry.key = encoder.encode('b', types:string_type())
+  entry.value = encoder.encode(300, types:uint32_type())
+  local dictionary = decoder.decode(
+    dictionary_message:SerializeToString(),
+    types:dictionary_type(types:string_type(), types:uint32_type()))
+  luaunit.assertEquals(1, dictionary['a'])
+  luaunit.assertEquals(300, dictionary['b'])
+
+  -- A value that encodes to nothing, an empty list here, is left out of the entry entirely
+  local empty_valued = schema.Dictionary()
+  entry = empty_valued.entries:add()
+  entry.key = encoder.encode('a', types:string_type())
+  entry.value = ''
+  local with_empty = decoder.decode(
+    empty_valued:SerializeToString(),
+    types:dictionary_type(types:string_type(), types:list_type(types:uint32_type())))
+  luaunit.assertEquals(0, #with_empty['a'])
 end
 
 function TestDecoder:test_decode_class()

--- a/client/lua/krpc/test/test_encoder.lua
+++ b/client/lua/krpc/test/test_encoder.lua
@@ -37,6 +37,80 @@ function TestEncoder:test_encode_message_with_size()
   luaunit.assertEquals(expected, platform.hexlify(data))
 end
 
+-- Take the size prefix off a message and check it counted the rest correctly.
+local function without_size_prefix(data)
+  local size = 0
+  local shift = 1
+  local position = 1
+  while true do
+    local byte = data:byte(position)
+    position = position + 1
+    size = size + (byte % 128) * shift
+    if byte < 128 then
+      break
+    end
+    shift = shift * 128
+  end
+  local body = data:sub(position)
+  luaunit.assertEquals(size, body:len())
+  return body
+end
+
+-- encode_request writes the field numbers and wire types of Request, ProcedureCall and Argument
+-- itself rather than going through the protocol buffer message layer, so this reads what it
+-- wrote back through that layer and checks the call arrived intact. A tag written wrongly, a
+-- length counted wrongly, or a field renumbered in the schema all show up here.
+--
+-- The comparison is on what the message carries rather than on its bytes, because the message
+-- layer writes the fields of a message in the order a hash table happens to hold them, so the
+-- bytes it produces for the same call differ from these and from each other.
+function TestEncoder:test_encode_request_round_trips_through_message_layer()
+  local long_name = string.rep('a', 200)
+  local long_value = string.rep('\7', 300)
+  local cases = {
+    { 'ServiceName', 'ProcedureName', {} },
+    { 'ServiceName', 'ProcedureName', { '\42' } },
+    { 'ServiceName', 'ProcedureName', { '\1', '\2', '\3' } },
+    { 'ServiceName', 'ProcedureName', { Types.none } },
+    { 'ServiceName', 'ProcedureName', { '\1', Types.none, '\3' } },
+    -- Lengths that take more than one byte to write, for the service and procedure names, for
+    -- an argument's value, and for the request as a whole
+    { long_name, 'ProcedureName', {} },
+    { 'ServiceName', long_name, {} },
+    { 'ServiceName', 'ProcedureName', { long_value } },
+    { long_name, long_name, { long_value, long_value } },
+    -- Enough arguments that their positions stop fitting in one byte
+    { 'ServiceName', 'ProcedureName', (function()
+        local many = {}
+        for i = 1, 200 do many[i] = '\1' end
+        return many
+      end)() },
+  }
+  for _, case in ipairs(cases) do
+    local service, procedure, arguments = case[1], case[2], case[3]
+    local request = schema.Request()
+    request:ParseFromString(
+      without_size_prefix(encoder.encode_request(service, procedure, arguments)))
+    luaunit.assertEquals(1, #request.calls)
+    local call = request.calls[1]
+    luaunit.assertEquals(service, call.service)
+    luaunit.assertEquals(procedure, call.procedure)
+    luaunit.assertEquals(#arguments, #call.arguments)
+    for i = 1, #arguments do
+      local argument = call.arguments[i]
+      luaunit.assertEquals(i-1, argument.position)
+      -- HasField answers with the value a field holds, and so with nil where it holds none
+      if arguments[i] == Types.none then
+        luaunit.assertEquals(true, argument.is_null)
+        luaunit.assertNil(argument:HasField('value'))
+      else
+        luaunit.assertEquals(arguments[i], argument.value)
+        luaunit.assertNil(argument:HasField('is_null'))
+      end
+    end
+  end
+end
+
 function TestEncoder:test_encode_class()
   local typ = types:class_type('ServiceName', 'ClassName')
   local class_type = typ.lua_type

--- a/client/lua/krpc/test/test_encoder.lua
+++ b/client/lua/krpc/test/test_encoder.lua
@@ -4,6 +4,9 @@ local encoder = require 'krpc.encoder'
 local platform = require 'krpc.platform'
 local Types = require 'krpc.types'
 local schema = require 'krpc.schema.KRPC'
+local List = require 'pl.List'
+local Map = require 'pl.Map'
+local Set = require 'pl.Set'
 
 local TestEncoder = class()
 
@@ -109,6 +112,47 @@ function TestEncoder:test_encode_request_round_trips_through_message_layer()
       end
     end
   end
+end
+
+-- A list, a set, a tuple and a dictionary are written the same way the request is, so they are
+-- read back through the message layer for the same reason.
+function TestEncoder:test_encode_collections_round_trip_through_message_layer()
+  local long = string.rep('x', 300)
+
+  local list_type = types:list_type(types:string_type())
+  local values = List{'one', 'two', long}
+  local list_message = schema.List()
+  list_message:ParseFromString(encoder.encode(values, list_type))
+  luaunit.assertEquals(3, #list_message.items)
+  for i, item in ipairs(list_message.items) do
+    luaunit.assertEquals(encoder.encode(values[i], types:string_type()), item)
+  end
+
+  local set_type = types:set_type(types:uint32_type())
+  local set_message = schema.Set()
+  set_message:ParseFromString(encoder.encode(Set{7}, set_type))
+  luaunit.assertEquals(1, #set_message.items)
+  luaunit.assertEquals(encoder.encode(7, types:uint32_type()), set_message.items[1])
+
+  local tuple_type = types:tuple_type(List{types:uint32_type(), types:string_type()})
+  local tuple_message = schema.Tuple()
+  tuple_message:ParseFromString(encoder.encode(List{7, long}, tuple_type))
+  luaunit.assertEquals(2, #tuple_message.items)
+  luaunit.assertEquals(encoder.encode(7, types:uint32_type()), tuple_message.items[1])
+  luaunit.assertEquals(encoder.encode(long, types:string_type()), tuple_message.items[2])
+
+  local dictionary_type = types:dictionary_type(types:string_type(), types:uint32_type())
+  local dictionary_message = schema.Dictionary()
+  dictionary_message:ParseFromString(encoder.encode(Map{a = 1, b = 2}, dictionary_type))
+  luaunit.assertEquals(2, #dictionary_message.entries)
+  luaunit.assertEquals(encoder.encode('a', types:string_type()),
+                       dictionary_message.entries[1].key)
+  luaunit.assertEquals(encoder.encode(1, types:uint32_type()),
+                       dictionary_message.entries[1].value)
+  luaunit.assertEquals(encoder.encode('b', types:string_type()),
+                       dictionary_message.entries[2].key)
+  luaunit.assertEquals(encoder.encode(2, types:uint32_type()),
+                       dictionary_message.entries[2].value)
 end
 
 function TestEncoder:test_encode_class()

--- a/client/lua/krpc/types.lua
+++ b/client/lua/krpc/types.lua
@@ -294,6 +294,10 @@ Types.TypeBase = class()
 
 function Types.TypeBase:_init(protobuf_type, lua_type, type_string)
   self.protobuf_type = protobuf_type
+  -- A copy of the type code as a plain field. It says everything the encoding needs to know
+  -- about a type, and is read once for every value encoded or decoded, where reading it off the
+  -- protobuf message goes through that message's field lookup every time.
+  self.code = protobuf_type.code
   self.lua_type = lua_type
   self._string = type_string
 end

--- a/client/python/CHANGELOG.md
+++ b/client/python/CHANGELOG.md
@@ -6,6 +6,15 @@
   such as `krpc.limits.SINT32_MAX` and `krpc.limits.DOUBLE_LOWEST`. Python names none of
   them itself, and a generated stub whose parameter defaults to one now names the constant
   rather than writing out the decimal value (#1045)
+- Reduce the cost of a remote procedure call. Type objects are cached by the arguments
+  naming them and their python type and type code read as plain attributes, values are
+  encoded and decoded through a lookup on their type code rather than a chain of
+  comparisons, floats and doubles are packed directly and short varints without going
+  through protobuf's varint routines, a request is built as a single message, a response
+  is read in one system call and taken out of the read buffer in one pass, a service
+  reaches its procedures by ordinary attribute lookup, and the client connections disable
+  Nagle's algorithm. A collection works out how to encode and decode its items once for
+  the collection rather than once for every item (#1056)
 
 ## [v0.6.0]
 - **Breaking:** Requires Python 3.10+ (#837)

--- a/client/python/krpc/client.py
+++ b/client/python/krpc/client.py
@@ -239,12 +239,10 @@ class Client(krpc.services.Client):
     ) -> object:
         """Execute an RPC"""
 
-        # Build the request
-        call = self._build_call(
-            service, procedure, args, param_names, param_types, return_type
-        )
+        # Build the request. A request carries exactly one call, so the call is
+        # filled in where it belongs rather than built on its own and copied in
         request = KRPC.Request()
-        request.calls.extend([call])
+        self._encode_call(request.calls.add(), service, procedure, args, param_types)
 
         # Send the request
         with self._rpc_connection_lock:
@@ -258,16 +256,17 @@ class Client(krpc.services.Client):
             raise self._build_error(response.error)
 
         # Check for an error in the procedure results
-        if response.results[0].HasField("error"):
-            raise self._build_error(response.results[0].error)
+        result = response.results[0]
+        if result.HasField("error"):
+            raise self._build_error(result.error)
 
         # Decode the response and return the (optional) result
-        result = None
-        if return_type is not None and not response.results[0].is_null:
-            result = Decoder.decode(self, response.results[0].value, return_type)
-            if isinstance(result, KRPC.Event):
-                result = Event(self, result)
-        return result
+        if return_type is None or result.is_null:
+            return None
+        value = Decoder.decode(self, result.value, return_type)
+        if isinstance(value, KRPC.Event):
+            value = Event(self, value)
+        return value
 
     def _build_call(
         self,
@@ -281,15 +280,29 @@ class Client(krpc.services.Client):
         """Build a KRPC.ProcedureCall object"""
 
         call = KRPC.ProcedureCall()
+        self._encode_call(call, service, procedure, args, param_types)
+        return call
+
+    def _encode_call(
+        self,
+        call: KRPC.ProcedureCall,
+        service: str,
+        procedure: str,
+        args: Iterable[object],
+        param_types: Iterable[TypeBase],
+    ) -> None:
+        """Fill in a KRPC.ProcedureCall message with a call and its arguments"""
+
         call.service = service
         call.procedure = procedure
+        arguments = call.arguments
 
         for i, (value, typ) in enumerate(zip(args, param_types)):
             if isinstance(value, DefaultArgument):
                 continue
             if value is None:
                 # A null argument is signaled out-of-band; the value field is left unset
-                call.arguments.add(position=i, is_null=True)
+                arguments.add(position=i, is_null=True)
                 continue
             if not isinstance(value, typ.python_type):
                 try:
@@ -299,9 +312,7 @@ class Client(krpc.services.Client):
                         "%s.%s() argument %d must be a %s, got a %s"
                         % (service, procedure, i, typ.python_type, type(value))
                     ) from exc
-            call.arguments.add(position=i, value=Encoder.encode(value, typ))
-
-        return call
+            arguments.add(position=i, value=Encoder.encode(value, typ))
 
     def _build_error(self, error: KRPC.Error) -> Exception:
         """Build an exception from an error message that

--- a/client/python/krpc/client.py
+++ b/client/python/krpc/client.py
@@ -79,7 +79,7 @@ class Client(krpc.services.Client):
 
         services = cast(
             KRPC.Services,
-            self._invoke("KRPC", "GetServices", [], [], [], self._types.services_type),
+            self._invoke("KRPC", "GetServices", [], [], self._types.services_type),
         ).services
 
         # Load services
@@ -233,7 +233,6 @@ class Client(krpc.services.Client):
         service: str,
         procedure: str,
         args: Iterable[object],
-        param_names: Iterable[str],
         param_types: Iterable[TypeBase],
         return_type: Optional[TypeBase],
     ) -> object:
@@ -273,7 +272,6 @@ class Client(krpc.services.Client):
         service: str,
         procedure: str,
         args: Iterable[object],
-        param_names: Iterable[str],  # pylint: disable=unused-argument
         param_types: Iterable[TypeBase],
         return_type: Optional[TypeBase],  # pylint: disable=unused-argument
     ) -> KRPC.ProcedureCall:

--- a/client/python/krpc/connection.py
+++ b/client/python/krpc/connection.py
@@ -41,20 +41,22 @@ class Connection:
     def receive_message(self, typ: type) -> google.protobuf.message.Message:
         """Receive a protobuf message and decode it"""
 
-        # Read the size prefix of the message, then discard it from the buffer
+        # Read until the buffer holds the size prefix and the whole message it
+        # describes, then take the message out in one go. An incomplete prefix
+        # runs off the end of the buffer, which is an IndexError
         buffer = self._buffer
         while True:
             try:
-                # A size prefix is a varint, so it is at most 10 bytes; decoding
-                # only those avoids copying the rest of the buffer to look at it
-                size, prefix_length = Decoder.decode_size_prefix(bytes(buffer[:10]))
-                break
+                size, prefix_length = Decoder.decode_size_prefix(buffer)
             except IndexError:
                 self._fill()
-        del buffer[:prefix_length]
-
-        # Read and decode the message itself
-        data = self.receive(size)
+                continue
+            end = prefix_length + size
+            if len(buffer) >= end:
+                break
+            self._fill()
+        data = bytes(buffer[prefix_length:end])
+        del buffer[:end]
         return Decoder.decode_message(data, typ)
 
     def send(self, data: bytes) -> None:

--- a/client/python/krpc/connection.py
+++ b/client/python/krpc/connection.py
@@ -6,12 +6,19 @@ import google.protobuf
 from krpc.encoder import Encoder
 from krpc.decoder import Decoder
 
+# Size of a socket read. Reads are made a block at a time and buffered, rather
+# than exactly the number of bytes wanted, so that a message costs one read
+# rather than one per byte of its size prefix plus one for its body.
+_READ_SIZE = 8192
+
 
 class Connection:
     def __init__(self, address: str, port: int) -> None:
         self._address = address
         self._port = port
         self._socket: socket.socket = None  # type: ignore[assignment]
+        # Data read from the socket that has not been consumed yet
+        self._buffer = bytearray()
 
     def connect(self) -> None:
         self._socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
@@ -31,17 +38,19 @@ class Connection:
     def receive_message(self, typ: type) -> google.protobuf.message.Message:
         """Receive a protobuf message and decode it"""
 
-        # Read the size and position of the response message
-        data = b""
+        # Read the size prefix of the message, then discard it from the buffer
+        buffer = self._buffer
         while True:
             try:
-                data += self.partial_receive(1)
-                size = Decoder.decode_message_size(data)
+                # A size prefix is a varint, so it is at most 10 bytes; decoding
+                # only those avoids copying the rest of the buffer to look at it
+                size, prefix_length = Decoder.decode_size_prefix(bytes(buffer[:10]))
                 break
             except IndexError:
-                pass
+                self._fill()
+        del buffer[:prefix_length]
 
-        # Read and decode the response message
+        # Read and decode the message itself
         data = self.receive(size)
         return Decoder.decode_message(data, typ)
 
@@ -49,11 +58,15 @@ class Connection:
         """Send data to the connection.
         Blocks until all data has been sent."""
         assert data
-        while data:
-            sent = self._socket.send(data)
-            if sent == 0:
-                raise socket.error("Connection closed")
-            data = data[sent:]
+        self._socket.sendall(data)
+
+    def _fill(self) -> None:
+        """Read a block from the socket into the buffer.
+        Blocks until at least one byte has been read."""
+        data = self._socket.recv(_READ_SIZE)
+        if not data:
+            raise socket.error("Connection closed")
+        self._buffer += data
 
     def receive(self, length: int) -> bytes:
         """Receive data from the connection.
@@ -61,19 +74,23 @@ class Connection:
         if length == 0:
             return b""
         assert length > 0
-        data = b""
-        while len(data) < length:
-            remaining = length - len(data)
-            result = self._socket.recv(min(4096, remaining))
-            if not result:
-                raise socket.error("Connection closed")
-            data += result
+        buffer = self._buffer
+        while len(buffer) < length:
+            self._fill()
+        data = bytes(buffer[:length])
+        del buffer[:length]
         return data
 
     def partial_receive(self, length: int, timeout: float = 0.01) -> bytes:
         """Receive up to length bytes of data from the connection.
         Returns no data if none arrived within the timeout."""
         assert length > 0
+        buffer = self._buffer
+        if buffer:
+            length = min(length, len(buffer))
+            data = bytes(buffer[:length])
+            del buffer[:length]
+            return data
         try:
             ready = select.select([self._socket], [], [], timeout)
         except ValueError as exn:

--- a/client/python/krpc/connection.py
+++ b/client/python/krpc/connection.py
@@ -23,6 +23,9 @@ class Connection:
     def connect(self) -> None:
         self._socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         self._socket.connect((self._address, self._port))
+        # The protocol is strictly request/response, so waiting for more data to
+        # coalesce with can only add latency
+        self._socket.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
 
     def close(self) -> None:
         if self._socket is not None:

--- a/client/python/krpc/decoder.py
+++ b/client/python/krpc/decoder.py
@@ -85,19 +85,20 @@ class Decoder:
         msg: object
         if isinstance(typ, ListType):
             msg = cast(KRPC.List, cls.decode_message(data, KRPC.List))
-            return [cls.decode(client, item, typ.value_type) for item in msg.items]
+            decode_item = cls._item_decoder(client, typ.value_type)
+            return [decode_item(item) for item in msg.items]
         if isinstance(typ, DictionaryType):
             msg = cast(KRPC.Dictionary, cls.decode_message(data, KRPC.Dictionary))
+            decode_key = cls._item_decoder(client, typ.key_type)
+            decode_value = cls._item_decoder(client, typ.value_type)
             return dict(
-                (
-                    cls.decode(client, entry.key, typ.key_type),
-                    cls.decode(client, entry.value, typ.value_type),
-                )
+                (decode_key(entry.key), decode_value(entry.value))
                 for entry in msg.entries
             )
         if isinstance(typ, SetType):
             msg = cast(KRPC.Set, cls.decode_message(data, KRPC.Set))
-            return set(cls.decode(client, item, typ.value_type) for item in msg.items)
+            decode_item = cls._item_decoder(client, typ.value_type)
+            return set(decode_item(item) for item in msg.items)
         if isinstance(typ, TupleType):
             msg = cast(KRPC.Tuple, cls.decode_message(data, KRPC.Tuple))
             return tuple(
@@ -124,6 +125,32 @@ class Decoder:
         message = typ()
         message.ParseFromString(data)
         return message
+
+    @classmethod
+    def _item_decoder(
+        cls, client: Optional[Client], typ: TypeBase
+    ) -> Callable[[bytes], object]:
+        """A function that decodes one value of the given type.
+
+        A collection carries many values of the same type, so working out how to decode
+        one of them is worth doing once for the collection rather than once for every
+        item in it. The types a collection usually holds are answered directly; anything
+        else falls back to the full decode.
+        """
+        if isinstance(typ, ValueType):
+            decode = _VALUE_DECODERS.get(typ.code)
+            if decode is None:
+                raise EncodingError("Invalid type")
+            return decode
+        if isinstance(typ, ClassType):
+            decode_id = _VALUE_DECODERS[cls._types.uint64_type.code]
+            python_type = typ.python_type
+            return lambda data: python_type(client, decode_id(data))
+        if isinstance(typ, EnumerationType):
+            decode_value = _VALUE_DECODERS[cls._types.sint32_type.code]
+            enum_type = typ.python_type
+            return lambda data: enum_type(decode_value(data))
+        return lambda data: cls.decode(client, data, typ)
 
     @classmethod
     def _decode_value(cls, data: bytes, typ: TypeBase) -> object:

--- a/client/python/krpc/decoder.py
+++ b/client/python/krpc/decoder.py
@@ -29,6 +29,22 @@ if TYPE_CHECKING:
     from krpc.client import Client
 
 
+def _decode_varint(data: bytes) -> Tuple[int, int]:
+    """Decode the varint at the start of the data, returning its value and the
+    number of bytes it occupies. Raises IndexError if the data does not hold a
+    complete varint.
+
+    A varint whose first byte has the top bit clear holds its own value in that
+    byte. Message sizes, and the length prefixes of strings and bytes, are
+    almost always that, so the common case is an index rather than a call into
+    protobuf's varint reader."""
+    first = data[0]
+    if first < 128:
+        return first, 1
+    # pylint: disable=line-too-long
+    return cast(Tuple[int, int], protobuf_decoder._DecodeVarint(data, 0))  # type: ignore[attr-defined]
+
+
 class Decoder:
     """Routines for decoding messages and values from
     the protocol buffer serialization format"""
@@ -90,15 +106,14 @@ class Decoder:
 
     @classmethod
     def decode_message_size(cls, data: bytes) -> int:
-        return cast(int, protobuf_decoder._DecodeVarint(data, 0)[0])  # type: ignore[attr-defined]
+        return _decode_varint(data)[0]
 
     @classmethod
     def decode_size_prefix(cls, data: bytes) -> Tuple[int, int]:
         """Decode the size prefix of a message, returning the size of the message
         and the number of bytes the prefix itself occupies. Raises IndexError if
         the data does not yet hold a complete prefix."""
-        # pylint: disable=line-too-long
-        return cast(Tuple[int, int], protobuf_decoder._DecodeVarint(data, 0))  # type: ignore[attr-defined]
+        return _decode_varint(data)
 
     @classmethod
     def decode_message(
@@ -125,12 +140,12 @@ class _ValueDecoder:
         # The zigzag payload is an unsigned varint. Reading it as a signed one would sign
         # extend it as two's complement first, which corrupts anything from 2**62 up once
         # the payload sets bit 63 - long.MaxValue would decode as -1.
-        value = protobuf_decoder._DecodeVarint(data, 0)[0]  # type: ignore[attr-defined]
+        value = _decode_varint(data)[0]
         return cast(int, protobuf_wire_format.ZigZagDecode(value))  # type: ignore[no-untyped-call]
 
     @classmethod
     def _decode_varint(cls, data: bytes) -> int:
-        return cast(int, protobuf_decoder._DecodeVarint(data, 0)[0])  # type: ignore[attr-defined]
+        return _decode_varint(data)[0]
 
     @classmethod
     def decode_sint32(cls, data: bytes) -> int:
@@ -212,12 +227,12 @@ class _ValueDecoder:
 
     @classmethod
     def decode_string(cls, data: bytes) -> str:
-        size, position = protobuf_decoder._DecodeVarint(data, 0)  # type: ignore[attr-defined]
+        size, position = _decode_varint(data)
         return data[position : position + size].decode("utf-8")
 
     @classmethod
     def decode_bytes(cls, data: bytes) -> bytes:
-        size, position = protobuf_decoder._DecodeVarint(data, 0)  # type: ignore[attr-defined]
+        size, position = _decode_varint(data)
         return data[position : position + size]
 
 

--- a/client/python/krpc/decoder.py
+++ b/client/python/krpc/decoder.py
@@ -125,7 +125,7 @@ class Decoder:
 
     @classmethod
     def _decode_value(cls, data: bytes, typ: TypeBase) -> object:
-        decode = _VALUE_DECODERS.get(typ.protobuf_type.code)
+        decode = _VALUE_DECODERS.get(typ.code)
         if decode is None:
             raise EncodingError("Invalid type")
         return decode(data)

--- a/client/python/krpc/decoder.py
+++ b/client/python/krpc/decoder.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import cast, Callable, Mapping, Optional, Type, TYPE_CHECKING
+from typing import cast, Callable, Mapping, Optional, Tuple, Type, TYPE_CHECKING
 import struct
 import google.protobuf
 
@@ -91,6 +91,14 @@ class Decoder:
     @classmethod
     def decode_message_size(cls, data: bytes) -> int:
         return cast(int, protobuf_decoder._DecodeVarint(data, 0)[0])  # type: ignore[attr-defined]
+
+    @classmethod
+    def decode_size_prefix(cls, data: bytes) -> Tuple[int, int]:
+        """Decode the size prefix of a message, returning the size of the message
+        and the number of bytes the prefix itself occupies. Raises IndexError if
+        the data does not yet hold a complete prefix."""
+        # pylint: disable=line-too-long
+        return cast(Tuple[int, int], protobuf_decoder._DecodeVarint(data, 0))  # type: ignore[attr-defined]
 
     @classmethod
     def decode_message(

--- a/client/python/krpc/decoder.py
+++ b/client/python/krpc/decoder.py
@@ -29,6 +29,16 @@ if TYPE_CHECKING:
     from krpc.client import Client
 
 
+# protobuf's varint reader and zigzag decoder are internal and carry no types, so they are
+# bound here with the types they do have rather than described again at every call. A call
+# carrying a collection reaches them once per value, so this also saves looking them up on
+# their module that many times
+_pb_decode_varint: Callable[[bytes, int], Tuple[int, int]] = (
+    protobuf_decoder._DecodeVarint  # type: ignore[attr-defined]
+)
+_pb_zigzag_decode: Callable[[int], int] = protobuf_wire_format.ZigZagDecode
+
+
 def _decode_varint(data: bytes) -> Tuple[int, int]:
     """Decode the varint at the start of the data, returning its value and the
     number of bytes it occupies. Raises IndexError if the data does not hold a
@@ -41,8 +51,7 @@ def _decode_varint(data: bytes) -> Tuple[int, int]:
     first = data[0]
     if first < 128:
         return first, 1
-    # pylint: disable=line-too-long
-    return cast(Tuple[int, int], protobuf_decoder._DecodeVarint(data, 0))  # type: ignore[attr-defined]
+    return _pb_decode_varint(data, 0)
 
 
 class Decoder:
@@ -169,8 +178,7 @@ class _ValueDecoder:
         # The zigzag payload is an unsigned varint. Reading it as a signed one would sign
         # extend it as two's complement first, which corrupts anything from 2**62 up once
         # the payload sets bit 63 - long.MaxValue would decode as -1.
-        value = _decode_varint(data)[0]
-        return cast(int, protobuf_wire_format.ZigZagDecode(value))  # type: ignore[no-untyped-call]
+        return _pb_zigzag_decode(_decode_varint(data)[0])
 
     @classmethod
     def _decode_varint(cls, data: bytes) -> int:

--- a/client/python/krpc/decoder.py
+++ b/client/python/krpc/decoder.py
@@ -69,13 +69,15 @@ class Decoder:
     @classmethod
     def decode(cls, client: Optional[Client], data: bytes, typ: TypeBase) -> object:
         """Given a python type, and serialized data, decode the value"""
+        # The value types come first: they are what most results are, and this is on
+        # the hot path of every remote procedure call
+        if isinstance(typ, ValueType):
+            return cls._decode_value(data, typ)
         if isinstance(typ, MessageType):
             return cls.decode_message(data, typ.python_type)
         if isinstance(typ, EnumerationType):
             value = cls._decode_value(data, cls._types.sint32_type)
             return typ.python_type(value)
-        if isinstance(typ, ValueType):
-            return cls._decode_value(data, typ)
         if isinstance(typ, ClassType):
             object_id_typ = cls._types.uint64_type
             object_id = cls._decode_value(data, object_id_typ)

--- a/client/python/krpc/decoder.py
+++ b/client/python/krpc/decoder.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import cast, Optional, Type, TYPE_CHECKING
+from typing import cast, Callable, Mapping, Optional, Type, TYPE_CHECKING
 import struct
 import google.protobuf
 
@@ -102,25 +102,10 @@ class Decoder:
 
     @classmethod
     def _decode_value(cls, data: bytes, typ: TypeBase) -> object:
-        if typ.protobuf_type.code == KRPC.Type.SINT32:
-            return _ValueDecoder.decode_sint32(data)
-        if typ.protobuf_type.code == KRPC.Type.SINT64:
-            return _ValueDecoder.decode_sint64(data)
-        if typ.protobuf_type.code == KRPC.Type.UINT32:
-            return _ValueDecoder.decode_uint32(data)
-        if typ.protobuf_type.code == KRPC.Type.UINT64:
-            return _ValueDecoder.decode_uint64(data)
-        if typ.protobuf_type.code == KRPC.Type.DOUBLE:
-            return _ValueDecoder.decode_double(data)
-        if typ.protobuf_type.code == KRPC.Type.FLOAT:
-            return _ValueDecoder.decode_float(data)
-        if typ.protobuf_type.code == KRPC.Type.BOOL:
-            return _ValueDecoder.decode_bool(data)
-        if typ.protobuf_type.code == KRPC.Type.STRING:
-            return _ValueDecoder.decode_string(data)
-        if typ.protobuf_type.code == KRPC.Type.BYTES:
-            return _ValueDecoder.decode_bytes(data)
-        raise EncodingError("Invalid type")
+        decode = _VALUE_DECODERS.get(typ.protobuf_type.code)
+        if decode is None:
+            raise EncodingError("Invalid type")
+        return decode(data)
 
 
 class _ValueDecoder:
@@ -226,3 +211,19 @@ class _ValueDecoder:
     def decode_bytes(cls, data: bytes) -> bytes:
         size, position = protobuf_decoder._DecodeVarint(data, 0)  # type: ignore[attr-defined]
         return data[position : position + size]
+
+
+# The decoder for each value type, looked up by type code rather than found by
+# comparing against each code in turn, as this is on the hot path of every
+# remote procedure call
+_VALUE_DECODERS: Mapping[KRPC.Type.TypeCode, Callable[[bytes], object]] = {
+    KRPC.Type.SINT32: _ValueDecoder.decode_sint32,
+    KRPC.Type.SINT64: _ValueDecoder.decode_sint64,
+    KRPC.Type.UINT32: _ValueDecoder.decode_uint32,
+    KRPC.Type.UINT64: _ValueDecoder.decode_uint64,
+    KRPC.Type.DOUBLE: _ValueDecoder.decode_double,
+    KRPC.Type.FLOAT: _ValueDecoder.decode_float,
+    KRPC.Type.BOOL: _ValueDecoder.decode_bool,
+    KRPC.Type.STRING: _ValueDecoder.decode_string,
+    KRPC.Type.BYTES: _ValueDecoder.decode_bytes,
+}

--- a/client/python/krpc/decoder.py
+++ b/client/python/krpc/decoder.py
@@ -178,7 +178,14 @@ class _ValueDecoder:
         # The zigzag payload is an unsigned varint. Reading it as a signed one would sign
         # extend it as two's complement first, which corrupts anything from 2**62 up once
         # the payload sets bit 63 - long.MaxValue would decode as -1.
-        return _pb_zigzag_decode(_decode_varint(data)[0])
+        #
+        # The single byte case is read here rather than through _decode_varint, which is the
+        # general form of it: a collection reaches this once per value it carries, and a
+        # value from -64 to 63 is one byte.
+        first = data[0]
+        if first < 128:
+            return _pb_zigzag_decode(first)
+        return _pb_zigzag_decode(_pb_decode_varint(data, 0)[0])
 
     @classmethod
     def _decode_varint(cls, data: bytes) -> int:

--- a/client/python/krpc/decoder.py
+++ b/client/python/krpc/decoder.py
@@ -176,22 +176,6 @@ class _ValueDecoder:
     def _decode_varint(cls, data: bytes) -> int:
         return _decode_varint(data)[0]
 
-    @classmethod
-    def decode_sint32(cls, data: bytes) -> int:
-        return cls._decode_signed_varint(data)
-
-    @classmethod
-    def decode_sint64(cls, data: bytes) -> int:
-        return cls._decode_signed_varint(data)
-
-    @classmethod
-    def decode_uint32(cls, data: bytes) -> int:
-        return cls._decode_varint(data)
-
-    @classmethod
-    def decode_uint64(cls, data: bytes) -> int:
-        return cls._decode_varint(data)
-
     # The code for the following two methods is taken from
     # google.protobuf.internal.decoder._FloatDecoder and _DoubleDecoder
     # Copyright 2008, Google Inc.
@@ -267,12 +251,13 @@ class _ValueDecoder:
 
 # The decoder for each value type, looked up by type code rather than found by
 # comparing against each code in turn, as this is on the hot path of every
-# remote procedure call
+# remote procedure call. The signed and unsigned integer types share a decoder
+# apiece, named for what it reads rather than for one of the types that read it
 _VALUE_DECODERS: Mapping[KRPC.Type.TypeCode, Callable[[bytes], object]] = {
-    KRPC.Type.SINT32: _ValueDecoder.decode_sint32,
-    KRPC.Type.SINT64: _ValueDecoder.decode_sint64,
-    KRPC.Type.UINT32: _ValueDecoder.decode_uint32,
-    KRPC.Type.UINT64: _ValueDecoder.decode_uint64,
+    KRPC.Type.SINT32: _ValueDecoder._decode_signed_varint,
+    KRPC.Type.SINT64: _ValueDecoder._decode_signed_varint,
+    KRPC.Type.UINT32: _ValueDecoder._decode_varint,
+    KRPC.Type.UINT64: _ValueDecoder._decode_varint,
     KRPC.Type.DOUBLE: _ValueDecoder.decode_double,
     KRPC.Type.FLOAT: _ValueDecoder.decode_float,
     KRPC.Type.BOOL: _ValueDecoder.decode_bool,

--- a/client/python/krpc/encoder.py
+++ b/client/python/krpc/encoder.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 from typing import cast, Any, Callable, Collection, Iterable, List, Mapping
 from enum import Enum
+import struct
 
 # pylint: disable=import-error,no-name-in-module
 import google.protobuf
@@ -28,8 +29,6 @@ from krpc.types import (
 # depends on the version of protobuf installed
 _pb_VarintEncoder = protobuf_encoder._VarintEncoder()  # type: ignore[attr-defined]  # pylint: disable=invalid-name
 _pb_SignedVarintEncoder = protobuf_encoder._SignedVarintEncoder()  # type: ignore[attr-defined]  # pylint: disable=invalid-name
-_pb_DoubleEncoder = protobuf_encoder.DoubleEncoder(1, False, False)  # type: ignore[arg-type]
-_pb_FloatEncoder = protobuf_encoder.FloatEncoder(1, False, False)  # type: ignore[arg-type]
 
 
 class Encoder:
@@ -113,32 +112,16 @@ class _ValueEncoder:
 
     @classmethod
     def encode_double(cls, value: float) -> bytes:
-        data: List[bytes] = []
-
-        def write(x: bytes) -> None:
-            data.append(x)
-
-        _pb_DoubleEncoder(write, value, True)  # type: ignore[operator]
-        return b"".join(data[1:])  # strips the tag value
+        return struct.pack("<d", value)
 
     @classmethod
     def encode_float(cls, value: float) -> bytes:
-        data: List[bytes] = []
-
-        def write(x: bytes) -> None:
-            data.append(x)
-
-        _pb_FloatEncoder(write, value, True)  # type: ignore[operator]
-        return b"".join(data[1:])  # strips the tag value
+        return struct.pack("<f", value)
 
     @classmethod
     def _encode_varint(cls, value: int) -> bytes:
         data: List[bytes] = []
-
-        def write(x: bytes) -> None:
-            data.append(x)
-
-        _pb_VarintEncoder(write, value, True)
+        _pb_VarintEncoder(data.append, value, True)
         return b"".join(data)
 
     @classmethod

--- a/client/python/krpc/encoder.py
+++ b/client/python/krpc/encoder.py
@@ -46,10 +46,12 @@ class Encoder:
     @classmethod
     def encode(cls, x: object, typ: TypeBase) -> bytes:
         """Encode a message or value of the given protocol buffer type"""
-        if isinstance(typ, MessageType):
-            return cast(google.protobuf.message.Message, x).SerializeToString()
+        # The value types come first: they are what most arguments are, and this is
+        # on the hot path of every remote procedure call
         if isinstance(typ, ValueType):
             return cls._encode_value(x, typ)
+        if isinstance(typ, MessageType):
+            return cast(google.protobuf.message.Message, x).SerializeToString()
         if isinstance(typ, EnumerationType):
             return cls._encode_value(cast(Enum, x).value, cls._types.sint32_type)
         if isinstance(typ, ClassType):

--- a/client/python/krpc/encoder.py
+++ b/client/python/krpc/encoder.py
@@ -173,6 +173,11 @@ class _ValueEncoder:
         value = _pb_zigzag_encode(value)
         if value < 128:
             return _SINGLE_BYTE_VARINTS[value]
+        # Two bytes carry a value up to 16383, which is most of what is not one byte, and
+        # writing them costs one call where protobuf's encoder builds a list and joins it.
+        # A collection reaches this once per value it carries.
+        if value < 16384:
+            return bytes((value & 0x7F | 0x80, value >> 7))
         data: List[bytes] = []
         _pb_SignedVarintEncoder(data.append, value, True)
         return b"".join(data)

--- a/client/python/krpc/encoder.py
+++ b/client/python/krpc/encoder.py
@@ -109,7 +109,7 @@ class Encoder:
 
     @classmethod
     def _encode_value(cls, value: object, typ: TypeBase) -> bytes:
-        encode = _VALUE_ENCODERS.get(typ.protobuf_type.code)
+        encode = _VALUE_ENCODERS.get(typ.code)
         if encode is None:
             raise EncodingError("Invalid type")
         return encode(value)

--- a/client/python/krpc/encoder.py
+++ b/client/python/krpc/encoder.py
@@ -173,14 +173,6 @@ class _ValueEncoder:
         return b"".join(data)
 
     @classmethod
-    def encode_sint32(cls, value: int) -> bytes:
-        return cls._encode_signed_varint(value)
-
-    @classmethod
-    def encode_sint64(cls, value: int) -> bytes:
-        return cls._encode_signed_varint(value)
-
-    @classmethod
     def encode_uint32(cls, value: int) -> bytes:
         if value < 0:
             raise EncodingError("Value must be non-negative, got %d" % value)
@@ -209,10 +201,11 @@ class _ValueEncoder:
 
 # The encoder for each value type, looked up by type code rather than found by
 # comparing against each code in turn, as this is on the hot path of every
-# remote procedure call
+# remote procedure call. The signed integer types share an encoder, named for
+# what it writes rather than for one of the types that write it
 _VALUE_ENCODERS: Mapping[KRPC.Type.TypeCode, Callable[[Any], bytes]] = {
-    KRPC.Type.SINT32: _ValueEncoder.encode_sint32,
-    KRPC.Type.SINT64: _ValueEncoder.encode_sint64,
+    KRPC.Type.SINT32: _ValueEncoder._encode_signed_varint,
+    KRPC.Type.SINT64: _ValueEncoder._encode_signed_varint,
     KRPC.Type.UINT32: _ValueEncoder.encode_uint32,
     KRPC.Type.UINT64: _ValueEncoder.encode_uint64,
     KRPC.Type.DOUBLE: _ValueEncoder.encode_double,

--- a/client/python/krpc/encoder.py
+++ b/client/python/krpc/encoder.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import cast, Callable, Collection, Iterable, List, Mapping
+from typing import cast, Any, Callable, Collection, Iterable, List, Mapping
 from enum import Enum
 
 # pylint: disable=import-error,no-name-in-module
@@ -101,25 +101,10 @@ class Encoder:
 
     @classmethod
     def _encode_value(cls, value: object, typ: TypeBase) -> bytes:
-        if typ.protobuf_type.code == KRPC.Type.SINT32:
-            return _ValueEncoder.encode_sint32(cast(int, value))
-        if typ.protobuf_type.code == KRPC.Type.SINT64:
-            return _ValueEncoder.encode_sint64(cast(int, value))
-        if typ.protobuf_type.code == KRPC.Type.UINT32:
-            return _ValueEncoder.encode_uint32(cast(int, value))
-        if typ.protobuf_type.code == KRPC.Type.UINT64:
-            return _ValueEncoder.encode_uint64(cast(int, value))
-        if typ.protobuf_type.code == KRPC.Type.DOUBLE:
-            return _ValueEncoder.encode_double(cast(float, value))
-        if typ.protobuf_type.code == KRPC.Type.FLOAT:
-            return _ValueEncoder.encode_float(cast(float, value))
-        if typ.protobuf_type.code == KRPC.Type.BOOL:
-            return _ValueEncoder.encode_bool(cast(bool, value))
-        if typ.protobuf_type.code == KRPC.Type.STRING:
-            return _ValueEncoder.encode_string(cast(str, value))
-        if typ.protobuf_type.code == KRPC.Type.BYTES:
-            return _ValueEncoder.encode_bytes(cast(bytes, value))
-        raise EncodingError("Invalid type")
+        encode = _VALUE_ENCODERS.get(typ.protobuf_type.code)
+        if encode is None:
+            raise EncodingError("Invalid type")
+        return encode(value)
 
 
 class _ValueEncoder:
@@ -196,3 +181,19 @@ class _ValueEncoder:
     @classmethod
     def encode_bytes(cls, value: bytes) -> bytes:
         return b"".join([cls._encode_varint(len(value)), value])
+
+
+# The encoder for each value type, looked up by type code rather than found by
+# comparing against each code in turn, as this is on the hot path of every
+# remote procedure call
+_VALUE_ENCODERS: Mapping[KRPC.Type.TypeCode, Callable[[Any], bytes]] = {
+    KRPC.Type.SINT32: _ValueEncoder.encode_sint32,
+    KRPC.Type.SINT64: _ValueEncoder.encode_sint64,
+    KRPC.Type.UINT32: _ValueEncoder.encode_uint32,
+    KRPC.Type.UINT64: _ValueEncoder.encode_uint64,
+    KRPC.Type.DOUBLE: _ValueEncoder.encode_double,
+    KRPC.Type.FLOAT: _ValueEncoder.encode_float,
+    KRPC.Type.BOOL: _ValueEncoder.encode_bool,
+    KRPC.Type.STRING: _ValueEncoder.encode_string,
+    KRPC.Type.BYTES: _ValueEncoder.encode_bytes,
+}

--- a/client/python/krpc/encoder.py
+++ b/client/python/krpc/encoder.py
@@ -59,27 +59,31 @@ class Encoder:
             return cls._encode_value(object_id, cls._types.uint64_type)
         if isinstance(typ, ListType):
             list_msg = KRPC.List()
+            encode_item = cls._item_encoder(typ.value_type)
             list_msg.items.extend(
-                cls.encode(item, typ.value_type) for item in cast(Iterable[object], x)
+                encode_item(item) for item in cast(Iterable[object], x)
             )
             return list_msg.SerializeToString()
         if isinstance(typ, DictionaryType):
             dict_msg = KRPC.Dictionary()
             entries = []
             dict_obj = cast(Mapping, x)  # type: ignore[type-arg]
+            encode_key = cls._item_encoder(typ.key_type)
+            encode_value = cls._item_encoder(typ.value_type)
             for key, value in sorted(
                 dict_obj.items(), key=lambda i: i[0]
             ):  # type: ignore[no-any-return]
                 entry = KRPC.DictionaryEntry()
-                entry.key = cls.encode(key, typ.key_type)
-                entry.value = cls.encode(value, typ.value_type)
+                entry.key = encode_key(key)
+                entry.value = encode_value(value)
                 entries.append(entry)
             dict_msg.entries.extend(entries)
             return dict_msg.SerializeToString()
         if isinstance(typ, SetType):
             set_msg = KRPC.Set()
+            encode_item = cls._item_encoder(typ.value_type)
             set_msg.items.extend(
-                cls.encode(item, typ.value_type) for item in cast(Iterable[object], x)
+                encode_item(item) for item in cast(Iterable[object], x)
             )
             return set_msg.SerializeToString()
         if isinstance(typ, TupleType):
@@ -108,6 +112,28 @@ class Encoder:
             return _SINGLE_BYTE_VARINTS[length] + data
         size: bytes = protobuf_encoder._VarintBytes(length)  # type: ignore[attr-defined]
         return size + data
+
+    @classmethod
+    def _item_encoder(cls, typ: TypeBase) -> Callable[[Any], bytes]:
+        """A function that encodes one value of the given type.
+
+        A collection carries many values of the same type, so working out how to encode
+        one of them is worth doing once for the collection rather than once for every
+        item in it. The types a collection usually holds are answered directly; anything
+        else falls back to the full encode.
+        """
+        if isinstance(typ, ValueType):
+            encode = _VALUE_ENCODERS.get(typ.code)
+            if encode is None:
+                raise EncodingError("Invalid type")
+            return encode
+        if isinstance(typ, ClassType):
+            encode_id = _VALUE_ENCODERS[cls._types.uint64_type.code]
+            return lambda x: encode_id(x._object_id)
+        if isinstance(typ, EnumerationType):
+            encode_value = _VALUE_ENCODERS[cls._types.sint32_type.code]
+            return lambda x: encode_value(x.value)
+        return lambda x: cls.encode(x, typ)
 
     @classmethod
     def _encode_value(cls, value: object, typ: TypeBase) -> bytes:
@@ -140,6 +166,8 @@ class _ValueEncoder:
     @classmethod
     def _encode_signed_varint(cls, value: int) -> bytes:
         value = protobuf_wire_format.ZigZagEncode(value)  # type: ignore[no-untyped-call]
+        if value < 128:
+            return _SINGLE_BYTE_VARINTS[value]
         data: List[bytes] = []
         _pb_SignedVarintEncoder(data.append, value, True)
         return b"".join(data)

--- a/client/python/krpc/encoder.py
+++ b/client/python/krpc/encoder.py
@@ -30,6 +30,12 @@ from krpc.types import (
 _pb_VarintEncoder = protobuf_encoder._VarintEncoder()  # type: ignore[attr-defined]  # pylint: disable=invalid-name
 _pb_SignedVarintEncoder = protobuf_encoder._SignedVarintEncoder()  # type: ignore[attr-defined]  # pylint: disable=invalid-name
 
+# The one byte encoding of every value that fits in one. A varint below 128 is
+# the byte itself, and message sizes and the length prefixes of strings and
+# bytes almost always are, so the common case is a lookup rather than a loop
+# that builds a list and joins it
+_SINGLE_BYTE_VARINTS = tuple(bytes((value,)) for value in range(128))
+
 
 class Encoder:
     """Routines for encoding messages and values in
@@ -95,7 +101,10 @@ class Encoder:
     ) -> bytes:
         """Encode a protobuf message, prepended with its size"""
         data = message.SerializeToString()
-        size: bytes = protobuf_encoder._VarintBytes(len(data))  # type: ignore[attr-defined]
+        length = len(data)
+        if length < 128:
+            return _SINGLE_BYTE_VARINTS[length] + data
+        size: bytes = protobuf_encoder._VarintBytes(length)  # type: ignore[attr-defined]
         return size + data
 
     @classmethod
@@ -120,6 +129,8 @@ class _ValueEncoder:
 
     @classmethod
     def _encode_varint(cls, value: int) -> bytes:
+        if value < 128:
+            return _SINGLE_BYTE_VARINTS[value]
         data: List[bytes] = []
         _pb_VarintEncoder(data.append, value, True)
         return b"".join(data)

--- a/client/python/krpc/encoder.py
+++ b/client/python/krpc/encoder.py
@@ -30,6 +30,11 @@ from krpc.types import (
 _pb_VarintEncoder = protobuf_encoder._VarintEncoder()  # type: ignore[attr-defined]  # pylint: disable=invalid-name
 _pb_SignedVarintEncoder = protobuf_encoder._SignedVarintEncoder()  # type: ignore[attr-defined]  # pylint: disable=invalid-name
 
+# protobuf's zigzag encoder carries no types, so it is bound here with the type it does
+# have rather than described again at every call. A call carrying a collection reaches it
+# once per value, so this also saves looking it up on its module that many times
+_pb_zigzag_encode: Callable[[int], int] = protobuf_wire_format.ZigZagEncode
+
 # The one byte encoding of every value that fits in one. A varint below 128 is
 # the byte itself, and message sizes and the length prefixes of strings and
 # bytes almost always are, so the common case is a lookup rather than a loop
@@ -165,7 +170,7 @@ class _ValueEncoder:
 
     @classmethod
     def _encode_signed_varint(cls, value: int) -> bytes:
-        value = protobuf_wire_format.ZigZagEncode(value)  # type: ignore[no-untyped-call]
+        value = _pb_zigzag_encode(value)
         if value < 128:
             return _SINGLE_BYTE_VARINTS[value]
         data: List[bytes] = []

--- a/client/python/krpc/service.py
+++ b/client/python/krpc/service.py
@@ -100,7 +100,6 @@ def _construct_func(
         "'" + str(service_name) + "'",
         "'" + str(procedure_name) + "'",
         "[" + ",".join(param_names) + "]",
-        "param_names",
         "param_types",
         "return_type",
     ]
@@ -114,7 +113,6 @@ def _construct_func(
     context = {
         "invoke": invoke,
         "DefaultArgument": DefaultArgument,
-        "param_names": param_names,
         "param_types": param_types,
         "return_type": return_type,
     }

--- a/client/python/krpc/test/test_connection.py
+++ b/client/python/krpc/test/test_connection.py
@@ -1,8 +1,10 @@
 import unittest
 import threading
 import socket
+from typing import List
 import krpc.schema.KRPC_pb2 as KRPC
 from krpc.connection import Connection
+from krpc.encoder import Encoder
 
 
 class ServerThread:
@@ -131,6 +133,84 @@ class TestConnection(unittest.TestCase):
         conn = self.connect()
         conn.close()
         self.assertRaises(socket.error, conn.partial_receive, 1)
+
+
+class ScriptedSocket:
+    """A socket that hands over a fixed script of reads, so that a message can be
+    made to arrive in whatever pieces a test needs. An exhausted script reads as
+    end of file, as a closed connection does."""
+
+    def __init__(self, chunks: List[bytes]) -> None:
+        self.chunks = list(chunks)
+
+    def recv(self, length: int) -> bytes:  # pylint: disable=unused-argument
+        if not self.chunks:
+            return b""
+        return self.chunks.pop(0)
+
+    def close(self) -> None:
+        pass
+
+
+class TestReceiveMessage(unittest.TestCase):
+    """Reads are made a block at a time, and a block has nothing to do with where a
+    message starts or ends, so receive_message has to reassemble one out of whatever
+    the socket hands over."""
+
+    @staticmethod
+    def encoded(value: bytes) -> bytes:
+        """A response carrying the given value, encoded with its size prefix"""
+        response = KRPC.Response()
+        response.results.add(value=value)
+        return Encoder.encode_message_with_size(response)
+
+    @staticmethod
+    def connection(*chunks: bytes) -> Connection:
+        conn = Connection("localhost", 0)
+        conn._socket = ScriptedSocket(list(chunks))  # type: ignore[assignment]
+        return conn
+
+    def receive(self, conn: Connection) -> bytes:
+        message = conn.receive_message(KRPC.Response)
+        return message.results[0].value  # type: ignore[attr-defined,no-any-return]
+
+    def test_whole_message_in_one_read(self) -> None:
+        conn = self.connection(self.encoded(b"foo"))
+        self.assertEqual(b"foo", self.receive(conn))
+        self.assertEqual(b"", conn._buffer)
+
+    def test_message_split_across_reads(self) -> None:
+        data = self.encoded(b"foo")
+        conn = self.connection(data[:1], data[1:3], data[3:])
+        self.assertEqual(b"foo", self.receive(conn))
+        self.assertEqual(b"", conn._buffer)
+
+    def test_size_prefix_split_across_reads(self) -> None:
+        # A payload this size needs a two byte size prefix, so the read can end
+        # part way through the prefix itself
+        value = b"x" * 300
+        data = self.encoded(value)
+        conn = self.connection(data[:1], data[1:])
+        self.assertEqual(value, self.receive(conn))
+        self.assertEqual(b"", conn._buffer)
+
+    def test_two_messages_in_one_read(self) -> None:
+        conn = self.connection(self.encoded(b"foo") + self.encoded(b"bar"))
+        self.assertEqual(b"foo", self.receive(conn))
+        self.assertEqual(b"bar", self.receive(conn))
+        self.assertEqual(b"", conn._buffer)
+
+    def test_message_and_the_start_of_the_next_in_one_read(self) -> None:
+        second = self.encoded(b"bar")
+        conn = self.connection(self.encoded(b"foo") + second[:2], second[2:])
+        self.assertEqual(b"foo", self.receive(conn))
+        self.assertEqual(b"bar", self.receive(conn))
+        self.assertEqual(b"", conn._buffer)
+
+    def test_connection_closed_partway_through_a_message(self) -> None:
+        data = self.encoded(b"foo")
+        conn = self.connection(data[:2])
+        self.assertRaises(socket.error, conn.receive_message, KRPC.Response)
 
 
 if __name__ == "__main__":

--- a/client/python/krpc/types.py
+++ b/client/python/krpc/types.py
@@ -330,22 +330,20 @@ class Types:
 class TypeBase:
     """Base class for all type objects"""
 
+    # The protocol buffer type, the python type and the type code are plain
+    # attributes rather than properties: naming one is on the hot path of every
+    # remote procedure call, where a property would cost a call
+
     def __init__(
         self, protobuf_type: KRPC.Type, python_type: type, string: str
     ) -> None:
-        self._protobuf_type = protobuf_type
-        self._python_type = python_type
+        self.protobuf_type = protobuf_type
+        self.python_type = python_type
+        # The type code, which is what the encoder and decoder select on. Held
+        # here as well as in the protocol buffer type, as reading it from there
+        # is a protocol buffer field access
+        self.code = protobuf_type.code
         self._string = string
-
-    @property
-    def protobuf_type(self) -> KRPC.Type:
-        """Get the protocol buffer type string for the type"""
-        return self._protobuf_type
-
-    @property
-    def python_type(self) -> type:
-        """Get the python type"""
-        return self._python_type
 
     def __str__(self) -> str:
         return "<type: " + str(self._string) + ">"
@@ -403,13 +401,13 @@ class EnumerationType(TypeBase):
     def has_values(self) -> bool:
         """Whether the values of the enumeration are known, which they are
         only once its definition has been registered by calling set_values"""
-        return self._python_type is not None
+        return self.python_type is not None
 
     def set_values(self, values: Mapping[str, Mapping[str, object]]) -> None:
         """Set the python type. Creates an Enum class
         using the given values."""
-        assert self._python_type is None
-        self._python_type = _create_enum_type(self._enum_name, values, self._doc)
+        assert self.python_type is None
+        self.python_type = _create_enum_type(self._enum_name, values, self._doc)
 
 
 class TupleType(TypeBase):

--- a/client/python/krpc/types.py
+++ b/client/python/krpc/types.py
@@ -73,22 +73,54 @@ class Types:
     strings, and stores python types for services and service defined
     class and enumeration types."""
 
+    # The value types are held one attribute each, so that naming one costs an
+    # attribute lookup on the hot path of every remote procedure call
+    # pylint: disable=too-many-instance-attributes
+
     def __init__(self) -> None:
         # Mapping from protobuf type strings to type objects
         self._types: dict[bytes, TypeBase] = {}
         self._exception_types: dict[tuple[str, str], Type[Exception]] = {}
+        # Type objects keyed by the arguments they were asked for, rather than by
+        # the serialized protobuf type that keys _types. The generated service
+        # stubs name their parameter and return types on every call, so this is on
+        # the hot path of every remote procedure call; a lookup here costs a tuple
+        # hash instead of building and serializing a protobuf message.
+        self._type_cache: dict[tuple[object, ...], TypeBase] = {}
+
+        # The value types are the same objects for the lifetime of the store, so
+        # they are resolved once here rather than on every access
+        self.double_type = self._value_type(KRPC.Type.DOUBLE)
+        self.float_type = self._value_type(KRPC.Type.FLOAT)
+        self.sint32_type = self._value_type(KRPC.Type.SINT32)
+        self.sint64_type = self._value_type(KRPC.Type.SINT64)
+        self.uint32_type = self._value_type(KRPC.Type.UINT32)
+        self.uint64_type = self._value_type(KRPC.Type.UINT64)
+        self.bool_type = self._value_type(KRPC.Type.BOOL)
+        self.string_type = self._value_type(KRPC.Type.STRING)
+        self.bytes_type = self._value_type(KRPC.Type.BYTES)
+        self.event_type = cast(
+            MessageType, self.as_type(_protobuf_type(KRPC.Type.EVENT))
+        )
+
+    def _value_type(self, code: int) -> ValueType:
+        return cast(ValueType, self.as_type(_protobuf_type(code)))
 
     def register_class_type(self, service: str, name: str, python_type: type) -> None:
         protobuf_type = _protobuf_type(KRPC.Type.CLASS, service, name)
         key = protobuf_type.SerializeToString()
         assert key not in self._types
-        self._types[key] = ClassType(protobuf_type, None, python_type)
+        typ = ClassType(protobuf_type, None, python_type)
+        self._types[key] = typ
+        self._type_cache[(KRPC.Type.CLASS, service, name)] = typ
 
     def register_enum_type(self, service: str, name: str, python_type: type) -> None:
         protobuf_type = _protobuf_type(KRPC.Type.ENUMERATION, service, name)
         key = protobuf_type.SerializeToString()
         assert key not in self._types
-        self._types[key] = EnumerationType(protobuf_type, None, python_type)
+        typ = EnumerationType(protobuf_type, None, python_type)
+        self._types[key] = typ
+        self._type_cache[(KRPC.Type.ENUMERATION, service, name)] = typ
 
     def as_type(self, protobuf_type: KRPC.Type, doc: str | None = None) -> TypeBase:
         """Return a type object given a protocol buffer type"""
@@ -125,68 +157,29 @@ class Types:
     def is_none_type(cls, protobuf_type: KRPC.Type) -> bool:
         return protobuf_type.code == KRPC.Type.NONE
 
-    @property
-    def double_type(self) -> ValueType:
-        """Get a double value type"""
-        return cast(ValueType, self.as_type(_protobuf_type(KRPC.Type.DOUBLE)))
-
-    @property
-    def float_type(self) -> ValueType:
-        """Get a float value type"""
-        return cast(ValueType, self.as_type(_protobuf_type(KRPC.Type.FLOAT)))
-
-    @property
-    def sint32_type(self) -> ValueType:
-        """Get an sint32 value type"""
-        return cast(ValueType, self.as_type(_protobuf_type(KRPC.Type.SINT32)))
-
-    @property
-    def sint64_type(self) -> ValueType:
-        """Get an sint64 value type"""
-        return cast(ValueType, self.as_type(_protobuf_type(KRPC.Type.SINT64)))
-
-    @property
-    def uint32_type(self) -> ValueType:
-        """Get a uint32 value type"""
-        return cast(ValueType, self.as_type(_protobuf_type(KRPC.Type.UINT32)))
-
-    @property
-    def uint64_type(self) -> ValueType:
-        """Get a uint64 value type"""
-        return cast(ValueType, self.as_type(_protobuf_type(KRPC.Type.UINT64)))
-
-    @property
-    def bool_type(self) -> ValueType:
-        """Get a bool value type"""
-        return cast(ValueType, self.as_type(_protobuf_type(KRPC.Type.BOOL)))
-
-    @property
-    def string_type(self) -> ValueType:
-        """Get a string value type"""
-        return cast(ValueType, self.as_type(_protobuf_type(KRPC.Type.STRING)))
-
-    @property
-    def bytes_type(self) -> TypeBase:
-        """Get a bytes value type"""
-        return cast(ValueType, self.as_type(_protobuf_type(KRPC.Type.BYTES)))
-
     def class_type(
         self, service: str, name: str, doc: Optional[str] = None
     ) -> ClassType:
         """Get a class type"""
-        return cast(
-            ClassType,
-            self.as_type(_protobuf_type(KRPC.Type.CLASS, service, name), doc=doc),
-        )
+        key = (KRPC.Type.CLASS, service, name)
+        typ = self._type_cache.get(key)
+        if typ is None:
+            typ = self.as_type(_protobuf_type(KRPC.Type.CLASS, service, name), doc=doc)
+            self._type_cache[key] = typ
+        return cast(ClassType, typ)
 
     def enumeration_type(
         self, service: str, name: str, doc: Optional[str] = None
     ) -> EnumerationType:
         """Get an enumeration type"""
-        return cast(
-            EnumerationType,
-            self.as_type(_protobuf_type(KRPC.Type.ENUMERATION, service, name), doc=doc),
-        )
+        key = (KRPC.Type.ENUMERATION, service, name)
+        typ = self._type_cache.get(key)
+        if typ is None:
+            typ = self.as_type(
+                _protobuf_type(KRPC.Type.ENUMERATION, service, name), doc=doc
+            )
+            self._type_cache[key] = typ
+        return cast(EnumerationType, typ)
 
     def exception_type(
         self, service: str, name: str, doc: Optional[str] = None
@@ -199,53 +192,56 @@ class Types:
 
     def tuple_type(self, *value_types: TypeBase) -> TupleType:
         """Get a tuple type"""
-        return cast(
-            TupleType,
-            self.as_type(
+        key: tuple[object, ...] = (KRPC.Type.TUPLE,) + value_types
+        typ = self._type_cache.get(key)
+        if typ is None:
+            typ = self.as_type(
                 _protobuf_type(
                     KRPC.Type.TUPLE, None, None, [t.protobuf_type for t in value_types]
                 )
-            ),
-        )
+            )
+            self._type_cache[key] = typ
+        return cast(TupleType, typ)
 
     def list_type(self, value_type: TypeBase) -> ListType:
         """Get a list type"""
-        return cast(
-            ListType,
-            self.as_type(
+        key = (KRPC.Type.LIST, value_type)
+        typ = self._type_cache.get(key)
+        if typ is None:
+            typ = self.as_type(
                 _protobuf_type(KRPC.Type.LIST, None, None, [value_type.protobuf_type])
-            ),
-        )
+            )
+            self._type_cache[key] = typ
+        return cast(ListType, typ)
 
     def set_type(self, value_type: TypeBase) -> SetType:
         """Get a set type"""
-        return cast(
-            SetType,
-            self.as_type(
+        key = (KRPC.Type.SET, value_type)
+        typ = self._type_cache.get(key)
+        if typ is None:
+            typ = self.as_type(
                 _protobuf_type(KRPC.Type.SET, None, None, [value_type.protobuf_type])
-            ),
-        )
+            )
+            self._type_cache[key] = typ
+        return cast(SetType, typ)
 
     def dictionary_type(
         self, key_type: TypeBase, value_type: TypeBase
     ) -> DictionaryType:
         """Get a dictionary type"""
-        return cast(
-            DictionaryType,
-            self.as_type(
+        key = (KRPC.Type.DICTIONARY, key_type, value_type)
+        typ = self._type_cache.get(key)
+        if typ is None:
+            typ = self.as_type(
                 _protobuf_type(
                     KRPC.Type.DICTIONARY,
                     None,
                     None,
                     [key_type.protobuf_type, value_type.protobuf_type],
                 )
-            ),
-        )
-
-    @property
-    def event_type(self) -> MessageType:
-        """Get an Event message type"""
-        return cast(MessageType, self.as_type(_protobuf_type(KRPC.Type.EVENT)))
+            )
+            self._type_cache[key] = typ
+        return cast(DictionaryType, typ)
 
     @property
     def procedure_call_type(self) -> MessageType:

--- a/doc/src/cnano/client.rst
+++ b/doc/src/cnano/client.rst
@@ -146,6 +146,14 @@ argument to the compiler.
 
 * Memory allocation
 
+  * ``KRPC_BUFFER_SIZE`` -- How much of a message to hold in memory while it is written to or read
+    from the connection, defaulting to 1024 bytes, and to 128 bytes when building for Arduino where
+    a kilobyte is a large share of the memory there is. A message larger than this is carried in as
+    many passes as it takes, so this bounds the memory a call costs and never the size of a message
+    it can carry. A message that fits is also cheaper to send, as its size can be written in front
+    of it rather than found by a pass over it first, so it is worth setting this above the largest
+    call a program makes. Two buffers of this size are used, one for a message being sent and one
+    for a message being received, and neither outlives the call it is made for.
   * ``KRPC_ALLOC_BLOCK_SIZE`` -- The size of collections (lists, sets, etc.) are not know ahead of
     time, so when they are received from the server they are decoded into dynamically allocated
     memory on the heap. This option controls how many items to increase the capacity of the

--- a/tools/krpctools/krpctools/clientgen/cpp.tmpl
+++ b/tools/krpctools/krpctools/clientgen/cpp.tmpl
@@ -1,6 +1,7 @@
 #pragma once
 {% macro args(parameters) %}
 std::vector<krpc::encoder::Value> _args;
+_args.reserve({{ parameters | length }});
 {% for x in parameters %}
 _args.push_back({% if x.nullable is defined and x.nullable %}encoder::encode_nullable({{x.name}}){% else %}encoder::encode({{x.name}}){% endif %});
 {% endfor %}

--- a/tools/krpctools/krpctools/clientgen/python.tmpl
+++ b/tools/krpctools/krpctools/clientgen/python.tmpl
@@ -17,8 +17,6 @@ from krpc.services import {{service|lower()}}
 self{% for x in parameters %}, {{x.name}}: {{ x.type.spec }}{%if 'default_value' in x %} = {{x.default_value}}{% endif %}{% endfor %}{% endmacro %}
 {% macro static_arg_list(parameters) %}
 {% for x in parameters %}{{x.name}}: {{ x.type.spec }}{%if 'default_value' in x %} = {{x.default_value}}{% endif %}{% if not loop.last %}, {% endif %}{% endfor %}{% endmacro %}
-{% macro arg_names(parameters) %}
-{% for x in parameters %}"{{x.name}}"{% if not loop.last %}, {% endif %}{% endfor %}{% endmacro %}
 {% macro arg_values(parameters) %}
 {% for x in parameters %}{{x.name}}{% if not loop.last %}, {% endif %}{% endfor %}{% endmacro %}
 {% macro arg_types(parameters) %}
@@ -59,7 +57,6 @@ class {{class_name}}(ClassBase):
             "{{ service_name }}",
             "{{ prop.getter.remote_name }}",
             [self],
-            ["self"],
             [self._client._types.class_type("{{ service_name }}", "{{ class_name }}")],
             {{ prop.getter.return_type.python_type }}
         )
@@ -79,7 +76,6 @@ class {{class_name}}(ClassBase):
             "{{ service_name }}",
             "{{ prop.setter.remote_name }}",
             [self, {{ arg_values(prop.setter.parameters) }}],
-            ["self", {{ arg_names(prop.setter.parameters) }}],
             [self._client._types.class_type("{{ service_name }}", "{{ class_name }}"), {{ arg_types(prop.setter.parameters) }}],
             None
         )
@@ -94,7 +90,6 @@ class {{class_name}}(ClassBase):
             "{{ service_name }}",
             "{{ prop.getter.remote_name }}",
             [self],
-            ["self"],
             [self._client._types.class_type("{{ service_name }}", "{{ class_name }}")],
             {{ prop.getter.return_type.python_type }}
         )
@@ -111,7 +106,6 @@ class {{class_name}}(ClassBase):
             "{{ service_name }}",
             "{{ procedure.remote_name }}",
             [self, {{ arg_values(procedure.parameters) }}],
-            ["self", {{ arg_names(procedure.parameters) }}],
             [self._client._types.class_type("{{ service_name }}", "{{ class_name }}"), {{ arg_types(procedure.parameters) }}],
             {{ procedure.return_type.python_type }}
         )
@@ -124,7 +118,6 @@ class {{class_name}}(ClassBase):
             "{{ service_name }}",
             "{{ procedure.remote_name }}",
             [self, {{ arg_values(procedure.parameters) }}],
-            ["self", {{ arg_names(procedure.parameters) }}],
             [self._client._types.class_type("{{ service_name }}", "{{ class_name }}"), {{ arg_types(procedure.parameters) }}],
             {{ procedure.return_type.python_type }}
         )
@@ -142,7 +135,6 @@ class {{class_name}}(ClassBase):
             "{{ service_name }}",
             "{{ procedure.remote_name }}",
             [{{ arg_values(procedure.parameters) }}],
-            [{{ arg_names(procedure.parameters) }}],
             [{{ arg_types(procedure.parameters) }}],
             {{ procedure.return_type.python_type }}
         )
@@ -159,7 +151,6 @@ class {{class_name}}(ClassBase):
             "{{ service_name }}",
             "{{ procedure.remote_name }}",
             [{{ arg_values(procedure.parameters) }}],
-            [{{ arg_names(procedure.parameters) }}],
             [{{ arg_types(procedure.parameters) }}],
             {{ procedure.return_type.python_type }}
         )
@@ -233,7 +224,6 @@ class {{ service_name }}:
             "{{ prop.getter.remote_name }}",
             [],
             [],
-            [],
             {{ prop.getter.return_type.python_type }}
         )
 
@@ -252,7 +242,6 @@ class {{ service_name }}:
             "{{ service_name }}",
             "{{ prop.setter.remote_name }}",
             [{{ arg_values(prop.setter.parameters) }}],
-            [{{ arg_names(prop.setter.parameters) }}],
             [{{ arg_types(prop.setter.parameters) }}],
             None
         )
@@ -266,7 +255,6 @@ class {{ service_name }}:
         return self._client._build_call(
             "{{ service_name }}",
             "{{ prop.getter.remote_name }}",
-            [],
             [],
             [],
             {{ prop.getter.return_type.python_type }}
@@ -284,7 +272,6 @@ class {{ service_name }}:
             "{{ service_name }}",
             "{{ procedure.remote_name }}",
             [{{ arg_values(procedure.parameters) }}],
-            [{{ arg_names(procedure.parameters) }}],
             [{{ arg_types(procedure.parameters) }}],
             {{ procedure.return_type.python_type }}
         )
@@ -297,7 +284,6 @@ class {{ service_name }}:
             "{{ service_name }}",
             "{{ procedure.remote_name }}",
             [{{ arg_values(procedure.parameters) }}],
-            [{{ arg_names(procedure.parameters) }}],
             [{{ arg_types(procedure.parameters) }}],
             {{ procedure.return_type.python_type }}
         )

--- a/tools/krpctools/krpctools/clientgen/python.tmpl
+++ b/tools/krpctools/krpctools/clientgen/python.tmpl
@@ -165,35 +165,31 @@ class {{ service_name }}:
 
     def __init__(self, client: Client) -> None:
         self._client = client
+        # The classes, enumerations and exceptions the service defines are put on the
+        # service here, so that reaching one is an ordinary attribute lookup and nothing
+        # has to intercept the lookups that do not name one - which is every call, as a
+        # call goes through a procedure or a property. A class is bound to the client it
+        # is reached through, so that its static methods use that client.
+        self.__dict__.update(self._enumerations)
+        self.__dict__.update(self._exceptions)
+        for name, class_type in self._classes.items():
+            self.__dict__[name] = WrappedClass(client, class_type)
 
-    def __getattribute__(self, name):
-        # Intercepts calls to obtain classes from the service,
-        # to inject the client instance so that it can be used
-        # for static method calls
-        classes = object.__getattribute__(self, "_classes")
-        if name in classes:
-            client = object.__getattribute__(self, "_client")
-            return WrappedClass(client, classes[name])
-
-        # Intercept calls to obtain enumeration types
-        enumerations = object.__getattribute__(self, "_enumerations")
-        if name in enumerations:
-           return enumerations[name]
-
-        # Intercept calls to obtain exception types
-        exceptions = object.__getattribute__(self, "_exceptions")
-        if name in exceptions:
-           return exceptions[name]
-
-        # Fall back to default behaviour
-        return object.__getattribute__(self, name)
-
-    def __dir__(self):
-        result = object.__dir__(self)
-        result.extend(object.__getattribute__(self, "_classes").keys())
-        result.extend(object.__getattribute__(self, "_enumerations").keys())
-        result.extend(object.__getattribute__(self, "_exceptions").keys())
-        return result
+    def __getattr__(self, name):
+        # Reached only once the ordinary lookup has failed, which for a service means
+        # either a name it does not define, or one it does whose procedure or property
+        # raised an AttributeError of its own. Python discards that error before calling
+        # this, so it cannot be reported here; what can be done is to not report a member
+        # that does exist as missing, which would point at the wrong thing entirely.
+        cls = type(self)
+        if hasattr(cls, name):
+            raise AttributeError(
+                "'%s' object attribute '%s' raised AttributeError"
+                % (cls.__name__, name)
+            )
+        raise AttributeError(
+            "'%s' object has no attribute '%s'" % (cls.__name__, name)
+        )
 
     _classes = {
     {% for class_name in classes.keys() %}

--- a/tools/krpctools/krpctools/test/clientgen-Empty-python.txt
+++ b/tools/krpctools/krpctools/test/clientgen-Empty-python.txt
@@ -15,35 +15,31 @@ class EmptyService:
 
     def __init__(self, client: Client) -> None:
         self._client = client
+        # The classes, enumerations and exceptions the service defines are put on the
+        # service here, so that reaching one is an ordinary attribute lookup and nothing
+        # has to intercept the lookups that do not name one - which is every call, as a
+        # call goes through a procedure or a property. A class is bound to the client it
+        # is reached through, so that its static methods use that client.
+        self.__dict__.update(self._enumerations)
+        self.__dict__.update(self._exceptions)
+        for name, class_type in self._classes.items():
+            self.__dict__[name] = WrappedClass(client, class_type)
 
-    def __getattribute__(self, name):
-        # Intercepts calls to obtain classes from the service,
-        # to inject the client instance so that it can be used
-        # for static method calls
-        classes = object.__getattribute__(self, "_classes")
-        if name in classes:
-            client = object.__getattribute__(self, "_client")
-            return WrappedClass(client, classes[name])
-
-        # Intercept calls to obtain enumeration types
-        enumerations = object.__getattribute__(self, "_enumerations")
-        if name in enumerations:
-           return enumerations[name]
-
-        # Intercept calls to obtain exception types
-        exceptions = object.__getattribute__(self, "_exceptions")
-        if name in exceptions:
-           return exceptions[name]
-
-        # Fall back to default behaviour
-        return object.__getattribute__(self, name)
-
-    def __dir__(self):
-        result = object.__dir__(self)
-        result.extend(object.__getattribute__(self, "_classes").keys())
-        result.extend(object.__getattribute__(self, "_enumerations").keys())
-        result.extend(object.__getattribute__(self, "_exceptions").keys())
-        return result
+    def __getattr__(self, name):
+        # Reached only once the ordinary lookup has failed, which for a service means
+        # either a name it does not define, or one it does whose procedure or property
+        # raised an AttributeError of its own. Python discards that error before calling
+        # this, so it cannot be reported here; what can be done is to not report a member
+        # that does exist as missing, which would point at the wrong thing entirely.
+        cls = type(self)
+        if hasattr(cls, name):
+            raise AttributeError(
+                "'%s' object attribute '%s' raised AttributeError"
+                % (cls.__name__, name)
+            )
+        raise AttributeError(
+            "'%s' object has no attribute '%s'" % (cls.__name__, name)
+        )
 
     _classes = {
     }

--- a/tools/krpctools/krpctools/test/clientgen-Ordering-cpp.txt
+++ b/tools/krpctools/krpctools/test/clientgen-Ordering-cpp.txt
@@ -47,24 +47,28 @@ inline ServiceA::ServiceA(Client* client):
 
 inline void ServiceA::frob(ServiceB::Mode mode = ServiceB::Mode::fast) {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
   _args.push_back(encoder::encode(mode));
   this->_client->invoke("ServiceA", "Frob", _args);
 }
 
 inline void ServiceA::frob_all(std::vector<ServiceB::Mode> modes = std::vector<ServiceB::Mode>{ServiceB::Mode::fast}) {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
   _args.push_back(encoder::encode(modes));
   this->_client->invoke("ServiceA", "FrobAll", _args);
 }
 
 inline ::krpc::schema::ProcedureCall ServiceA::frob_call(ServiceB::Mode mode = ServiceB::Mode::fast) {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
   _args.push_back(encoder::encode(mode));
   return this->_client->build_call("ServiceA", "Frob", _args);
 }
 
 inline ::krpc::schema::ProcedureCall ServiceA::frob_all_call(std::vector<ServiceB::Mode> modes = std::vector<ServiceB::Mode>{ServiceB::Mode::fast}) {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
   _args.push_back(encoder::encode(modes));
   return this->_client->build_call("ServiceA", "FrobAll", _args);
 }

--- a/tools/krpctools/krpctools/test/clientgen-Ordering-python.txt
+++ b/tools/krpctools/krpctools/test/clientgen-Ordering-python.txt
@@ -64,7 +64,6 @@ class ServiceA:
             "ServiceA",
             "Frob",
             [mode],
-            ["mode"],
             [self._client._types.enumeration_type("ServiceB", "Mode")],
             None
         )
@@ -77,7 +76,6 @@ class ServiceA:
             "ServiceA",
             "Frob",
             [mode],
-            ["mode"],
             [self._client._types.enumeration_type("ServiceB", "Mode")],
             None
         )
@@ -90,7 +88,6 @@ class ServiceA:
             "ServiceA",
             "FrobAll",
             [modes],
-            ["modes"],
             [self._client._types.list_type(self._client._types.enumeration_type("ServiceB", "Mode"))],
             None
         )
@@ -103,7 +100,6 @@ class ServiceA:
             "ServiceA",
             "FrobAll",
             [modes],
-            ["modes"],
             [self._client._types.list_type(self._client._types.enumeration_type("ServiceB", "Mode"))],
             None
         )

--- a/tools/krpctools/krpctools/test/clientgen-Ordering-python.txt
+++ b/tools/krpctools/krpctools/test/clientgen-Ordering-python.txt
@@ -19,35 +19,31 @@ class ServiceA:
 
     def __init__(self, client: Client) -> None:
         self._client = client
+        # The classes, enumerations and exceptions the service defines are put on the
+        # service here, so that reaching one is an ordinary attribute lookup and nothing
+        # has to intercept the lookups that do not name one - which is every call, as a
+        # call goes through a procedure or a property. A class is bound to the client it
+        # is reached through, so that its static methods use that client.
+        self.__dict__.update(self._enumerations)
+        self.__dict__.update(self._exceptions)
+        for name, class_type in self._classes.items():
+            self.__dict__[name] = WrappedClass(client, class_type)
 
-    def __getattribute__(self, name):
-        # Intercepts calls to obtain classes from the service,
-        # to inject the client instance so that it can be used
-        # for static method calls
-        classes = object.__getattribute__(self, "_classes")
-        if name in classes:
-            client = object.__getattribute__(self, "_client")
-            return WrappedClass(client, classes[name])
-
-        # Intercept calls to obtain enumeration types
-        enumerations = object.__getattribute__(self, "_enumerations")
-        if name in enumerations:
-           return enumerations[name]
-
-        # Intercept calls to obtain exception types
-        exceptions = object.__getattribute__(self, "_exceptions")
-        if name in exceptions:
-           return exceptions[name]
-
-        # Fall back to default behaviour
-        return object.__getattribute__(self, name)
-
-    def __dir__(self):
-        result = object.__dir__(self)
-        result.extend(object.__getattribute__(self, "_classes").keys())
-        result.extend(object.__getattribute__(self, "_enumerations").keys())
-        result.extend(object.__getattribute__(self, "_exceptions").keys())
-        return result
+    def __getattr__(self, name):
+        # Reached only once the ordinary lookup has failed, which for a service means
+        # either a name it does not define, or one it does whose procedure or property
+        # raised an AttributeError of its own. Python discards that error before calling
+        # this, so it cannot be reported here; what can be done is to not report a member
+        # that does exist as missing, which would point at the wrong thing entirely.
+        cls = type(self)
+        if hasattr(cls, name):
+            raise AttributeError(
+                "'%s' object attribute '%s' raised AttributeError"
+                % (cls.__name__, name)
+            )
+        raise AttributeError(
+            "'%s' object has no attribute '%s'" % (cls.__name__, name)
+        )
 
     _classes = {
     }

--- a/tools/krpctools/krpctools/test/clientgen-TestService-cpp.txt
+++ b/tools/krpctools/krpctools/test/clientgen-TestService-cpp.txt
@@ -694,6 +694,7 @@ inline TestService::TestService(Client* client):
 
 inline std::string TestService::add_multiple_values(float x, int32_t y, int64_t z) {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(3);
   _args.push_back(encoder::encode(x));
   _args.push_back(encoder::encode(y));
   _args.push_back(encoder::encode(z));
@@ -706,6 +707,7 @@ inline std::string TestService::add_multiple_values(float x, int32_t y, int64_t 
 
 inline std::vector<TestService::TestClass> TestService::add_to_object_list(std::vector<TestService::TestClass> l, std::string value) {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(2);
   _args.push_back(encoder::encode(l));
   _args.push_back(encoder::encode(value));
   auto _data = this->_client->invoke("TestService", "AddToObjectList", _args);
@@ -717,6 +719,7 @@ inline std::vector<TestService::TestClass> TestService::add_to_object_list(std::
 
 inline int32_t TestService::blocking_procedure(int32_t n, int32_t sum = 0) {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(2);
   _args.push_back(encoder::encode(n));
   _args.push_back(encoder::encode(sum));
   auto _data = this->_client->invoke("TestService", "BlockingProcedure", _args);
@@ -728,6 +731,7 @@ inline int32_t TestService::blocking_procedure(int32_t n, int32_t sum = 0) {
 
 inline std::string TestService::bool_to_string(bool value) {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
   _args.push_back(encoder::encode(value));
   auto _data = this->_client->invoke("TestService", "BoolToString", _args);
   std::string _result{};
@@ -738,6 +742,7 @@ inline std::string TestService::bool_to_string(bool value) {
 
 inline std::string TestService::bytes_to_hex_string(std::string value) {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
   _args.push_back(encoder::encode(value));
   auto _data = this->_client->invoke("TestService", "BytesToHexString", _args);
   std::string _result{};
@@ -748,6 +753,7 @@ inline std::string TestService::bytes_to_hex_string(std::string value) {
 
 inline int32_t TestService::counter(std::string id = "", int32_t divisor = 1) {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(2);
   _args.push_back(encoder::encode(id));
   _args.push_back(encoder::encode(divisor));
   auto _data = this->_client->invoke("TestService", "Counter", _args);
@@ -759,6 +765,7 @@ inline int32_t TestService::counter(std::string id = "", int32_t divisor = 1) {
 
 inline TestService::TestClass TestService::create_test_object(std::string value) {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
   _args.push_back(encoder::encode(value));
   auto _data = this->_client->invoke("TestService", "CreateTestObject", _args);
   TestService::TestClass _result{};
@@ -769,6 +776,7 @@ inline TestService::TestClass TestService::create_test_object(std::string value)
 
 inline std::string TestService::deprecated_procedure(float value) {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
   _args.push_back(encoder::encode(value));
   auto _data = this->_client->invoke("TestService", "DeprecatedProcedure", _args);
   std::string _result{};
@@ -779,6 +787,7 @@ inline std::string TestService::deprecated_procedure(float value) {
 
 inline std::string TestService::deprecated_procedure_no_message(float value) {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
   _args.push_back(encoder::encode(value));
   auto _data = this->_client->invoke("TestService", "DeprecatedProcedureNoMessage", _args);
   std::string _result{};
@@ -789,6 +798,7 @@ inline std::string TestService::deprecated_procedure_no_message(float value) {
 
 inline std::map<int32_t, bool> TestService::dictionary_default(std::map<int32_t, bool> x = std::map<int32_t, bool>{{1, false}, {2, true}}) {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
   _args.push_back(encoder::encode(x));
   auto _data = this->_client->invoke("TestService", "DictionaryDefault", _args);
   std::map<int32_t, bool> _result{};
@@ -799,6 +809,7 @@ inline std::map<int32_t, bool> TestService::dictionary_default(std::map<int32_t,
 
 inline std::vector<double> TestService::double_special_defaults(double nan = std::numeric_limits<double>::quiet_NaN(), double infinity = std::numeric_limits<double>::infinity(), double negative_infinity = -std::numeric_limits<double>::infinity(), double maximum = (std::numeric_limits<double>::max)(), double lowest = std::numeric_limits<double>::lowest()) {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(5);
   _args.push_back(encoder::encode(nan));
   _args.push_back(encoder::encode(infinity));
   _args.push_back(encoder::encode(negative_infinity));
@@ -813,6 +824,7 @@ inline std::vector<double> TestService::double_special_defaults(double nan = std
 
 inline std::string TestService::double_to_string(double value) {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
   _args.push_back(encoder::encode(value));
   auto _data = this->_client->invoke("TestService", "DoubleToString", _args);
   std::string _result{};
@@ -823,6 +835,7 @@ inline std::string TestService::double_to_string(double value) {
 
 inline std::optional<int32_t> TestService::echo_nullable_int(std::optional<int32_t> value) {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
   _args.push_back(encoder::encode_nullable(value));
   auto _data = this->_client->invoke("TestService", "EchoNullableInt", _args);
   std::optional<int32_t> _result{};
@@ -833,6 +846,7 @@ inline std::optional<int32_t> TestService::echo_nullable_int(std::optional<int32
 
 inline std::optional<std::vector<int32_t> > TestService::echo_nullable_list(std::optional<std::vector<int32_t> > l) {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
   _args.push_back(encoder::encode_nullable(l));
   auto _data = this->_client->invoke("TestService", "EchoNullableList", _args);
   std::optional<std::vector<int32_t> > _result{};
@@ -843,6 +857,7 @@ inline std::optional<std::vector<int32_t> > TestService::echo_nullable_list(std:
 
 inline std::optional<std::string> TestService::echo_nullable_string(std::optional<std::string> value) {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
   _args.push_back(encoder::encode_nullable(value));
   auto _data = this->_client->invoke("TestService", "EchoNullableString", _args);
   std::optional<std::string> _result{};
@@ -853,6 +868,7 @@ inline std::optional<std::string> TestService::echo_nullable_string(std::optiona
 
 inline TestService::TestClass TestService::echo_test_object(TestService::TestClass value) {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
   _args.push_back(encoder::encode_nullable(value));
   auto _data = this->_client->invoke("TestService", "EchoTestObject", _args);
   TestService::TestClass _result{};
@@ -863,6 +879,7 @@ inline TestService::TestClass TestService::echo_test_object(TestService::TestCla
 
 inline std::vector<std::string> TestService::empty_list_default(std::vector<std::string> x = std::vector<std::string>{}) {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
   _args.push_back(encoder::encode(x));
   auto _data = this->_client->invoke("TestService", "EmptyListDefault", _args);
   std::vector<std::string> _result{};
@@ -873,6 +890,7 @@ inline std::vector<std::string> TestService::empty_list_default(std::vector<std:
 
 inline TestService::TestEnum TestService::enum_default_arg(TestService::TestEnum x = TestService::TestEnum::value_c) {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
   _args.push_back(encoder::encode(x));
   auto _data = this->_client->invoke("TestService", "EnumDefaultArg", _args);
   TestService::TestEnum _result{};
@@ -883,6 +901,7 @@ inline TestService::TestEnum TestService::enum_default_arg(TestService::TestEnum
 
 inline TestService::TestEnum TestService::enum_echo(TestService::TestEnum x) {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
   _args.push_back(encoder::encode(x));
   auto _data = this->_client->invoke("TestService", "EnumEcho", _args);
   TestService::TestEnum _result{};
@@ -893,6 +912,7 @@ inline TestService::TestEnum TestService::enum_echo(TestService::TestEnum x) {
 
 inline std::vector<TestService::TestEnum> TestService::enum_list_default(std::vector<TestService::TestEnum> x = std::vector<TestService::TestEnum>{TestService::TestEnum::value_b, TestService::TestEnum::value_c}) {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
   _args.push_back(encoder::encode(x));
   auto _data = this->_client->invoke("TestService", "EnumListDefault", _args);
   std::vector<TestService::TestEnum> _result{};
@@ -911,6 +931,7 @@ inline TestService::TestEnum TestService::enum_return() {
 
 inline std::vector<float> TestService::float_special_defaults(float nan = std::numeric_limits<float>::quiet_NaN(), float infinity = std::numeric_limits<float>::infinity(), float negative_infinity = -std::numeric_limits<float>::infinity(), float maximum = (std::numeric_limits<float>::max)(), float lowest = std::numeric_limits<float>::lowest(), float fraction = 0.1f) {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(6);
   _args.push_back(encoder::encode(nan));
   _args.push_back(encoder::encode(infinity));
   _args.push_back(encoder::encode(negative_infinity));
@@ -926,6 +947,7 @@ inline std::vector<float> TestService::float_special_defaults(float nan = std::n
 
 inline std::string TestService::float_to_string(float value) {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
   _args.push_back(encoder::encode(value));
   auto _data = this->_client->invoke("TestService", "FloatToString", _args);
   std::string _result{};
@@ -936,6 +958,7 @@ inline std::string TestService::float_to_string(float value) {
 
 inline std::map<std::string, int32_t> TestService::increment_dictionary(std::map<std::string, int32_t> d) {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
   _args.push_back(encoder::encode(d));
   auto _data = this->_client->invoke("TestService", "IncrementDictionary", _args);
   std::map<std::string, int32_t> _result{};
@@ -946,6 +969,7 @@ inline std::map<std::string, int32_t> TestService::increment_dictionary(std::map
 
 inline std::vector<int32_t> TestService::increment_list(std::vector<int32_t> l) {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
   _args.push_back(encoder::encode(l));
   auto _data = this->_client->invoke("TestService", "IncrementList", _args);
   std::vector<int32_t> _result{};
@@ -956,6 +980,7 @@ inline std::vector<int32_t> TestService::increment_list(std::vector<int32_t> l) 
 
 inline std::map<std::string, std::vector<int32_t> > TestService::increment_nested_collection(std::map<std::string, std::vector<int32_t> > d) {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
   _args.push_back(encoder::encode(d));
   auto _data = this->_client->invoke("TestService", "IncrementNestedCollection", _args);
   std::map<std::string, std::vector<int32_t> > _result{};
@@ -966,6 +991,7 @@ inline std::map<std::string, std::vector<int32_t> > TestService::increment_neste
 
 inline std::set<int32_t> TestService::increment_set(std::set<int32_t> h) {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
   _args.push_back(encoder::encode(h));
   auto _data = this->_client->invoke("TestService", "IncrementSet", _args);
   std::set<int32_t> _result{};
@@ -976,6 +1002,7 @@ inline std::set<int32_t> TestService::increment_set(std::set<int32_t> h) {
 
 inline std::tuple<int32_t, int64_t> TestService::increment_tuple(std::tuple<int32_t, int64_t> t) {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
   _args.push_back(encoder::encode(t));
   auto _data = this->_client->invoke("TestService", "IncrementTuple", _args);
   std::tuple<int32_t, int64_t> _result{};
@@ -986,6 +1013,7 @@ inline std::tuple<int32_t, int64_t> TestService::increment_tuple(std::tuple<int3
 
 inline std::vector<int32_t> TestService::int32_special_defaults(int32_t maximum = (std::numeric_limits<int32_t>::max)(), int32_t minimum = (std::numeric_limits<int32_t>::min)()) {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(2);
   _args.push_back(encoder::encode(maximum));
   _args.push_back(encoder::encode(minimum));
   auto _data = this->_client->invoke("TestService", "Int32SpecialDefaults", _args);
@@ -997,6 +1025,7 @@ inline std::vector<int32_t> TestService::int32_special_defaults(int32_t maximum 
 
 inline std::string TestService::int32_to_string(int32_t value) {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
   _args.push_back(encoder::encode(value));
   auto _data = this->_client->invoke("TestService", "Int32ToString", _args);
   std::string _result{};
@@ -1007,6 +1036,7 @@ inline std::string TestService::int32_to_string(int32_t value) {
 
 inline std::vector<int64_t> TestService::int64_special_defaults(int64_t maximum = (std::numeric_limits<int64_t>::max)(), int64_t minimum = (std::numeric_limits<int64_t>::min)()) {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(2);
   _args.push_back(encoder::encode(maximum));
   _args.push_back(encoder::encode(minimum));
   auto _data = this->_client->invoke("TestService", "Int64SpecialDefaults", _args);
@@ -1018,6 +1048,7 @@ inline std::vector<int64_t> TestService::int64_special_defaults(int64_t maximum 
 
 inline std::string TestService::int64_to_string(int64_t value) {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
   _args.push_back(encoder::encode(value));
   auto _data = this->_client->invoke("TestService", "Int64ToString", _args);
   std::string _result{};
@@ -1028,6 +1059,7 @@ inline std::string TestService::int64_to_string(int64_t value) {
 
 inline std::vector<int32_t> TestService::list_default(std::vector<int32_t> x = std::vector<int32_t>{1, 2, 3}) {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
   _args.push_back(encoder::encode(x));
   auto _data = this->_client->invoke("TestService", "ListDefault", _args);
   std::vector<int32_t> _result{};
@@ -1038,6 +1070,7 @@ inline std::vector<int32_t> TestService::list_default(std::vector<int32_t> x = s
 
 inline TestService::TestClass TestService::not_nullable_object(TestService::TestClass value) {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
   _args.push_back(encoder::encode(value));
   auto _data = this->_client->invoke("TestService", "NotNullableObject", _args);
   TestService::TestClass _result{};
@@ -1048,6 +1081,7 @@ inline TestService::TestClass TestService::not_nullable_object(TestService::Test
 
 inline ::krpc::Event TestService::on_timer(uint32_t milliseconds, uint32_t repeats = 1) {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(2);
   _args.push_back(encoder::encode(milliseconds));
   _args.push_back(encoder::encode(repeats));
   auto _data = this->_client->invoke("TestService", "OnTimer", _args);
@@ -1059,6 +1093,7 @@ inline ::krpc::Event TestService::on_timer(uint32_t milliseconds, uint32_t repea
 
 inline ::krpc::Event TestService::on_timer_using_lambda(uint32_t milliseconds) {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
   _args.push_back(encoder::encode(milliseconds));
   auto _data = this->_client->invoke("TestService", "OnTimerUsingLambda", _args);
   ::krpc::Event _result{};
@@ -1069,6 +1104,7 @@ inline ::krpc::Event TestService::on_timer_using_lambda(uint32_t milliseconds) {
 
 inline std::string TestService::optional_arguments(std::string x, std::string y = "foo", std::string z = "bar", TestService::TestClass obj = TestService::TestClass()) {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(4);
   _args.push_back(encoder::encode(x));
   _args.push_back(encoder::encode(y));
   _args.push_back(encoder::encode(z));
@@ -1098,6 +1134,7 @@ inline TestService::TestClass TestService::return_null_when_not_allowed() {
 
 inline std::set<int32_t> TestService::set_default(std::set<int32_t> x = std::set<int32_t>{1, 2, 3}) {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
   _args.push_back(encoder::encode(x));
   auto _data = this->_client->invoke("TestService", "SetDefault", _args);
   std::set<int32_t> _result{};
@@ -1108,6 +1145,7 @@ inline std::set<int32_t> TestService::set_default(std::set<int32_t> x = std::set
 
 inline int32_t TestService::string_to_int32(std::string value) {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
   _args.push_back(encoder::encode(value));
   auto _data = this->_client->invoke("TestService", "StringToInt32", _args);
   int32_t _result{};
@@ -1126,6 +1164,7 @@ inline int32_t TestService::throw_argument_exception() {
 
 inline int32_t TestService::throw_argument_null_exception(std::string foo) {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
   _args.push_back(encoder::encode(foo));
   auto _data = this->_client->invoke("TestService", "ThrowArgumentNullException", _args);
   int32_t _result{};
@@ -1136,6 +1175,7 @@ inline int32_t TestService::throw_argument_null_exception(std::string foo) {
 
 inline int32_t TestService::throw_argument_out_of_range_exception(int32_t foo) {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
   _args.push_back(encoder::encode(foo));
   auto _data = this->_client->invoke("TestService", "ThrowArgumentOutOfRangeException", _args);
   int32_t _result{};
@@ -1178,6 +1218,7 @@ inline int32_t TestService::throw_invalid_operation_exception_later() {
 
 inline std::tuple<int32_t, bool> TestService::tuple_default(std::tuple<int32_t, bool> x = std::tuple<int32_t, bool>{1, false}) {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
   _args.push_back(encoder::encode(x));
   auto _data = this->_client->invoke("TestService", "TupleDefault", _args);
   std::tuple<int32_t, bool> _result{};
@@ -1188,6 +1229,7 @@ inline std::tuple<int32_t, bool> TestService::tuple_default(std::tuple<int32_t, 
 
 inline std::vector<uint32_t> TestService::uint32_special_defaults(uint32_t maximum = (std::numeric_limits<uint32_t>::max)()) {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
   _args.push_back(encoder::encode(maximum));
   auto _data = this->_client->invoke("TestService", "Uint32SpecialDefaults", _args);
   std::vector<uint32_t> _result{};
@@ -1198,6 +1240,7 @@ inline std::vector<uint32_t> TestService::uint32_special_defaults(uint32_t maxim
 
 inline std::vector<uint64_t> TestService::uint64_special_defaults(uint64_t maximum = (std::numeric_limits<uint64_t>::max)()) {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
   _args.push_back(encoder::encode(maximum));
   auto _data = this->_client->invoke("TestService", "Uint64SpecialDefaults", _args);
   std::vector<uint64_t> _result{};
@@ -1216,6 +1259,7 @@ inline std::string TestService::deprecated_property() {
 
 inline void TestService::set_deprecated_property(std::string value) {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
   _args.push_back(encoder::encode(value));
   this->_client->invoke("TestService", "set_DeprecatedProperty", _args);
 }
@@ -1230,6 +1274,7 @@ inline TestService::TestClass TestService::nullable_object() {
 
 inline void TestService::set_nullable_object(TestService::TestClass value) {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
   _args.push_back(encoder::encode_nullable(value));
   this->_client->invoke("TestService", "set_NullableObject", _args);
 }
@@ -1244,6 +1289,7 @@ inline TestService::TestClass TestService::object_property() {
 
 inline void TestService::set_object_property(TestService::TestClass value) {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
   _args.push_back(encoder::encode_nullable(value));
   this->_client->invoke("TestService", "set_ObjectProperty", _args);
 }
@@ -1258,12 +1304,14 @@ inline std::string TestService::string_property() {
 
 inline void TestService::set_string_property(std::string value) {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
   _args.push_back(encoder::encode(value));
   this->_client->invoke("TestService", "set_StringProperty", _args);
 }
 
 inline void TestService::set_string_property_private_get(std::string value) {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
   _args.push_back(encoder::encode(value));
   this->_client->invoke("TestService", "set_StringPropertyPrivateGet", _args);
 }
@@ -1278,6 +1326,7 @@ inline std::string TestService::string_property_private_set() {
 
 inline ::krpc::Stream<std::string> TestService::add_multiple_values_stream(float x, int32_t y, int64_t z) {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(3);
   _args.push_back(encoder::encode(x));
   _args.push_back(encoder::encode(y));
   _args.push_back(encoder::encode(z));
@@ -1286,6 +1335,7 @@ inline ::krpc::Stream<std::string> TestService::add_multiple_values_stream(float
 
 inline ::krpc::Stream<std::vector<TestService::TestClass>> TestService::add_to_object_list_stream(std::vector<TestService::TestClass> l, std::string value) {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(2);
   _args.push_back(encoder::encode(l));
   _args.push_back(encoder::encode(value));
   return ::krpc::Stream<std::vector<TestService::TestClass>>(this->_client, this->_client->build_call("TestService", "AddToObjectList", _args));
@@ -1293,6 +1343,7 @@ inline ::krpc::Stream<std::vector<TestService::TestClass>> TestService::add_to_o
 
 inline ::krpc::Stream<int32_t> TestService::blocking_procedure_stream(int32_t n, int32_t sum = 0) {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(2);
   _args.push_back(encoder::encode(n));
   _args.push_back(encoder::encode(sum));
   return ::krpc::Stream<int32_t>(this->_client, this->_client->build_call("TestService", "BlockingProcedure", _args));
@@ -1300,18 +1351,21 @@ inline ::krpc::Stream<int32_t> TestService::blocking_procedure_stream(int32_t n,
 
 inline ::krpc::Stream<std::string> TestService::bool_to_string_stream(bool value) {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
   _args.push_back(encoder::encode(value));
   return ::krpc::Stream<std::string>(this->_client, this->_client->build_call("TestService", "BoolToString", _args));
 }
 
 inline ::krpc::Stream<std::string> TestService::bytes_to_hex_string_stream(std::string value) {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
   _args.push_back(encoder::encode(value));
   return ::krpc::Stream<std::string>(this->_client, this->_client->build_call("TestService", "BytesToHexString", _args));
 }
 
 inline ::krpc::Stream<int32_t> TestService::counter_stream(std::string id = "", int32_t divisor = 1) {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(2);
   _args.push_back(encoder::encode(id));
   _args.push_back(encoder::encode(divisor));
   return ::krpc::Stream<int32_t>(this->_client, this->_client->build_call("TestService", "Counter", _args));
@@ -1319,30 +1373,35 @@ inline ::krpc::Stream<int32_t> TestService::counter_stream(std::string id = "", 
 
 inline ::krpc::Stream<TestService::TestClass> TestService::create_test_object_stream(std::string value) {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
   _args.push_back(encoder::encode(value));
   return ::krpc::Stream<TestService::TestClass>(this->_client, this->_client->build_call("TestService", "CreateTestObject", _args));
 }
 
 inline ::krpc::Stream<std::string> TestService::deprecated_procedure_stream(float value) {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
   _args.push_back(encoder::encode(value));
   return ::krpc::Stream<std::string>(this->_client, this->_client->build_call("TestService", "DeprecatedProcedure", _args));
 }
 
 inline ::krpc::Stream<std::string> TestService::deprecated_procedure_no_message_stream(float value) {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
   _args.push_back(encoder::encode(value));
   return ::krpc::Stream<std::string>(this->_client, this->_client->build_call("TestService", "DeprecatedProcedureNoMessage", _args));
 }
 
 inline ::krpc::Stream<std::map<int32_t, bool>> TestService::dictionary_default_stream(std::map<int32_t, bool> x = std::map<int32_t, bool>{{1, false}, {2, true}}) {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
   _args.push_back(encoder::encode(x));
   return ::krpc::Stream<std::map<int32_t, bool>>(this->_client, this->_client->build_call("TestService", "DictionaryDefault", _args));
 }
 
 inline ::krpc::Stream<std::vector<double>> TestService::double_special_defaults_stream(double nan = std::numeric_limits<double>::quiet_NaN(), double infinity = std::numeric_limits<double>::infinity(), double negative_infinity = -std::numeric_limits<double>::infinity(), double maximum = (std::numeric_limits<double>::max)(), double lowest = std::numeric_limits<double>::lowest()) {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(5);
   _args.push_back(encoder::encode(nan));
   _args.push_back(encoder::encode(infinity));
   _args.push_back(encoder::encode(negative_infinity));
@@ -1353,54 +1412,63 @@ inline ::krpc::Stream<std::vector<double>> TestService::double_special_defaults_
 
 inline ::krpc::Stream<std::string> TestService::double_to_string_stream(double value) {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
   _args.push_back(encoder::encode(value));
   return ::krpc::Stream<std::string>(this->_client, this->_client->build_call("TestService", "DoubleToString", _args));
 }
 
 inline ::krpc::Stream<std::optional<int32_t>> TestService::echo_nullable_int_stream(std::optional<int32_t> value) {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
   _args.push_back(encoder::encode_nullable(value));
   return ::krpc::Stream<std::optional<int32_t>>(this->_client, this->_client->build_call("TestService", "EchoNullableInt", _args));
 }
 
 inline ::krpc::Stream<std::optional<std::vector<int32_t> >> TestService::echo_nullable_list_stream(std::optional<std::vector<int32_t> > l) {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
   _args.push_back(encoder::encode_nullable(l));
   return ::krpc::Stream<std::optional<std::vector<int32_t> >>(this->_client, this->_client->build_call("TestService", "EchoNullableList", _args));
 }
 
 inline ::krpc::Stream<std::optional<std::string>> TestService::echo_nullable_string_stream(std::optional<std::string> value) {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
   _args.push_back(encoder::encode_nullable(value));
   return ::krpc::Stream<std::optional<std::string>>(this->_client, this->_client->build_call("TestService", "EchoNullableString", _args));
 }
 
 inline ::krpc::Stream<TestService::TestClass> TestService::echo_test_object_stream(TestService::TestClass value) {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
   _args.push_back(encoder::encode_nullable(value));
   return ::krpc::Stream<TestService::TestClass>(this->_client, this->_client->build_call("TestService", "EchoTestObject", _args));
 }
 
 inline ::krpc::Stream<std::vector<std::string>> TestService::empty_list_default_stream(std::vector<std::string> x = std::vector<std::string>{}) {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
   _args.push_back(encoder::encode(x));
   return ::krpc::Stream<std::vector<std::string>>(this->_client, this->_client->build_call("TestService", "EmptyListDefault", _args));
 }
 
 inline ::krpc::Stream<TestService::TestEnum> TestService::enum_default_arg_stream(TestService::TestEnum x = TestService::TestEnum::value_c) {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
   _args.push_back(encoder::encode(x));
   return ::krpc::Stream<TestService::TestEnum>(this->_client, this->_client->build_call("TestService", "EnumDefaultArg", _args));
 }
 
 inline ::krpc::Stream<TestService::TestEnum> TestService::enum_echo_stream(TestService::TestEnum x) {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
   _args.push_back(encoder::encode(x));
   return ::krpc::Stream<TestService::TestEnum>(this->_client, this->_client->build_call("TestService", "EnumEcho", _args));
 }
 
 inline ::krpc::Stream<std::vector<TestService::TestEnum>> TestService::enum_list_default_stream(std::vector<TestService::TestEnum> x = std::vector<TestService::TestEnum>{TestService::TestEnum::value_b, TestService::TestEnum::value_c}) {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
   _args.push_back(encoder::encode(x));
   return ::krpc::Stream<std::vector<TestService::TestEnum>>(this->_client, this->_client->build_call("TestService", "EnumListDefault", _args));
 }
@@ -1411,6 +1479,7 @@ inline ::krpc::Stream<TestService::TestEnum> TestService::enum_return_stream() {
 
 inline ::krpc::Stream<std::vector<float>> TestService::float_special_defaults_stream(float nan = std::numeric_limits<float>::quiet_NaN(), float infinity = std::numeric_limits<float>::infinity(), float negative_infinity = -std::numeric_limits<float>::infinity(), float maximum = (std::numeric_limits<float>::max)(), float lowest = std::numeric_limits<float>::lowest(), float fraction = 0.1f) {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(6);
   _args.push_back(encoder::encode(nan));
   _args.push_back(encoder::encode(infinity));
   _args.push_back(encoder::encode(negative_infinity));
@@ -1422,42 +1491,49 @@ inline ::krpc::Stream<std::vector<float>> TestService::float_special_defaults_st
 
 inline ::krpc::Stream<std::string> TestService::float_to_string_stream(float value) {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
   _args.push_back(encoder::encode(value));
   return ::krpc::Stream<std::string>(this->_client, this->_client->build_call("TestService", "FloatToString", _args));
 }
 
 inline ::krpc::Stream<std::map<std::string, int32_t>> TestService::increment_dictionary_stream(std::map<std::string, int32_t> d) {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
   _args.push_back(encoder::encode(d));
   return ::krpc::Stream<std::map<std::string, int32_t>>(this->_client, this->_client->build_call("TestService", "IncrementDictionary", _args));
 }
 
 inline ::krpc::Stream<std::vector<int32_t>> TestService::increment_list_stream(std::vector<int32_t> l) {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
   _args.push_back(encoder::encode(l));
   return ::krpc::Stream<std::vector<int32_t>>(this->_client, this->_client->build_call("TestService", "IncrementList", _args));
 }
 
 inline ::krpc::Stream<std::map<std::string, std::vector<int32_t> >> TestService::increment_nested_collection_stream(std::map<std::string, std::vector<int32_t> > d) {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
   _args.push_back(encoder::encode(d));
   return ::krpc::Stream<std::map<std::string, std::vector<int32_t> >>(this->_client, this->_client->build_call("TestService", "IncrementNestedCollection", _args));
 }
 
 inline ::krpc::Stream<std::set<int32_t>> TestService::increment_set_stream(std::set<int32_t> h) {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
   _args.push_back(encoder::encode(h));
   return ::krpc::Stream<std::set<int32_t>>(this->_client, this->_client->build_call("TestService", "IncrementSet", _args));
 }
 
 inline ::krpc::Stream<std::tuple<int32_t, int64_t>> TestService::increment_tuple_stream(std::tuple<int32_t, int64_t> t) {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
   _args.push_back(encoder::encode(t));
   return ::krpc::Stream<std::tuple<int32_t, int64_t>>(this->_client, this->_client->build_call("TestService", "IncrementTuple", _args));
 }
 
 inline ::krpc::Stream<std::vector<int32_t>> TestService::int32_special_defaults_stream(int32_t maximum = (std::numeric_limits<int32_t>::max)(), int32_t minimum = (std::numeric_limits<int32_t>::min)()) {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(2);
   _args.push_back(encoder::encode(maximum));
   _args.push_back(encoder::encode(minimum));
   return ::krpc::Stream<std::vector<int32_t>>(this->_client, this->_client->build_call("TestService", "Int32SpecialDefaults", _args));
@@ -1465,12 +1541,14 @@ inline ::krpc::Stream<std::vector<int32_t>> TestService::int32_special_defaults_
 
 inline ::krpc::Stream<std::string> TestService::int32_to_string_stream(int32_t value) {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
   _args.push_back(encoder::encode(value));
   return ::krpc::Stream<std::string>(this->_client, this->_client->build_call("TestService", "Int32ToString", _args));
 }
 
 inline ::krpc::Stream<std::vector<int64_t>> TestService::int64_special_defaults_stream(int64_t maximum = (std::numeric_limits<int64_t>::max)(), int64_t minimum = (std::numeric_limits<int64_t>::min)()) {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(2);
   _args.push_back(encoder::encode(maximum));
   _args.push_back(encoder::encode(minimum));
   return ::krpc::Stream<std::vector<int64_t>>(this->_client, this->_client->build_call("TestService", "Int64SpecialDefaults", _args));
@@ -1478,24 +1556,28 @@ inline ::krpc::Stream<std::vector<int64_t>> TestService::int64_special_defaults_
 
 inline ::krpc::Stream<std::string> TestService::int64_to_string_stream(int64_t value) {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
   _args.push_back(encoder::encode(value));
   return ::krpc::Stream<std::string>(this->_client, this->_client->build_call("TestService", "Int64ToString", _args));
 }
 
 inline ::krpc::Stream<std::vector<int32_t>> TestService::list_default_stream(std::vector<int32_t> x = std::vector<int32_t>{1, 2, 3}) {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
   _args.push_back(encoder::encode(x));
   return ::krpc::Stream<std::vector<int32_t>>(this->_client, this->_client->build_call("TestService", "ListDefault", _args));
 }
 
 inline ::krpc::Stream<TestService::TestClass> TestService::not_nullable_object_stream(TestService::TestClass value) {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
   _args.push_back(encoder::encode(value));
   return ::krpc::Stream<TestService::TestClass>(this->_client, this->_client->build_call("TestService", "NotNullableObject", _args));
 }
 
 inline ::krpc::Stream<::krpc::Event> TestService::on_timer_stream(uint32_t milliseconds, uint32_t repeats = 1) {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(2);
   _args.push_back(encoder::encode(milliseconds));
   _args.push_back(encoder::encode(repeats));
   return ::krpc::Stream<::krpc::Event>(this->_client, this->_client->build_call("TestService", "OnTimer", _args));
@@ -1503,12 +1585,14 @@ inline ::krpc::Stream<::krpc::Event> TestService::on_timer_stream(uint32_t milli
 
 inline ::krpc::Stream<::krpc::Event> TestService::on_timer_using_lambda_stream(uint32_t milliseconds) {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
   _args.push_back(encoder::encode(milliseconds));
   return ::krpc::Stream<::krpc::Event>(this->_client, this->_client->build_call("TestService", "OnTimerUsingLambda", _args));
 }
 
 inline ::krpc::Stream<std::string> TestService::optional_arguments_stream(std::string x, std::string y = "foo", std::string z = "bar", TestService::TestClass obj = TestService::TestClass()) {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(4);
   _args.push_back(encoder::encode(x));
   _args.push_back(encoder::encode(y));
   _args.push_back(encoder::encode(z));
@@ -1522,12 +1606,14 @@ inline ::krpc::Stream<TestService::TestClass> TestService::return_null_when_not_
 
 inline ::krpc::Stream<std::set<int32_t>> TestService::set_default_stream(std::set<int32_t> x = std::set<int32_t>{1, 2, 3}) {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
   _args.push_back(encoder::encode(x));
   return ::krpc::Stream<std::set<int32_t>>(this->_client, this->_client->build_call("TestService", "SetDefault", _args));
 }
 
 inline ::krpc::Stream<int32_t> TestService::string_to_int32_stream(std::string value) {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
   _args.push_back(encoder::encode(value));
   return ::krpc::Stream<int32_t>(this->_client, this->_client->build_call("TestService", "StringToInt32", _args));
 }
@@ -1538,12 +1624,14 @@ inline ::krpc::Stream<int32_t> TestService::throw_argument_exception_stream() {
 
 inline ::krpc::Stream<int32_t> TestService::throw_argument_null_exception_stream(std::string foo) {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
   _args.push_back(encoder::encode(foo));
   return ::krpc::Stream<int32_t>(this->_client, this->_client->build_call("TestService", "ThrowArgumentNullException", _args));
 }
 
 inline ::krpc::Stream<int32_t> TestService::throw_argument_out_of_range_exception_stream(int32_t foo) {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
   _args.push_back(encoder::encode(foo));
   return ::krpc::Stream<int32_t>(this->_client, this->_client->build_call("TestService", "ThrowArgumentOutOfRangeException", _args));
 }
@@ -1566,18 +1654,21 @@ inline ::krpc::Stream<int32_t> TestService::throw_invalid_operation_exception_la
 
 inline ::krpc::Stream<std::tuple<int32_t, bool>> TestService::tuple_default_stream(std::tuple<int32_t, bool> x = std::tuple<int32_t, bool>{1, false}) {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
   _args.push_back(encoder::encode(x));
   return ::krpc::Stream<std::tuple<int32_t, bool>>(this->_client, this->_client->build_call("TestService", "TupleDefault", _args));
 }
 
 inline ::krpc::Stream<std::vector<uint32_t>> TestService::uint32_special_defaults_stream(uint32_t maximum = (std::numeric_limits<uint32_t>::max)()) {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
   _args.push_back(encoder::encode(maximum));
   return ::krpc::Stream<std::vector<uint32_t>>(this->_client, this->_client->build_call("TestService", "Uint32SpecialDefaults", _args));
 }
 
 inline ::krpc::Stream<std::vector<uint64_t>> TestService::uint64_special_defaults_stream(uint64_t maximum = (std::numeric_limits<uint64_t>::max)()) {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
   _args.push_back(encoder::encode(maximum));
   return ::krpc::Stream<std::vector<uint64_t>>(this->_client, this->_client->build_call("TestService", "Uint64SpecialDefaults", _args));
 }
@@ -1604,6 +1695,7 @@ inline ::krpc::Stream<std::string> TestService::string_property_private_set_stre
 
 inline ::krpc::schema::ProcedureCall TestService::add_multiple_values_call(float x, int32_t y, int64_t z) {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(3);
   _args.push_back(encoder::encode(x));
   _args.push_back(encoder::encode(y));
   _args.push_back(encoder::encode(z));
@@ -1612,6 +1704,7 @@ inline ::krpc::schema::ProcedureCall TestService::add_multiple_values_call(float
 
 inline ::krpc::schema::ProcedureCall TestService::add_to_object_list_call(std::vector<TestService::TestClass> l, std::string value) {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(2);
   _args.push_back(encoder::encode(l));
   _args.push_back(encoder::encode(value));
   return this->_client->build_call("TestService", "AddToObjectList", _args);
@@ -1619,6 +1712,7 @@ inline ::krpc::schema::ProcedureCall TestService::add_to_object_list_call(std::v
 
 inline ::krpc::schema::ProcedureCall TestService::blocking_procedure_call(int32_t n, int32_t sum = 0) {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(2);
   _args.push_back(encoder::encode(n));
   _args.push_back(encoder::encode(sum));
   return this->_client->build_call("TestService", "BlockingProcedure", _args);
@@ -1626,18 +1720,21 @@ inline ::krpc::schema::ProcedureCall TestService::blocking_procedure_call(int32_
 
 inline ::krpc::schema::ProcedureCall TestService::bool_to_string_call(bool value) {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
   _args.push_back(encoder::encode(value));
   return this->_client->build_call("TestService", "BoolToString", _args);
 }
 
 inline ::krpc::schema::ProcedureCall TestService::bytes_to_hex_string_call(std::string value) {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
   _args.push_back(encoder::encode(value));
   return this->_client->build_call("TestService", "BytesToHexString", _args);
 }
 
 inline ::krpc::schema::ProcedureCall TestService::counter_call(std::string id = "", int32_t divisor = 1) {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(2);
   _args.push_back(encoder::encode(id));
   _args.push_back(encoder::encode(divisor));
   return this->_client->build_call("TestService", "Counter", _args);
@@ -1645,30 +1742,35 @@ inline ::krpc::schema::ProcedureCall TestService::counter_call(std::string id = 
 
 inline ::krpc::schema::ProcedureCall TestService::create_test_object_call(std::string value) {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
   _args.push_back(encoder::encode(value));
   return this->_client->build_call("TestService", "CreateTestObject", _args);
 }
 
 inline ::krpc::schema::ProcedureCall TestService::deprecated_procedure_call(float value) {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
   _args.push_back(encoder::encode(value));
   return this->_client->build_call("TestService", "DeprecatedProcedure", _args);
 }
 
 inline ::krpc::schema::ProcedureCall TestService::deprecated_procedure_no_message_call(float value) {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
   _args.push_back(encoder::encode(value));
   return this->_client->build_call("TestService", "DeprecatedProcedureNoMessage", _args);
 }
 
 inline ::krpc::schema::ProcedureCall TestService::dictionary_default_call(std::map<int32_t, bool> x = std::map<int32_t, bool>{{1, false}, {2, true}}) {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
   _args.push_back(encoder::encode(x));
   return this->_client->build_call("TestService", "DictionaryDefault", _args);
 }
 
 inline ::krpc::schema::ProcedureCall TestService::double_special_defaults_call(double nan = std::numeric_limits<double>::quiet_NaN(), double infinity = std::numeric_limits<double>::infinity(), double negative_infinity = -std::numeric_limits<double>::infinity(), double maximum = (std::numeric_limits<double>::max)(), double lowest = std::numeric_limits<double>::lowest()) {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(5);
   _args.push_back(encoder::encode(nan));
   _args.push_back(encoder::encode(infinity));
   _args.push_back(encoder::encode(negative_infinity));
@@ -1679,54 +1781,63 @@ inline ::krpc::schema::ProcedureCall TestService::double_special_defaults_call(d
 
 inline ::krpc::schema::ProcedureCall TestService::double_to_string_call(double value) {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
   _args.push_back(encoder::encode(value));
   return this->_client->build_call("TestService", "DoubleToString", _args);
 }
 
 inline ::krpc::schema::ProcedureCall TestService::echo_nullable_int_call(std::optional<int32_t> value) {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
   _args.push_back(encoder::encode_nullable(value));
   return this->_client->build_call("TestService", "EchoNullableInt", _args);
 }
 
 inline ::krpc::schema::ProcedureCall TestService::echo_nullable_list_call(std::optional<std::vector<int32_t> > l) {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
   _args.push_back(encoder::encode_nullable(l));
   return this->_client->build_call("TestService", "EchoNullableList", _args);
 }
 
 inline ::krpc::schema::ProcedureCall TestService::echo_nullable_string_call(std::optional<std::string> value) {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
   _args.push_back(encoder::encode_nullable(value));
   return this->_client->build_call("TestService", "EchoNullableString", _args);
 }
 
 inline ::krpc::schema::ProcedureCall TestService::echo_test_object_call(TestService::TestClass value) {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
   _args.push_back(encoder::encode_nullable(value));
   return this->_client->build_call("TestService", "EchoTestObject", _args);
 }
 
 inline ::krpc::schema::ProcedureCall TestService::empty_list_default_call(std::vector<std::string> x = std::vector<std::string>{}) {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
   _args.push_back(encoder::encode(x));
   return this->_client->build_call("TestService", "EmptyListDefault", _args);
 }
 
 inline ::krpc::schema::ProcedureCall TestService::enum_default_arg_call(TestService::TestEnum x = TestService::TestEnum::value_c) {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
   _args.push_back(encoder::encode(x));
   return this->_client->build_call("TestService", "EnumDefaultArg", _args);
 }
 
 inline ::krpc::schema::ProcedureCall TestService::enum_echo_call(TestService::TestEnum x) {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
   _args.push_back(encoder::encode(x));
   return this->_client->build_call("TestService", "EnumEcho", _args);
 }
 
 inline ::krpc::schema::ProcedureCall TestService::enum_list_default_call(std::vector<TestService::TestEnum> x = std::vector<TestService::TestEnum>{TestService::TestEnum::value_b, TestService::TestEnum::value_c}) {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
   _args.push_back(encoder::encode(x));
   return this->_client->build_call("TestService", "EnumListDefault", _args);
 }
@@ -1737,6 +1848,7 @@ inline ::krpc::schema::ProcedureCall TestService::enum_return_call() {
 
 inline ::krpc::schema::ProcedureCall TestService::float_special_defaults_call(float nan = std::numeric_limits<float>::quiet_NaN(), float infinity = std::numeric_limits<float>::infinity(), float negative_infinity = -std::numeric_limits<float>::infinity(), float maximum = (std::numeric_limits<float>::max)(), float lowest = std::numeric_limits<float>::lowest(), float fraction = 0.1f) {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(6);
   _args.push_back(encoder::encode(nan));
   _args.push_back(encoder::encode(infinity));
   _args.push_back(encoder::encode(negative_infinity));
@@ -1748,42 +1860,49 @@ inline ::krpc::schema::ProcedureCall TestService::float_special_defaults_call(fl
 
 inline ::krpc::schema::ProcedureCall TestService::float_to_string_call(float value) {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
   _args.push_back(encoder::encode(value));
   return this->_client->build_call("TestService", "FloatToString", _args);
 }
 
 inline ::krpc::schema::ProcedureCall TestService::increment_dictionary_call(std::map<std::string, int32_t> d) {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
   _args.push_back(encoder::encode(d));
   return this->_client->build_call("TestService", "IncrementDictionary", _args);
 }
 
 inline ::krpc::schema::ProcedureCall TestService::increment_list_call(std::vector<int32_t> l) {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
   _args.push_back(encoder::encode(l));
   return this->_client->build_call("TestService", "IncrementList", _args);
 }
 
 inline ::krpc::schema::ProcedureCall TestService::increment_nested_collection_call(std::map<std::string, std::vector<int32_t> > d) {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
   _args.push_back(encoder::encode(d));
   return this->_client->build_call("TestService", "IncrementNestedCollection", _args);
 }
 
 inline ::krpc::schema::ProcedureCall TestService::increment_set_call(std::set<int32_t> h) {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
   _args.push_back(encoder::encode(h));
   return this->_client->build_call("TestService", "IncrementSet", _args);
 }
 
 inline ::krpc::schema::ProcedureCall TestService::increment_tuple_call(std::tuple<int32_t, int64_t> t) {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
   _args.push_back(encoder::encode(t));
   return this->_client->build_call("TestService", "IncrementTuple", _args);
 }
 
 inline ::krpc::schema::ProcedureCall TestService::int32_special_defaults_call(int32_t maximum = (std::numeric_limits<int32_t>::max)(), int32_t minimum = (std::numeric_limits<int32_t>::min)()) {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(2);
   _args.push_back(encoder::encode(maximum));
   _args.push_back(encoder::encode(minimum));
   return this->_client->build_call("TestService", "Int32SpecialDefaults", _args);
@@ -1791,12 +1910,14 @@ inline ::krpc::schema::ProcedureCall TestService::int32_special_defaults_call(in
 
 inline ::krpc::schema::ProcedureCall TestService::int32_to_string_call(int32_t value) {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
   _args.push_back(encoder::encode(value));
   return this->_client->build_call("TestService", "Int32ToString", _args);
 }
 
 inline ::krpc::schema::ProcedureCall TestService::int64_special_defaults_call(int64_t maximum = (std::numeric_limits<int64_t>::max)(), int64_t minimum = (std::numeric_limits<int64_t>::min)()) {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(2);
   _args.push_back(encoder::encode(maximum));
   _args.push_back(encoder::encode(minimum));
   return this->_client->build_call("TestService", "Int64SpecialDefaults", _args);
@@ -1804,24 +1925,28 @@ inline ::krpc::schema::ProcedureCall TestService::int64_special_defaults_call(in
 
 inline ::krpc::schema::ProcedureCall TestService::int64_to_string_call(int64_t value) {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
   _args.push_back(encoder::encode(value));
   return this->_client->build_call("TestService", "Int64ToString", _args);
 }
 
 inline ::krpc::schema::ProcedureCall TestService::list_default_call(std::vector<int32_t> x = std::vector<int32_t>{1, 2, 3}) {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
   _args.push_back(encoder::encode(x));
   return this->_client->build_call("TestService", "ListDefault", _args);
 }
 
 inline ::krpc::schema::ProcedureCall TestService::not_nullable_object_call(TestService::TestClass value) {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
   _args.push_back(encoder::encode(value));
   return this->_client->build_call("TestService", "NotNullableObject", _args);
 }
 
 inline ::krpc::schema::ProcedureCall TestService::on_timer_call(uint32_t milliseconds, uint32_t repeats = 1) {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(2);
   _args.push_back(encoder::encode(milliseconds));
   _args.push_back(encoder::encode(repeats));
   return this->_client->build_call("TestService", "OnTimer", _args);
@@ -1829,12 +1954,14 @@ inline ::krpc::schema::ProcedureCall TestService::on_timer_call(uint32_t millise
 
 inline ::krpc::schema::ProcedureCall TestService::on_timer_using_lambda_call(uint32_t milliseconds) {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
   _args.push_back(encoder::encode(milliseconds));
   return this->_client->build_call("TestService", "OnTimerUsingLambda", _args);
 }
 
 inline ::krpc::schema::ProcedureCall TestService::optional_arguments_call(std::string x, std::string y = "foo", std::string z = "bar", TestService::TestClass obj = TestService::TestClass()) {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(4);
   _args.push_back(encoder::encode(x));
   _args.push_back(encoder::encode(y));
   _args.push_back(encoder::encode(z));
@@ -1856,12 +1983,14 @@ inline ::krpc::schema::ProcedureCall TestService::return_null_when_not_allowed_c
 
 inline ::krpc::schema::ProcedureCall TestService::set_default_call(std::set<int32_t> x = std::set<int32_t>{1, 2, 3}) {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
   _args.push_back(encoder::encode(x));
   return this->_client->build_call("TestService", "SetDefault", _args);
 }
 
 inline ::krpc::schema::ProcedureCall TestService::string_to_int32_call(std::string value) {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
   _args.push_back(encoder::encode(value));
   return this->_client->build_call("TestService", "StringToInt32", _args);
 }
@@ -1872,12 +2001,14 @@ inline ::krpc::schema::ProcedureCall TestService::throw_argument_exception_call(
 
 inline ::krpc::schema::ProcedureCall TestService::throw_argument_null_exception_call(std::string foo) {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
   _args.push_back(encoder::encode(foo));
   return this->_client->build_call("TestService", "ThrowArgumentNullException", _args);
 }
 
 inline ::krpc::schema::ProcedureCall TestService::throw_argument_out_of_range_exception_call(int32_t foo) {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
   _args.push_back(encoder::encode(foo));
   return this->_client->build_call("TestService", "ThrowArgumentOutOfRangeException", _args);
 }
@@ -1900,18 +2031,21 @@ inline ::krpc::schema::ProcedureCall TestService::throw_invalid_operation_except
 
 inline ::krpc::schema::ProcedureCall TestService::tuple_default_call(std::tuple<int32_t, bool> x = std::tuple<int32_t, bool>{1, false}) {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
   _args.push_back(encoder::encode(x));
   return this->_client->build_call("TestService", "TupleDefault", _args);
 }
 
 inline ::krpc::schema::ProcedureCall TestService::uint32_special_defaults_call(uint32_t maximum = (std::numeric_limits<uint32_t>::max)()) {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
   _args.push_back(encoder::encode(maximum));
   return this->_client->build_call("TestService", "Uint32SpecialDefaults", _args);
 }
 
 inline ::krpc::schema::ProcedureCall TestService::uint64_special_defaults_call(uint64_t maximum = (std::numeric_limits<uint64_t>::max)()) {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
   _args.push_back(encoder::encode(maximum));
   return this->_client->build_call("TestService", "Uint64SpecialDefaults", _args);
 }
@@ -1922,6 +2056,7 @@ inline ::krpc::schema::ProcedureCall TestService::deprecated_property_call() {
 
 inline ::krpc::schema::ProcedureCall TestService::set_deprecated_property_call(std::string value) {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
   _args.push_back(encoder::encode(value));
   return this->_client->build_call("TestService", "set_DeprecatedProperty", _args);
 }
@@ -1932,6 +2067,7 @@ inline ::krpc::schema::ProcedureCall TestService::nullable_object_call() {
 
 inline ::krpc::schema::ProcedureCall TestService::set_nullable_object_call(TestService::TestClass value) {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
   _args.push_back(encoder::encode_nullable(value));
   return this->_client->build_call("TestService", "set_NullableObject", _args);
 }
@@ -1942,6 +2078,7 @@ inline ::krpc::schema::ProcedureCall TestService::object_property_call() {
 
 inline ::krpc::schema::ProcedureCall TestService::set_object_property_call(TestService::TestClass value) {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
   _args.push_back(encoder::encode_nullable(value));
   return this->_client->build_call("TestService", "set_ObjectProperty", _args);
 }
@@ -1952,12 +2089,14 @@ inline ::krpc::schema::ProcedureCall TestService::string_property_call() {
 
 inline ::krpc::schema::ProcedureCall TestService::set_string_property_call(std::string value) {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
   _args.push_back(encoder::encode(value));
   return this->_client->build_call("TestService", "set_StringProperty", _args);
 }
 
 inline ::krpc::schema::ProcedureCall TestService::set_string_property_private_get_call(std::string value) {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
   _args.push_back(encoder::encode(value));
   return this->_client->build_call("TestService", "set_StringPropertyPrivateGet", _args);
 }
@@ -1971,6 +2110,7 @@ inline TestService::DeprecatedClass::DeprecatedClass(Client* client, uint64_t id
 
 inline std::string TestService::DeprecatedClass::deprecated_method() {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
   _args.push_back(encoder::encode(*this));
   auto _data = this->_client->invoke("TestService", "DeprecatedClass_DeprecatedMethod", _args);
   std::string _result{};
@@ -1981,12 +2121,14 @@ inline std::string TestService::DeprecatedClass::deprecated_method() {
 
 inline ::krpc::Stream<std::string> TestService::DeprecatedClass::deprecated_method_stream() {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
   _args.push_back(encoder::encode(*this));
   return ::krpc::Stream<std::string>(this->_client, this->_client->build_call("TestService", "DeprecatedClass_DeprecatedMethod", _args));
 }
 
 inline ::krpc::schema::ProcedureCall TestService::DeprecatedClass::deprecated_method_call() {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
   _args.push_back(encoder::encode(*this));
   return this->_client->build_call("TestService", "DeprecatedClass_DeprecatedMethod", _args);
 }
@@ -1996,6 +2138,7 @@ inline TestService::TestClass::TestClass(Client* client, uint64_t id):
 
 inline TestService::TestClass TestService::TestClass::echo_nullable_object(TestService::TestClass value) {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(2);
   _args.push_back(encoder::encode(*this));
   _args.push_back(encoder::encode_nullable(value));
   auto _data = this->_client->invoke("TestService", "TestClass_EchoNullableObject", _args);
@@ -2007,6 +2150,7 @@ inline TestService::TestClass TestService::TestClass::echo_nullable_object(TestS
 
 inline std::string TestService::TestClass::float_to_string(float x) {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(2);
   _args.push_back(encoder::encode(*this));
   _args.push_back(encoder::encode(x));
   auto _data = this->_client->invoke("TestService", "TestClass_FloatToString", _args);
@@ -2018,6 +2162,7 @@ inline std::string TestService::TestClass::float_to_string(float x) {
 
 inline std::string TestService::TestClass::get_value() {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
   _args.push_back(encoder::encode(*this));
   auto _data = this->_client->invoke("TestService", "TestClass_GetValue", _args);
   std::string _result{};
@@ -2028,6 +2173,7 @@ inline std::string TestService::TestClass::get_value() {
 
 inline std::string TestService::TestClass::object_to_string(TestService::TestClass other) {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(2);
   _args.push_back(encoder::encode(*this));
   _args.push_back(encoder::encode_nullable(other));
   auto _data = this->_client->invoke("TestService", "TestClass_ObjectToString", _args);
@@ -2039,6 +2185,7 @@ inline std::string TestService::TestClass::object_to_string(TestService::TestCla
 
 inline std::string TestService::TestClass::optional_arguments(std::string x, std::string y = "foo", std::string z = "bar", TestService::TestClass obj = TestService::TestClass()) {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(5);
   _args.push_back(encoder::encode(*this));
   _args.push_back(encoder::encode(x));
   _args.push_back(encoder::encode(y));
@@ -2053,6 +2200,7 @@ inline std::string TestService::TestClass::optional_arguments(std::string x, std
 
 inline int32_t TestService::TestClass::int_property() {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
   _args.push_back(encoder::encode(*this));
   auto _data = this->_client->invoke("TestService", "TestClass_get_IntProperty", _args);
   int32_t _result{};
@@ -2063,6 +2211,7 @@ inline int32_t TestService::TestClass::int_property() {
 
 inline void TestService::TestClass::set_int_property(int32_t value) {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(2);
   _args.push_back(encoder::encode(*this));
   _args.push_back(encoder::encode(value));
   this->_client->invoke("TestService", "TestClass_set_IntProperty", _args);
@@ -2070,6 +2219,7 @@ inline void TestService::TestClass::set_int_property(int32_t value) {
 
 inline TestService::TestClass TestService::TestClass::object_property() {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
   _args.push_back(encoder::encode(*this));
   auto _data = this->_client->invoke("TestService", "TestClass_get_ObjectProperty", _args);
   TestService::TestClass _result{};
@@ -2080,6 +2230,7 @@ inline TestService::TestClass TestService::TestClass::object_property() {
 
 inline void TestService::TestClass::set_object_property(TestService::TestClass value) {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(2);
   _args.push_back(encoder::encode(*this));
   _args.push_back(encoder::encode_nullable(value));
   this->_client->invoke("TestService", "TestClass_set_ObjectProperty", _args);
@@ -2087,6 +2238,7 @@ inline void TestService::TestClass::set_object_property(TestService::TestClass v
 
 inline void TestService::TestClass::set_string_property_private_get(std::string value) {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(2);
   _args.push_back(encoder::encode(*this));
   _args.push_back(encoder::encode(value));
   this->_client->invoke("TestService", "TestClass_set_StringPropertyPrivateGet", _args);
@@ -2094,6 +2246,7 @@ inline void TestService::TestClass::set_string_property_private_get(std::string 
 
 inline std::string TestService::TestClass::string_property_private_set() {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
   _args.push_back(encoder::encode(*this));
   auto _data = this->_client->invoke("TestService", "TestClass_get_StringPropertyPrivateSet", _args);
   std::string _result{};
@@ -2104,6 +2257,7 @@ inline std::string TestService::TestClass::string_property_private_set() {
 
 inline std::string TestService::TestClass::static_method(Client& _client, std::string a = "", std::string b = "") {
     std::vector<krpc::encoder::Value> _args;
+  _args.reserve(2);
   _args.push_back(encoder::encode(a));
   _args.push_back(encoder::encode(b));
   auto _data = _client.invoke("TestService", "TestClass_static_StaticMethod", _args);
@@ -2115,6 +2269,7 @@ inline std::string TestService::TestClass::static_method(Client& _client, std::s
 
 inline TestService::TestClass TestService::TestClass::static_nullable_object(Client& _client, TestService::TestClass value) {
     std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
   _args.push_back(encoder::encode_nullable(value));
   auto _data = _client.invoke("TestService", "TestClass_static_StaticNullableObject", _args);
     TestService::TestClass _result{};
@@ -2125,6 +2280,7 @@ inline TestService::TestClass TestService::TestClass::static_nullable_object(Cli
 
 inline ::krpc::Stream<TestService::TestClass> TestService::TestClass::echo_nullable_object_stream(TestService::TestClass value) {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(2);
   _args.push_back(encoder::encode(*this));
   _args.push_back(encoder::encode_nullable(value));
   return ::krpc::Stream<TestService::TestClass>(this->_client, this->_client->build_call("TestService", "TestClass_EchoNullableObject", _args));
@@ -2132,6 +2288,7 @@ inline ::krpc::Stream<TestService::TestClass> TestService::TestClass::echo_nulla
 
 inline ::krpc::Stream<std::string> TestService::TestClass::float_to_string_stream(float x) {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(2);
   _args.push_back(encoder::encode(*this));
   _args.push_back(encoder::encode(x));
   return ::krpc::Stream<std::string>(this->_client, this->_client->build_call("TestService", "TestClass_FloatToString", _args));
@@ -2139,12 +2296,14 @@ inline ::krpc::Stream<std::string> TestService::TestClass::float_to_string_strea
 
 inline ::krpc::Stream<std::string> TestService::TestClass::get_value_stream() {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
   _args.push_back(encoder::encode(*this));
   return ::krpc::Stream<std::string>(this->_client, this->_client->build_call("TestService", "TestClass_GetValue", _args));
 }
 
 inline ::krpc::Stream<std::string> TestService::TestClass::object_to_string_stream(TestService::TestClass other) {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(2);
   _args.push_back(encoder::encode(*this));
   _args.push_back(encoder::encode_nullable(other));
   return ::krpc::Stream<std::string>(this->_client, this->_client->build_call("TestService", "TestClass_ObjectToString", _args));
@@ -2152,6 +2311,7 @@ inline ::krpc::Stream<std::string> TestService::TestClass::object_to_string_stre
 
 inline ::krpc::Stream<std::string> TestService::TestClass::optional_arguments_stream(std::string x, std::string y = "foo", std::string z = "bar", TestService::TestClass obj = TestService::TestClass()) {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(5);
   _args.push_back(encoder::encode(*this));
   _args.push_back(encoder::encode(x));
   _args.push_back(encoder::encode(y));
@@ -2162,24 +2322,28 @@ inline ::krpc::Stream<std::string> TestService::TestClass::optional_arguments_st
 
 inline ::krpc::Stream<int32_t> TestService::TestClass::int_property_stream() {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
   _args.push_back(encoder::encode(*this));
   return ::krpc::Stream<int32_t>(this->_client, this->_client->build_call("TestService", "TestClass_get_IntProperty", _args));
 }
 
 inline ::krpc::Stream<TestService::TestClass> TestService::TestClass::object_property_stream() {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
   _args.push_back(encoder::encode(*this));
   return ::krpc::Stream<TestService::TestClass>(this->_client, this->_client->build_call("TestService", "TestClass_get_ObjectProperty", _args));
 }
 
 inline ::krpc::Stream<std::string> TestService::TestClass::string_property_private_set_stream() {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
   _args.push_back(encoder::encode(*this));
   return ::krpc::Stream<std::string>(this->_client, this->_client->build_call("TestService", "TestClass_get_StringPropertyPrivateSet", _args));
 }
 
 inline ::krpc::Stream<std::string> TestService::TestClass::static_method_stream(Client& _client, std::string a = "", std::string b = "") {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(2);
   _args.push_back(encoder::encode(a));
   _args.push_back(encoder::encode(b));
   return ::krpc::Stream<std::string>(&_client, _client.build_call("TestService", "TestClass_static_StaticMethod", _args));
@@ -2187,12 +2351,14 @@ inline ::krpc::Stream<std::string> TestService::TestClass::static_method_stream(
 
 inline ::krpc::Stream<TestService::TestClass> TestService::TestClass::static_nullable_object_stream(Client& _client, TestService::TestClass value) {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
   _args.push_back(encoder::encode_nullable(value));
   return ::krpc::Stream<TestService::TestClass>(&_client, _client.build_call("TestService", "TestClass_static_StaticNullableObject", _args));
 }
 
 inline ::krpc::schema::ProcedureCall TestService::TestClass::echo_nullable_object_call(TestService::TestClass value) {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(2);
   _args.push_back(encoder::encode(*this));
   _args.push_back(encoder::encode_nullable(value));
   return this->_client->build_call("TestService", "TestClass_EchoNullableObject", _args);
@@ -2200,6 +2366,7 @@ inline ::krpc::schema::ProcedureCall TestService::TestClass::echo_nullable_objec
 
 inline ::krpc::schema::ProcedureCall TestService::TestClass::float_to_string_call(float x) {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(2);
   _args.push_back(encoder::encode(*this));
   _args.push_back(encoder::encode(x));
   return this->_client->build_call("TestService", "TestClass_FloatToString", _args);
@@ -2207,12 +2374,14 @@ inline ::krpc::schema::ProcedureCall TestService::TestClass::float_to_string_cal
 
 inline ::krpc::schema::ProcedureCall TestService::TestClass::get_value_call() {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
   _args.push_back(encoder::encode(*this));
   return this->_client->build_call("TestService", "TestClass_GetValue", _args);
 }
 
 inline ::krpc::schema::ProcedureCall TestService::TestClass::object_to_string_call(TestService::TestClass other) {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(2);
   _args.push_back(encoder::encode(*this));
   _args.push_back(encoder::encode_nullable(other));
   return this->_client->build_call("TestService", "TestClass_ObjectToString", _args);
@@ -2220,6 +2389,7 @@ inline ::krpc::schema::ProcedureCall TestService::TestClass::object_to_string_ca
 
 inline ::krpc::schema::ProcedureCall TestService::TestClass::optional_arguments_call(std::string x, std::string y = "foo", std::string z = "bar", TestService::TestClass obj = TestService::TestClass()) {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(5);
   _args.push_back(encoder::encode(*this));
   _args.push_back(encoder::encode(x));
   _args.push_back(encoder::encode(y));
@@ -2230,12 +2400,14 @@ inline ::krpc::schema::ProcedureCall TestService::TestClass::optional_arguments_
 
 inline ::krpc::schema::ProcedureCall TestService::TestClass::int_property_call() {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
   _args.push_back(encoder::encode(*this));
   return this->_client->build_call("TestService", "TestClass_get_IntProperty", _args);
 }
 
 inline ::krpc::schema::ProcedureCall TestService::TestClass::set_int_property_call(int32_t value) {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(2);
   _args.push_back(encoder::encode(*this));
   _args.push_back(encoder::encode(value));
   return this->_client->build_call("TestService", "TestClass_set_IntProperty", _args);
@@ -2243,12 +2415,14 @@ inline ::krpc::schema::ProcedureCall TestService::TestClass::set_int_property_ca
 
 inline ::krpc::schema::ProcedureCall TestService::TestClass::object_property_call() {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
   _args.push_back(encoder::encode(*this));
   return this->_client->build_call("TestService", "TestClass_get_ObjectProperty", _args);
 }
 
 inline ::krpc::schema::ProcedureCall TestService::TestClass::set_object_property_call(TestService::TestClass value) {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(2);
   _args.push_back(encoder::encode(*this));
   _args.push_back(encoder::encode_nullable(value));
   return this->_client->build_call("TestService", "TestClass_set_ObjectProperty", _args);
@@ -2256,6 +2430,7 @@ inline ::krpc::schema::ProcedureCall TestService::TestClass::set_object_property
 
 inline ::krpc::schema::ProcedureCall TestService::TestClass::set_string_property_private_get_call(std::string value) {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(2);
   _args.push_back(encoder::encode(*this));
   _args.push_back(encoder::encode(value));
   return this->_client->build_call("TestService", "TestClass_set_StringPropertyPrivateGet", _args);
@@ -2263,12 +2438,14 @@ inline ::krpc::schema::ProcedureCall TestService::TestClass::set_string_property
 
 inline ::krpc::schema::ProcedureCall TestService::TestClass::string_property_private_set_call() {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
   _args.push_back(encoder::encode(*this));
   return this->_client->build_call("TestService", "TestClass_get_StringPropertyPrivateSet", _args);
 }
 
 inline ::krpc::schema::ProcedureCall TestService::TestClass::static_method_call(Client& _client, std::string a = "", std::string b = "") {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(2);
   _args.push_back(encoder::encode(a));
   _args.push_back(encoder::encode(b));
   return _client.build_call("TestService", "TestClass_static_StaticMethod", _args);
@@ -2276,6 +2453,7 @@ inline ::krpc::schema::ProcedureCall TestService::TestClass::static_method_call(
 
 inline ::krpc::schema::ProcedureCall TestService::TestClass::static_nullable_object_call(Client& _client, TestService::TestClass value) {
   std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
   _args.push_back(encoder::encode_nullable(value));
   return _client.build_call("TestService", "TestClass_static_StaticNullableObject", _args);
 }

--- a/tools/krpctools/krpctools/test/clientgen-TestService-python.txt
+++ b/tools/krpctools/krpctools/test/clientgen-TestService-python.txt
@@ -70,7 +70,6 @@ class DeprecatedClass(ClassBase):
             "TestService",
             "DeprecatedClass_DeprecatedMethod",
             [self, ],
-            ["self", ],
             [self._client._types.class_type("TestService", "DeprecatedClass"), ],
             self._client._types.string_type
         )
@@ -83,7 +82,6 @@ class DeprecatedClass(ClassBase):
             "TestService",
             "DeprecatedClass_DeprecatedMethod",
             [self, ],
-            ["self", ],
             [self._client._types.class_type("TestService", "DeprecatedClass"), ],
             self._client._types.string_type
         )
@@ -103,7 +101,6 @@ class TestClass(ClassBase):
             "TestService",
             "TestClass_get_IntProperty",
             [self],
-            ["self"],
             [self._client._types.class_type("TestService", "TestClass")],
             self._client._types.sint32_type
         )
@@ -114,7 +111,6 @@ class TestClass(ClassBase):
             "TestService",
             "TestClass_set_IntProperty",
             [self, value],
-            ["self", "value"],
             [self._client._types.class_type("TestService", "TestClass"), self._client._types.sint32_type],
             None
         )
@@ -127,7 +123,6 @@ class TestClass(ClassBase):
             "TestService",
             "TestClass_get_IntProperty",
             [self],
-            ["self"],
             [self._client._types.class_type("TestService", "TestClass")],
             self._client._types.sint32_type
         )
@@ -138,7 +133,6 @@ class TestClass(ClassBase):
             "TestService",
             "TestClass_get_ObjectProperty",
             [self],
-            ["self"],
             [self._client._types.class_type("TestService", "TestClass")],
             self._client._types.class_type("TestService", "TestClass")
         )
@@ -149,7 +143,6 @@ class TestClass(ClassBase):
             "TestService",
             "TestClass_set_ObjectProperty",
             [self, value],
-            ["self", "value"],
             [self._client._types.class_type("TestService", "TestClass"), self._client._types.class_type("TestService", "TestClass")],
             None
         )
@@ -162,7 +155,6 @@ class TestClass(ClassBase):
             "TestService",
             "TestClass_get_ObjectProperty",
             [self],
-            ["self"],
             [self._client._types.class_type("TestService", "TestClass")],
             self._client._types.class_type("TestService", "TestClass")
         )
@@ -177,7 +169,6 @@ class TestClass(ClassBase):
             "TestService",
             "TestClass_set_StringPropertyPrivateGet",
             [self, value],
-            ["self", "value"],
             [self._client._types.class_type("TestService", "TestClass"), self._client._types.string_type],
             None
         )
@@ -188,7 +179,6 @@ class TestClass(ClassBase):
             "TestService",
             "TestClass_get_StringPropertyPrivateSet",
             [self],
-            ["self"],
             [self._client._types.class_type("TestService", "TestClass")],
             self._client._types.string_type
         )
@@ -201,7 +191,6 @@ class TestClass(ClassBase):
             "TestService",
             "TestClass_get_StringPropertyPrivateSet",
             [self],
-            ["self"],
             [self._client._types.class_type("TestService", "TestClass")],
             self._client._types.string_type
         )
@@ -211,7 +200,6 @@ class TestClass(ClassBase):
             "TestService",
             "TestClass_EchoNullableObject",
             [self, value],
-            ["self", "value"],
             [self._client._types.class_type("TestService", "TestClass"), self._client._types.class_type("TestService", "TestClass")],
             self._client._types.class_type("TestService", "TestClass")
         )
@@ -224,7 +212,6 @@ class TestClass(ClassBase):
             "TestService",
             "TestClass_EchoNullableObject",
             [self, value],
-            ["self", "value"],
             [self._client._types.class_type("TestService", "TestClass"), self._client._types.class_type("TestService", "TestClass")],
             self._client._types.class_type("TestService", "TestClass")
         )
@@ -234,7 +221,6 @@ class TestClass(ClassBase):
             "TestService",
             "TestClass_FloatToString",
             [self, x],
-            ["self", "x"],
             [self._client._types.class_type("TestService", "TestClass"), self._client._types.float_type],
             self._client._types.string_type
         )
@@ -247,7 +233,6 @@ class TestClass(ClassBase):
             "TestService",
             "TestClass_FloatToString",
             [self, x],
-            ["self", "x"],
             [self._client._types.class_type("TestService", "TestClass"), self._client._types.float_type],
             self._client._types.string_type
         )
@@ -260,7 +245,6 @@ class TestClass(ClassBase):
             "TestService",
             "TestClass_GetValue",
             [self, ],
-            ["self", ],
             [self._client._types.class_type("TestService", "TestClass"), ],
             self._client._types.string_type
         )
@@ -273,7 +257,6 @@ class TestClass(ClassBase):
             "TestService",
             "TestClass_GetValue",
             [self, ],
-            ["self", ],
             [self._client._types.class_type("TestService", "TestClass"), ],
             self._client._types.string_type
         )
@@ -283,7 +266,6 @@ class TestClass(ClassBase):
             "TestService",
             "TestClass_ObjectToString",
             [self, other],
-            ["self", "other"],
             [self._client._types.class_type("TestService", "TestClass"), self._client._types.class_type("TestService", "TestClass")],
             self._client._types.string_type
         )
@@ -296,7 +278,6 @@ class TestClass(ClassBase):
             "TestService",
             "TestClass_ObjectToString",
             [self, other],
-            ["self", "other"],
             [self._client._types.class_type("TestService", "TestClass"), self._client._types.class_type("TestService", "TestClass")],
             self._client._types.string_type
         )
@@ -306,7 +287,6 @@ class TestClass(ClassBase):
             "TestService",
             "TestClass_OptionalArguments",
             [self, x, y, z, obj],
-            ["self", "x", "y", "z", "obj"],
             [self._client._types.class_type("TestService", "TestClass"), self._client._types.string_type, self._client._types.string_type, self._client._types.string_type, self._client._types.class_type("TestService", "TestClass")],
             self._client._types.string_type
         )
@@ -319,7 +299,6 @@ class TestClass(ClassBase):
             "TestService",
             "TestClass_OptionalArguments",
             [self, x, y, z, obj],
-            ["self", "x", "y", "z", "obj"],
             [self._client._types.class_type("TestService", "TestClass"), self._client._types.string_type, self._client._types.string_type, self._client._types.string_type, self._client._types.class_type("TestService", "TestClass")],
             self._client._types.string_type
         )
@@ -331,7 +310,6 @@ class TestClass(ClassBase):
             "TestService",
             "TestClass_static_StaticMethod",
             [a, b],
-            ["a", "b"],
             [self._client._types.string_type, self._client._types.string_type],
             self._client._types.string_type
         )
@@ -348,7 +326,6 @@ class TestClass(ClassBase):
             "TestService",
             "TestClass_static_StaticMethod",
             [a, b],
-            ["a", "b"],
             [self._client._types.string_type, self._client._types.string_type],
             self._client._types.string_type
         )
@@ -360,7 +337,6 @@ class TestClass(ClassBase):
             "TestService",
             "TestClass_static_StaticNullableObject",
             [value],
-            ["value"],
             [self._client._types.class_type("TestService", "TestClass")],
             self._client._types.class_type("TestService", "TestClass")
         )
@@ -377,7 +353,6 @@ class TestClass(ClassBase):
             "TestService",
             "TestClass_static_StaticNullableObject",
             [value],
-            ["value"],
             [self._client._types.class_type("TestService", "TestClass")],
             self._client._types.class_type("TestService", "TestClass")
         )
@@ -447,7 +422,6 @@ class TestService:
             "get_DeprecatedProperty",
             [],
             [],
-            [],
             self._client._types.string_type
         )
 
@@ -458,7 +432,6 @@ class TestService:
             "TestService",
             "set_DeprecatedProperty",
             [value],
-            ["value"],
             [self._client._types.string_type],
             None
         )
@@ -472,7 +445,6 @@ class TestService:
             "get_DeprecatedProperty",
             [],
             [],
-            [],
             self._client._types.string_type
         )
 
@@ -481,7 +453,6 @@ class TestService:
         return self._client._invoke(
             "TestService",
             "get_NullableObject",
-            [],
             [],
             [],
             self._client._types.class_type("TestService", "TestClass")
@@ -493,7 +464,6 @@ class TestService:
             "TestService",
             "set_NullableObject",
             [value],
-            ["value"],
             [self._client._types.class_type("TestService", "TestClass")],
             None
         )
@@ -507,7 +477,6 @@ class TestService:
             "get_NullableObject",
             [],
             [],
-            [],
             self._client._types.class_type("TestService", "TestClass")
         )
 
@@ -516,7 +485,6 @@ class TestService:
         return self._client._invoke(
             "TestService",
             "get_ObjectProperty",
-            [],
             [],
             [],
             self._client._types.class_type("TestService", "TestClass")
@@ -528,7 +496,6 @@ class TestService:
             "TestService",
             "set_ObjectProperty",
             [value],
-            ["value"],
             [self._client._types.class_type("TestService", "TestClass")],
             None
         )
@@ -540,7 +507,6 @@ class TestService:
         return self._client._build_call(
             "TestService",
             "get_ObjectProperty",
-            [],
             [],
             [],
             self._client._types.class_type("TestService", "TestClass")
@@ -556,7 +522,6 @@ class TestService:
             "get_StringProperty",
             [],
             [],
-            [],
             self._client._types.string_type
         )
 
@@ -566,7 +531,6 @@ class TestService:
             "TestService",
             "set_StringProperty",
             [value],
-            ["value"],
             [self._client._types.string_type],
             None
         )
@@ -578,7 +542,6 @@ class TestService:
         return self._client._build_call(
             "TestService",
             "get_StringProperty",
-            [],
             [],
             [],
             self._client._types.string_type
@@ -594,7 +557,6 @@ class TestService:
             "TestService",
             "set_StringPropertyPrivateGet",
             [value],
-            ["value"],
             [self._client._types.string_type],
             None
         )
@@ -604,7 +566,6 @@ class TestService:
         return self._client._invoke(
             "TestService",
             "get_StringPropertyPrivateSet",
-            [],
             [],
             [],
             self._client._types.string_type
@@ -619,7 +580,6 @@ class TestService:
             "get_StringPropertyPrivateSet",
             [],
             [],
-            [],
             self._client._types.string_type
         )
 
@@ -628,7 +588,6 @@ class TestService:
             "TestService",
             "AddMultipleValues",
             [x, y, z],
-            ["x", "y", "z"],
             [self._client._types.float_type, self._client._types.sint32_type, self._client._types.sint64_type],
             self._client._types.string_type
         )
@@ -641,7 +600,6 @@ class TestService:
             "TestService",
             "AddMultipleValues",
             [x, y, z],
-            ["x", "y", "z"],
             [self._client._types.float_type, self._client._types.sint32_type, self._client._types.sint64_type],
             self._client._types.string_type
         )
@@ -651,7 +609,6 @@ class TestService:
             "TestService",
             "AddToObjectList",
             [l, value],
-            ["l", "value"],
             [self._client._types.list_type(self._client._types.class_type("TestService", "TestClass")), self._client._types.string_type],
             self._client._types.list_type(self._client._types.class_type("TestService", "TestClass"))
         )
@@ -664,7 +621,6 @@ class TestService:
             "TestService",
             "AddToObjectList",
             [l, value],
-            ["l", "value"],
             [self._client._types.list_type(self._client._types.class_type("TestService", "TestClass")), self._client._types.string_type],
             self._client._types.list_type(self._client._types.class_type("TestService", "TestClass"))
         )
@@ -674,7 +630,6 @@ class TestService:
             "TestService",
             "BlockingProcedure",
             [n, sum],
-            ["n", "sum"],
             [self._client._types.sint32_type, self._client._types.sint32_type],
             self._client._types.sint32_type
         )
@@ -687,7 +642,6 @@ class TestService:
             "TestService",
             "BlockingProcedure",
             [n, sum],
-            ["n", "sum"],
             [self._client._types.sint32_type, self._client._types.sint32_type],
             self._client._types.sint32_type
         )
@@ -697,7 +651,6 @@ class TestService:
             "TestService",
             "BoolToString",
             [value],
-            ["value"],
             [self._client._types.bool_type],
             self._client._types.string_type
         )
@@ -710,7 +663,6 @@ class TestService:
             "TestService",
             "BoolToString",
             [value],
-            ["value"],
             [self._client._types.bool_type],
             self._client._types.string_type
         )
@@ -720,7 +672,6 @@ class TestService:
             "TestService",
             "BytesToHexString",
             [value],
-            ["value"],
             [self._client._types.bytes_type],
             self._client._types.string_type
         )
@@ -733,7 +684,6 @@ class TestService:
             "TestService",
             "BytesToHexString",
             [value],
-            ["value"],
             [self._client._types.bytes_type],
             self._client._types.string_type
         )
@@ -743,7 +693,6 @@ class TestService:
             "TestService",
             "Counter",
             [id, divisor],
-            ["id", "divisor"],
             [self._client._types.string_type, self._client._types.sint32_type],
             self._client._types.sint32_type
         )
@@ -756,7 +705,6 @@ class TestService:
             "TestService",
             "Counter",
             [id, divisor],
-            ["id", "divisor"],
             [self._client._types.string_type, self._client._types.sint32_type],
             self._client._types.sint32_type
         )
@@ -766,7 +714,6 @@ class TestService:
             "TestService",
             "CreateTestObject",
             [value],
-            ["value"],
             [self._client._types.string_type],
             self._client._types.class_type("TestService", "TestClass")
         )
@@ -779,7 +726,6 @@ class TestService:
             "TestService",
             "CreateTestObject",
             [value],
-            ["value"],
             [self._client._types.string_type],
             self._client._types.class_type("TestService", "TestClass")
         )
@@ -795,7 +741,6 @@ class TestService:
             "TestService",
             "DeprecatedProcedure",
             [value],
-            ["value"],
             [self._client._types.float_type],
             self._client._types.string_type
         )
@@ -808,7 +753,6 @@ class TestService:
             "TestService",
             "DeprecatedProcedure",
             [value],
-            ["value"],
             [self._client._types.float_type],
             self._client._types.string_type
         )
@@ -824,7 +768,6 @@ class TestService:
             "TestService",
             "DeprecatedProcedureNoMessage",
             [value],
-            ["value"],
             [self._client._types.float_type],
             self._client._types.string_type
         )
@@ -837,7 +780,6 @@ class TestService:
             "TestService",
             "DeprecatedProcedureNoMessage",
             [value],
-            ["value"],
             [self._client._types.float_type],
             self._client._types.string_type
         )
@@ -847,7 +789,6 @@ class TestService:
             "TestService",
             "DictionaryDefault",
             [x],
-            ["x"],
             [self._client._types.dictionary_type(self._client._types.sint32_type, self._client._types.bool_type)],
             self._client._types.dictionary_type(self._client._types.sint32_type, self._client._types.bool_type)
         )
@@ -860,7 +801,6 @@ class TestService:
             "TestService",
             "DictionaryDefault",
             [x],
-            ["x"],
             [self._client._types.dictionary_type(self._client._types.sint32_type, self._client._types.bool_type)],
             self._client._types.dictionary_type(self._client._types.sint32_type, self._client._types.bool_type)
         )
@@ -873,7 +813,6 @@ class TestService:
             "TestService",
             "DoubleSpecialDefaults",
             [nan, infinity, negative_infinity, maximum, lowest],
-            ["nan", "infinity", "negative_infinity", "maximum", "lowest"],
             [self._client._types.double_type, self._client._types.double_type, self._client._types.double_type, self._client._types.double_type, self._client._types.double_type],
             self._client._types.list_type(self._client._types.double_type)
         )
@@ -886,7 +825,6 @@ class TestService:
             "TestService",
             "DoubleSpecialDefaults",
             [nan, infinity, negative_infinity, maximum, lowest],
-            ["nan", "infinity", "negative_infinity", "maximum", "lowest"],
             [self._client._types.double_type, self._client._types.double_type, self._client._types.double_type, self._client._types.double_type, self._client._types.double_type],
             self._client._types.list_type(self._client._types.double_type)
         )
@@ -896,7 +834,6 @@ class TestService:
             "TestService",
             "DoubleToString",
             [value],
-            ["value"],
             [self._client._types.double_type],
             self._client._types.string_type
         )
@@ -909,7 +846,6 @@ class TestService:
             "TestService",
             "DoubleToString",
             [value],
-            ["value"],
             [self._client._types.double_type],
             self._client._types.string_type
         )
@@ -919,7 +855,6 @@ class TestService:
             "TestService",
             "EchoNullableInt",
             [value],
-            ["value"],
             [self._client._types.sint32_type],
             self._client._types.sint32_type
         )
@@ -932,7 +867,6 @@ class TestService:
             "TestService",
             "EchoNullableInt",
             [value],
-            ["value"],
             [self._client._types.sint32_type],
             self._client._types.sint32_type
         )
@@ -942,7 +876,6 @@ class TestService:
             "TestService",
             "EchoNullableList",
             [l],
-            ["l"],
             [self._client._types.list_type(self._client._types.sint32_type)],
             self._client._types.list_type(self._client._types.sint32_type)
         )
@@ -955,7 +888,6 @@ class TestService:
             "TestService",
             "EchoNullableList",
             [l],
-            ["l"],
             [self._client._types.list_type(self._client._types.sint32_type)],
             self._client._types.list_type(self._client._types.sint32_type)
         )
@@ -965,7 +897,6 @@ class TestService:
             "TestService",
             "EchoNullableString",
             [value],
-            ["value"],
             [self._client._types.string_type],
             self._client._types.string_type
         )
@@ -978,7 +909,6 @@ class TestService:
             "TestService",
             "EchoNullableString",
             [value],
-            ["value"],
             [self._client._types.string_type],
             self._client._types.string_type
         )
@@ -988,7 +918,6 @@ class TestService:
             "TestService",
             "EchoTestObject",
             [value],
-            ["value"],
             [self._client._types.class_type("TestService", "TestClass")],
             self._client._types.class_type("TestService", "TestClass")
         )
@@ -1001,7 +930,6 @@ class TestService:
             "TestService",
             "EchoTestObject",
             [value],
-            ["value"],
             [self._client._types.class_type("TestService", "TestClass")],
             self._client._types.class_type("TestService", "TestClass")
         )
@@ -1011,7 +939,6 @@ class TestService:
             "TestService",
             "EmptyListDefault",
             [x],
-            ["x"],
             [self._client._types.list_type(self._client._types.string_type)],
             self._client._types.list_type(self._client._types.string_type)
         )
@@ -1024,7 +951,6 @@ class TestService:
             "TestService",
             "EmptyListDefault",
             [x],
-            ["x"],
             [self._client._types.list_type(self._client._types.string_type)],
             self._client._types.list_type(self._client._types.string_type)
         )
@@ -1034,7 +960,6 @@ class TestService:
             "TestService",
             "EnumDefaultArg",
             [x],
-            ["x"],
             [self._client._types.enumeration_type("TestService", "TestEnum")],
             self._client._types.enumeration_type("TestService", "TestEnum")
         )
@@ -1047,7 +972,6 @@ class TestService:
             "TestService",
             "EnumDefaultArg",
             [x],
-            ["x"],
             [self._client._types.enumeration_type("TestService", "TestEnum")],
             self._client._types.enumeration_type("TestService", "TestEnum")
         )
@@ -1057,7 +981,6 @@ class TestService:
             "TestService",
             "EnumEcho",
             [x],
-            ["x"],
             [self._client._types.enumeration_type("TestService", "TestEnum")],
             self._client._types.enumeration_type("TestService", "TestEnum")
         )
@@ -1070,7 +993,6 @@ class TestService:
             "TestService",
             "EnumEcho",
             [x],
-            ["x"],
             [self._client._types.enumeration_type("TestService", "TestEnum")],
             self._client._types.enumeration_type("TestService", "TestEnum")
         )
@@ -1080,7 +1002,6 @@ class TestService:
             "TestService",
             "EnumListDefault",
             [x],
-            ["x"],
             [self._client._types.list_type(self._client._types.enumeration_type("TestService", "TestEnum"))],
             self._client._types.list_type(self._client._types.enumeration_type("TestService", "TestEnum"))
         )
@@ -1093,7 +1014,6 @@ class TestService:
             "TestService",
             "EnumListDefault",
             [x],
-            ["x"],
             [self._client._types.list_type(self._client._types.enumeration_type("TestService", "TestEnum"))],
             self._client._types.list_type(self._client._types.enumeration_type("TestService", "TestEnum"))
         )
@@ -1102,7 +1022,6 @@ class TestService:
         return self._client._invoke(
             "TestService",
             "EnumReturn",
-            [],
             [],
             [],
             self._client._types.enumeration_type("TestService", "TestEnum")
@@ -1117,7 +1036,6 @@ class TestService:
             "EnumReturn",
             [],
             [],
-            [],
             self._client._types.enumeration_type("TestService", "TestEnum")
         )
 
@@ -1130,7 +1048,6 @@ class TestService:
             "TestService",
             "FloatSpecialDefaults",
             [nan, infinity, negative_infinity, maximum, lowest, fraction],
-            ["nan", "infinity", "negative_infinity", "maximum", "lowest", "fraction"],
             [self._client._types.float_type, self._client._types.float_type, self._client._types.float_type, self._client._types.float_type, self._client._types.float_type, self._client._types.float_type],
             self._client._types.list_type(self._client._types.float_type)
         )
@@ -1143,7 +1060,6 @@ class TestService:
             "TestService",
             "FloatSpecialDefaults",
             [nan, infinity, negative_infinity, maximum, lowest, fraction],
-            ["nan", "infinity", "negative_infinity", "maximum", "lowest", "fraction"],
             [self._client._types.float_type, self._client._types.float_type, self._client._types.float_type, self._client._types.float_type, self._client._types.float_type, self._client._types.float_type],
             self._client._types.list_type(self._client._types.float_type)
         )
@@ -1156,7 +1072,6 @@ class TestService:
             "TestService",
             "FloatToString",
             [value],
-            ["value"],
             [self._client._types.float_type],
             self._client._types.string_type
         )
@@ -1169,7 +1084,6 @@ class TestService:
             "TestService",
             "FloatToString",
             [value],
-            ["value"],
             [self._client._types.float_type],
             self._client._types.string_type
         )
@@ -1179,7 +1093,6 @@ class TestService:
             "TestService",
             "IncrementDictionary",
             [d],
-            ["d"],
             [self._client._types.dictionary_type(self._client._types.string_type, self._client._types.sint32_type)],
             self._client._types.dictionary_type(self._client._types.string_type, self._client._types.sint32_type)
         )
@@ -1192,7 +1105,6 @@ class TestService:
             "TestService",
             "IncrementDictionary",
             [d],
-            ["d"],
             [self._client._types.dictionary_type(self._client._types.string_type, self._client._types.sint32_type)],
             self._client._types.dictionary_type(self._client._types.string_type, self._client._types.sint32_type)
         )
@@ -1202,7 +1114,6 @@ class TestService:
             "TestService",
             "IncrementList",
             [l],
-            ["l"],
             [self._client._types.list_type(self._client._types.sint32_type)],
             self._client._types.list_type(self._client._types.sint32_type)
         )
@@ -1215,7 +1126,6 @@ class TestService:
             "TestService",
             "IncrementList",
             [l],
-            ["l"],
             [self._client._types.list_type(self._client._types.sint32_type)],
             self._client._types.list_type(self._client._types.sint32_type)
         )
@@ -1225,7 +1135,6 @@ class TestService:
             "TestService",
             "IncrementNestedCollection",
             [d],
-            ["d"],
             [self._client._types.dictionary_type(self._client._types.string_type, self._client._types.list_type(self._client._types.sint32_type))],
             self._client._types.dictionary_type(self._client._types.string_type, self._client._types.list_type(self._client._types.sint32_type))
         )
@@ -1238,7 +1147,6 @@ class TestService:
             "TestService",
             "IncrementNestedCollection",
             [d],
-            ["d"],
             [self._client._types.dictionary_type(self._client._types.string_type, self._client._types.list_type(self._client._types.sint32_type))],
             self._client._types.dictionary_type(self._client._types.string_type, self._client._types.list_type(self._client._types.sint32_type))
         )
@@ -1248,7 +1156,6 @@ class TestService:
             "TestService",
             "IncrementSet",
             [h],
-            ["h"],
             [self._client._types.set_type(self._client._types.sint32_type)],
             self._client._types.set_type(self._client._types.sint32_type)
         )
@@ -1261,7 +1168,6 @@ class TestService:
             "TestService",
             "IncrementSet",
             [h],
-            ["h"],
             [self._client._types.set_type(self._client._types.sint32_type)],
             self._client._types.set_type(self._client._types.sint32_type)
         )
@@ -1271,7 +1177,6 @@ class TestService:
             "TestService",
             "IncrementTuple",
             [t],
-            ["t"],
             [self._client._types.tuple_type(self._client._types.sint32_type, self._client._types.sint64_type)],
             self._client._types.tuple_type(self._client._types.sint32_type, self._client._types.sint64_type)
         )
@@ -1284,7 +1189,6 @@ class TestService:
             "TestService",
             "IncrementTuple",
             [t],
-            ["t"],
             [self._client._types.tuple_type(self._client._types.sint32_type, self._client._types.sint64_type)],
             self._client._types.tuple_type(self._client._types.sint32_type, self._client._types.sint64_type)
         )
@@ -1297,7 +1201,6 @@ class TestService:
             "TestService",
             "Int32SpecialDefaults",
             [maximum, minimum],
-            ["maximum", "minimum"],
             [self._client._types.sint32_type, self._client._types.sint32_type],
             self._client._types.list_type(self._client._types.sint32_type)
         )
@@ -1310,7 +1213,6 @@ class TestService:
             "TestService",
             "Int32SpecialDefaults",
             [maximum, minimum],
-            ["maximum", "minimum"],
             [self._client._types.sint32_type, self._client._types.sint32_type],
             self._client._types.list_type(self._client._types.sint32_type)
         )
@@ -1320,7 +1222,6 @@ class TestService:
             "TestService",
             "Int32ToString",
             [value],
-            ["value"],
             [self._client._types.sint32_type],
             self._client._types.string_type
         )
@@ -1333,7 +1234,6 @@ class TestService:
             "TestService",
             "Int32ToString",
             [value],
-            ["value"],
             [self._client._types.sint32_type],
             self._client._types.string_type
         )
@@ -1346,7 +1246,6 @@ class TestService:
             "TestService",
             "Int64SpecialDefaults",
             [maximum, minimum],
-            ["maximum", "minimum"],
             [self._client._types.sint64_type, self._client._types.sint64_type],
             self._client._types.list_type(self._client._types.sint64_type)
         )
@@ -1359,7 +1258,6 @@ class TestService:
             "TestService",
             "Int64SpecialDefaults",
             [maximum, minimum],
-            ["maximum", "minimum"],
             [self._client._types.sint64_type, self._client._types.sint64_type],
             self._client._types.list_type(self._client._types.sint64_type)
         )
@@ -1369,7 +1267,6 @@ class TestService:
             "TestService",
             "Int64ToString",
             [value],
-            ["value"],
             [self._client._types.sint64_type],
             self._client._types.string_type
         )
@@ -1382,7 +1279,6 @@ class TestService:
             "TestService",
             "Int64ToString",
             [value],
-            ["value"],
             [self._client._types.sint64_type],
             self._client._types.string_type
         )
@@ -1392,7 +1288,6 @@ class TestService:
             "TestService",
             "ListDefault",
             [x],
-            ["x"],
             [self._client._types.list_type(self._client._types.sint32_type)],
             self._client._types.list_type(self._client._types.sint32_type)
         )
@@ -1405,7 +1300,6 @@ class TestService:
             "TestService",
             "ListDefault",
             [x],
-            ["x"],
             [self._client._types.list_type(self._client._types.sint32_type)],
             self._client._types.list_type(self._client._types.sint32_type)
         )
@@ -1415,7 +1309,6 @@ class TestService:
             "TestService",
             "NotNullableObject",
             [value],
-            ["value"],
             [self._client._types.class_type("TestService", "TestClass")],
             self._client._types.class_type("TestService", "TestClass")
         )
@@ -1428,7 +1321,6 @@ class TestService:
             "TestService",
             "NotNullableObject",
             [value],
-            ["value"],
             [self._client._types.class_type("TestService", "TestClass")],
             self._client._types.class_type("TestService", "TestClass")
         )
@@ -1438,7 +1330,6 @@ class TestService:
             "TestService",
             "OnTimer",
             [milliseconds, repeats],
-            ["milliseconds", "repeats"],
             [self._client._types.uint32_type, self._client._types.uint32_type],
             self._client._types.event_type
         )
@@ -1451,7 +1342,6 @@ class TestService:
             "TestService",
             "OnTimer",
             [milliseconds, repeats],
-            ["milliseconds", "repeats"],
             [self._client._types.uint32_type, self._client._types.uint32_type],
             self._client._types.event_type
         )
@@ -1461,7 +1351,6 @@ class TestService:
             "TestService",
             "OnTimerUsingLambda",
             [milliseconds],
-            ["milliseconds"],
             [self._client._types.uint32_type],
             self._client._types.event_type
         )
@@ -1474,7 +1363,6 @@ class TestService:
             "TestService",
             "OnTimerUsingLambda",
             [milliseconds],
-            ["milliseconds"],
             [self._client._types.uint32_type],
             self._client._types.event_type
         )
@@ -1484,7 +1372,6 @@ class TestService:
             "TestService",
             "OptionalArguments",
             [x, y, z, obj],
-            ["x", "y", "z", "obj"],
             [self._client._types.string_type, self._client._types.string_type, self._client._types.string_type, self._client._types.class_type("TestService", "TestClass")],
             self._client._types.string_type
         )
@@ -1497,7 +1384,6 @@ class TestService:
             "TestService",
             "OptionalArguments",
             [x, y, z, obj],
-            ["x", "y", "z", "obj"],
             [self._client._types.string_type, self._client._types.string_type, self._client._types.string_type, self._client._types.class_type("TestService", "TestClass")],
             self._client._types.string_type
         )
@@ -1506,7 +1392,6 @@ class TestService:
         return self._client._invoke(
             "TestService",
             "ResetCustomExceptionLater",
-            [],
             [],
             [],
             None
@@ -1521,7 +1406,6 @@ class TestService:
             "ResetCustomExceptionLater",
             [],
             [],
-            [],
             None
         )
 
@@ -1529,7 +1413,6 @@ class TestService:
         return self._client._invoke(
             "TestService",
             "ResetInvalidOperationExceptionLater",
-            [],
             [],
             [],
             None
@@ -1544,7 +1427,6 @@ class TestService:
             "ResetInvalidOperationExceptionLater",
             [],
             [],
-            [],
             None
         )
 
@@ -1552,7 +1434,6 @@ class TestService:
         return self._client._invoke(
             "TestService",
             "ReturnNullWhenNotAllowed",
-            [],
             [],
             [],
             self._client._types.class_type("TestService", "TestClass")
@@ -1567,7 +1448,6 @@ class TestService:
             "ReturnNullWhenNotAllowed",
             [],
             [],
-            [],
             self._client._types.class_type("TestService", "TestClass")
         )
 
@@ -1576,7 +1456,6 @@ class TestService:
             "TestService",
             "SetDefault",
             [x],
-            ["x"],
             [self._client._types.set_type(self._client._types.sint32_type)],
             self._client._types.set_type(self._client._types.sint32_type)
         )
@@ -1589,7 +1468,6 @@ class TestService:
             "TestService",
             "SetDefault",
             [x],
-            ["x"],
             [self._client._types.set_type(self._client._types.sint32_type)],
             self._client._types.set_type(self._client._types.sint32_type)
         )
@@ -1599,7 +1477,6 @@ class TestService:
             "TestService",
             "StringToInt32",
             [value],
-            ["value"],
             [self._client._types.string_type],
             self._client._types.sint32_type
         )
@@ -1612,7 +1489,6 @@ class TestService:
             "TestService",
             "StringToInt32",
             [value],
-            ["value"],
             [self._client._types.string_type],
             self._client._types.sint32_type
         )
@@ -1621,7 +1497,6 @@ class TestService:
         return self._client._invoke(
             "TestService",
             "ThrowArgumentException",
-            [],
             [],
             [],
             self._client._types.sint32_type
@@ -1636,7 +1511,6 @@ class TestService:
             "ThrowArgumentException",
             [],
             [],
-            [],
             self._client._types.sint32_type
         )
 
@@ -1645,7 +1519,6 @@ class TestService:
             "TestService",
             "ThrowArgumentNullException",
             [foo],
-            ["foo"],
             [self._client._types.string_type],
             self._client._types.sint32_type
         )
@@ -1658,7 +1531,6 @@ class TestService:
             "TestService",
             "ThrowArgumentNullException",
             [foo],
-            ["foo"],
             [self._client._types.string_type],
             self._client._types.sint32_type
         )
@@ -1668,7 +1540,6 @@ class TestService:
             "TestService",
             "ThrowArgumentOutOfRangeException",
             [foo],
-            ["foo"],
             [self._client._types.sint32_type],
             self._client._types.sint32_type
         )
@@ -1681,7 +1552,6 @@ class TestService:
             "TestService",
             "ThrowArgumentOutOfRangeException",
             [foo],
-            ["foo"],
             [self._client._types.sint32_type],
             self._client._types.sint32_type
         )
@@ -1690,7 +1560,6 @@ class TestService:
         return self._client._invoke(
             "TestService",
             "ThrowCustomException",
-            [],
             [],
             [],
             self._client._types.sint32_type
@@ -1705,7 +1574,6 @@ class TestService:
             "ThrowCustomException",
             [],
             [],
-            [],
             self._client._types.sint32_type
         )
 
@@ -1713,7 +1581,6 @@ class TestService:
         return self._client._invoke(
             "TestService",
             "ThrowCustomExceptionLater",
-            [],
             [],
             [],
             self._client._types.sint32_type
@@ -1728,7 +1595,6 @@ class TestService:
             "ThrowCustomExceptionLater",
             [],
             [],
-            [],
             self._client._types.sint32_type
         )
 
@@ -1736,7 +1602,6 @@ class TestService:
         return self._client._invoke(
             "TestService",
             "ThrowInvalidOperationException",
-            [],
             [],
             [],
             self._client._types.sint32_type
@@ -1751,7 +1616,6 @@ class TestService:
             "ThrowInvalidOperationException",
             [],
             [],
-            [],
             self._client._types.sint32_type
         )
 
@@ -1759,7 +1623,6 @@ class TestService:
         return self._client._invoke(
             "TestService",
             "ThrowInvalidOperationExceptionLater",
-            [],
             [],
             [],
             self._client._types.sint32_type
@@ -1774,7 +1637,6 @@ class TestService:
             "ThrowInvalidOperationExceptionLater",
             [],
             [],
-            [],
             self._client._types.sint32_type
         )
 
@@ -1783,7 +1645,6 @@ class TestService:
             "TestService",
             "TupleDefault",
             [x],
-            ["x"],
             [self._client._types.tuple_type(self._client._types.sint32_type, self._client._types.bool_type)],
             self._client._types.tuple_type(self._client._types.sint32_type, self._client._types.bool_type)
         )
@@ -1796,7 +1657,6 @@ class TestService:
             "TestService",
             "TupleDefault",
             [x],
-            ["x"],
             [self._client._types.tuple_type(self._client._types.sint32_type, self._client._types.bool_type)],
             self._client._types.tuple_type(self._client._types.sint32_type, self._client._types.bool_type)
         )
@@ -1809,7 +1669,6 @@ class TestService:
             "TestService",
             "Uint32SpecialDefaults",
             [maximum],
-            ["maximum"],
             [self._client._types.uint32_type],
             self._client._types.list_type(self._client._types.uint32_type)
         )
@@ -1822,7 +1681,6 @@ class TestService:
             "TestService",
             "Uint32SpecialDefaults",
             [maximum],
-            ["maximum"],
             [self._client._types.uint32_type],
             self._client._types.list_type(self._client._types.uint32_type)
         )
@@ -1835,7 +1693,6 @@ class TestService:
             "TestService",
             "Uint64SpecialDefaults",
             [maximum],
-            ["maximum"],
             [self._client._types.uint64_type],
             self._client._types.list_type(self._client._types.uint64_type)
         )
@@ -1848,7 +1705,6 @@ class TestService:
             "TestService",
             "Uint64SpecialDefaults",
             [maximum],
-            ["maximum"],
             [self._client._types.uint64_type],
             self._client._types.list_type(self._client._types.uint64_type)
         )

--- a/tools/krpctools/krpctools/test/clientgen-TestService-python.txt
+++ b/tools/krpctools/krpctools/test/clientgen-TestService-python.txt
@@ -366,35 +366,31 @@ class TestService:
 
     def __init__(self, client: Client) -> None:
         self._client = client
+        # The classes, enumerations and exceptions the service defines are put on the
+        # service here, so that reaching one is an ordinary attribute lookup and nothing
+        # has to intercept the lookups that do not name one - which is every call, as a
+        # call goes through a procedure or a property. A class is bound to the client it
+        # is reached through, so that its static methods use that client.
+        self.__dict__.update(self._enumerations)
+        self.__dict__.update(self._exceptions)
+        for name, class_type in self._classes.items():
+            self.__dict__[name] = WrappedClass(client, class_type)
 
-    def __getattribute__(self, name):
-        # Intercepts calls to obtain classes from the service,
-        # to inject the client instance so that it can be used
-        # for static method calls
-        classes = object.__getattribute__(self, "_classes")
-        if name in classes:
-            client = object.__getattribute__(self, "_client")
-            return WrappedClass(client, classes[name])
-
-        # Intercept calls to obtain enumeration types
-        enumerations = object.__getattribute__(self, "_enumerations")
-        if name in enumerations:
-           return enumerations[name]
-
-        # Intercept calls to obtain exception types
-        exceptions = object.__getattribute__(self, "_exceptions")
-        if name in exceptions:
-           return exceptions[name]
-
-        # Fall back to default behaviour
-        return object.__getattribute__(self, name)
-
-    def __dir__(self):
-        result = object.__dir__(self)
-        result.extend(object.__getattribute__(self, "_classes").keys())
-        result.extend(object.__getattribute__(self, "_enumerations").keys())
-        result.extend(object.__getattribute__(self, "_exceptions").keys())
-        return result
+    def __getattr__(self, name):
+        # Reached only once the ordinary lookup has failed, which for a service means
+        # either a name it does not define, or one it does whose procedure or property
+        # raised an AttributeError of its own. Python discards that error before calling
+        # this, so it cannot be reported here; what can be done is to not report a member
+        # that does exist as missing, which would point at the wrong thing entirely.
+        cls = type(self)
+        if hasattr(cls, name):
+            raise AttributeError(
+                "'%s' object attribute '%s' raised AttributeError"
+                % (cls.__name__, name)
+            )
+        raise AttributeError(
+            "'%s' object has no attribute '%s'" % (cls.__name__, name)
+        )
 
     _classes = {
         "DeprecatedClass": DeprecatedClass,


### PR DESCRIPTION
Makes a remote procedure call cheaper in the python, lua, C#, C++ and cnano clients. The wire protocol is untouched and the java client is unchanged.

**Optimizations.** Not every client needed every one; the commits are grouped by client.

- Encode a request straight to protobuf bytes, rather than populating a `Request` holding a `ProcedureCall` holding an `Argument` per parameter and asking the protobuf library to serialize it.
- Encode and decode the lists, sets, tuples and dictionaries a call carries the same way, writing and reading their bytes directly instead of going through a message object.
- Work out what a type is, and how to encode and decode its values, once per type rather than once per value; a collection works it out once for itself rather than once per item.
- Encode and decode a value without a protobuf stream of its own, and pack floats, doubles and short varints directly.
- Read a response a block at a time and parse it straight out of the read buffer, rather than a byte or a field at a time.
- Keep the request, response and collection messages from one call to the next rather than allocating and freeing them per call.
- Size buffers and argument lists from what the call already knows.
- Disable Nagle's algorithm on the client connections.

**User visible.**

- cnano gains `KRPC_BUFFER_SIZE`, which bounds the memory a call costs, never the size of a message. 1024 bytes, 128 on Arduino.
- C++ `Client::invoke`, `Client::build_request` and `Client::build_call` name a service and a procedure with `std::string_view`, so a call no longer builds a string for either.

**Results.** Milliseconds per round trip, before against after, lower is better.

| case | cpp | java | csharp | python | lua | cnano |
| --- | --- | --- | --- | --- | --- | --- |
| round trip | .01259 -> .01212 | .01270 -> .01252 | .01406 -> .01274 | .02146 -> .01571 | .02760 -> .01756 | .05071 -> .01285 |
| round trip, 3 arguments | .01326 -> .01255 | .01316 -> .01316 | .01522 -> .01349 | .02515 -> .01714 | .03610 -> .01873 | .09497 -> .01336 |
| round trip, list of 100 values | .04008 -> .03385 | .03498 -> .03557 | .06536 -> .04223 | .15058 -> .06267 | .23672 -> .09569 | .99820 -> .03889 |

The same figures as a speedup, after against before, higher is better.

| case | cpp | java | csharp | python | lua | cnano |
| --- | --- | --- | --- | --- | --- | --- |
| round trip | 1.04x | 1.01x | 1.10x | 1.37x | 1.57x | 3.95x |
| round trip, 3 arguments | 1.06x | 1.00x | 1.13x | 1.47x | 1.93x | 7.11x |
| round trip, list of 100 values | 1.18x | 0.98x | 1.55x | 2.40x | 2.47x | 25.67x |

- cnano goes from the slowest client to level with C#, and scales with message size, which is the shape a buffering change produces.
- The spread between the fastest and slowest client on the collection case narrows from 28x to 2.8x.

**Method.**

- `bazel run //tools/benchmarks:clients`, each client's own benchmark against a TestServer of its own, one language after another.
- Two passes of each build, giving two independent before/after pairs; every case reported itself as settled in all four. Both revisions built and run in the same worktree at the same path.
- Noise floor measured rather than assumed, with `//tools/benchmarks:compare --noise`: 3% for almost every case, 4.5% at worst.
- Measured on a AMD Ryzen 9 7950X3D, 64 GB RAM, over TCP/IP, frame pacing and adaptive rate control off, 5000 us maximum time per update, 1000 us receive timeout.

**Testing.** The lua encoder and decoder gained tests that round-trip a request, and the collections a call carries, through protobuf's own message layer, so the bytes they now write themselves are checked against the format rather than against each other. The python client gained tests for taking a message out of the read buffer: split across reads, a size prefix split across reads, two messages in one read, and a connection closed partway through a message.
