### PR TITLE
Fix C++ client vcpkg install docs

### DIFF
--- a/client/cpp/INSTALL.txt
+++ b/client/cpp/INSTALL.txt
@@ -4,16 +4,16 @@ Installing the kRPC C++ client library
 Via vcpkg
 ---------
 
-The library can be installed using the bundled vcpkg overlay port. Extract this
-archive and run:
+The library is published to the vcpkg registry, so it can be installed without
+this archive:
 
 On Linux:
 
-    vcpkg install krpc --overlay-ports=vcpkg-port
+    vcpkg install krpc
 
 On Windows:
 
-    vcpkg install krpc:x64-windows --overlay-ports=vcpkg-port
+    vcpkg install krpc:x64-windows
 
 Then pass the vcpkg toolchain file when configuring your CMake project:
 


### PR DESCRIPTION
The C++ client's `INSTALL.txt` told the reader to extract the release archive and install `krpc` from a bundled overlay port. The archive does not hold the port, which is published to the vcpkg registry when a release is cut, so the commands did not work.

The instructions now install straight from the registry, matching what `doc/src/cpp/client.rst` already documents.