### PR TITLE
Leave nothing but progress messages in a full build

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,8 +27,10 @@ Outputs in `bazel-bin`, test logs in `bazel-testlogs`.
 
 ### Tests and lint
 
- * `bazel test //:test` — full non-game suite. **The gate before proposing a change.**
+ * `bazel test //:test` — full non-game suite. **A gate before proposing a change.**
    `bazel test //...` does not work.
+ * `bazel build //...` — **the second gate**: `//:test` does not build every target. Its log must
+   be clean, build progress messages only, with no warnings or other output.
  * `//:lint` — Python, C++, C, Java, doc lint.
  * `//core:test`, `//client/python:test`, … — one package, when iterating.
  * `//doc:spelling` — American-English gate; `//doc:check-documented` — every RPC documented.

--- a/service/SpaceCenter/src/Services/Parts/PartField.cs
+++ b/service/SpaceCenter/src/Services/Parts/PartField.cs
@@ -25,11 +25,11 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         BaseField InternalField {
             get {
-                var field = Module.InternalModule.Fields [name];
-                if (field == null)
+                var partField = Module.InternalModule.Fields [name];
+                if (partField == null)
                     throw new ObjectDestroyedException (
                         "The part module no longer has a field called " + name + ".");
-                return field;
+                return partField;
             }
         }
 

--- a/tools/build/lua/lua.BUILD
+++ b/tools/build/lua/lua.BUILD
@@ -7,6 +7,13 @@ supplies its own linit.c in place of the one here.
 
 load("@rules_cc//cc:defs.bzl", "cc_library")
 
+# Upstream sources, compiled unmodified. The warnings the toolchain's -Wall finds in
+# them are not ours to fix.
+_NO_WARNINGS = select({
+    "@platforms//os:windows": ["/w"],
+    "//conditions:default": ["-w"],
+})
+
 cc_library(
     name = "lua",
     srcs = glob(
@@ -23,6 +30,7 @@ cc_library(
         ],
     ),
     hdrs = glob(["src/*.h"]),
+    copts = _NO_WARNINGS,
     defines = select({
         # MSVC deprecates the C library functions lua calls throughout (fopen, getenv,
         # tmpnam), which is otherwise a warning on nearly every file.
@@ -51,6 +59,7 @@ cc_library(
     name = "interpreter",
     srcs = ["src/lua.c"],
     alwayslink = True,
+    copts = _NO_WARNINGS,
     visibility = ["//visibility:public"],
     deps = [":lua"],
 )

--- a/tools/build/lua/luasocket.BUILD
+++ b/tools/build/lua/luasocket.BUILD
@@ -31,6 +31,12 @@ cc_library(
         "@platforms//os:windows": ["src/wsocket.c"],
         "//conditions:default": ["src/usocket.c"],
     }),
+    # Upstream sources, compiled unmodified. The warnings the toolchain's -Wall
+    # finds in them are not ours to fix.
+    copts = select({
+        "@platforms//os:windows": ["/w"],
+        "//conditions:default": ["-w"],
+    }),
     local_defines = [
         "LUASOCKET_DEBUG",
         # The modules are linked into the interpreter rather than loaded from shared

--- a/tools/build/run_cog_check.py
+++ b/tools/build/run_cog_check.py
@@ -27,7 +27,9 @@ def regenerate(clang_format, config, src):
     with tempfile.TemporaryDirectory() as tmp:
         copy = os.path.join(tmp, os.path.basename(src))
         shutil.copyfile(src, copy)
-        Cog().main(["cog", "-r", copy])
+        # --verbosity=0: cog announces every file it rewrites, and this rewrites one
+        # per source in a scratch copy nobody sees.
+        Cog().main(["cog", "-r", "--verbosity=0", copy])
         subprocess.run(
             [clang_format, "-i", "--style=file:" + config, copy],
             check=True,


### PR DESCRIPTION
`bazel test //:test` does not build every target, so a change can pass it and still break or pollute a target it never compiles. `bazel build //...` covers everything, and is now documented as a second gate before proposing a change. Its log should carry build progress messages and nothing else.

Four things stood in the way of that. A local named `field` in a property accessor, which the C# preview language version treats as a contextual keyword. Cog announcing every scratch copy it rewrote during the generated-source check. And `-Wall` warnings from the lua and luasocket sources, which are compiled exactly as upstream ships them and so are silenced with `-w` rather than patched.
