### PR TITLE
Add structure types

### DIFF
--- a/client/cnano/CHANGELOG.md
+++ b/client/cnano/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## [v0.7.0] - unreleased
+- Support structure types, which a service defines as a compound value with named fields. One
+  is generated as a C struct with a member per field, named for the field it carries (#1066)
 - **Breaking:** Support null for any nullable type; a nullable non-class return adds a `bool*
   returnValueIsNull` out-parameter and a nullable argument is a pointer (#1017)
 - Add `KRPC_COMMUNICATION_TCP`, which builds the library to communicate with a server over

--- a/client/cnano/test/test_client.cpp
+++ b/client/cnano/test/test_client.cpp
@@ -412,6 +412,74 @@ TEST_F(test_client, test_collections) {
   }
 }
 
+TEST_F(test_client, test_structs) {
+  krpc_TestService_TestStruct_t value = {0, NULL, 0, KRPC_NULL_LIST};
+  value.int_field = 42;
+  value.string_field = (char*)"jeb";
+  value.enum_field = KRPC_TESTSERVICE_TESTENUM_VALUEB;
+  value.list_field.size = 3;
+  value.list_field.items = new int32_t[3]{1, 2, 3};
+
+  krpc_TestService_TestStruct_t result = {0, NULL, 0, KRPC_NULL_LIST};
+  ASSERT_EQ(KRPC_OK, krpc_TestService_StructEcho(conn, &result, &value));
+  ASSERT_EQ(42, result.int_field);
+  ASSERT_STREQ("jeb", result.string_field);
+  ASSERT_EQ(KRPC_TESTSERVICE_TESTENUM_VALUEB, result.enum_field);
+  ASSERT_EQ(3u, result.list_field.size);
+  ASSERT_EQ(1, result.list_field.items[0]);
+  ASSERT_EQ(3, result.list_field.items[2]);
+
+  delete[] value.list_field.items;
+  krpc_free(result.string_field);
+  KRPC_FREE_LIST(result.list_field);
+}
+
+TEST_F(test_client, test_nested_structs) {
+  krpc_TestService_TestClass_t obj = KRPC_NULL;
+  ASSERT_EQ(KRPC_OK, krpc_TestService_CreateTestObject(conn, &obj, "bob"));
+
+  krpc_TestService_TestNestedStruct_t value = {{0, NULL, 0, KRPC_NULL_LIST}, KRPC_NULL, NULL};
+  value.struct_field.int_field = 1;
+  value.struct_field.string_field = (char*)"jeb";
+  value.object_field = obj;
+  value.string_field = (char*)"bill";
+
+  krpc_TestService_TestNestedStruct_t result = {{0, NULL, 0, KRPC_NULL_LIST}, KRPC_NULL, NULL};
+  ASSERT_EQ(KRPC_OK, krpc_TestService_NestedStructEcho(conn, &result, &value));
+  ASSERT_EQ(1, result.struct_field.int_field);
+  ASSERT_STREQ("jeb", result.struct_field.string_field);
+  ASSERT_EQ(obj, result.object_field);
+  ASSERT_STREQ("bill", result.string_field);
+
+  krpc_free(result.struct_field.string_field);
+  KRPC_FREE_LIST(result.struct_field.list_field);
+  krpc_free(result.string_field);
+}
+
+TEST_F(test_client, test_collections_of_structs) {
+  krpc_TestService_TestStruct_t items[2] = {{0, NULL, 0, KRPC_NULL_LIST},
+                                            {0, NULL, 0, KRPC_NULL_LIST}};
+  items[0].int_field = 0;
+  items[0].string_field = (char*)"jeb";
+  items[1].int_field = 1;
+  items[1].string_field = (char*)"bob";
+  krpc_list_TestService_TestStruct_t list = KRPC_NULL_LIST;
+  list.size = 2;
+  list.items = items;
+
+  krpc_list_TestService_TestStruct_t result = KRPC_NULL_LIST;
+  ASSERT_EQ(KRPC_OK, krpc_TestService_IncrementListOfStructs(conn, &result, &list));
+  ASSERT_EQ(2u, result.size);
+  ASSERT_EQ(1, result.items[0].int_field);
+  ASSERT_EQ(2, result.items[1].int_field);
+
+  for (size_t i = 0; i < result.size; i++) {
+    krpc_free(result.items[i].string_field);
+    KRPC_FREE_LIST(result.items[i].list_field);
+  }
+  KRPC_FREE_LIST(result);
+}
+
 TEST_F(test_client, test_nested_collections) {
   {
     krpc_dictionary_string_list_int32_t dictionary = KRPC_NULL_DICTIONARY;

--- a/client/cpp/CHANGELOG.md
+++ b/client/cpp/CHANGELOG.md
@@ -1,4 +1,7 @@
 ## [v0.7.0] - unreleased
+- Support structure types, which a service defines as a compound value with named fields. One
+  is generated as a `struct` carrying its fields as members, with a constructor taking them in
+  the order the structure declares them and equality over them (#1066)
 - **Breaking:** Support null for any nullable type; nullable non-class values use
   `std::optional`, changing generated signatures (#1017)
 - Add `krpc::connect_local`, which connects to a server on the same machine over unix

--- a/client/cpp/test/test_client.cpp
+++ b/client/cpp/test/test_client.cpp
@@ -359,6 +359,48 @@ TEST_F(test_client, test_collections_of_objects) {
   ASSERT_EQ("value=bob", l3[1].get_value());
 }
 
+TEST_F(test_client, test_structs) {
+  krpc::services::TestService::TestStruct value(
+      42, "jeb", krpc::services::TestService::TestEnum::value_b, {1, 2, 3});
+  auto result = test_service.struct_echo(value);
+  ASSERT_EQ(value, result);
+  ASSERT_EQ(42, result.int_field);
+  ASSERT_EQ("jeb", result.string_field);
+  ASSERT_EQ(krpc::services::TestService::TestEnum::value_b, result.enum_field);
+  ASSERT_EQ(std::vector<int32_t>({1, 2, 3}), result.list_field);
+}
+
+TEST_F(test_client, test_nested_structs) {
+  auto obj = test_service.create_test_object("bob");
+  krpc::services::TestService::TestNestedStruct value(
+      krpc::services::TestService::TestStruct(1, "jeb",
+                                              krpc::services::TestService::TestEnum::value_a, {}),
+      obj, "bill");
+  auto result = test_service.nested_struct_echo(value);
+  ASSERT_EQ(value, result);
+  ASSERT_EQ(1, result.struct_field.int_field);
+  ASSERT_EQ(obj, result.object_field);
+  ASSERT_EQ("bill", result.string_field);
+}
+
+TEST_F(test_client, test_collections_of_structs) {
+  std::vector<krpc::services::TestService::TestStruct> values{
+      krpc::services::TestService::TestStruct(0, "jeb",
+                                              krpc::services::TestService::TestEnum::value_c, {}),
+      krpc::services::TestService::TestStruct(1, "bob",
+                                              krpc::services::TestService::TestEnum::value_c, {})};
+  auto result = test_service.increment_list_of_structs(values);
+  ASSERT_EQ(2, result.size());
+  ASSERT_EQ(1, result[0].int_field);
+  ASSERT_EQ(2, result[1].int_field);
+}
+
+TEST_F(test_client, test_struct_default_value) {
+  krpc::services::TestService::TestStruct value(
+      42, "jeb", krpc::services::TestService::TestEnum::value_b, {1, 2, 3});
+  ASSERT_EQ(value, test_service.struct_default());
+}
+
 TEST_F(test_client, test_collections_default_values) {
   std::tuple<int, bool> t{1, false};
   ASSERT_EQ(t, test_service.tuple_default());

--- a/client/csharp/CHANGELOG.md
+++ b/client/csharp/CHANGELOG.md
@@ -1,4 +1,7 @@
 ## [v0.7.0] - unreleased
+- Support structure types, which a service defines as a compound value with named fields. One
+  is generated as a `struct` carrying its fields as properties, with a constructor taking them
+  in the order the structure declares them and equality over them (#1066)
 - **Breaking:** Support `null` for any nullable type; nullable value types use the nullable
   form (`int?`) (#1017)
 - Add `Connection.ConnectLocal`, which connects to a server on the same machine over unix

--- a/client/csharp/src/Attributes/KRPCStructAttribute.cs
+++ b/client/csharp/src/Attributes/KRPCStructAttribute.cs
@@ -1,0 +1,14 @@
+using System;
+
+namespace KRPC.Client.Attributes
+{
+    /// <summary>
+    /// Attribute attached to a struct that a service defines as a structure type. The order the
+    /// struct declares its properties in is the order their values are encoded in, and the struct
+    /// has a constructor taking them in that order.
+    /// </summary>
+    [AttributeUsage (AttributeTargets.Struct)]
+    public sealed class KRPCStructAttribute : Attribute
+    {
+    }
+}

--- a/client/csharp/src/Encoder.cs
+++ b/client/csharp/src/Encoder.cs
@@ -78,6 +78,7 @@ namespace KRPC.Client
                 return EncodeBytes ((byte[])value);
             case TypeKind.Class:
                 return Varint (((RemoteObject)value).id);
+            case TypeKind.Struct:
             case TypeKind.Tuple:
                 return EncodeTuple (value, info).ToByteString ();
             case TypeKind.List:
@@ -164,6 +165,7 @@ namespace KRPC.Client
                 return value => EncodeBytes ((byte[])value);
             case TypeKind.Class:
                 return value => Varint (((RemoteObject)value).id);
+            case TypeKind.Struct:
             case TypeKind.Tuple:
                 return value => EncodeTuple (value, info).ToByteString ();
             case TypeKind.List:
@@ -273,6 +275,7 @@ namespace KRPC.Client
                 if (client == null)
                     throw new ArgumentException ("Client not passed when decoding remote object");
                 return info.NewObject (client, ReadVarint (value));
+            case TypeKind.Struct:
             case TypeKind.Tuple:
                 return DecodeTuple (value, info, client);
             case TypeKind.List:
@@ -348,6 +351,7 @@ namespace KRPC.Client
                         throw new ArgumentException ("Client not passed when decoding remote object");
                     return info.NewObject (client, ReadVarint (value));
                 };
+            case TypeKind.Struct:
             case TypeKind.Tuple:
                 return (value, client) => DecodeTuple (value, info, client);
             case TypeKind.List:
@@ -373,10 +377,21 @@ namespace KRPC.Client
             }
         }
 
+        /// <remarks>
+        /// A structure carries the values of its fields in order, which is the same encoding as
+        /// a tuple of those values. Fields are only ever appended to a structure, so a value
+        /// from a newer server may carry more items than the type names, and the extra ones are
+        /// ignored. Fewer items than the type names is an error, as the missing ones cannot be
+        /// given a value.
+        /// </remarks>
         static object DecodeTuple (ByteString data, TypeInfo info, IConnection client)
         {
             var encodedTuple = Schema.KRPC.Tuple.Parser.ParseFrom (data);
             var values = new object [info.Arguments.Length];
+            if (encodedTuple.Items.Count < values.Length)
+                throw new ArgumentException (
+                    "Value has " + encodedTuple.Items.Count + " items; expected at least " +
+                    values.Length);
             for (int i = 0; i < values.Length; i++)
                 values [i] = Decode (encodedTuple.Items [i], info.Arguments [i], client);
             return info.NewTuple (values);

--- a/client/csharp/src/KRPC.Client.csproj
+++ b/client/csharp/src/KRPC.Client.csproj
@@ -30,6 +30,7 @@
     <Compile Include="..\InternalsVisibleTo.cs">
       <Link>InternalsVisibleTo.cs</Link>
     </Compile>
+    <Compile Include="Attributes\KRPCStructAttribute.cs" />
     <Compile Include="Attributes\RPCAttribute.cs" />
     <Compile Include="Connection.cs" />
     <Compile Include="ConnectionException.cs" />
@@ -45,6 +46,7 @@
     <Compile Include="StreamManager.cs" />
     <Compile Include="TypeInfo.cs" />
     <Compile Include="UnixEndPoint.cs" />
+    <Compile Include="ValueUtils.cs" />
     <Compile Include="$(bazel-bin)\protobuf\KRPC.cs">
       <Link>KRPC.cs</Link>
     </Compile>

--- a/client/csharp/src/TypeInfo.cs
+++ b/client/csharp/src/TypeInfo.cs
@@ -3,7 +3,9 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq.Expressions;
+using System.Reflection;
 using Google.Protobuf;
+using KRPC.Client.Attributes;
 
 namespace KRPC.Client
 {
@@ -16,6 +18,7 @@ namespace KRPC.Client
         Unsupported,
         Bytes,
         Class,
+        Struct,
         Tuple,
         List,
         Set,
@@ -61,6 +64,12 @@ namespace KRPC.Client
             } else if (type.IsSubclassOf (typeof(RemoteObject))) {
                 Kind = TypeKind.Class;
                 NewObject = ObjectConstructor (type);
+            } else if (type.IsDefined (typeof(KRPCStructAttribute), false)) {
+                Kind = TypeKind.Struct;
+                var fields = StructFields (type);
+                Arguments = Array.ConvertAll (fields, field => field.PropertyType);
+                Items = StructItems (type, fields);
+                NewTuple = StructConstructor (type, Arguments);
             } else if (IsATupleType (type)) {
                 Kind = TypeKind.Tuple;
                 Arguments = type.GetGenericArguments ();
@@ -116,12 +125,14 @@ namespace KRPC.Client
         public Action<object, object> Add { get; private set; }
 
         /// <summary>
-        /// Build a tuple from its items, in the order <see cref="Arguments"/> names them.
+        /// Build a tuple, or a structure, from its items, in the order <see cref="Arguments"/>
+        /// names them.
         /// </summary>
         public Func<object[], object> NewTuple { get; private set; }
 
         /// <summary>
-        /// Take the items out of a tuple, in the order <see cref="Arguments"/> names them.
+        /// Take the items out of a tuple, or the fields out of a structure, in the order
+        /// <see cref="Arguments"/> names them.
         /// </summary>
         public Func<object, object>[] Items { get; private set; }
 
@@ -151,6 +162,46 @@ namespace KRPC.Client
                                      Expression.Convert (item, valueType)),
                     Expression.Empty ()),
                 set, item).Compile ();
+        }
+
+        /// <summary>
+        /// The properties that carry the fields of a structure type, in the order the type
+        /// declares them, which is the order their values are encoded in. Reflection does not
+        /// promise an order for the properties of a type, so they are ordered by metadata token,
+        /// which is assigned in declaration order.
+        /// </summary>
+        static PropertyInfo[] StructFields (Type type)
+        {
+            var fields = type.GetProperties (BindingFlags.Public | BindingFlags.Instance);
+            Array.Sort (fields, (x, y) => x.MetadataToken.CompareTo (y.MetadataToken));
+            return fields;
+        }
+
+        static Func<object[], object> StructConstructor (Type type, Type[] fieldTypes)
+        {
+            var values = Expression.Parameter (typeof(object[]));
+            var items = new Expression [fieldTypes.Length];
+            for (var i = 0; i < fieldTypes.Length; i++)
+                items [i] = Expression.Convert (
+                    Expression.ArrayIndex (values, Expression.Constant (i)), fieldTypes [i]);
+            return Expression.Lambda<Func<object[], object>> (
+                Expression.Convert (
+                    Expression.New (type.GetConstructor (fieldTypes), items), typeof(object)),
+                values).Compile ();
+        }
+
+        static Func<object, object>[] StructItems (Type type, PropertyInfo[] fields)
+        {
+            var items = new Func<object, object> [fields.Length];
+            for (var i = 0; i < fields.Length; i++) {
+                var value = Expression.Parameter (typeof(object));
+                items [i] = Expression.Lambda<Func<object, object>> (
+                    Expression.Convert (
+                        Expression.Property (Expression.Convert (value, type), fields [i]),
+                        typeof(object)),
+                    value).Compile ();
+            }
+            return items;
         }
 
         static Type TupleType (Type[] valueTypes)

--- a/client/csharp/src/ValueUtils.cs
+++ b/client/csharp/src/ValueUtils.cs
@@ -1,0 +1,109 @@
+using System.Collections;
+
+namespace KRPC.Client
+{
+    /// <summary>
+    /// Equality and hashing for the values of the fields of a structure. A collection is
+    /// compared by its contents, where the equality a collection type provides itself
+    /// compares references.
+    /// </summary>
+    public static class ValueUtils
+    {
+        /// <summary>
+        /// Returns true if the two field values are equal.
+        /// </summary>
+        public static bool Equal (object x, object y)
+        {
+            if (ReferenceEquals (x, y))
+                return true;
+            if (ReferenceEquals (x, null) || ReferenceEquals (y, null))
+                return false;
+            var dictionary = x as IDictionary;
+            if (dictionary != null)
+                return DictionariesEqual (dictionary, y as IDictionary);
+            var list = x as IList;
+            if (list != null)
+                return ListsEqual (list, y as IList);
+            if (x is IEnumerable && !(x is string))
+                return SetsEqual ((IEnumerable)x, y as IEnumerable);
+            return x.Equals (y);
+        }
+
+        /// <summary>
+        /// Returns a hash code for a field value, equal for values that compare equal.
+        /// </summary>
+        public static int HashCode (object value)
+        {
+            if (ReferenceEquals (value, null))
+                return 0;
+            var dictionary = value as IDictionary;
+            if (dictionary != null) {
+                int hash = 0;
+                foreach (DictionaryEntry entry in dictionary)
+                    hash ^= HashCode (entry.Key) * 31 + HashCode (entry.Value);
+                return hash;
+            }
+            var list = value as IList;
+            if (list != null) {
+                int hash = 17;
+                foreach (var item in list)
+                    hash = hash * 31 + HashCode (item);
+                return hash;
+            }
+            if (value is IEnumerable && !(value is string)) {
+                int hash = 0;
+                foreach (var item in (IEnumerable)value)
+                    hash ^= HashCode (item);
+                return hash;
+            }
+            return value.GetHashCode ();
+        }
+
+        static bool ListsEqual (IList x, IList y)
+        {
+            if (y == null || x.Count != y.Count)
+                return false;
+            for (int i = 0; i < x.Count; i++) {
+                if (!Equal (x [i], y [i]))
+                    return false;
+            }
+            return true;
+        }
+
+        static bool SetsEqual (IEnumerable x, IEnumerable y)
+        {
+            if (y == null)
+                return false;
+            var itemsY = new ArrayList ();
+            foreach (var item in y)
+                itemsY.Add (item);
+            int sizeX = 0;
+            foreach (var itemX in x) {
+                sizeX++;
+                bool found = false;
+                foreach (var itemY in itemsY) {
+                    if (Equal (itemX, itemY)) {
+                        found = true;
+                        break;
+                    }
+                }
+                if (!found)
+                    return false;
+            }
+            return sizeX == itemsY.Count;
+        }
+
+        static bool DictionariesEqual (IDictionary x, IDictionary y)
+        {
+            if (y == null || x.Count != y.Count)
+                return false;
+            foreach (DictionaryEntry entry in x) {
+                if (!y.Contains (entry.Key))
+                    return false;
+                if (!Equal (entry.Value, y [entry.Key]))
+                    return false;
+            }
+            return true;
+        }
+    }
+}

--- a/client/csharp/test/ConnectionTest.cs
+++ b/client/csharp/test/ConnectionTest.cs
@@ -350,6 +350,70 @@ namespace KRPC.Client.Test
         }
 
         [Test]
+        public void Structs ()
+        {
+            var value = new TestStruct (42, "jeb", TestEnum.ValueB, new List<int> { 1, 2, 3 });
+            var result = Connection.TestService ().StructEcho (value);
+            Assert.AreEqual (value, result);
+            Assert.AreEqual (value.GetHashCode (), result.GetHashCode ());
+            Assert.AreEqual (42, result.IntField);
+            Assert.AreEqual ("jeb", result.StringField);
+            Assert.AreEqual (TestEnum.ValueB, result.EnumField);
+            CollectionAssert.AreEqual (new List<int> { 1, 2, 3 }, result.ListField);
+        }
+
+        [Test]
+        public void NestedStructs ()
+        {
+            var obj = Connection.TestService ().CreateTestObject ("bob");
+            var value = new TestNestedStruct (
+                new TestStruct (1, "jeb", TestEnum.ValueA, new List<int> ()), obj, "bill");
+            var result = Connection.TestService ().NestedStructEcho (value);
+            Assert.AreEqual (value, result);
+            Assert.AreEqual (1, result.StructField.IntField);
+            Assert.AreEqual (obj, result.ObjectField);
+            Assert.AreEqual ("bill", result.StringField);
+        }
+
+        [Test]
+        public void CollectionsOfStructs ()
+        {
+            var values = new List<TestStruct> {
+                new TestStruct (0, "jeb", TestEnum.ValueC, new List<int> ()),
+                new TestStruct (1, "bob", TestEnum.ValueC, new List<int> ())
+            };
+            var result = Connection.TestService ().IncrementListOfStructs (values);
+            CollectionAssert.AreEqual (
+                new List<TestStruct> {
+                    new TestStruct (1, "jeb", TestEnum.ValueC, new List<int> ()),
+                    new TestStruct (2, "bob", TestEnum.ValueC, new List<int> ())
+                },
+                result);
+        }
+
+        [Test]
+        public void NullableStructs ()
+        {
+            Assert.IsNull (Connection.TestService ().StructEchoNullable (null));
+            var value = new TestStruct (1, "jeb", TestEnum.ValueA, new List<int> ());
+            var result = Connection.TestService ().StructEchoNullable (value);
+            Assert.IsTrue (result.HasValue);
+            Assert.AreEqual (value, result.Value);
+        }
+
+        [Test]
+        public void StructDefaultValue ()
+        {
+            var result = Connection.TestService ().StructDefault ();
+            Assert.AreEqual (
+                new TestStruct (42, "jeb", TestEnum.ValueB, new List<int> { 1, 2, 3 }), result);
+            Assert.AreEqual (42, result.IntField);
+            Assert.AreEqual ("jeb", result.StringField);
+            Assert.AreEqual (TestEnum.ValueB, result.EnumField);
+            CollectionAssert.AreEqual (new List<int> { 1, 2, 3 }, result.ListField);
+        }
+
+        [Test]
         public void CollectionsDefaultValues ()
         {
             Assert.AreEqual (new Tuple<int,bool> (1, false), Connection.TestService ().TupleDefault ());

--- a/client/csharp/test/EncoderTest.cs
+++ b/client/csharp/test/EncoderTest.cs
@@ -289,5 +289,15 @@ namespace KRPC.Client.Test
             var decodeResult = (Tuple<uint,string,bool>)Encoder.Decode (data.ToByteString (), value.GetType (), null);
             Assert.AreEqual (value, decodeResult);
         }
+
+        [Test]
+        public void TupleCollectionWithMissingItems ()
+        {
+            // The same decoder reads a structure, where too few items is what an older
+            // server sends for one this client has more fields for
+            const string data = "0a0101";
+            Assert.Throws<ArgumentException> (
+                () => Encoder.Decode (data.ToByteString (), typeof(Tuple<uint,string>), null));
+        }
     }
 }

--- a/client/java/CHANGELOG.md
+++ b/client/java/CHANGELOG.md
@@ -1,4 +1,7 @@
 ## [v0.7.0] - unreleased
+- Support structure types, which a service defines as a compound value with named fields. One
+  is generated as a class carrying its fields, with a constructor taking them in the order the
+  structure declares them, getters and equality over them (#1066)
 - **Breaking:** Requires Java 17 or later, up from Java 9, for the unix domain sockets the
   local socket protocol is carried over (#1065)
 - **Breaking:** Support `null` for any nullable type; nullable value types use the boxed type

--- a/client/java/src/krpc/client/Encoder.java
+++ b/client/java/src/krpc/client/Encoder.java
@@ -9,12 +9,15 @@ import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import krpc.client.EncodingException;
 import krpc.schema.KRPC;
 import org.javatuples.Decade;
@@ -85,6 +88,8 @@ public class Encoder {
           return encodeObject((RemoteObject) value);
         case ENUMERATION:
           return encodeEnum((RemoteEnum) value);
+        case STRUCT:
+          return encodeStruct((RemoteStruct) value, type);
         case TUPLE:
           return encodeTuple((Tuple) value, type.getTypesList());
         case LIST:
@@ -132,6 +137,8 @@ public class Encoder {
           return decodeObject(data, type, connection);
         case ENUMERATION:
           return decodeEnum(data, type);
+        case STRUCT:
+          return decodeStruct(data, type, connection);
         case TUPLE:
           return decodeTuple(data, type.getTypesList(), connection);
         case LIST:
@@ -245,6 +252,78 @@ public class Encoder {
 
   static ByteString encodeEnum(RemoteEnum value) throws IOException {
     return encodeSint32(value.getValue());
+  }
+
+  /**
+   * What encoding a structure needs from the generated class that defines it: the types of its
+   * fields, in the order they are encoded in, and the method that builds one from their values.
+   * A struct type carries only the service and the name of the structure, so this is found by
+   * reflection, once per structure rather than for every value encoded or decoded.
+   */
+  private static final class StructInfo {
+    final List<KRPC.Type> fieldTypes;
+    final Method fromFieldValues;
+
+    @SuppressWarnings("unchecked")
+    StructInfo(KRPC.Type type) {
+      try {
+        Class<?> structType = Class.forName(
+            "krpc.client.services." + type.getService() + "$" + type.getName());
+        fieldTypes = (List<KRPC.Type>) structType.getMethod("fieldTypes").invoke(null);
+        fromFieldValues = structType.getMethod("fromFieldValues", Object[].class);
+      } catch (ClassNotFoundException | NoSuchMethodException | IllegalAccessException
+          | InvocationTargetException exn) {
+        throw new EncodingException("Failed to find the fields of a struct", exn);
+      }
+    }
+  }
+
+  private static final ConcurrentMap<String, StructInfo> STRUCT_INFOS =
+      new ConcurrentHashMap<>();
+
+  static StructInfo structInfo(KRPC.Type type) {
+    return STRUCT_INFOS.computeIfAbsent(
+        type.getService() + "$" + type.getName(), name -> new StructInfo(type));
+  }
+
+  /**
+   * A structure is encoded as the values of its fields in order, which is the same encoding
+   * as a tuple of those values.
+   */
+  static ByteString encodeStruct(RemoteStruct value, KRPC.Type type) throws IOException {
+    List<KRPC.Type> fieldTypes = structInfo(type).fieldTypes;
+    Object[] values = value.fieldValues();
+    if (values.length != fieldTypes.size()) {
+      throw new EncodingException("Failed to encode struct");
+    }
+    KRPC.Tuple.Builder struct = KRPC.Tuple.newBuilder();
+    for (int i = 0; i < values.length; i++) {
+      struct.addItems(encode(values[i], fieldTypes.get(i)));
+    }
+    return UnsafeByteOperations.unsafeWrap(struct.build().toByteArray());
+  }
+
+  /**
+   * Fields are only ever appended to a structure, so a value from a newer server may carry
+   * more items than this client knows about, and those are ignored.
+   */
+  @SuppressWarnings("unchecked")
+  static <T> T decodeStruct(ByteString data, KRPC.Type type, Connection connection)
+      throws IOException {
+    StructInfo info = structInfo(type);
+    KRPC.Tuple structMessage = KRPC.Tuple.newBuilder().mergeFrom(data).build();
+    if (structMessage.getItemsCount() < info.fieldTypes.size()) {
+      throw new EncodingException("Failed to decode struct");
+    }
+    Object[] values = new Object[info.fieldTypes.size()];
+    for (int i = 0; i < values.length; i++) {
+      values[i] = decode(structMessage.getItems(i), info.fieldTypes.get(i), connection);
+    }
+    try {
+      return (T) info.fromFieldValues.invoke(null, (Object) values);
+    } catch (IllegalAccessException | InvocationTargetException exn) {
+      throw new EncodingException("Failed to decode struct", exn);
+    }
   }
 
   static ByteString encodeTuple(Tuple value, List<KRPC.Type> valueTypes) throws IOException {

--- a/client/java/src/krpc/client/RemoteStruct.java
+++ b/client/java/src/krpc/client/RemoteStruct.java
@@ -1,0 +1,14 @@
+package krpc.client;
+
+/**
+ * A structure defined by a service: a compound value whose fields are sent inline, rather
+ * than a reference to an object that stays on the server.
+ *
+ * <p>A generated structure also has the static methods {@code fieldTypes}, giving the types
+ * of its fields in the order they are encoded in, and {@code fromFieldValues}, building one from
+ * their values.
+ */
+public interface RemoteStruct {
+  /** Returns the values of the fields, in the order they are encoded in. */
+  public Object[] fieldValues();
+}

--- a/client/java/src/krpc/client/Types.java
+++ b/client/java/src/krpc/client/Types.java
@@ -34,6 +34,15 @@ public class Types {
       .build();
   }
 
+  /** Create a struct type with the given name. */
+  public static Type createStruct(String service, String name) {
+    return Type.newBuilder()
+      .setCode(TypeCode.STRUCT)
+      .setService(service)
+      .setName(name)
+      .build();
+  }
+
   /** Create a tuple type with the given element types. */
   public static Type createTuple(Type... valueTypes) {
     Type.Builder type = Type.newBuilder();

--- a/client/java/test/krpc/client/ConnectionTest.java
+++ b/client/java/test/krpc/client/ConnectionTest.java
@@ -249,6 +249,53 @@ public class ConnectionTest {
   }
 
   @Test
+  public void testStructs() throws RPCException {
+    TestService.TestStruct value = new TestService.TestStruct(
+        42, "jeb", TestService.TestEnum.VALUE_B, Arrays.asList(new Integer[] { 1, 2, 3 }));
+    TestService.TestStruct result = testService.structEcho(value);
+    assertEquals(value, result);
+    assertEquals(42, result.getIntField());
+    assertEquals("jeb", result.getStringField());
+    assertEquals(TestService.TestEnum.VALUE_B, result.getEnumField());
+    assertEquals(Arrays.asList(new Integer[] { 1, 2, 3 }), result.getListField());
+  }
+
+  @Test
+  public void testNestedStructs() throws RPCException {
+    TestService.TestClass obj = testService.createTestObject("bob");
+    TestService.TestNestedStruct value = new TestService.TestNestedStruct(
+        new TestService.TestStruct(
+            1, "jeb", TestService.TestEnum.VALUE_A, new ArrayList<Integer>()),
+        obj, "bill");
+    TestService.TestNestedStruct result = testService.nestedStructEcho(value);
+    assertEquals(value, result);
+    assertEquals(1, result.getStructField().getIntField());
+    assertEquals(obj, result.getObjectField());
+    assertEquals("bill", result.getStringField());
+  }
+
+  @Test
+  public void testCollectionsOfStructs() throws RPCException {
+    List<TestService.TestStruct> values = Arrays.asList(
+        new TestService.TestStruct(
+            0, "jeb", TestService.TestEnum.VALUE_C, new ArrayList<Integer>()),
+        new TestService.TestStruct(
+            1, "bob", TestService.TestEnum.VALUE_C, new ArrayList<Integer>()));
+    List<TestService.TestStruct> result = testService.incrementListOfStructs(values);
+    assertEquals(2, result.size());
+    assertEquals(1, result.get(0).getIntField());
+    assertEquals(2, result.get(1).getIntField());
+  }
+
+  @Test
+  public void testNullableStructs() throws RPCException {
+    assertNull(testService.structEchoNullable(null));
+    TestService.TestStruct value = new TestService.TestStruct(
+        1, "jeb", TestService.TestEnum.VALUE_A, new ArrayList<Integer>());
+    assertEquals(value, testService.structEchoNullable(value));
+  }
+
+  @Test
   @SuppressWarnings("serial")
   public void testCollectionsNested() throws RPCException {
     assertEquals(new HashMap<String, List<Integer>>(),

--- a/client/lua/CHANGELOG.md
+++ b/client/lua/CHANGELOG.md
@@ -1,4 +1,10 @@
 ## [v0.7.0] - unreleased
+- Support structure types, which a service defines as a compound value with named fields. A
+  value of one is built from the values of its fields in order and gives them named access; a
+  list with one element per field is accepted where one is expected (#1066)
+- A service definition that names a type this client does not know about, as one from a newer
+  server may, now skips the member that names it with a warning, rather than failing to
+  connect (#1066)
 - **Breaking:** Support `Types.none` for any nullable type (#1017)
 - Add `krpc.connect_local`, which connects to a server on the same machine over a unix
   domain socket rather than TCP/IP. The connection behaves identically once established.

--- a/client/lua/krpc/decoder.lua
+++ b/client/lua/krpc/decoder.lua
@@ -170,6 +170,19 @@ function decoder.decode(data, typ)
       result[i] = decoder.decode(items[i], value_types[i])
     end
     return result
+  elseif code == Types.STRUCT then
+    -- Fields are only ever appended to a structure, so a value from a newer server may
+    -- carry more items than this client knows about, and those are ignored
+    local items, count = _decode_items(data, _ITEMS)
+    local field_types = typ.field_types
+    if count < #field_types then
+      error('Value for ' .. typ._struct_name .. ' does not have all of its fields')
+    end
+    local values = {}
+    for i = 1, #field_types do
+      values[i] = decoder.decode(items[i], field_types[i])
+    end
+    return typ.lua_type(unpack(values))
   elseif typ:is_a(Types.MessageType) then
     return decoder.decode_message(data, typ.lua_type)
   end

--- a/client/lua/krpc/encoder.lua
+++ b/client/lua/krpc/encoder.lua
@@ -148,6 +148,16 @@ function encoder.encode(x, typ)
       parts[count] = _delimited(_ITEMS, encoder.encode(item[1], item[2]))
     end
     return _concat(parts)
+  elseif code == Types.STRUCT then
+    -- A structure is encoded as the values of its fields in order, which is the same
+    -- encoding as a tuple of those values
+    local field_names = typ.field_names
+    local field_types = typ.field_types
+    local parts = {}
+    for i = 1, #field_names do
+      parts[i] = _delimited(_ITEMS, encoder.encode(x[field_names[i]], field_types[i]))
+    end
+    return _concat(parts)
   elseif typ:is_a(Types.MessageType) then
     return x:SerializeToString()
   end

--- a/client/lua/krpc/service.lua
+++ b/client/lua/krpc/service.lua
@@ -83,6 +83,18 @@ function ServiceBase:_parse_procedure(procedure)
 
   local param_names = seq.copy(seq.map(function (x) return service.to_snake_case(x.name) end, procedure.parameters))
   local param_types = seq.copy(seq.map(function (x) return self._client._types:as_type(x.type) end, procedure.parameters))
+  local return_type = nil
+  if procedure:HasField('return_type') then
+    return_type = self._client._types:as_type(procedure.return_type)
+  end
+  -- Checked before anything is built from the types, so that a procedure naming a structure
+  -- whose definition was skipped is skipped along with it
+  for _,typ in ipairs(param_types) do
+    Types.check_type_is_known(typ)
+  end
+  if return_type ~= nil then
+    Types.check_type_is_known(return_type)
+  end
   local param_required = seq.copy(seq.map(function (x) return not x.has_default_value end, procedure.parameters))
   local param_default = List{}
   for param,typ in seq.zip(procedure.parameters, param_types) do
@@ -95,10 +107,6 @@ function ServiceBase:_parse_procedure(procedure)
     else
       param_default:append(nil)
     end
-  end
-  local return_type = nil
-  if procedure:HasField('return_type') then
-    return_type = self._client._types:as_type(procedure.return_type)
   end
   return param_names, param_types, param_required, param_default, return_type
 end
@@ -115,6 +123,24 @@ function service.register_definitions(types, svc)
     end
     types:enumeration_type(svc.name, enum.name):set_values(values)
   end
+  for _,struct in ipairs(svc.structs) do
+    -- A structure whose fields cannot all be resolved is left without any, so that whatever
+    -- names it is skipped rather than the whole service failing to build
+    local known = true
+    for _,field in ipairs(struct.fields) do
+      known = known and Types.is_a_known_type(field.type)
+    end
+    if known then
+      local fields = {}
+      for i,field in ipairs(struct.fields) do
+        fields[i] = { service.to_snake_case(field.name), types:as_type(field.type) }
+      end
+      types:struct_type(svc.name, struct.name):set_fields(fields)
+    else
+      io.stderr:write('Skipping the struct ' .. svc.name .. '.' .. struct.name .. ', as the ' ..
+                      'type of one of its fields is not a type this client knows about\n')
+    end
+  end
 end
 
 -- The types a service defines are registered from its definitions, before any service is
@@ -129,6 +155,11 @@ end
 --- Add an enumeration type
 function ServiceBase:_add_service_enumeration(enum)
   self[enum.name] = self._client._types:enumeration_type(self._name, enum.name).lua_type
+end
+
+--- Add a structure type
+function ServiceBase:_add_service_struct(struct)
+  self[struct.name] = self._client._types:struct_type(self._name, struct.name).lua_type
 end
 
 --- Add a procedure
@@ -198,6 +229,20 @@ function ServiceBase:_add_service_class_property(class_name, property_name, gett
   return class_cls:_add_property(property_name, getter, setter)
 end
 
+--- Run one step of building a service, skipping it with a warning if it names a type this
+--- client does not know about, rather than failing to create the service at all. That is what
+--- a definition from a newer server looks like, where a member has been added whose type is
+--- from a later version of the protocol.
+local function _skipping_unknown_types(what, build)
+  local ok, err = pcall(build)
+  if not ok then
+    if type(err) ~= 'string' or not err:find(Types.UNKNOWN_TYPE_ERROR, 1, true) then
+      error(err)
+    end
+    io.stderr:write('Skipping ' .. what .. ': ' .. tostring(err) .. '\n')
+  end
+end
+
 --- Create a new service type
 function service.create_service(client, service)
   local cls = class(ServiceBase)
@@ -215,10 +260,19 @@ function service.create_service(client, service)
     cls:_add_service_enumeration(enum)
   end
 
+  -- Add structure types to service
+  for _,struct in ipairs(service.structs) do
+    if client._types:struct_type(service.name, struct.name).lua_type ~= nil then
+      cls:_add_service_struct(struct)
+    end
+  end
+
   -- Add procedures
   for _,procedure in ipairs(service.procedures) do
     if Attributes.is_a_procedure(procedure.name) then
-      cls:_add_service_procedure(procedure)
+      _skipping_unknown_types(service.name .. '.' .. procedure.name, function ()
+        cls:_add_service_procedure(procedure)
+      end)
     end
   end
 
@@ -238,7 +292,9 @@ function service.create_service(client, service)
     end
   end
   for name, procedures in pairs(properties) do
-    cls:_add_service_property(name, procedures['get'], procedures['set'])
+    _skipping_unknown_types(service.name .. '.' .. name, function ()
+      cls:_add_service_property(name, procedures['get'], procedures['set'])
+    end)
   end
 
   -- Add class methods
@@ -246,7 +302,9 @@ function service.create_service(client, service)
     if Attributes.is_a_class_method(procedure.name) then
       local class_name = Attributes.get_class_name(procedure.name)
       local method_name = Attributes.get_class_member_name(procedure.name)
-      cls:_add_service_class_method(class_name, method_name, procedure)
+      _skipping_unknown_types(service.name .. '.' .. class_name .. '.' .. method_name, function ()
+        cls:_add_service_class_method(class_name, method_name, procedure)
+      end)
     end
   end
 
@@ -255,7 +313,9 @@ function service.create_service(client, service)
     if Attributes.is_a_class_static_method(procedure.name) then
       local class_name = Attributes.get_class_name(procedure.name)
       local method_name = Attributes.get_class_member_name(procedure.name)
-      cls:_add_service_class_static_method(class_name, method_name, procedure)
+      _skipping_unknown_types(service.name .. '.' .. class_name .. '.' .. method_name, function ()
+        cls:_add_service_class_static_method(class_name, method_name, procedure)
+      end)
     end
   end
 
@@ -278,7 +338,9 @@ function service.create_service(client, service)
   end
   for key, procedures in pairs(properties) do
     local class_name, _, property_name = stringx.partition(key, '.')
-    cls:_add_service_class_property(class_name, property_name, procedures['get'], procedures['set'])
+    _skipping_unknown_types(service.name .. '.' .. key, function ()
+      cls:_add_service_class_property(class_name, property_name, procedures['get'], procedures['set'])
+    end)
   end
 
   return cls()

--- a/client/lua/krpc/test/test_client.lua
+++ b/client/lua/krpc/test/test_client.lua
@@ -261,6 +261,54 @@ function TestClient:test_collections_of_objects()
   luaunit.assertEquals("value=bob", l[2]:get_value())
 end
 
+function TestClient:test_structs()
+  local service = self.conn.test_service
+  local value = service.TestStruct(42, 'jeb', service.TestEnum.value_b, List{1, 2, 3})
+  local result = service.struct_echo(value)
+  luaunit.assertEquals(value, result)
+  luaunit.assertEquals(42, result.int_field)
+  luaunit.assertEquals('jeb', result.string_field)
+  luaunit.assertEquals(service.TestEnum.value_b, result.enum_field)
+  luaunit.assertEquals(List{1, 2, 3}, result.list_field)
+end
+
+function TestClient:test_nested_structs()
+  local service = self.conn.test_service
+  local obj = service.create_test_object('bob')
+  local value = service.TestNestedStruct(
+    service.TestStruct(1, 'jeb', service.TestEnum.value_a, List{}), obj, 'bill')
+  local result = service.nested_struct_echo(value)
+  luaunit.assertEquals(value, result)
+  luaunit.assertEquals(1, result.struct_field.int_field)
+  luaunit.assertEquals(obj, result.object_field)
+  luaunit.assertEquals('bill', result.string_field)
+end
+
+function TestClient:test_collections_of_structs()
+  local service = self.conn.test_service
+  local values = List{
+    service.TestStruct(0, 'jeb', service.TestEnum.value_c, List{}),
+    service.TestStruct(1, 'bob', service.TestEnum.value_c, List{})}
+  local result = service.increment_list_of_structs(values)
+  luaunit.assertEquals(2, #result)
+  luaunit.assertEquals(1, result[1].int_field)
+  luaunit.assertEquals(2, result[2].int_field)
+end
+
+function TestClient:test_nullable_structs()
+  local service = self.conn.test_service
+  luaunit.assertEquals(Types.none, service.struct_echo_nullable(Types.none))
+  local value = service.TestStruct(1, 'jeb', service.TestEnum.value_a, List{})
+  luaunit.assertEquals(value, service.struct_echo_nullable(value))
+end
+
+function TestClient:test_struct_default_value()
+  local service = self.conn.test_service
+  luaunit.assertEquals(
+    service.TestStruct(42, 'jeb', service.TestEnum.value_b, List{1, 2, 3}),
+    service.struct_default())
+end
+
 function TestClient:test_collections_default_values()
   luaunit.assertEquals(List{1, false}, self.conn.test_service.tuple_default())
   luaunit.assertEquals(List{1, 2, 3}, self.conn.test_service.list_default())
@@ -364,12 +412,15 @@ function TestClient:test_test_service_service_members()
      'DeprecatedStruct',
      'TestClass',
      'TestEnum',
+     'TestNestedStruct',
+     'TestStruct',
      'add_multiple_values',
      'add_to_object_list',
      'blocking_procedure',
      'bool_to_string',
      'bytes_to_hex_string',
      'counter',
+     'counter_struct',
      'create_test_object',
      'deprecated_procedure',
      'deprecated_procedure_no_message',
@@ -394,6 +445,7 @@ function TestClient:test_test_service_service_members()
      'get_string_property_private_set',
      'increment_dictionary',
      'increment_list',
+     'increment_list_of_structs',
      'increment_nested_collection',
      'increment_set',
      'increment_tuple',
@@ -402,6 +454,7 @@ function TestClient:test_test_service_service_members()
      'int64_special_defaults',
      'int64_to_string',
      'list_default',
+     'nested_struct_echo',
      'not_nullable_object',
      'on_timer',
      'on_timer_using_lambda',
@@ -416,6 +469,9 @@ function TestClient:test_test_service_service_members()
      'set_string_property',
      'set_string_property_private_get',
      'string_to_int32',
+     'struct_default',
+     'struct_echo',
+     'struct_echo_nullable',
      'throw_argument_exception',
      'throw_argument_null_exception',
      'throw_argument_out_of_range_exception',

--- a/client/lua/krpc/test/test_client.lua
+++ b/client/lua/krpc/test/test_client.lua
@@ -361,6 +361,7 @@ function TestClient:test_test_service_service_members()
     members,
     {'DeprecatedClass',
      'DeprecatedEnum',
+     'DeprecatedStruct',
      'TestClass',
      'TestEnum',
      'add_multiple_values',

--- a/client/lua/krpc/test/test_service_definitions.lua
+++ b/client/lua/krpc/test/test_service_definitions.lua
@@ -63,6 +63,47 @@ local function default_service(name, enum_service_name, in_a_list)
   return svc
 end
 
+-- A type code from a later version of the protocol than this client knows about
+local UNKNOWN_TYPE_CODE = 9999
+
+--- A service defining a structure with a single field, whose type the given function sets
+local function struct_service(name, set_field_type)
+  local svc = schema.Service()
+  svc.name = name
+  local struct = svc.structs:add()
+  struct.name = 'Thing'
+  local field = struct.fields:add()
+  field.name = 'Value'
+  set_field_type(field.type)
+  return svc
+end
+
+--- A service with a procedure taking a parameter of another service's structure
+local function struct_using_service(name, struct_service_name)
+  local svc = schema.Service()
+  svc.name = name
+  local procedure = svc.procedures:add()
+  procedure.name = 'Frob'
+  local parameter = procedure.parameters:add()
+  parameter.name = 'thing'
+  parameter.type.code = Types.STRUCT
+  parameter.type.service = struct_service_name
+  parameter.type.name = 'Thing'
+  return svc
+end
+
+local function unknown_field_type(typ)
+  typ.code = UNKNOWN_TYPE_CODE
+end
+
+local function struct_field_type(service_name)
+  return function (typ)
+    typ.code = Types.STRUCT
+    typ.service = service_name
+    typ.name = 'Thing'
+  end
+end
+
 local function create_services(svcs)
   local client = FakeClient()
   for _,svc in ipairs(svcs) do
@@ -111,6 +152,28 @@ end
 
 function TestServiceDefinitions:test_used_inside_a_collection()
   self:check_services({default_service('ServiceA', 'ServiceB', true), enum_service('ServiceB')}, true)
+end
+
+function TestServiceDefinitions:check_struct_is_skipped(svcs)
+  local _, created = create_services(svcs)
+  luaunit.assertNil(created['ServiceA'].frob)
+end
+
+function TestServiceDefinitions:test_procedure_naming_a_skipped_struct_is_skipped()
+  local _, created = create_services({
+    struct_service('ServiceB', unknown_field_type),
+    struct_using_service('ServiceA', 'ServiceB')
+  })
+  luaunit.assertNil(created['ServiceA'].frob)
+  luaunit.assertNil(created['ServiceB'].Thing)
+end
+
+function TestServiceDefinitions:test_struct_holding_a_skipped_struct_is_skipped()
+  self:check_struct_is_skipped({
+    struct_service('ServiceC', unknown_field_type),
+    struct_service('ServiceB', struct_field_type('ServiceC')),
+    struct_using_service('ServiceA', 'ServiceB')
+  })
 end
 
 return TestServiceDefinitions

--- a/client/lua/krpc/types.lua
+++ b/client/lua/krpc/types.lua
@@ -23,6 +23,7 @@ Types.STRING = schema.TYPE_TYPECODE_STRING_ENUM.number
 Types.BYTES = schema.TYPE_TYPECODE_BYTES_ENUM.number
 Types.CLASS = schema.TYPE_TYPECODE_CLASS_ENUM.number
 Types.ENUMERATION = schema.TYPE_TYPECODE_ENUMERATION_ENUM.number
+Types.STRUCT = schema.TYPE_TYPECODE_STRUCT_ENUM.number
 Types.TUPLE = schema.TYPE_TYPECODE_TUPLE_ENUM.number
 Types.LIST = schema.TYPE_TYPECODE_LIST_ENUM.number
 Types.SET = schema.TYPE_TYPECODE_SET_ENUM.number
@@ -50,6 +51,24 @@ MESSAGE_TYPES:set(Types.PROCEDURE_CALL, schema.ProcedureCall)
 MESSAGE_TYPES:set(Types.STREAM, schema.Stream)
 MESSAGE_TYPES:set(Types.SERVICES, schema.Services)
 MESSAGE_TYPES:set(Types.STATUS, schema.Status)
+
+-- Every type code a type object can be built for. A definition from a newer server may name a
+-- type code that is not among them, which is what makes a definition partly unusable rather
+-- than malformed
+KNOWN_TYPE_CODES = Set{
+  Types.CLASS, Types.ENUMERATION, Types.STRUCT,
+  Types.TUPLE, Types.LIST, Types.SET, Types.DICTIONARY
+}
+for code in VALUE_TYPES:iter() do
+  KNOWN_TYPE_CODES[code] = true
+end
+for code in MESSAGE_TYPES:iter() do
+  KNOWN_TYPE_CODES[code] = true
+end
+
+--- The start of the error raised for a type this client cannot use. What names such a type is
+--- skipped rather than failing the whole service, so the error has to be recognizable.
+Types.UNKNOWN_TYPE_ERROR = 'Unknown type'
 
 CODE_TO_STRING = Map{}
 CODE_TO_STRING:set(Types.DOUBLE, 'double')
@@ -115,6 +134,8 @@ function Types:as_type(protobuf_type)
     typ = Types.ClassType(protobuf_type)
   elseif protobuf_type.code == Types.ENUMERATION then
     typ = Types.EnumerationType(protobuf_type)
+  elseif protobuf_type.code == Types.STRUCT then
+    typ = Types.StructType(protobuf_type)
   elseif protobuf_type.code == Types.TUPLE then
     typ = Types.TupleType(protobuf_type, self)
   elseif protobuf_type.code == Types.LIST then
@@ -126,7 +147,7 @@ function Types:as_type(protobuf_type)
   elseif MESSAGE_TYPES:get(protobuf_type.code) then
     typ = Types.MessageType(protobuf_type)
   else
-    error('Invalid type')
+    error(Types.UNKNOWN_TYPE_ERROR .. ' code ' .. tostring(protobuf_type.code))
   end
 
   self._types:set(key, typ)
@@ -186,6 +207,11 @@ end
 function Types:enumeration_type(service, name)
   -- Get an enumeration type
   return self:as_type(_protobuf_type(Types.ENUMERATION, service, name))
+end
+
+function Types:struct_type(service, name)
+  -- Get a struct type
+  return self:as_type(_protobuf_type(Types.STRUCT, service, name))
 end
 
 function Types:tuple_type(value_types)
@@ -266,6 +292,15 @@ function Types:coerce_to(value, typ)
     end
     return result
   end
+  -- Coerce lists (with one element per field) to structs, taking their elements as the
+  -- fields in order
+  if type(value) == 'table' and value._object_id ~= 0 and typ:is_a(Types.StructType) and #(value) == #(typ.field_types) then
+    local values = {}
+    for i, x in ipairs(value) do
+      values[i] = self:coerce_to(x, typ.field_types[i])
+    end
+    return typ.lua_type(unpack(values))
+  end
   error('Failed to coerce value ' .. tostring(value) .. ' of type ' .. type(value) .. ' to type ' .. tostring(typ))
 end
 
@@ -280,6 +315,14 @@ Types.Enum = class()
 
 function Types.Enum:_init(value)
   self.value = value
+end
+
+local function _create_struct_type(service_name, struct_name, field_names)
+  local cls = class(Types.StructBase)
+  cls['_service_name'] = service_name
+  cls['_struct_name'] = struct_name
+  cls['_field_names'] = field_names
+  return cls
 end
 
 local function _create_enum_type(service_name, class_name, values)
@@ -356,6 +399,40 @@ function Types.EnumerationType:set_values(values)
   self.lua_type = _create_enum_type(self._service_name, self._class_name, values)
 end
 
+Types.StructType = class(Types.TypeBase)
+
+function Types.StructType:_init(protobuf_type)
+  if protobuf_type.code ~= Types.STRUCT then
+    error('Not a struct type')
+  end
+  if protobuf_type.service == '' then
+    error('Struct type has no service name')
+  end
+  if protobuf_type.name == '' then
+    error('Struct type has no struct name')
+  end
+  self._service_name = protobuf_type.service
+  self._struct_name = protobuf_type.name
+  -- The names and types of the fields, in the order their values are encoded in. Empty until
+  -- set_fields is called, as the field list is not carried by the type itself
+  self.field_names = List{}
+  self.field_types = List{}
+  local type_string = 'Struct(' .. protobuf_type.service .. '.' .. protobuf_type.name .. ')'
+  self:super(protobuf_type, nil, type_string)
+end
+
+--- Set the fields of the structure, as a list of {name, type} pairs in the order the
+--- structure declares them
+function Types.StructType:set_fields(fields)
+  self.field_names = List{}
+  self.field_types = List{}
+  for _, field in ipairs(fields) do
+    self.field_names:append(field[1])
+    self.field_types:append(field[2])
+  end
+  self.lua_type = _create_struct_type(self._service_name, self._struct_name, self.field_names)
+end
+
 Types.TupleType = class(Types.TypeBase)
 
 function Types.TupleType:_init(protobuf_type, types)
@@ -426,6 +503,44 @@ function Types.MessageType:_init(protobuf_type)
   self:super(protobuf_type, MESSAGE_TYPES:get(protobuf_type.code), CODE_TO_STRING:get(protobuf_type.code))
 end
 
+--- Whether a type object can be built for the given protocol buffer type. It cannot when the
+--- type, or one it contains, has a type code this client does not know about.
+function Types.is_a_known_type(protobuf_type)
+  if not KNOWN_TYPE_CODES[protobuf_type.code] then
+    return false
+  end
+  for _, typ in ipairs(protobuf_type.types) do
+    if not Types.is_a_known_type(typ) then
+      return false
+    end
+  end
+  return true
+end
+
+--- Raise an error if the given type, or a type it contains, is a structure whose definition
+--- was skipped and whose fields are therefore not known. Whatever names such a type cannot be
+--- encoded or decoded, and is skipped in turn.
+function Types.check_type_is_known(typ)
+  if typ:is_a(Types.StructType) then
+    if typ.lua_type == nil then
+      error(Types.UNKNOWN_TYPE_ERROR .. ': the definition of the struct ' ..
+            typ._service_name .. '.' .. typ._struct_name .. ' was skipped')
+    end
+    for _, field_type in ipairs(typ.field_types) do
+      Types.check_type_is_known(field_type)
+    end
+  elseif typ:is_a(Types.TupleType) then
+    for _, value_type in ipairs(typ.value_types) do
+      Types.check_type_is_known(value_type)
+    end
+  elseif typ:is_a(Types.ListType) or typ:is_a(Types.SetType) then
+    Types.check_type_is_known(typ.value_type)
+  elseif typ:is_a(Types.DictionaryType) then
+    Types.check_type_is_known(typ.key_type)
+    Types.check_type_is_known(typ.value_type)
+  end
+end
+
 Types.DynamicType = class(class.properties)
 
 --- Add a method
@@ -451,6 +566,34 @@ function Types.DynamicType:_add_property(name, getter, setter)
   if setter then
     self['set_' .. name] = setter
   end
+end
+
+Types.StructBase = class()
+
+--- A structure value, built from the values of its fields in the order the structure
+--- declares them
+function Types.StructBase:_init(...)
+  local values = {...}
+  for i, name in ipairs(self._field_names) do
+    self[name] = values[i]
+  end
+end
+
+function Types.StructBase:__eq(other)
+  for _, name in ipairs(self._field_names) do
+    if self[name] ~= other[name] then
+      return false
+    end
+  end
+  return true
+end
+
+function Types.StructBase:__tostring()
+  local parts = {}
+  for i, name in ipairs(self._field_names) do
+    parts[i] = name .. ' = ' .. tostring(self[name])
+  end
+  return self._struct_name .. '{' .. stringx.join(', ', parts) .. '}'
 end
 
 Types.ClassBase = class(Types.DynamicType)

--- a/client/python/CHANGELOG.md
+++ b/client/python/CHANGELOG.md
@@ -1,4 +1,11 @@
 ## [v0.7.0] - unreleased
+- Support structure types, which a service defines as a compound value with named fields. A
+  value of one is a named tuple, so its fields can be read by name and it is also the tuple of
+  their values; a tuple or list with one element per field is accepted where one is expected
+  (#1066)
+- A service definition that names a type this client does not know about, as one from a newer
+  server may, now skips the member that names it with a warning, rather than failing to
+  connect (#1066)
 - **Breaking:** Support `None` for any nullable type (#1017)
 - Fix a service failing to load when one of its procedures defaults to a member of an
   enumeration defined by a service that had not been loaded yet (#1044)

--- a/client/python/krpc/client.py
+++ b/client/python/krpc/client.py
@@ -4,8 +4,9 @@ from types import TracebackType
 from contextlib import contextmanager
 import sys
 import threading
+import warnings
 from krpc.connection import Connection
-from krpc.definitions import CLASS, ENUMERATION, Definition, register_all
+from krpc.definitions import CLASS, ENUMERATION, STRUCT, Definition, register_all
 from krpc.error import StreamError
 from krpc.event import Event
 from krpc.types import Types, TypeBase, DefaultArgument, EXCEPTION_TYPES
@@ -21,10 +22,13 @@ import krpc.schema.KRPC_pb2 as KRPC
 import krpc.services
 
 
-def _stub_definitions(name: str, service: object) -> Iterator[Definition]:
+def _stub_definitions(
+    service_info: KRPC.Service, service: object
+) -> Iterator[Definition]:
     """The types of a service whose stubs were generated ahead of time, as records that can be
     registered in a type registry. The stubs already provide the python types, so registering
     them is what lets a dynamically created service use them."""
+    name = service_info.name
 
     def register_class(class_name: str, python_type: type) -> Callable[[Types], None]:
         def register(types: Types) -> None:
@@ -37,6 +41,32 @@ def _stub_definitions(name: str, service: object) -> Iterator[Definition]:
     ) -> Callable[[Types], None]:
         def register(types: Types) -> None:
             types.register_enum_type(name, enum_name, python_type)
+
+        return register
+
+    def register_struct(
+        struct: KRPC.Struct, python_type: type
+    ) -> Callable[[Types], None]:
+        field_names = python_type._fields  # type: ignore[attr-defined]
+        build_as: Optional[type] = python_type
+        if len(struct.fields) < len(field_names):
+            # Fields are only ever appended to a structure, so a server that declares fewer
+            # of them than the stubs is an older one. Its values cannot be built as the stub
+            # type, so a plain named tuple of the fields it does declare is used instead
+            warnings.warn(
+                "Reading the struct %s.%s as a plain named tuple, as the server declares "
+                "fewer fields for it than this client was generated against"
+                % (name, struct.name)
+            )
+            field_names = field_names[: len(struct.fields)]
+            build_as = None
+
+        def register(types: Types) -> None:
+            fields = [
+                (field_name, types.as_type(field.type))
+                for field_name, field in zip(field_names, struct.fields)
+            ]
+            types.struct_type(name, struct.name).set_fields(fields, build_as)
 
         return register
 
@@ -53,6 +83,21 @@ def _stub_definitions(name: str, service: object) -> Iterator[Definition]:
             enum_name,
             [],
             register_enumeration(enum_name, python_type),
+        )
+    # The field types of a structure come from the service definition rather than from the
+    # stubs, so that the same code decodes a structure whether its stubs were generated
+    # ahead of time or not. Only the type a value is built as comes from the stubs
+    structs = service._structs  # type: ignore[attr-defined]
+    for struct in service_info.structs:
+        python_type = structs.get(struct.name)
+        if python_type is None:
+            continue
+        yield Definition(
+            STRUCT,
+            name,
+            struct.name,
+            [field.type for field in struct.fields],
+            register_struct(struct, python_type),
         )
 
 
@@ -90,7 +135,7 @@ class Client(krpc.services.Client):
             if use_pregenerated_stubs:
                 service = self._services.get(service_info.name)
             if service is not None:
-                definitions.extend(_stub_definitions(service_info.name, service))
+                definitions.extend(_stub_definitions(service_info, service))
             else:
                 dynamic_services.append(service_info)
                 definitions.extend(service_definitions(service_info))

--- a/client/python/krpc/decoder.py
+++ b/client/python/krpc/decoder.py
@@ -18,6 +18,7 @@ from krpc.types import (
     ClassType,
     EnumerationType,
     MessageType,
+    StructType,
     TupleType,
     ListType,
     SetType,
@@ -113,6 +114,22 @@ class Decoder:
             return tuple(
                 cls.decode(client, item, value_type)
                 for item, value_type in zip(msg.items, typ.value_types)
+            )
+        if isinstance(typ, StructType):
+            # A structure is encoded as the values of its fields in order, which is the
+            # same encoding as a tuple of those values
+            msg = cast(KRPC.Tuple, cls.decode_message(data, KRPC.Tuple))
+            if len(msg.items) < len(typ.field_types):
+                raise EncodingError(
+                    "Struct has wrong number of fields. "
+                    + "Expected at least %d, got %d."
+                    % (len(typ.field_types), len(msg.items))
+                )
+            return typ.python_type(
+                *[
+                    cls.decode(client, item, field_type)
+                    for item, field_type in zip(msg.items, typ.field_types)
+                ]
             )
         raise EncodingError("Cannot decode type %s" % str(typ))
 

--- a/client/python/krpc/definitions.py
+++ b/client/python/krpc/definitions.py
@@ -18,6 +18,7 @@ from krpc.types import (
     EnumerationType,
     ListType,
     SetType,
+    StructType,
     TupleType,
     TypeBase,
     Types,
@@ -31,11 +32,13 @@ if TYPE_CHECKING:
 CLASS = "class"
 ENUMERATION = "enumeration"
 EXCEPTION = "exception"
+STRUCT = "struct"
 
 # The kind of definition that each named protocol buffer type refers to
 _KIND_FROM_CODE = {
     KRPC.Type.CLASS: CLASS,
     KRPC.Type.ENUMERATION: ENUMERATION,
+    KRPC.Type.STRUCT: STRUCT,
 }
 
 # What identifies a definition, and therefore what a reference to one resolves against
@@ -155,7 +158,8 @@ def decode_default_value(
 
 def _check_registered(typ: TypeBase, location: str) -> None:
     """Raise a RuntimeError if the given type, or a type it contains, is an enumeration whose
-    definition was never registered and whose values are therefore unknown."""
+    values, or a structure whose fields, were never registered and are therefore unknown.
+    """
     if isinstance(typ, EnumerationType):
         if not typ.has_values:
             service = typ.protobuf_type.service
@@ -164,6 +168,16 @@ def _check_registered(typ: TypeBase, location: str) -> None:
                 "%s were not provided"
                 % (location, service, typ.protobuf_type.name, service)
             )
+    elif isinstance(typ, StructType):
+        if not typ.has_fields:
+            service = typ.protobuf_type.service
+            raise RuntimeError(
+                "%s has the struct %s.%s in its type, but the definitions for service "
+                "%s were not provided"
+                % (location, service, typ.protobuf_type.name, service)
+            )
+        for field_type in typ.field_types:
+            _check_registered(field_type, location)
     elif isinstance(typ, TupleType):
         for value_type in typ.value_types:
             _check_registered(value_type, location)

--- a/client/python/krpc/encoder.py
+++ b/client/python/krpc/encoder.py
@@ -19,6 +19,7 @@ from krpc.types import (
     ClassType,
     EnumerationType,
     MessageType,
+    StructType,
     TupleType,
     ListType,
     SetType,
@@ -104,6 +105,21 @@ class Encoder:
                 for item, value_type in zip(tuple_obj, typ.value_types)
             )
             return tuple_msg.SerializeToString()
+        if isinstance(typ, StructType):
+            # A structure is encoded as the values of its fields in order, which is the
+            # same encoding as a tuple of those values
+            struct_msg = KRPC.Tuple()
+            struct_obj = cast(Collection[object], x)
+            if len(struct_obj) != len(typ.field_types):
+                raise EncodingError(
+                    "Struct has wrong number of fields. "
+                    + "Expected %d, got %d." % (len(typ.field_types), len(struct_obj))
+                )
+            struct_msg.items.extend(
+                cls.encode(item, field_type)
+                for item, field_type in zip(struct_obj, typ.field_types)
+            )
+            return struct_msg.SerializeToString()
         raise EncodingError("Cannot encode objects of type " + str(type(x)))
 
     @classmethod

--- a/client/python/krpc/service.py
+++ b/client/python/krpc/service.py
@@ -19,10 +19,20 @@ from krpc.definitions import (
     CLASS,
     ENUMERATION,
     EXCEPTION,
+    STRUCT,
     Definition,
     decode_default_value,
 )
-from krpc.types import Types, TypeBase, DynamicType, DynamicClassBase, DefaultArgument
+from krpc.types import (
+    Types,
+    TypeBase,
+    DynamicType,
+    DynamicClassBase,
+    DefaultArgument,
+    UnknownTypeError,
+    check_type_is_known,
+    is_a_known_type,
+)
 from krpc.utils import snake_case
 from krpc.attributes import Attributes
 import krpc.schema.KRPC_pb2 as KRPC
@@ -294,6 +304,29 @@ def service_definitions(service: KRPC.Service) -> Iterator[Definition]:
 
         return register
 
+    def register_struct(struct: KRPC.Struct) -> Callable[[Types], None]:
+        doc = _documentation(struct, name)
+        field_names = _update_names(
+            *[snake_case(field.name) for field in struct.fields]
+        )
+
+        def register(types: Types) -> None:
+            # A structure whose fields cannot all be resolved is left without any, so that
+            # whatever names it is skipped rather than the whole service failing to build
+            if not all(is_a_known_type(field.type) for field in struct.fields):
+                warnings.warn(
+                    "Skipping the struct %s.%s, as the type of one of its fields is not a "
+                    "type this client knows about" % (name, struct.name)
+                )
+                return
+            fields = [
+                (field_name, types.as_type(field.type))
+                for field_name, field in zip(field_names, struct.fields)
+            ]
+            types.struct_type(name, struct.name, doc).set_fields(fields)
+
+        return register
+
     for cls in service.classes:
         yield Definition(CLASS, name, cls.name, [], register_class(cls))
     for enumeration in service.enumerations:
@@ -304,6 +337,29 @@ def service_definitions(service: KRPC.Service) -> Iterator[Definition]:
         yield Definition(
             EXCEPTION, name, exception.name, [], register_exception(exception)
         )
+    # A structure is registered after the definitions its field types name, as building its
+    # fields resolves those types
+    for struct in service.structs:
+        yield Definition(
+            STRUCT,
+            name,
+            struct.name,
+            [field.type for field in struct.fields],
+            register_struct(struct),
+        )
+
+
+def _skipping_unknown_types(
+    what: str, build: Callable[..., None], *args: object  # type: ignore[type-arg]
+) -> None:
+    """Run one step of building a service, skipping it with a warning if it names a type this
+    client does not know about, rather than failing to create the service at all. That is
+    what a definition from a newer server looks like, where a member has been added whose
+    type is from a later version of the protocol."""
+    try:
+        build(*args)
+    except UnknownTypeError as exn:
+        warnings.warn("Skipping %s: %s" % (what, exn))
 
 
 def create_service(client: Client, service: KRPC.Service) -> object:
@@ -336,10 +392,19 @@ def create_service(client: Client, service: KRPC.Service) -> object:
     for exception in service.exceptions:
         cls._add_service_exception(exception)
 
+    # Add structure types to service
+    for struct in service.structs:
+        if client._types.struct_type(service.name, struct.name).has_fields:
+            cls._add_service_struct(struct)
+
     # Add procedures
     for procedure in service.procedures:
         if Attributes.is_a_procedure(procedure.name):
-            cls._add_service_procedure(procedure)
+            _skipping_unknown_types(
+                "%s.%s" % (service.name, procedure.name),
+                cls._add_service_procedure,
+                procedure,
+            )
 
     # Add properties
     properties: DefaultDict[str, List[Optional[KRPC.Procedure]]] = defaultdict(
@@ -353,21 +418,39 @@ def create_service(client: Client, service: KRPC.Service) -> object:
             else:
                 properties[name][1] = procedure
     for name, procedures in properties.items():
-        cls._add_service_property(name, procedures[0], procedures[1])
+        _skipping_unknown_types(
+            "%s.%s" % (service.name, name),
+            cls._add_service_property,
+            name,
+            procedures[0],
+            procedures[1],
+        )
 
     # Add class methods
     for procedure in service.procedures:
         if Attributes.is_a_class_method(procedure.name):
             class_name = Attributes.get_class_name(procedure.name)
             method_name = Attributes.get_class_member_name(procedure.name)
-            cls._add_service_class_method(class_name, method_name, procedure)
+            _skipping_unknown_types(
+                "%s.%s.%s" % (service.name, class_name, method_name),
+                cls._add_service_class_method,
+                class_name,
+                method_name,
+                procedure,
+            )
 
     # Add static class methods
     for procedure in service.procedures:
         if Attributes.is_a_class_static_method(procedure.name):
             class_name = Attributes.get_class_name(procedure.name)
             method_name = Attributes.get_class_member_name(procedure.name)
-            cls._add_service_class_static_method(class_name, method_name, procedure)
+            _skipping_unknown_types(
+                "%s.%s.%s" % (service.name, class_name, method_name),
+                cls._add_service_class_static_method,
+                class_name,
+                method_name,
+                procedure,
+            )
 
     # Add class properties
     class_properties: DefaultDict[Tuple[str, str], List[Optional[KRPC.Procedure]]] = (
@@ -383,8 +466,13 @@ def create_service(client: Client, service: KRPC.Service) -> object:
             else:
                 class_properties[key][1] = procedure
     for (class_name, property_name), procedures in class_properties.items():
-        cls._add_service_class_property(
-            class_name, property_name, procedures[0], procedures[1]
+        _skipping_unknown_types(
+            "%s.%s.%s" % (service.name, class_name, property_name),
+            cls._add_service_class_property,
+            class_name,
+            property_name,
+            procedures[0],
+            procedures[1],
         )
 
     return cls()  # type: ignore[operator]
@@ -416,6 +504,12 @@ class ServiceBase(DynamicType):
         setattr(cls, enumeration.name, enumeration_type.python_type)
 
     @classmethod
+    def _add_service_struct(cls, struct: KRPC.Struct) -> None:
+        """Add a structure type"""
+        struct_type = cls._client._types.struct_type(cls._name, struct.name)
+        setattr(cls, struct.name, struct_type.python_type)
+
+    @classmethod
     def _add_service_exception(cls, exception: KRPC.Exception) -> None:
         """Add an exception type"""
         exception_type = cls._client._types.exception_type(cls._name, exception.name)
@@ -433,6 +527,15 @@ class ServiceBase(DynamicType):
         param_types = [
             cls._client._types.as_type(param.type) for param in procedure.parameters
         ]
+        return_type: Optional[TypeBase] = None
+        if not Types.is_none_type(procedure.return_type):
+            return_type = cls._client._types.as_type(procedure.return_type)
+        # Checked before anything is built from the types, so that a procedure naming a
+        # structure whose definition was skipped is skipped along with it
+        for typ in param_types:
+            check_type_is_known(typ)
+        if return_type is not None:
+            check_type_is_known(return_type)
         param_required = [not param.has_default_value for param in procedure.parameters]
         param_default: List[Optional[object]] = []
         for param, typ in zip(procedure.parameters, param_types):
@@ -449,9 +552,6 @@ class ServiceBase(DynamicType):
                 )
             else:
                 param_default.append(None)
-        return_type: Optional[TypeBase] = None
-        if not Types.is_none_type(procedure.return_type):
-            return_type = cls._client._types.as_type(procedure.return_type)
         return param_names, param_types, param_required, param_default, return_type
 
     @classmethod

--- a/client/python/krpc/test/test_client.py
+++ b/client/python/krpc/test/test_client.py
@@ -424,6 +424,82 @@ class TestClient(ServerTestCase, unittest.TestCase):
         self.assertEqual("value=jeb", objs[0].get_value())
         self.assertEqual("value=bob", objs[1].get_value())
 
+    def test_structs(self) -> None:
+        service = self.conn.test_service
+        value = service.TestStruct(
+            int_field=42,
+            string_field="jeb",
+            enum_field=service.TestEnum.value_b,
+            list_field=[1, 2, 3],
+        )
+        result = service.struct_echo(value)
+        self.assertEqual(value, result)
+        # A structure has named fields, and is a tuple of their values
+        self.assertEqual(42, result.int_field)
+        self.assertEqual(service.TestEnum.value_b, result.enum_field)
+        self.assertEqual(
+            (42, "jeb", service.TestEnum.value_b, [1, 2, 3]), tuple(result)
+        )
+        # A tuple of the field values coerces to the structure
+        self.assertEqual(
+            value, service.struct_echo((42, "jeb", service.TestEnum.value_b, [1, 2, 3]))
+        )
+
+    def test_nested_structs(self) -> None:
+        service = self.conn.test_service
+        obj = service.create_test_object("bob")
+        value = service.TestNestedStruct(
+            struct_field=service.TestStruct(
+                int_field=1,
+                string_field="jeb",
+                enum_field=service.TestEnum.value_a,
+                list_field=[],
+            ),
+            object_field=obj,
+            string_field="bill",
+        )
+        result = service.nested_struct_echo(value)
+        self.assertEqual(value, result)
+        self.assertEqual(1, result.struct_field.int_field)
+        self.assertEqual("value=bob", result.object_field.get_value())
+
+    def test_collections_of_structs(self) -> None:
+        service = self.conn.test_service
+        values = [
+            service.TestStruct(
+                int_field=i,
+                string_field="jeb",
+                enum_field=service.TestEnum.value_c,
+                list_field=[i],
+            )
+            for i in range(3)
+        ]
+        result = service.increment_list_of_structs(values)
+        self.assertEqual([1, 2, 3], [x.int_field for x in result])
+
+    def test_nullable_structs(self) -> None:
+        service = self.conn.test_service
+        self.assertIsNone(service.struct_echo_nullable(None))
+        value = service.TestStruct(
+            int_field=1,
+            string_field="jeb",
+            enum_field=service.TestEnum.value_a,
+            list_field=[],
+        )
+        self.assertEqual(value, service.struct_echo_nullable(value))
+
+    def test_struct_default_value(self) -> None:
+        service = self.conn.test_service
+        self.assertEqual(
+            service.TestStruct(
+                int_field=42,
+                string_field="jeb",
+                enum_field=service.TestEnum.value_b,
+                list_field=[1, 2, 3],
+            ),
+            service.struct_default(),
+        )
+
     def test_colllections_default_values(self) -> None:
         self.assertEqual((1, False), self.conn.test_service.tuple_default())
         self.assertEqual([1, 2, 3], self.conn.test_service.list_default())
@@ -629,6 +705,14 @@ class TestClient(ServerTestCase, unittest.TestCase):
                     "set_default",
                     "add_to_object_list",
                     "counter",
+                    "TestStruct",
+                    "TestNestedStruct",
+                    "struct_echo",
+                    "nested_struct_echo",
+                    "increment_list_of_structs",
+                    "struct_default",
+                    "struct_echo_nullable",
+                    "counter_struct",
                     "CustomException",
                     "throw_custom_exception",
                     "reset_custom_exception_later",
@@ -647,6 +731,7 @@ class TestClient(ServerTestCase, unittest.TestCase):
                     "DeprecatedClass",
                     "DeprecatedEnum",
                     "DeprecatedException",
+                    "DeprecatedStruct",
                     "double_special_defaults",
                     "float_special_defaults",
                     "int32_special_defaults",

--- a/client/python/krpc/test/test_definitions.py
+++ b/client/python/krpc/test/test_definitions.py
@@ -2,6 +2,7 @@ import unittest
 from typing import Dict, Iterable, List
 from krpc.definitions import (
     ENUMERATION,
+    STRUCT,
     Definition,
     decode_default_value,
     register_all,
@@ -23,6 +24,14 @@ def enumeration_type(service: str, name: str) -> Type:
 def class_type(service: str, name: str) -> Type:
     protobuf_type = Type()
     protobuf_type.code = Type.CLASS
+    protobuf_type.service = service
+    protobuf_type.name = name
+    return protobuf_type
+
+
+def struct_type(service: str, name: str) -> Type:
+    protobuf_type = Type()
+    protobuf_type.code = Type.STRUCT
     protobuf_type.service = service
     protobuf_type.name = name
     return protobuf_type
@@ -142,6 +151,37 @@ class TestRegisterAll(unittest.TestCase):
             str(cm.exception),
         )
 
+    def test_struct_registered_after_the_types_of_its_fields(self) -> None:
+        # The struct B has a field whose type is the struct A, so A has to be registered
+        # first for the field to resolve
+        definitions = {
+            "A": self.definition("A", kind=STRUCT),
+            "B": self.definition("B", [struct_type("ServiceA", "A")], kind=STRUCT),
+        }
+        for order in (["A", "B"], ["B", "A"]):
+            self.registered = []
+            register_all(self.types, [definitions[name] for name in order])
+            self.assertEqual(["A", "B"], self.registered)
+
+    def test_struct_cycle(self) -> None:
+        # Neither struct can be registered first, as each has a field whose type is the
+        # other. The server rejects this, but definitions can come from anywhere
+        with self.assertRaises(RuntimeError) as cm:
+            register_all(
+                self.types,
+                [
+                    self.definition(
+                        "A", [list_type(struct_type("ServiceA", "B"))], kind=STRUCT
+                    ),
+                    self.definition("B", [struct_type("ServiceA", "A")], kind=STRUCT),
+                ],
+            )
+        self.assertEqual(
+            "Cyclic dependency: struct ServiceA.A -> struct ServiceA.B "
+            "-> struct ServiceA.A",
+            str(cm.exception),
+        )
+
     def test_defined_twice(self) -> None:
         with self.assertRaises(RuntimeError) as cm:
             register_all(self.types, [self.definition("A"), self.definition("A")])
@@ -212,6 +252,13 @@ class TestDecodeDefaultValue(unittest.TestCase):
             decode_default_value(None, b"", typ, self.location)
         self.assertIn(self.location, str(cm.exception))
         self.assertIn("ServiceA.Mode", str(cm.exception))
+
+    def test_struct_that_was_never_registered(self) -> None:
+        typ = self.types.struct_type("ServiceA", "Frobnicator")
+        with self.assertRaises(RuntimeError) as cm:
+            decode_default_value(None, b"", typ, self.location)
+        self.assertIn(self.location, str(cm.exception))
+        self.assertIn("ServiceA.Frobnicator", str(cm.exception))
 
     def test_value_the_enumeration_does_not_declare(self) -> None:
         with self.assertRaises(RuntimeError) as cm:

--- a/client/python/krpc/test/test_encodedecode.py
+++ b/client/python/krpc/test/test_encodedecode.py
@@ -157,6 +157,36 @@ class TestEncodeDecode(unittest.TestCase):
         self._run_test_encode_value(typ, cases)
         self._run_test_decode_value(typ, cases)
 
+    def test_struct(self) -> None:
+        typ = self.types.struct_type("ServiceName", "StructName")
+        typ.set_fields(
+            [
+                ("count", self.types.uint32_type),
+                ("name", self.types.string_type),
+                ("flag", self.types.bool_type),
+            ]
+        )
+        value = typ.python_type(count=1, name="jeb", flag=False)
+        # A structure carries the values of its fields in order, which is what a tuple of
+        # those values encodes to
+        cases: List[Tuple[object, str]] = [(value, "0a01010a04036a65620a0100")]
+        self._run_test_encode_value(typ, cases)
+        self._run_test_decode_value(typ, cases)
+
+    def test_struct_with_the_wrong_number_of_fields(self) -> None:
+        typ = self.types.struct_type("ServiceName", "OtherStructName")
+        typ.set_fields([("count", self.types.uint32_type)])
+        self.assertRaises(EncodingError, Encoder.encode, (1, 2), typ)
+        self.assertRaises(EncodingError, Decoder.decode, None, b"", typ)
+
+    def test_struct_with_appended_fields(self) -> None:
+        # A value from a newer server may carry fields this client does not know about,
+        # which come after the ones it does and are ignored
+        typ = self.types.struct_type("ServiceName", "AppendedStructName")
+        typ.set_fields([("count", self.types.uint32_type)])
+        value = Decoder.decode(None, unhexlify("0a01010a04036a6562"), typ)
+        self.assertEqual(typ.python_type(count=1), value)
+
     def test_list(self) -> None:
         cases: List[Tuple[object, str]] = [
             ([], ""),

--- a/client/python/krpc/test/test_service_definitions.py
+++ b/client/python/krpc/test/test_service_definitions.py
@@ -1,6 +1,8 @@
 import unittest
+import warnings
 from inspect import signature
-from typing import List
+from typing import Dict, List, NamedTuple
+from krpc.client import _stub_definitions
 from krpc.definitions import register_all
 from krpc.encoder import Encoder
 from krpc.service import create_service, service_definitions
@@ -62,6 +64,49 @@ def default_service(
     return service
 
 
+# A type code from a later version of the protocol than this client knows about
+UNKNOWN_TYPE_CODE = 9999
+
+
+def struct_service(name: str, field_type: KRPC.Type) -> KRPC.Service:
+    """A service defining a structure with a single field of the given type"""
+    service = KRPC.Service()
+    service.name = name
+    struct = service.structs.add()
+    struct.name = "Thing"
+    field = struct.fields.add()
+    field.name = "Value"
+    field.type.CopyFrom(field_type)
+    return service
+
+
+def struct_using_service(
+    name: str, struct_service_name: str, with_default: bool = False
+) -> KRPC.Service:
+    """A service with a procedure taking a parameter of another service's structure,
+    optionally one with a default value"""
+    types = Types()
+    struct_type = types.struct_type(struct_service_name, "Thing")
+
+    service = KRPC.Service()
+    service.name = name
+    procedure = service.procedures.add()
+    procedure.name = "Frob"
+    parameter = procedure.parameters.add()
+    parameter.name = "thing"
+    parameter.type.CopyFrom(struct_type.protobuf_type)
+    if with_default:
+        parameter.has_default_value = True
+        parameter.default_value = KRPC.Tuple().SerializeToString()
+    return service
+
+
+def unknown_type() -> KRPC.Type:
+    typ = KRPC.Type()
+    typ.code = UNKNOWN_TYPE_CODE
+    return typ
+
+
 class TestServiceDefinitions(unittest.TestCase):
     @staticmethod
     def create_services(services: List[KRPC.Service]) -> FakeClient:
@@ -106,6 +151,67 @@ class TestServiceDefinitions(unittest.TestCase):
         service = default_service("ServiceA", "ServiceA")
         service.enumerations.extend(enum_service("ServiceA").enumerations)
         self.check_default(self.create_services([service]), "Mode.fast")
+
+    def check_struct_is_skipped(self, services: List[KRPC.Service]) -> None:
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            client = self.create_services(services)
+        messages = [str(warning.message) for warning in caught]
+        self.assertTrue(any("Thing" in message for message in messages), messages)
+        self.assertTrue(
+            any("ServiceA.Frob" in message for message in messages), messages
+        )
+        self.assertFalse(hasattr(getattr(client, "ServiceA"), "frob"))
+
+    def test_procedure_naming_a_skipped_struct_is_skipped(self) -> None:
+        self.check_struct_is_skipped(
+            [
+                struct_service("ServiceB", unknown_type()),
+                struct_using_service("ServiceA", "ServiceB"),
+            ]
+        )
+
+    def test_defaulted_parameter_of_a_skipped_struct_is_skipped(self) -> None:
+        self.check_struct_is_skipped(
+            [
+                struct_service("ServiceB", unknown_type()),
+                struct_using_service("ServiceA", "ServiceB", with_default=True),
+            ]
+        )
+
+    def test_struct_holding_a_skipped_struct_is_skipped(self) -> None:
+        types = Types()
+        skipped = struct_service("ServiceC", unknown_type())
+        holder = struct_service(
+            "ServiceB", types.struct_type("ServiceC", "Thing").protobuf_type
+        )
+        self.check_struct_is_skipped(
+            [skipped, holder, struct_using_service("ServiceA", "ServiceB")]
+        )
+
+    def test_stub_with_more_fields_than_the_server(self) -> None:
+        # An older server declares fewer fields than the stubs were generated against, so a
+        # value of the structure cannot be built as the type the stubs provide
+        class Thing(NamedTuple):
+            value: int
+            appended: str
+
+        class StubService:
+            _classes: Dict[str, type] = {}
+            _enumerations: Dict[str, type] = {}
+            _structs = {"Thing": Thing}
+
+        client = FakeClient()
+        service = struct_service("ServiceB", Types().sint32_type.protobuf_type)
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            register_all(client._types, _stub_definitions(service, StubService()))
+        self.assertTrue(
+            any("ServiceB.Thing" in str(warning.message) for warning in caught)
+        )
+        struct_type = client._types.struct_type("ServiceB", "Thing")
+        self.assertEqual(["value"], struct_type.field_names)
+        self.assertIsNot(Thing, struct_type.python_type)
 
     def test_defined_by_no_service(self) -> None:
         with self.assertRaises(RuntimeError) as cm:

--- a/client/python/krpc/test/test_stream.py
+++ b/client/python/krpc/test/test_stream.py
@@ -88,6 +88,33 @@ class TestStream(ServerTestCase, unittest.TestCase):
                         self.fail("Timed out waiting for stream to update")
                     i += 1
 
+    def test_struct_counter(self) -> None:
+        service = self.conn.test_service
+        with self.conn.stream(
+            service.counter_struct, "TestStream.test_struct_counter"
+        ) as x:
+            count = -1
+            for _ in range(5):
+                self.assertLess(count, x().int_field)
+                count = x().int_field
+                i = 0
+                while count == x().int_field:
+                    self.wait()
+                    if i > 1000:
+                        self.fail("Timed out waiting for stream to update")
+                    i += 1
+
+    def test_unchanging_struct_sends_one_update(self) -> None:
+        # The server compares a struct field by field, so a struct whose list field is a
+        # different object every frame still counts as unchanged and is sent once
+        updates = []
+        with self.conn.stream(self.conn.test_service.struct_default) as x:
+            x.add_callback(updates.append)
+            x.start()
+            for _ in range(20):
+                self.wait()
+        self.assertEqual(1, len(updates))
+
     def test_nested(self) -> None:
         with self.conn.stream(self.conn.test_service.float_to_string, 0.123) as x0:
             with self.conn.stream(self.conn.test_service.float_to_string, 1.234) as x1:

--- a/client/python/krpc/test/test_types.py
+++ b/client/python/krpc/test/test_types.py
@@ -7,6 +7,7 @@ from krpc.types import (
     EnumerationType,
     MessageType,
     ClassBase,
+    StructType,
     TupleType,
     ListType,
     SetType,
@@ -94,6 +95,27 @@ class TestTypes(unittest.TestCase):
         self.assertEqual("doca", typ.python_type.a.__doc__)  # type: ignore[attr-defined]
         self.assertEqual("docb", typ.python_type.b.__doc__)  # type: ignore[attr-defined]
         self.assertEqual("docc", typ.python_type.c.__doc__)  # type: ignore[attr-defined]
+        typ2 = types.as_type(typ.protobuf_type)
+        self.assertEqual(typ, typ2)
+
+    def test_struct_types(self) -> None:
+        types = Types()
+        typ = types.struct_type("ServiceName", "StructName", "struct documentation")
+        self.assertTrue(isinstance(typ, StructType))
+        self.assertIsNone(typ.python_type)
+        self.assertFalse(typ.has_fields)
+        self.check_protobuf_type(
+            Type.STRUCT, "ServiceName", "StructName", 0, typ.protobuf_type
+        )
+        typ.set_fields([("count", types.uint32_type), ("name", types.string_type)])
+        self.assertTrue(typ.has_fields)
+        self.assertEqual(["count", "name"], typ.field_names)
+        self.assertEqual([types.uint32_type, types.string_type], list(typ.field_types))
+        self.assertEqual("struct documentation", typ.python_type.__doc__)
+        value = typ.python_type(count=42, name="jeb")
+        self.assertEqual(42, value.count)
+        self.assertEqual("jeb", value.name)
+        self.assertEqual((42, "jeb"), tuple(value))
         typ2 = types.as_type(typ.protobuf_type)
         self.assertEqual(typ, typ2)
 
@@ -204,6 +226,19 @@ class TestTypes(unittest.TestCase):
         self.assertTrue(isinstance(typ.value_type, ValueType))
         self.assertEqual(int, typ.value_type.python_type)
         self.check_protobuf_type(Type.UINT32, "", "", 0, typ.value_type.protobuf_type)
+
+    def test_coerce_to_struct(self) -> None:
+        types = Types()
+        typ = types.struct_type("ServiceName", "StructName")
+        typ.set_fields([("count", types.uint32_type), ("name", types.string_type)])
+        expected = typ.python_type(count=42, name="jeb")
+        for value in ((42, "jeb"), [42, "jeb"]):
+            coerced_value = types.coerce_to(value, typ)
+            self.assertEqual(expected, coerced_value)
+            self.assertEqual(typ.python_type, type(coerced_value))
+        # A value with the wrong number of fields is not a value of the structure
+        self.assertRaises(ValueError, types.coerce_to, (42,), typ)
+        self.assertRaises(ValueError, types.coerce_to, (42, "jeb", 1), typ)
 
     def test_coerce_to(self) -> None:
         types = Types()

--- a/client/python/krpc/types.py
+++ b/client/python/krpc/types.py
@@ -13,6 +13,7 @@ from typing import (
     List,
     Mapping,
     Optional,
+    Tuple,
     Type,
     cast,
 )
@@ -21,6 +22,13 @@ import krpc.schema.KRPC_pb2 as KRPC
 
 if TYPE_CHECKING:
     from krpc.client import Client
+
+
+class UnknownTypeError(ValueError):
+    """Raised when a type in a service definition is one this client cannot use, either
+    because its type code is not one this client knows about, or because it names a structure
+    whose definition was skipped. Both are what a definition from a newer server looks like.
+    """
 
 
 VALUE_TYPES = {
@@ -49,6 +57,33 @@ EXCEPTION_TYPES = {
     "ArgumentNullException": ValueError,
     "ArgumentOutOfRangeException": ValueError,
 }
+
+
+# Every type code a type object can be built for. A definition from a newer server may name
+# a type code that is not among them, which is what makes a definition partly unusable
+# rather than malformed
+_KNOWN_TYPE_CODES = (
+    set(VALUE_TYPES)
+    | set(MESSAGE_TYPES)
+    | {
+        KRPC.Type.NONE,
+        KRPC.Type.CLASS,
+        KRPC.Type.ENUMERATION,
+        KRPC.Type.STRUCT,
+        KRPC.Type.TUPLE,
+        KRPC.Type.LIST,
+        KRPC.Type.SET,
+        KRPC.Type.DICTIONARY,
+    }
+)
+
+
+def is_a_known_type(protobuf_type: KRPC.Type) -> bool:
+    """Whether a type object can be built for the given protocol buffer type. It cannot when
+    the type, or one it contains, has a type code this client does not know about."""
+    if protobuf_type.code not in _KNOWN_TYPE_CODES:
+        return False
+    return all(is_a_known_type(typ) for typ in protobuf_type.types)
 
 
 def _protobuf_type(
@@ -137,6 +172,8 @@ class Types:
             typ = ClassType(protobuf_type, doc)
         elif protobuf_type.code == KRPC.Type.ENUMERATION:
             typ = EnumerationType(protobuf_type, doc)
+        elif protobuf_type.code == KRPC.Type.STRUCT:
+            typ = StructType(protobuf_type, doc)
         elif protobuf_type.code == KRPC.Type.TUPLE:
             typ = TupleType(protobuf_type, self)
         elif protobuf_type.code == KRPC.Type.LIST:
@@ -148,7 +185,7 @@ class Types:
         elif protobuf_type.code in MESSAGE_TYPES:
             typ = MessageType(protobuf_type)
         else:
-            raise ValueError("Invalid type")
+            raise UnknownTypeError("Unknown type code %d" % protobuf_type.code)
 
         self._types[key] = typ
         return typ
@@ -180,6 +217,17 @@ class Types:
             )
             self._type_cache[key] = typ
         return cast(EnumerationType, typ)
+
+    def struct_type(
+        self, service: str, name: str, doc: Optional[str] = None
+    ) -> StructType:
+        """Get a structure type"""
+        key = (KRPC.Type.STRUCT, service, name)
+        typ = self._type_cache.get(key)
+        if typ is None:
+            typ = self.as_type(_protobuf_type(KRPC.Type.STRUCT, service, name), doc=doc)
+            self._type_cache[key] = typ
+        return cast(StructType, typ)
 
     def exception_type(
         self, service: str, name: str, doc: Optional[str] = None
@@ -297,6 +345,20 @@ class Types:
                 return typ.python_type(
                     [self.coerce_to(x, typ.value_types[i]) for i, x in enumerate(value)]
                 )
+            # Coerce tuples and lists (with the right number of elements) to structures,
+            # taking their elements as the fields in order
+            if isinstance(value, collections.abc.Iterable) and isinstance(
+                typ, StructType
+            ):
+                values = list(value)
+                if len(values) != len(typ.field_types):
+                    raise ValueError
+                return typ.python_type(
+                    *[
+                        self.coerce_to(x, typ.field_types[i])
+                        for i, x in enumerate(values)
+                    ]
+                )
         except ValueError as exn:
             raise ValueError(
                 "Failed to coerce value "
@@ -410,6 +472,54 @@ class EnumerationType(TypeBase):
         self.python_type = _create_enum_type(self._enum_name, values, self._doc)
 
 
+class StructType(TypeBase):
+    """A structure type, whose value is the values of its fields"""
+
+    def __init__(
+        self, protobuf_type: KRPC.Type, doc: Optional[str], typ: Optional[type] = None
+    ) -> None:
+        if protobuf_type.code != KRPC.Type.STRUCT:
+            raise ValueError("Not a struct type")
+        if not protobuf_type.service:
+            raise ValueError("Struct type has no service name")
+        if not protobuf_type.name:
+            raise ValueError("Struct type has no struct name")
+        self._service_name = protobuf_type.service
+        self._struct_name = protobuf_type.name
+        self._doc = doc
+        # The names and types of the fields, in the order their values are encoded in. Empty
+        # until set_fields is called, as the field list is not carried by the type itself
+        self.field_names: List[str] = []
+        self.field_types: List[TypeBase] = []
+        string = "Struct(%s.%s)" % (protobuf_type.service, protobuf_type.name)
+        # When typ is None, set_fields must be called to set the python_type
+        super().__init__(protobuf_type, cast(type, typ), string)
+
+    @property
+    def has_fields(self) -> bool:
+        """Whether the fields of the structure are known, which they are only once its
+        definition has been registered by calling set_fields"""
+        return self.python_type is not None
+
+    def set_fields(
+        self,
+        fields: Iterable[Tuple[str, TypeBase]],
+        python_type: Optional[type] = None,
+    ) -> None:
+        """Set the fields of the structure, as pairs of a name and a type in the order the
+        structure declares them. Creates a named tuple to represent a value of the
+        structure, unless a python type to use instead is given."""
+        assert self.python_type is None
+        fields = list(fields)
+        self.field_names = [name for name, _ in fields]
+        self.field_types = [typ for _, typ in fields]
+        if python_type is None:
+            python_type = _create_struct_type(
+                self._struct_name, self.field_names, self._doc
+            )
+        self.python_type = python_type
+
+
 class TupleType(TypeBase):
     """A tuple collection type"""
 
@@ -471,6 +581,28 @@ class MessageType(TypeBase):
             raise ValueError("Not a message type")
         typ = MESSAGE_TYPES[protobuf_type.code]
         super().__init__(protobuf_type, typ, typ.__name__)
+
+
+def check_type_is_known(typ: TypeBase) -> None:
+    """Raise an UnknownTypeError if the given type, or a type it contains, is a structure
+    whose definition was skipped and whose fields are therefore not known. Whatever names
+    such a type cannot be encoded or decoded, and is skipped in turn."""
+    if isinstance(typ, StructType):
+        if not typ.has_fields:
+            raise UnknownTypeError(
+                "The definition of the struct %s.%s was skipped"
+                % (typ.protobuf_type.service, typ.protobuf_type.name)
+            )
+        for field_type in typ.field_types:
+            check_type_is_known(field_type)
+    elif isinstance(typ, TupleType):
+        for value_type in typ.value_types:
+            check_type_is_known(value_type)
+    elif isinstance(typ, (ListType, SetType)):
+        check_type_is_known(typ.value_type)
+    elif isinstance(typ, DictionaryType):
+        check_type_is_known(typ.key_type)
+        check_type_is_known(typ.value_type)
 
 
 class DynamicType:
@@ -582,6 +714,14 @@ def _create_enum_type(
     for name in values.keys():
         setattr(getattr(typ, name), "__doc__", values[name]["doc"])
     return typ  # type: ignore[return-value]
+
+
+def _create_struct_type(
+    struct_name: str, field_names: List[str], doc: Optional[str]
+) -> type:
+    typ = collections.namedtuple(struct_name, field_names)  # type: ignore[misc]
+    setattr(typ, "__doc__", doc)
+    return typ
 
 
 def _create_exception_type(

--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -1,4 +1,9 @@
 ## [v0.7.0] - unreleased
+- Add structure types: a compound value with named fields, whose value is sent to the client in
+  full rather than as a reference to an object that stays on the server. A structure is declared
+  with `KRPCStruct` on a C# `struct`, its fields are the properties annotated with
+  `KRPCProperty`, and its value is encoded as the values of those fields in the order the
+  structure declares them (#1066)
 - Add a communication protocol carrying protocol buffer messages over a unix domain socket, for
   clients running on the same machine as the game. It carries the same messages as the TCP/IP
   protocol over a cheaper path: a client that makes many calls in quick succession completes

--- a/core/src/KRPC.Core.csproj
+++ b/core/src/KRPC.Core.csproj
@@ -112,6 +112,7 @@
     <Compile Include="Service\Attributes\KRPCProcedureAttribute.cs" />
     <Compile Include="Service\Attributes\KRPCPropertyAttribute.cs" />
     <Compile Include="Service\Attributes\KRPCServiceAttribute.cs" />
+    <Compile Include="Service\Attributes\KRPCStructAttribute.cs" />
     <Compile Include="Service\CallContext.cs" />
     <Compile Include="Service\ClassMethodHandler.cs" />
     <Compile Include="Service\ClassStaticMethodHandler.cs" />
@@ -152,6 +153,8 @@
     <Compile Include="Service\Messages\Stream.cs" />
     <Compile Include="Service\Messages\StreamResult.cs" />
     <Compile Include="Service\Messages\StreamUpdate.cs" />
+    <Compile Include="Service\Messages\Struct.cs" />
+    <Compile Include="Service\Messages\StructField.cs" />
     <Compile Include="Service\ObjectStore.cs" />
     <Compile Include="Service\ProcedureCallContinuation.cs" />
     <Compile Include="Service\ProcedureCallStream.cs" />
@@ -167,6 +170,8 @@
     <Compile Include="Service\Scanner\ProcedureSignature.cs" />
     <Compile Include="Service\Scanner\Scanner.cs" />
     <Compile Include="Service\Scanner\ServiceSignature.cs" />
+    <Compile Include="Service\Scanner\StructFieldSignature.cs" />
+    <Compile Include="Service\Scanner\StructSignature.cs" />
     <Compile Include="Service\ServiceException.cs" />
     <Compile Include="Service\Services.cs" />
     <Compile Include="Service\Stream.cs" />

--- a/core/src/Server/ProtocolBuffers/Encoder.cs
+++ b/core/src/Server/ProtocolBuffers/Encoder.cs
@@ -62,6 +62,8 @@ namespace KRPC.Server.ProtocolBuffers
                         stream.WriteBytes (ByteString.CopyFrom ((byte[])value));
                     else if (TypeUtils.IsAClassType (type))
                         stream.WriteUInt64 (ObjectStore.Instance.AddInstance (value));
+                    else if (TypeUtils.IsAStructType (type))
+                        WriteStruct (value, stream);
                     else if (TypeUtils.IsATupleCollectionType (type))
                         WriteTuple (value, stream);
                     else if (TypeUtils.IsAListCollectionType (type))
@@ -96,6 +98,27 @@ namespace KRPC.Server.ProtocolBuffers
                 }
             }
             encodedTuple.WriteTo (stream);
+        }
+
+        /// <summary>
+        /// Write a structure value as the values of its fields, in the order the structure
+        /// declares them, which is the same encoding as a tuple of those values.
+        /// </summary>
+        static void WriteStruct (object value, CodedOutputStream stream)
+        {
+            var encodedStruct = new Schema.KRPC.Tuple ();
+            var type = value.GetType ();
+            using (var internalBuffer = new MemoryStream ()) {
+                var internalStream = new CodedOutputStream (internalBuffer);
+                foreach (var field in TypeUtils.GetStructFields (type)) {
+                    var item = field.GetGetMethod ().Invoke (value, null);
+                    if (item == null)
+                        throw new ServiceException (
+                            "Field " + field.Name + " of " + type.Name + " is null; struct fields cannot be null");
+                    encodedStruct.Items.Add (EncodeObject (item, internalBuffer, internalStream));
+                }
+            }
+            encodedStruct.WriteTo (stream);
         }
 
         static void WriteList (object value, CodedOutputStream stream)
@@ -182,6 +205,8 @@ namespace KRPC.Server.ProtocolBuffers
                         return stream.ReadBytes ().ToByteArray ();
                     if (TypeUtils.IsAClassType (type))
                         return ObjectStore.Instance.GetInstance (stream.ReadUInt64 ());
+                    if (TypeUtils.IsAStructType (type))
+                        return DecodeStruct (stream, type);
                     if (TypeUtils.IsATupleCollectionType (type))
                         return DecodeTuple (stream, type);
                     if (TypeUtils.IsAListCollectionType (type))
@@ -213,6 +238,32 @@ namespace KRPC.Server.ProtocolBuffers
                 .GetConstructor (valueTypes)
                 .Invoke (values);
             return tuple;
+        }
+
+        /// <summary>
+        /// Read a structure value from the values of its fields, in the order the structure
+        /// declares them. Fields may only ever be appended to a structure, so items beyond the
+        /// ones the structure declares come from a newer definition and are ignored. A field is
+        /// never null, so a value that decodes one is rejected rather than passed to a service.
+        /// </summary>
+        static object DecodeStruct (CodedInputStream stream, Type type)
+        {
+            var encodedStruct = Schema.KRPC.Tuple.Parser.ParseFrom (stream);
+            var fields = TypeUtils.GetStructFields (type);
+            if (encodedStruct.Items.Count < fields.Count)
+                throw new ArgumentException (
+                    "Value for " + type.Name + " has " + encodedStruct.Items.Count +
+                    " fields; expected at least " + fields.Count);
+            var value = Activator.CreateInstance (type);
+            for (int i = 0; i < fields.Count; i++) {
+                var field = fields [i];
+                var item = Decode (encodedStruct.Items [i], field.PropertyType);
+                if (item == null)
+                    throw new ArgumentException (
+                        "Field " + field.Name + " of " + type.Name + " is null; struct fields cannot be null");
+                field.GetSetMethod ().Invoke (value, new [] { item });
+            }
+            return value;
         }
 
         static object DecodeList (CodedInputStream stream, Type type)

--- a/core/src/Server/ProtocolBuffers/MessageExtensions.cs
+++ b/core/src/Server/ProtocolBuffers/MessageExtensions.cs
@@ -85,6 +85,7 @@ namespace KRPC.Server.ProtocolBuffers
             result.Procedures.Add (service.Procedures.Select (ToProtobufMessage));
             result.Classes.Add (service.Classes.Select (ToProtobufMessage));
             result.Enumerations.Add (service.Enumerations.Select (ToProtobufMessage));
+            result.Structs.Add (service.Structs.Select (ToProtobufMessage));
             result.Exceptions.Add (service.Exceptions.Select (ToProtobufMessage));
             result.Documentation = service.Documentation;
             result.Deprecated = service.Deprecated;
@@ -176,6 +177,28 @@ namespace KRPC.Server.ProtocolBuffers
             return result;
         }
 
+        public static Schema.KRPC.Struct ToProtobufMessage (this Service.Messages.Struct str)
+        {
+            var result = new Schema.KRPC.Struct ();
+            result.Name = str.Name;
+            result.Fields.Add (str.Fields.Select (ToProtobufMessage));
+            result.Documentation = str.Documentation;
+            result.Deprecated = str.Deprecated;
+            result.DeprecatedReason = str.DeprecatedReason;
+            return result;
+        }
+
+        public static Schema.KRPC.StructField ToProtobufMessage (this StructField field)
+        {
+            var result = new Schema.KRPC.StructField ();
+            result.Name = field.Name;
+            result.Type = field.Type.ToProtobufMessage ();
+            result.Documentation = field.Documentation;
+            result.Deprecated = field.Deprecated;
+            result.DeprecatedReason = field.DeprecatedReason;
+            return result;
+        }
+
         public static Schema.KRPC.Exception ToProtobufMessage (this Service.Messages.Exception exception)
         {
             var result = new Schema.KRPC.Exception ();
@@ -238,6 +261,10 @@ namespace KRPC.Server.ProtocolBuffers
             } else if (TypeUtils.IsAnEnumType (type)) {
                 result.Code = Schema.KRPC.Type.Types.TypeCode.Enumeration;
                 result.Service = TypeUtils.GetEnumServiceName (type);
+                result.Name = type.Name;
+            } else if (TypeUtils.IsAStructType (type)) {
+                result.Code = Schema.KRPC.Type.Types.TypeCode.Struct;
+                result.Service = TypeUtils.GetStructServiceName (type);
                 result.Name = type.Name;
             } else if (TypeUtils.IsAListCollectionType (type)) {
                 result.Code = Schema.KRPC.Type.Types.TypeCode.List;

--- a/core/src/Service/Attributes/KRPCStructAttribute.cs
+++ b/core/src/Service/Attributes/KRPCStructAttribute.cs
@@ -1,0 +1,18 @@
+using System;
+
+namespace KRPC.Service.Attributes
+{
+    /// <summary>
+    /// A kRPC structure. Its fields are the properties annotated with
+    /// <see cref="KRPCPropertyAttribute"/>, and its value is serialized inline
+    /// rather than through a server-side handle.
+    /// </summary>
+    [AttributeUsage (AttributeTargets.Struct)]
+    public sealed class KRPCStructAttribute : Attribute
+    {
+        /// <summary>
+        /// Name of the service in which the structure is declared.
+        /// </summary>
+        public string Service { get; set; }
+    }
+}

--- a/core/src/Service/DocumentationUtils.cs
+++ b/core/src/Service/DocumentationUtils.cs
@@ -177,7 +177,8 @@ namespace KRPC.Service
             var candidates = context.Assembly.GetTypes ()
                 .Where (t => Reflection.HasAttribute<KRPCServiceAttribute> (t) ||
                         Reflection.HasAttribute<KRPCClassAttribute> (t) ||
-                        Reflection.HasAttribute<KRPCEnumAttribute> (t))
+                        Reflection.HasAttribute<KRPCEnumAttribute> (t) ||
+                        Reflection.HasAttribute<KRPCStructAttribute> (t))
                 .Where (t => t.Name == name ||
                         (t.FullName != null && t.FullName.Replace ('+', '.').EndsWith ("." + name, StringComparison.Ordinal)))
                 .ToList ();
@@ -207,8 +208,12 @@ namespace KRPC.Service
             } else if (Reflection.HasAttribute<KRPCEnumAttribute> (type)) {
                 TypeUtils.ValidateKRPCEnum (type);
                 return "T:" + TypeUtils.GetEnumServiceName (type) + "." + name;
+            } else if (Reflection.HasAttribute<KRPCStructAttribute> (type)) {
+                TypeUtils.ValidateKRPCStruct (type);
+                return "T:" + TypeUtils.GetStructServiceName (type) + "." + name;
             }
-            throw new DocumentationException ("Type '" + name + "' is not a kRPC service, class or enumeration");
+            throw new DocumentationException (
+                "Type '" + name + "' is not a kRPC service, class, enumeration or structure");
         }
 
         static string ResolveMethodCref (string reference)
@@ -250,8 +255,12 @@ namespace KRPC.Service
                        Reflection.HasAttribute<KRPCPropertyAttribute> (property)) {
                 TypeUtils.ValidateKRPCClassProperty (type, property);
                 return "M:" + TypeUtils.GetClassServiceName (type) + "." + name;
+            } else if (Reflection.HasAttribute<KRPCStructAttribute> (type) &&
+                       Reflection.HasAttribute<KRPCPropertyAttribute> (property)) {
+                TypeUtils.ValidateKRPCStruct (type);
+                return "M:" + TypeUtils.GetStructServiceName (type) + "." + name;
             }
-            throw new DocumentationException ("'" + name + "' is not a kRPC property");
+            throw new DocumentationException ("'" + name + "' is not a kRPC property or structure field");
         }
 
         static string ResolveFieldCref (string reference)

--- a/core/src/Service/KRPC/KRPC.cs
+++ b/core/src/Service/KRPC/KRPC.cs
@@ -115,6 +115,22 @@ namespace KRPC.Service.KRPC
                     }
                     service.Enumerations.Add (enm);
                 }
+                foreach (var structSignature in serviceSignature.Structs.Values) {
+                    var str = new Messages.Struct (structSignature.Name);
+                    if (structSignature.Documentation.Length > 0)
+                        str.Documentation = structSignature.Documentation;
+                    str.Deprecated = structSignature.Deprecated;
+                    str.DeprecatedReason = structSignature.DeprecatedReason;
+                    foreach (var fieldSignature in structSignature.Fields) {
+                        var field = new StructField (fieldSignature.Name, fieldSignature.Type);
+                        if (fieldSignature.Documentation.Length > 0)
+                            field.Documentation = fieldSignature.Documentation;
+                        field.Deprecated = fieldSignature.Deprecated;
+                        field.DeprecatedReason = fieldSignature.DeprecatedReason;
+                        str.Fields.Add (field);
+                    }
+                    service.Structs.Add (str);
+                }
                 foreach (var exnSignature in serviceSignature.Exceptions.Values) {
                     var exn = new Messages.Exception (exnSignature.Name);
                     if (exnSignature.Documentation.Length > 0)

--- a/core/src/Service/Messages/Service.cs
+++ b/core/src/Service/Messages/Service.cs
@@ -13,6 +13,8 @@ namespace KRPC.Service.Messages
 
         public IList<Enumeration> Enumerations { get; private set; }
 
+        public IList<Struct> Structs { get; private set; }
+
         public IList<Exception> Exceptions { get; private set; }
 
         public string Documentation { get; set; }
@@ -27,6 +29,7 @@ namespace KRPC.Service.Messages
             Procedures = new List<Procedure> ();
             Classes = new List<Class> ();
             Enumerations = new List<Enumeration> ();
+            Structs = new List<Struct> ();
             Exceptions = new List<Exception> ();
             Documentation = string.Empty;
             DeprecatedReason = string.Empty;

--- a/core/src/Service/Messages/Struct.cs
+++ b/core/src/Service/Messages/Struct.cs
@@ -1,0 +1,26 @@
+using System.Collections.Generic;
+
+namespace KRPC.Service.Messages
+{
+    #pragma warning disable 1591
+    public class Struct : IMessage
+    {
+        public string Name { get; private set; }
+
+        public IList<StructField> Fields { get; private set; }
+
+        public string Documentation { get; set; }
+
+        public bool Deprecated { get; set; }
+
+        public string DeprecatedReason { get; set; }
+
+        public Struct (string name)
+        {
+            Name = name;
+            Fields = new List<StructField> ();
+            Documentation = string.Empty;
+            DeprecatedReason = string.Empty;
+        }
+    }
+}

--- a/core/src/Service/Messages/StructField.cs
+++ b/core/src/Service/Messages/StructField.cs
@@ -1,0 +1,26 @@
+using System;
+
+namespace KRPC.Service.Messages
+{
+    #pragma warning disable 1591
+    public class StructField : IMessage
+    {
+        public string Name { get; private set; }
+
+        public Type Type { get; private set; }
+
+        public string Documentation { get; set; }
+
+        public bool Deprecated { get; set; }
+
+        public string DeprecatedReason { get; set; }
+
+        public StructField (string name, Type type)
+        {
+            Name = name;
+            Type = type;
+            Documentation = string.Empty;
+            DeprecatedReason = string.Empty;
+        }
+    }
+}

--- a/core/src/Service/Scanner/Scanner.cs
+++ b/core/src/Service/Scanner/Scanner.cs
@@ -111,6 +111,22 @@ namespace KRPC.Service.Scanner
                 }
             }
 
+            // Scan for structures annotated with KRPCStruct. Every one found is validated,
+            // including its fields, whether or not any procedure refers to it
+            foreach (var structType in Reflection.GetTypesWith<KRPCStructAttribute> ()) {
+                try {
+                    CurrentAssembly = structType.Assembly;
+                    TypeUtils.ValidateKRPCStruct (structType);
+                    var serviceName = TypeUtils.GetStructServiceName (structType);
+                    if (!signatures.ContainsKey (serviceName))
+                        HandleError(errors, "service " + serviceName, "Service does not exist, when loading struct");
+                    var service = signatures [serviceName];
+                    service.AddStruct (structType);
+                } catch (ServiceException exn) {
+                    HandleError(errors, string.Empty, exn);
+                }
+            }
+
             // Scan for classes annotated with KRPCException
             foreach (var exnType in Reflection.GetTypesWith<KRPCExceptionAttribute> ()) {
                 try {

--- a/core/src/Service/Scanner/ServiceSignature.cs
+++ b/core/src/Service/Scanner/ServiceSignature.cs
@@ -43,6 +43,11 @@ namespace KRPC.Service.Scanner
         public Dictionary<string,EnumerationSignature> Enumerations { get; private set; }
 
         /// <summary>
+        /// The structures defined in this service, and their fields
+        /// </summary>
+        public Dictionary<string,StructSignature> Structs { get; private set; }
+
+        /// <summary>
         /// The exceptions defined in this service
         /// </summary>
         public Dictionary<string,ExceptionSignature> Exceptions { get; private set; }
@@ -73,6 +78,7 @@ namespace KRPC.Service.Scanner
             Documentation = DocumentationUtils.ResolveCrefs (type.GetDocumentation ());
             Classes = new Dictionary<string, ClassSignature> ();
             Enumerations = new Dictionary<string, EnumerationSignature> ();
+            Structs = new Dictionary<string, StructSignature> ();
             Procedures = new Dictionary<string, ProcedureSignature> ();
             Exceptions = new Dictionary<string, ExceptionSignature> ();
             gameScene = TypeUtils.GetServiceGameScene (type);
@@ -92,6 +98,7 @@ namespace KRPC.Service.Scanner
             Documentation = string.Empty;
             Classes = new Dictionary<string, ClassSignature> ();
             Enumerations = new Dictionary<string, EnumerationSignature> ();
+            Structs = new Dictionary<string, StructSignature> ();
             Procedures = new Dictionary<string, ProcedureSignature> ();
             Exceptions = new Dictionary<string, ExceptionSignature> ();
             gameScene = GameScene.All;
@@ -200,6 +207,30 @@ namespace KRPC.Service.Scanner
         }
 
         /// <summary>
+        /// Add a structure to the service for the given struct type annotated with the KRPCStruct attribute.
+        /// Returns the name of the structure.
+        /// </summary>
+        public string AddStruct (Type structType)
+        {
+            TypeUtils.ValidateKRPCStruct (structType);
+            var name = structType.Name;
+            if (Structs.ContainsKey (name))
+                throw new ServiceException ("Service " + Name + " contains duplicate structs " + name);
+            var fields = new List<StructFieldSignature> ();
+            foreach (var property in TypeUtils.GetStructFields (structType)) {
+                string fieldDeprecatedReason;
+                var fieldDeprecated = TypeUtils.GetPropertyDeprecated (property, property.GetGetMethod (), out fieldDeprecatedReason);
+                fields.Add (new StructFieldSignature (
+                    Name, name, property.Name, property.PropertyType, property.GetDocumentation (),
+                    fieldDeprecated, fieldDeprecatedReason));
+            }
+            string deprecatedReason;
+            var deprecated = TypeUtils.GetDeprecated (structType, out deprecatedReason);
+            Structs [name] = new StructSignature (Name, name, fields, structType.GetDocumentation (), deprecated, deprecatedReason);
+            return name;
+        }
+
+        /// <summary>
         /// Add an exception to the service for the given exception type annotated with the KRPCException attribute.
         /// Returns the name of the exception.
         /// </summary>
@@ -289,6 +320,7 @@ namespace KRPC.Service.Scanner
             info.AddValue ("procedures", Procedures);
             info.AddValue ("classes", Classes);
             info.AddValue ("enumerations", Enumerations);
+            info.AddValue ("structs", Structs);
             info.AddValue ("exceptions", Exceptions);
             if (Deprecated) {
                 info.AddValue ("deprecated", true);

--- a/core/src/Service/Scanner/StructFieldSignature.cs
+++ b/core/src/Service/Scanner/StructFieldSignature.cs
@@ -1,0 +1,69 @@
+using System;
+using System.Runtime.Serialization;
+
+namespace KRPC.Service.Scanner
+{
+    /// <summary>
+    /// Signature information for a field of a structure type.
+    /// </summary>
+    [Serializable]
+    public sealed class StructFieldSignature : ISerializable
+    {
+        /// <summary>
+        /// Name of the field.
+        /// </summary>
+        public string Name { get; private set; }
+
+        /// <summary>
+        /// Name of the field including the service and structure it is in.
+        /// </summary>
+        public string FullyQualifiedName { get; private set; }
+
+        /// <summary>
+        /// Type of the field.
+        /// </summary>
+        public Type Type { get; private set; }
+
+        /// <summary>
+        /// Documentation for the field.
+        /// </summary>
+        public string Documentation { get; private set; }
+
+        /// <summary>
+        /// Whether the field is deprecated.
+        /// </summary>
+        public bool Deprecated { get; private set; }
+
+        /// <summary>
+        /// If the field is deprecated, the reason for its deprecation (may be empty).
+        /// </summary>
+        public string DeprecatedReason { get; private set; }
+
+        /// <summary>
+        /// Create a signature for a field of a structure.
+        /// </summary>
+        public StructFieldSignature (string serviceName, string structName, string fieldName, Type type, string documentation, bool deprecated, string deprecatedReason)
+        {
+            Name = fieldName;
+            FullyQualifiedName = serviceName + "." + structName + "." + Name;
+            Type = type;
+            Documentation = DocumentationUtils.ResolveCrefs (documentation);
+            Deprecated = deprecated;
+            DeprecatedReason = deprecatedReason;
+        }
+
+        /// <summary>
+        /// Serialize the signature.
+        /// </summary>
+        public void GetObjectData (SerializationInfo info, StreamingContext context)
+        {
+            info.AddValue ("name", Name);
+            info.AddValue ("type", TypeUtils.SerializeType (Type));
+            info.AddValue ("documentation", Documentation);
+            if (Deprecated) {
+                info.AddValue ("deprecated", true);
+                info.AddValue ("deprecated_reason", DeprecatedReason);
+            }
+        }
+    }
+}

--- a/core/src/Service/Scanner/StructSignature.cs
+++ b/core/src/Service/Scanner/StructSignature.cs
@@ -1,0 +1,70 @@
+using System;
+using System.Collections.Generic;
+using System.Runtime.Serialization;
+
+namespace KRPC.Service.Scanner
+{
+    /// <summary>
+    /// Signature information for a structure type, including name, fields and documentation.
+    /// </summary>
+    [Serializable]
+    public sealed class StructSignature : ISerializable
+    {
+        /// <summary>
+        /// Name of the structure, not including the service it is in.
+        /// </summary>
+        public string Name { get; private set; }
+
+        /// <summary>
+        /// Name of the structure including the service it is in.
+        /// </summary>
+        public string FullyQualifiedName { get; private set; }
+
+        /// <summary>
+        /// Signatures of the fields of the structure, in the order they are declared, which is
+        /// the order their values are serialized in.
+        /// </summary>
+        public IList<StructFieldSignature> Fields { get; private set; }
+
+        /// <summary>
+        /// Documentation for the structure.
+        /// </summary>
+        public string Documentation { get; private set; }
+
+        /// <summary>
+        /// Whether the structure is deprecated.
+        /// </summary>
+        public bool Deprecated { get; private set; }
+
+        /// <summary>
+        /// If the structure is deprecated, the reason for its deprecation (may be empty).
+        /// </summary>
+        public string DeprecatedReason { get; private set; }
+
+        /// <summary>
+        /// Create a structure signature
+        /// </summary>
+        public StructSignature (string serviceName, string structName, IList<StructFieldSignature> fields, string documentation, bool deprecated, string deprecatedReason)
+        {
+            Name = structName;
+            FullyQualifiedName = serviceName + "." + Name;
+            Fields = fields;
+            Documentation = DocumentationUtils.ResolveCrefs (documentation);
+            Deprecated = deprecated;
+            DeprecatedReason = deprecatedReason;
+        }
+
+        /// <summary>
+        /// Serialize the signature.
+        /// </summary>
+        public void GetObjectData (SerializationInfo info, StreamingContext context)
+        {
+            info.AddValue ("documentation", Documentation);
+            info.AddValue ("fields", Fields);
+            if (Deprecated) {
+                info.AddValue ("deprecated", true);
+                info.AddValue ("deprecated_reason", DeprecatedReason);
+            }
+        }
+    }
+}

--- a/core/src/Service/TypeUtils.cs
+++ b/core/src/Service/TypeUtils.cs
@@ -31,7 +31,7 @@ namespace KRPC.Service
         /// </summary>
         public static bool IsAValidType (Type type)
         {
-            return IsAValueType (type) || IsAMessageType (type) || IsAClassType (type) || IsAnEnumType (type) || IsACollectionType (type);
+            return IsAValueType (type) || IsAMessageType (type) || IsAClassType (type) || IsAnEnumType (type) || IsAStructType (type) || IsACollectionType (type);
         }
 
         /// <summary>
@@ -88,6 +88,46 @@ namespace KRPC.Service
         {
             return Reflection.HasAttribute<KRPCEnumAttribute> (type) && Enum.GetUnderlyingType (type) == typeof(int);
         }
+
+        /// <summary>
+        /// Returns true if the given type can be used as a kRPC structure type.
+        /// </summary>
+        public static bool IsAStructType (ICustomAttributeProvider type)
+        {
+            return Reflection.HasAttribute<KRPCStructAttribute> (type);
+        }
+
+        /// <summary>
+        /// The properties that make up the fields of the given kRPC structure type, in the
+        /// order they are declared in. The fields are the public instance properties
+        /// annotated with the KRPCProperty attribute that have both a getter and a setter.
+        ///
+        /// The order is the order the wire encoding puts the field values in, so it has to
+        /// be the same every time it is asked for, whichever assembly the structure is in.
+        /// Reflection does not promise an order for the properties of a type, so they are
+        /// ordered by metadata token, which is assigned in declaration order.
+        /// </summary>
+        public static IList<PropertyInfo> GetStructFields (Type type)
+        {
+            lock (structFields) {
+                IList<PropertyInfo> fields;
+                if (structFields.TryGetValue (type, out fields))
+                    return fields;
+                fields = Reflection.GetPropertiesWith<KRPCPropertyAttribute> (type)
+                    .Where (property => property.IsPublic () && !property.IsStatic () &&
+                            property.GetGetMethod () != null && property.GetSetMethod () != null)
+                    .OrderBy (property => property.MetadataToken)
+                    .ToList ();
+                structFields [type] = fields;
+                return fields;
+            }
+        }
+
+        /// <summary>
+        /// The fields of every structure type they have been asked for. Encoding a structure
+        /// value needs them, which happens once per stream update per value.
+        /// </summary>
+        static readonly IDictionary<Type, IList<PropertyInfo>> structFields = new Dictionary<Type, IList<PropertyInfo>> ();
 
         /// <summary>
         /// Returns true if the given type can be used as a kRPC collection type.
@@ -297,6 +337,16 @@ namespace KRPC.Service
         }
 
         /// <summary>
+        /// Get the name of the service for the given KRPCStruct annotated type
+        /// </summary>
+        public static string GetStructServiceName (Type type)
+        {
+            ValidateKRPCStruct (type);
+            var attribute = Reflection.GetAttribute<KRPCStructAttribute> (type);
+            return attribute.Service ?? GetServiceName (type.DeclaringType);
+        }
+
+        /// <summary>
         /// Get the name of the service for the given KRPCException annotated type
         /// </summary>
         public static string GetExceptionServiceName (Type type)
@@ -461,6 +511,112 @@ namespace KRPC.Service
         }
 
         /// <summary>
+        /// Check the given type is a valid kRPC structure
+        /// 1. Must have KRPCStruct attribute
+        /// 2. Must have a valid identifier
+        /// 3. Must be a public non-generic value type
+        /// 4. Must be declared inside a kRPC service if it doesn't have the service explicity set
+        /// 5. Must not be declared inside a kRPC service if it does have the service explicity set
+        /// 6. Must have valid fields, see <see cref="ValidateStructFields"/>
+        /// </summary>
+        public static void ValidateKRPCStruct (Type type)
+        {
+            if (!Reflection.HasAttribute<KRPCStructAttribute> (type))
+                throw new ArgumentException (type + " does not have KRPCStruct attribute");
+            var attribute = Reflection.GetAttribute<KRPCStructAttribute> (type);
+            // Note: Type must already be a struct, due to AttributeUsage definition
+            // Validate the identifier.
+            ValidateIdentifier (type.Name);
+            // Check it's public and not generic
+            if (!(type.IsPublic || type.IsNestedPublic))
+                throw new ServiceException ("KRPCStruct " + type + " is not public");
+            if (type.IsGenericType)
+                throw new ServiceException ("KRPCStruct " + type + " is generic");
+            // If it doesn't have the Service property set, check the struct is defined directly inside a KRPCService
+            var declaringType = type.DeclaringType;
+            if (attribute.Service == null && (declaringType == null || !Reflection.HasAttribute<KRPCServiceAttribute> (declaringType)))
+                throw new ServiceException ("KRPCStruct " + type + " is not declared inside a KRPCService");
+            // If it does have the Service property set, check the struct isn't defined in a KRPCService
+            if (attribute.Service != null) {
+                ValidateIdentifier (attribute.Service);
+                while (declaringType != null) {
+                    if (Reflection.HasAttribute<KRPCServiceAttribute> (declaringType))
+                        throw new ServiceException ("KRPCStruct " + type + " is declared inside a KRPCService, but has the service name explicitly set");
+                    declaringType = declaringType.DeclaringType;
+                }
+            }
+            ValidateStructFields (type);
+        }
+
+        /// <summary>
+        /// Check the fields of the given structure type
+        /// 1. Every property marked as a field must have a valid identifier
+        /// 2. Every property marked as a field must be a public instance property with both a
+        ///    getter and a setter, so that a value can be both read and constructed
+        /// 3. Every field must have a valid kRPC type
+        /// 4. A field must not be nullable or restricted to a game scene
+        /// 5. There must be at least one field
+        /// 6. The structure must not contain itself, directly or through the fields of another
+        ///    structure
+        /// </summary>
+        public static void ValidateStructFields (Type type)
+        {
+            foreach (var property in Reflection.GetPropertiesWith<KRPCPropertyAttribute> (type)) {
+                ValidateIdentifier (property.Name);
+                if (!property.IsPublic () || property.IsStatic ())
+                    throw new ServiceException ("KRPCStruct " + type + " field " + property.Name + " is not a public instance property");
+                if (property.GetGetMethod () == null || property.GetSetMethod () == null)
+                    throw new ServiceException ("KRPCStruct " + type + " field " + property.Name + " does not have both a getter and a setter");
+                if (!IsAValidType (property.PropertyType))
+                    throw new ServiceException ("KRPCStruct " + type + " field " + property.Name + " has type " + property.PropertyType + ", which is not a valid kRPC type");
+                var propertyAttribute = Reflection.GetAttribute<KRPCPropertyAttribute> (property);
+                if (propertyAttribute.Nullable)
+                    throw new ServiceException ("KRPCStruct " + type + " field " + property.Name + " is nullable, which struct fields cannot be");
+                if (propertyAttribute.GameScene != GameScene.Inherit)
+                    throw new ServiceException ("KRPCStruct " + type + " field " + property.Name + " sets a game scene, which struct fields cannot do");
+            }
+            if (GetStructFields (type).Count == 0)
+                throw new ServiceException ("KRPCStruct " + type + " does not have any fields");
+            CheckStructIsNotRecursive (type, type, new List<Type> ());
+        }
+
+        /// <summary>
+        /// Check that none of the fields of the given structure type contain the structure type
+        /// the check started from, whether directly or through the fields of another structure.
+        /// A structure value is serialized inline, so a structure containing itself could not be
+        /// serialized at all.
+        /// </summary>
+        static void CheckStructIsNotRecursive (Type start, Type type, IList<Type> path)
+        {
+            path.Add (type);
+            foreach (var property in GetStructFields (type)) {
+                foreach (var fieldStructType in StructTypesIn (property.PropertyType)) {
+                    if (fieldStructType == start)
+                        throw new ServiceException ("KRPCStruct " + start + " contains itself, via " +
+                            string.Join (" -> ", path.Select (x => x.Name).Concat (new [] { start.Name }).ToArray ()));
+                    if (!path.Contains (fieldStructType))
+                        CheckStructIsNotRecursive (start, fieldStructType, path);
+                }
+            }
+            path.RemoveAt (path.Count - 1);
+        }
+
+        /// <summary>
+        /// The structure types that the given type is, or holds in a collection.
+        /// </summary>
+        static IEnumerable<Type> StructTypesIn (Type type)
+        {
+            if (IsAStructType (type)) {
+                yield return type;
+            } else if (IsACollectionType (type)) {
+                foreach (var argument in type.GetGenericArguments ()) {
+                    foreach (var structType in StructTypesIn (argument))
+                        yield return structType;
+                }
+            }
+        }
+
+        /// <summary>
         /// Check the given method is a valid kRPC class method
         /// 1. Must have KRPCMethod attribute
         /// 2. Must have a valid identifier
@@ -602,6 +758,10 @@ namespace KRPC.Service
             } else if (IsAnEnumType (type)) {
                 result["code"] = "ENUMERATION";
                 result["service"] = GetEnumServiceName (type);
+                result["name"] = type.Name;
+            } else if (IsAStructType (type)) {
+                result["code"] = "STRUCT";
+                result["service"] = GetStructServiceName (type);
                 result["name"] = type.Name;
             } else if (IsATupleCollectionType (type)) {
                 result["code"] = "TUPLE";

--- a/core/src/Service/ValueUtils.cs
+++ b/core/src/Service/ValueUtils.cs
@@ -19,7 +19,23 @@ namespace KRPC.Service
                 return SetsEqual((IEnumerable)x, (IEnumerable)y);
             if (TypeUtils.IsADictionaryCollectionType(type))
                 return DictionariesEqual((IDictionary)x, (IDictionary)y);
+            if (TypeUtils.IsAStructType(type))
+                return StructsEqual(type, x, y);
             return x.Equals(y);
+        }
+
+        /// <summary>
+        /// Compare two structure values field by field. The default equality of a C# struct
+        /// compares its fields with their own equality, which for a collection-typed field is
+        /// reference equality, so a structure holding one has to be compared here instead.
+        /// </summary>
+        static bool StructsEqual(Type type, object x, object y) {
+            foreach (var field in TypeUtils.GetStructFields(type)) {
+                var getter = field.GetGetMethod();
+                if (!Equal(getter.Invoke(x, null), getter.Invoke(y, null)))
+                    return false;
+            }
+            return true;
         }
 
         static bool ListsEqual(IList x, IList y) {

--- a/core/test/Server/ProtocolBuffers/EncoderTest.cs
+++ b/core/test/Server/ProtocolBuffers/EncoderTest.cs
@@ -281,5 +281,119 @@ namespace KRPC.Test.Server.ProtocolBuffers
             Assert.AreEqual (value.Item2, decodeResult.Item2);
             Assert.AreEqual (value.Item3, decodeResult.Item3);
         }
+
+        [Test]
+        public void Struct ()
+        {
+            var obj = new TestService.TestClass ("foo");
+            var value = new TestService.TestStruct {
+                IntField = 42,
+                StringField = "jeb",
+                EnumField = TestService.TestEnum.Z,
+                ObjectField = obj,
+                ListField = new List<string> { "a", "b" }
+            };
+            var data = Encoder.Encode (value).ToHexString ();
+            var decodeResult = (TestService.TestStruct)Encoder.Decode (
+                data.ToByteString (), typeof(TestService.TestStruct));
+            Assert.AreEqual (value.IntField, decodeResult.IntField);
+            Assert.AreEqual (value.StringField, decodeResult.StringField);
+            Assert.AreEqual (value.EnumField, decodeResult.EnumField);
+            Assert.AreSame (obj, decodeResult.ObjectField);
+            CollectionAssert.AreEqual (value.ListField, decodeResult.ListField);
+        }
+
+        [Test]
+        public void StructIsEncodedAsATupleOfItsFields ()
+        {
+            var value = new TestService.TestNestedStruct {
+                StructField = new TestService.TestStruct {
+                    IntField = 1,
+                    StringField = "jeb",
+                    EnumField = TestService.TestEnum.X,
+                    ObjectField = new TestService.TestClass ("foo"),
+                    ListField = new List<string> ()
+                },
+                IntField = 2
+            };
+            var expected = Encoder.Encode (Tuple.Create (value.StructField, value.IntField)).ToHexString ();
+            Assert.AreEqual (expected, Encoder.Encode (value).ToHexString ());
+        }
+
+        [Test]
+        public void NestedStruct ()
+        {
+            var value = new TestService.TestNestedStruct {
+                StructField = new TestService.TestStruct {
+                    IntField = 1,
+                    StringField = "jeb",
+                    EnumField = TestService.TestEnum.Y,
+                    ObjectField = new TestService.TestClass ("foo"),
+                    ListField = new List<string> { "a" }
+                },
+                IntField = 2
+            };
+            var data = Encoder.Encode (value).ToHexString ();
+            var decodeResult = (TestService.TestNestedStruct)Encoder.Decode (
+                data.ToByteString (), typeof(TestService.TestNestedStruct));
+            Assert.AreEqual (1, decodeResult.StructField.IntField);
+            Assert.AreEqual ("jeb", decodeResult.StructField.StringField);
+            Assert.AreEqual (2, decodeResult.IntField);
+        }
+
+        [Test]
+        public void EncodeStructWithNullField ()
+        {
+            var value = new TestService.TestStruct {
+                IntField = 42,
+                StringField = null,
+                EnumField = TestService.TestEnum.X,
+                ObjectField = new TestService.TestClass ("foo"),
+                ListField = new List<string> ()
+            };
+            Assert.Throws<ServiceException> (() => Encoder.Encode (value));
+        }
+
+        [Test]
+        public void DecodeStructWithMissingFields ()
+        {
+            var data = Encoder.Encode (Tuple.Create (42, "jeb")).ToHexString ();
+            Assert.Throws<ArgumentException> (
+                () => Encoder.Decode (data.ToByteString (), typeof(TestService.TestStruct)));
+        }
+
+        [Test]
+        public void DecodeStructWithNullField ()
+        {
+            // The object id 0 decodes to a null object, which a structure field can never be
+            var data = Encoder.Encode (Tuple.Create (
+                42, "jeb", TestService.TestEnum.Z, (ulong)0, new List<string> ())).ToHexString ();
+            Assert.Throws<ArgumentException> (
+                () => Encoder.Decode (data.ToByteString (), typeof(TestService.TestStruct)));
+        }
+
+        [Test]
+        public void DecodeStructWithExtraFields ()
+        {
+            // A client generated against a newer definition of the structure sends the
+            // fields that were appended to it, which are ignored
+            var value = new TestService.TestStruct {
+                IntField = 42,
+                StringField = "jeb",
+                EnumField = TestService.TestEnum.Z,
+                ObjectField = new TestService.TestClass ("foo"),
+                ListField = new List<string> { "a" }
+            };
+            var extended = Tuple.Create (
+                value.IntField, value.StringField, value.EnumField, value.ObjectField,
+                value.ListField, "an appended field");
+            var data = Encoder.Encode (extended).ToHexString ();
+            var decodeResult = (TestService.TestStruct)Encoder.Decode (
+                data.ToByteString (), typeof(TestService.TestStruct));
+            Assert.AreEqual (value.IntField, decodeResult.IntField);
+            Assert.AreEqual (value.StringField, decodeResult.StringField);
+            Assert.AreEqual (value.EnumField, decodeResult.EnumField);
+            CollectionAssert.AreEqual (value.ListField, decodeResult.ListField);
+        }
     }
 }

--- a/core/test/Service/DocumentationUtilsTest.cs
+++ b/core/test/Service/DocumentationUtilsTest.cs
@@ -14,6 +14,8 @@ namespace KRPC.Test.Service
         [TestCase ("<see cref=\"T:KRPC.Test.Service.TestService+TestClass\" />", "<see cref=\"T:TestService.TestClass\" />")]
         [TestCase ("<see cref=\"M:KRPC.Test.Service.TestService.TestClass.FloatToString(System.Single)\" />", "<see cref=\"M:TestService.TestClass.FloatToString\" />")]
         [TestCase ("<see cref=\"P:KRPC.Test.Service.TestService.TestClass.IntProperty\" />", "<see cref=\"M:TestService.TestClass.IntProperty\" />")]
+        [TestCase ("<see cref=\"T:KRPC.Test.Service.TestService+TestStruct\" />", "<see cref=\"T:TestService.TestStruct\" />")]
+        [TestCase ("<see cref=\"P:KRPC.Test.Service.TestService.TestStruct.IntField\" />", "<see cref=\"M:TestService.TestStruct.IntField\" />")]
         [TestCase ("<doc>\n<summary>\nThe game scene. See <see cref=\"P:KRPC.Service.KRPC.KRPC.GameScene\" />.\n</summary>\n</doc>",
             "<doc>\n<summary>\nThe game scene. See <see cref=\"M:KRPC.GameScene\" />.\n</summary>\n</doc>")]
         public void ResolveCrefs (string input, string output)
@@ -49,6 +51,10 @@ namespace KRPC.Test.Service
             "Use <see cref=\"T:TestService.TestEnum\" /> instead.")]
         [TestCase ("Use <see cref='TestEnum.X'/> instead.",
             "Use <see cref=\"M:TestService.TestEnum.X\" /> instead.")]
+        [TestCase ("Use <see cref='TestStruct'/> instead.",
+            "Use <see cref=\"T:TestService.TestStruct\" /> instead.")]
+        [TestCase ("Use <see cref='TestStruct.IntField'/> instead.",
+            "Use <see cref=\"M:TestService.TestStruct.IntField\" /> instead.")]
         [TestCase ("See <see cref='M:KRPC.Test.Service.TestService.ProcedureNoArgsNoReturn'/> and <see cref='TestClass'/>.",
             "See <see cref=\"M:TestService.ProcedureNoArgsNoReturn\" /> and <see cref=\"T:TestService.TestClass\" />.")]
         public void ResolveDeprecationReason (string input, string output)
@@ -72,6 +78,15 @@ namespace KRPC.Test.Service
                 "Use <see cref=\"M:TestService.TestEnum.X\" /> instead.",
                 DocumentationUtils.ResolveDeprecationReason (
                     "Use <see cref='X'/> instead.", typeof (TestService.TestEnum)));
+        }
+
+        [Test]
+        public void ResolveDeprecationReasonInStructContext ()
+        {
+            Assert.AreEqual (
+                "Use <see cref=\"M:TestService.TestStruct.IntField\" /> instead.",
+                DocumentationUtils.ResolveDeprecationReason (
+                    "Use <see cref='IntField'/> instead.", typeof (TestService.TestStruct)));
         }
 
         [TestCase ("Use <see cref='NonExistent'/> instead.")]

--- a/core/test/Service/ITestService.cs
+++ b/core/test/Service/ITestService.cs
@@ -75,6 +75,14 @@ namespace KRPC.Test.Service
 
         IDictionary<int,bool> DictionaryDefault (IDictionary<int,bool> x);
 
+        TestService.TestStruct EchoStruct (TestService.TestStruct x);
+
+        IList<TestService.TestStruct> EchoListOfStructs (IList<TestService.TestStruct> l);
+
+        TestService.TestNestedStruct EchoNestedStruct (TestService.TestNestedStruct x);
+
+        TestService.TestStruct StructDefault (TestService.TestStruct x);
+
         void ProcedureAvailableInInheritedGameScene();
 
         void ProcedureAvailableInSpecifiedGameScene();

--- a/core/test/Service/MessageAssert.cs
+++ b/core/test/Service/MessageAssert.cs
@@ -103,6 +103,41 @@ namespace KRPC.Test.Service
             Assert.AreEqual (documentation, cls.Documentation);
         }
 
+        public static void HasNoDocumentation (Struct str)
+        {
+            Assert.AreEqual (string.Empty, str.Documentation);
+        }
+
+        public static void HasDocumentation (Struct str, string documentation)
+        {
+            Assert.AreEqual (documentation, str.Documentation);
+        }
+
+        public static void HasFields (Struct str, int count)
+        {
+            Assert.AreEqual (count, str.Fields.Count);
+        }
+
+        public static void HasField (Struct str, int position, string name, Type type)
+        {
+            HasField (str, position, name, type, string.Empty);
+        }
+
+        public static void HasField (Struct str, int position, string name, Type type, string documentation)
+        {
+            Assert.Less (position, str.Fields.Count);
+            var field = str.Fields [position];
+            Assert.AreEqual (name, field.Name);
+            Assert.AreEqual (type, field.Type);
+            Assert.AreEqual (documentation, field.Documentation);
+        }
+
+        public static void IsNotDeprecated (Struct str)
+        {
+            Assert.IsFalse (str.Deprecated);
+            Assert.AreEqual (string.Empty, str.DeprecatedReason);
+        }
+
         public static void HasValues (Enumeration enumeration, int count)
         {
             Assert.AreEqual (count, enumeration.Values.Count);

--- a/core/test/Service/ScannerTest.cs
+++ b/core/test/Service/ScannerTest.cs
@@ -31,9 +31,10 @@ namespace KRPC.Test.Service
         public void TestService ()
         {
             var service = services.ServicesList.First (x => x.Name == "TestService");
-            Assert.AreEqual (61, service.Procedures.Count);
+            Assert.AreEqual (65, service.Procedures.Count);
             Assert.AreEqual (3, service.Classes.Count);
             Assert.AreEqual (2, service.Enumerations.Count);
+            Assert.AreEqual (2, service.Structs.Count);
             Assert.AreEqual ("<doc>\n<summary>\nTest service documentation.\n</summary>\n</doc>", service.Documentation);
             MessageAssert.IsNotDeprecated (service);
         }
@@ -419,6 +420,39 @@ namespace KRPC.Test.Service
                     MessageAssert.HasReturnType (proc, typeof(IDictionary<int,bool>));
                     MessageAssert.HasGameScene (proc, global::KRPC.Service.GameScene.Flight);
                     MessageAssert.HasNoDocumentation (proc);
+                } else if (proc.Name == "EchoStruct") {
+                    MessageAssert.HasParameters (proc, 1);
+                    MessageAssert.HasParameter (proc, 0, typeof(TestService.TestStruct), "x");
+                    MessageAssert.HasReturnType (proc, typeof(TestService.TestStruct));
+                    MessageAssert.HasGameScene (proc, global::KRPC.Service.GameScene.Flight);
+                    MessageAssert.HasNoDocumentation (proc);
+                } else if (proc.Name == "EchoListOfStructs") {
+                    MessageAssert.HasParameters (proc, 1);
+                    MessageAssert.HasParameter (proc, 0, typeof(IList<TestService.TestStruct>), "l");
+                    MessageAssert.HasReturnType (proc, typeof(IList<TestService.TestStruct>));
+                    MessageAssert.HasGameScene (proc, global::KRPC.Service.GameScene.Flight);
+                    MessageAssert.HasNoDocumentation (proc);
+                } else if (proc.Name == "EchoNestedStruct") {
+                    MessageAssert.HasParameters (proc, 1);
+                    MessageAssert.HasParameter (proc, 0, typeof(TestService.TestNestedStruct), "x");
+                    MessageAssert.HasReturnType (proc, typeof(TestService.TestNestedStruct));
+                    MessageAssert.HasGameScene (proc, global::KRPC.Service.GameScene.Flight);
+                    MessageAssert.HasNoDocumentation (proc);
+                } else if (proc.Name == "StructDefault") {
+                    MessageAssert.HasParameters (proc, 1);
+                    var parameter = proc.Parameters [0];
+                    Assert.AreEqual (typeof(TestService.TestStruct), parameter.Type);
+                    Assert.AreEqual ("x", parameter.Name);
+                    Assert.IsTrue (parameter.HasDefaultValue);
+                    var defaultValue = (TestService.TestStruct)parameter.DefaultValue;
+                    Assert.AreEqual (42, defaultValue.IntField);
+                    Assert.AreEqual ("jeb", defaultValue.StringField);
+                    Assert.AreEqual (global::KRPC.Test.Service.TestService.TestEnum.Y, defaultValue.EnumField);
+                    Assert.AreEqual ("kerbin", defaultValue.ObjectField.Value);
+                    CollectionAssert.AreEqual (new [] { "a", "b" }, defaultValue.ListField);
+                    MessageAssert.HasReturnType (proc, typeof(TestService.TestStruct));
+                    MessageAssert.HasGameScene (proc, global::KRPC.Service.GameScene.Flight);
+                    MessageAssert.HasNoDocumentation (proc);
                 } else if (proc.Name == "ProcedureAvailableInInheritedGameScene") {
                     MessageAssert.HasNoParameters (proc);
                     MessageAssert.HasNoReturnType (proc);
@@ -444,8 +478,8 @@ namespace KRPC.Test.Service
                 }
                 foundProcedures++;
             }
-            Assert.AreEqual (61, foundProcedures);
-            Assert.AreEqual (61, service.Procedures.Count);
+            Assert.AreEqual (65, foundProcedures);
+            Assert.AreEqual (65, service.Procedures.Count);
         }
 
         [Test]
@@ -499,6 +533,36 @@ namespace KRPC.Test.Service
             }
             Assert.AreEqual (2, foundEnumerations);
             Assert.AreEqual (2, service.Enumerations.Count);
+        }
+
+        [Test]
+        public void TestServiceStructs ()
+        {
+            var service = services.ServicesList.First (x => x.Name == "TestService");
+            int foundStructs = 0;
+            foreach (var str in service.Structs) {
+                if (str.Name == "TestStruct") {
+                    MessageAssert.HasDocumentation (str, "<doc>\n<summary>\nDocumentation string for TestStruct.\n</summary>\n</doc>");
+                    MessageAssert.HasFields (str, 5);
+                    MessageAssert.HasField (str, 0, "IntField", typeof(int), "<doc>\n<summary>\nDocumented struct field\n</summary>\n</doc>");
+                    MessageAssert.HasField (str, 1, "StringField", typeof(string));
+                    MessageAssert.HasField (str, 2, "EnumField", typeof(TestService.TestEnum));
+                    MessageAssert.HasField (str, 3, "ObjectField", typeof(TestService.TestClass));
+                    MessageAssert.HasField (str, 4, "ListField", typeof(IList<string>));
+                    MessageAssert.IsNotDeprecated (str);
+                } else if (str.Name == "TestNestedStruct") {
+                    MessageAssert.HasNoDocumentation (str);
+                    MessageAssert.HasFields (str, 2);
+                    MessageAssert.HasField (str, 0, "StructField", typeof(TestService.TestStruct));
+                    MessageAssert.HasField (str, 1, "IntField", typeof(int));
+                    MessageAssert.IsNotDeprecated (str);
+                } else {
+                    Assert.Fail ();
+                }
+                foundStructs++;
+            }
+            Assert.AreEqual (2, foundStructs);
+            Assert.AreEqual (2, service.Structs.Count);
         }
 
         [Test]

--- a/core/test/Service/TestService.cs
+++ b/core/test/Service/TestService.cs
@@ -369,6 +369,87 @@ namespace KRPC.Test.Service
             return Service.DictionaryDefault (x);
         }
 
+        /// <summary>
+        /// Documentation string for TestStruct.
+        /// </summary>
+        [KRPCStruct]
+        public struct TestStruct
+        {
+            /// <summary>
+            /// Documented struct field
+            /// </summary>
+            [KRPCProperty]
+            public int IntField { get; set; }
+
+            [KRPCProperty]
+            public string StringField { get; set; }
+
+            [KRPCProperty]
+            public TestEnum EnumField { get; set; }
+
+            [KRPCProperty]
+            public TestClass ObjectField { get; set; }
+
+            [KRPCProperty]
+            public IList<string> ListField { get; set; }
+
+            /// <summary>
+            /// A property that is not a field of the structure, as it is not marked as one.
+            /// </summary>
+            public int NotAField {
+                get { return IntField + 1; }
+            }
+        }
+
+        [KRPCStruct]
+        public struct TestNestedStruct
+        {
+            [KRPCProperty]
+            public TestStruct StructField { get; set; }
+
+            [KRPCProperty]
+            public int IntField { get; set; }
+        }
+
+        [KRPCProcedure]
+        public static TestStruct EchoStruct (TestStruct x)
+        {
+            return Service.EchoStruct (x);
+        }
+
+        [KRPCProcedure]
+        public static IList<TestStruct> EchoListOfStructs (IList<TestStruct> l)
+        {
+            return Service.EchoListOfStructs (l);
+        }
+
+        [KRPCProcedure]
+        public static TestNestedStruct EchoNestedStruct (TestNestedStruct x)
+        {
+            return Service.EchoNestedStruct (x);
+        }
+
+        public static class CreateStructDefault
+        {
+            public static object Create ()
+            {
+                return new TestStruct {
+                    IntField = 42,
+                    StringField = "jeb",
+                    EnumField = TestEnum.Y,
+                    ObjectField = new TestClass ("kerbin"),
+                    ListField = new List<string> { "a", "b" }
+                };
+            }
+        }
+
+        [KRPCProcedure]
+        public static TestStruct StructDefault (
+            [KRPCDefaultValue (typeof(CreateStructDefault))] TestStruct x)
+        {
+            return Service.StructDefault (x);
+        }
+
         [KRPCProcedure]
         public static void ProcedureAvailableInInheritedGameScene()
         {

--- a/core/test/Service/TypeUtilsTest.cs
+++ b/core/test/Service/TypeUtilsTest.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using KRPC.Service;
+using KRPC.Service.Attributes;
 using KRPC.Service.Messages;
 using NUnit.Framework;
 using Newtonsoft.Json;
@@ -41,6 +43,9 @@ namespace KRPC.Test.Service
         [TestCase (typeof(IList<IDictionary<int,string>>))]
         [TestCase (typeof(IList<TestService.TestClass>))]
         [TestCase (typeof(IList<TestService.TestEnum>))]
+        [TestCase (typeof(TestService.TestStruct))]
+        [TestCase (typeof(TestService.TestNestedStruct))]
+        [TestCase (typeof(IList<TestService.TestStruct>))]
         public void IsAValidType (Type type)
         {
             Assert.IsTrue (TypeUtils.IsAValidType (type));
@@ -52,6 +57,8 @@ namespace KRPC.Test.Service
         [TestCase (typeof(IDictionary<TestService.TestClass,string>))]
         [TestCase (typeof(IList<TestService.TestEnumWithoutAttribute>))]
         [TestCase (typeof(IEnumerable<string>))]
+        [TestCase (typeof(StructWithoutFields))]
+        [TestCase (typeof(IList<StructWithoutFields>))]
         public void IsNotAValidType (Type type)
         {
             Assert.IsFalse (TypeUtils.IsAValidType (type));
@@ -343,6 +350,109 @@ namespace KRPC.Test.Service
             Assert.AreEqual (name, TypeUtils.GetEnumServiceName (type));
         }
 
+        [TestCase (typeof(TestService.TestStruct))]
+        [TestCase (typeof(TestService.TestNestedStruct))]
+        public void IsAStructType (Type type)
+        {
+            Assert.IsTrue (TypeUtils.IsAStructType (type));
+        }
+
+        [TestCase (typeof(string))]
+        [TestCase (typeof(long))]
+        [TestCase (typeof(Status))]
+        [TestCase (typeof(TestService.TestClass))]
+        [TestCase (typeof(TestService.TestEnum))]
+        [TestCase (typeof(StructWithoutFields))]
+        [TestCase (typeof(IList<TestService.TestStruct>))]
+        public void IsNotAStructType (Type type)
+        {
+            Assert.IsFalse (TypeUtils.IsAStructType (type));
+        }
+
+        [TestCase (typeof(TestService.TestStruct), "TestService")]
+        [TestCase (typeof(TestService.TestNestedStruct), "TestService")]
+        public void GetStructServiceName (Type type, string name)
+        {
+            Assert.AreEqual (name, TypeUtils.GetStructServiceName (type));
+        }
+
+        [Test]
+        public void GetStructFields ()
+        {
+            CollectionAssert.AreEqual (
+                new [] { "IntField", "StringField", "EnumField", "ObjectField", "ListField" },
+                TypeUtils.GetStructFields (typeof(TestService.TestStruct)).Select (x => x.Name).ToList ());
+            CollectionAssert.AreEqual (
+                new [] { "StructField", "IntField" },
+                TypeUtils.GetStructFields (typeof(TestService.TestNestedStruct)).Select (x => x.Name).ToList ());
+        }
+
+        [TestCase (typeof(TestService.TestStruct))]
+        [TestCase (typeof(TestService.TestNestedStruct))]
+        public void ValidKRPCStruct (Type type)
+        {
+            Assert.DoesNotThrow (() => TypeUtils.ValidateKRPCStruct (type));
+        }
+
+        [Test]
+        public void ValidateKRPCStructWithoutTheAttribute ()
+        {
+            Assert.Throws<ArgumentException> (
+                () => TypeUtils.ValidateKRPCStruct (typeof(StructWithoutFields)));
+        }
+
+        // Structures whose fields break one of the rules. They do not carry the KRPCStruct
+        // attribute, as the scanner finds every type that does and would report them for every
+        // test in this assembly rather than only here.
+
+        public struct StructWithoutFields
+        {
+            public int NotAField { get; set; }
+        }
+
+        public struct StructWithAnInvalidFieldType
+        {
+            [KRPCProperty]
+            public TestService.TestEnumWithoutAttribute Field { get; set; }
+        }
+
+        public struct StructWithAFieldWithoutASetter
+        {
+            [KRPCProperty]
+            public int Field {
+                get { return 0; }
+            }
+        }
+
+        public struct StructWithANullableField
+        {
+            [KRPCProperty (Nullable = true)]
+            public TestService.TestClass Field { get; set; }
+        }
+
+        public struct StructWithAGameSceneField
+        {
+            [KRPCProperty (GameScene = GameScene.Flight)]
+            public int Field { get; set; }
+        }
+
+        [TestCase (typeof(StructWithoutFields))]
+        [TestCase (typeof(StructWithAnInvalidFieldType))]
+        [TestCase (typeof(StructWithAFieldWithoutASetter))]
+        [TestCase (typeof(StructWithANullableField))]
+        [TestCase (typeof(StructWithAGameSceneField))]
+        public void InvalidStructFields (Type type)
+        {
+            Assert.Throws<ServiceException> (() => TypeUtils.ValidateStructFields (type));
+        }
+
+        [TestCase (typeof(TestService.TestStruct))]
+        [TestCase (typeof(TestService.TestNestedStruct))]
+        public void ValidStructFields (Type type)
+        {
+            Assert.DoesNotThrow (() => TypeUtils.ValidateStructFields (type));
+        }
+
         [TestCase ("IdentifierName")]
         [TestCase ("Foo123")]
         public void ValidIdentifier (string identifier)
@@ -386,6 +496,11 @@ namespace KRPC.Test.Service
         [TestCase ("{\"code\":\"LIST\",\"types\":[" +
                    "{\"code\":\"ENUMERATION\",\"service\":\"TestService\",\"name\":\"TestEnum\"}" +
                    "]}", typeof(IList<TestService.TestEnum>))]
+        [TestCase ("{\"code\":\"STRUCT\",\"service\":\"TestService\",\"name\":\"TestStruct\"}",
+                   typeof(TestService.TestStruct))]
+        [TestCase ("{\"code\":\"LIST\",\"types\":[" +
+                   "{\"code\":\"STRUCT\",\"service\":\"TestService\",\"name\":\"TestStruct\"}" +
+                   "]}", typeof(IList<TestService.TestStruct>))]
         public void SerializeType (string name, Type type)
         {
             Assert.AreEqual (name, JsonConvert.SerializeObject (TypeUtils.SerializeType (type)));

--- a/core/test/Service/ValueUtilsTest.cs
+++ b/core/test/Service/ValueUtilsTest.cs
@@ -130,5 +130,42 @@ namespace KRPC.Test.Service
                 x[keysY[i]] = valuesY[i];
             Assert.IsFalse(ValueUtils.Equal(x, y));
         }
+
+        static TestService.TestStruct MakeStruct(int intField, params string[] listField)
+        {
+            return new TestService.TestStruct {
+                IntField = intField,
+                StringField = "jeb",
+                EnumField = TestService.TestEnum.X,
+                ObjectField = null,
+                ListField = new List<string>(listField)
+            };
+        }
+
+        [Test]
+        public void StructsEqual()
+        {
+            // The list fields are equal but are separate objects, which the default equality
+            // of a C# struct would compare by reference
+            Assert.IsTrue(ValueUtils.Equal(MakeStruct(1, "a", "b"), MakeStruct(1, "a", "b")));
+        }
+
+        [Test]
+        public void StructsNotEqual()
+        {
+            Assert.IsFalse(ValueUtils.Equal(MakeStruct(1, "a"), MakeStruct(2, "a")));
+            Assert.IsFalse(ValueUtils.Equal(MakeStruct(1, "a"), MakeStruct(1, "b")));
+            Assert.IsFalse(ValueUtils.Equal(MakeStruct(1, "a"), MakeStruct(1)));
+        }
+
+        [Test]
+        public void NestedStructsEqual()
+        {
+            var x = new TestService.TestNestedStruct { StructField = MakeStruct(1, "a"), IntField = 2 };
+            var y = new TestService.TestNestedStruct { StructField = MakeStruct(1, "a"), IntField = 2 };
+            Assert.IsTrue(ValueUtils.Equal(x, y));
+            y.StructField = MakeStruct(1, "b");
+            Assert.IsFalse(ValueUtils.Equal(x, y));
+        }
     }
 }

--- a/core/test/Utils/ReflectionTest.cs
+++ b/core/test/Utils/ReflectionTest.cs
@@ -24,13 +24,14 @@ namespace KRPC.Test.Utils
         {
             Assert.AreEqual (5, Reflection.GetTypesWith<KRPCServiceAttribute> ().Count ());
             Assert.AreEqual (6, Reflection.GetTypesWith<KRPCClassAttribute> ().Count ());
+            Assert.AreEqual (2, Reflection.GetTypesWith<KRPCStructAttribute> ().Count ());
             Assert.AreEqual (0, Reflection.GetTypesWith<KRPCPropertyAttribute> ().Count ());
         }
 
         [Test]
         public void GetMethodsWithAttribute ()
         {
-            Assert.AreEqual (34, Reflection.GetMethodsWith<KRPCProcedureAttribute> (typeof(TestService)).Count ());
+            Assert.AreEqual (38, Reflection.GetMethodsWith<KRPCProcedureAttribute> (typeof(TestService)).Count ());
             Assert.AreEqual (8, Reflection.GetMethodsWith<KRPCMethodAttribute> (typeof(TestService.TestClass)).Count ());
             Assert.AreEqual (0, Reflection.GetMethodsWith<KRPCProcedureAttribute> (typeof(TestService.TestClass)).Count ());
             Assert.AreEqual (0, Reflection.GetMethodsWith<KRPCProcedureAttribute> (typeof(string)).Count ());

--- a/doc/src/communication-protocols/messages.rst
+++ b/doc/src/communication-protocols/messages.rst
@@ -368,6 +368,7 @@ with the format:
      string documentation = 6;
      bool deprecated = 7;
      string deprecated_reason = 8;
+     repeated Struct structs = 9;
    }
 
 The fields are:
@@ -385,6 +386,9 @@ The fields are:
 * ``exceptions`` - A list of ``Exception`` messages, one for each :csharp:attr:`KRPCException`
   defined by the service.
 
+* ``structs`` - A list of ``Struct`` messages, one for each :csharp:attr:`KRPCStruct`
+  defined by the service.
+
 * ``documentation`` - Documentation for the service, as `C# XML documentation`_.
 
 * ``deprecated`` - Whether the service is deprecated. Deprecated services remain fully functional;
@@ -393,7 +397,7 @@ The fields are:
 * ``deprecated_reason`` - If the service is deprecated, the reason for its deprecation. May be empty.
 
 .. note:: See the :ref:`extending` documentation for more details about :csharp:attr:`KRPCClass`,
-          :csharp:attr:`KRPCEnum` and :csharp:attr:`KRPCException`.
+          :csharp:attr:`KRPCEnum`, :csharp:attr:`KRPCStruct` and :csharp:attr:`KRPCException`.
 
 Procedures
 ^^^^^^^^^^
@@ -561,6 +565,79 @@ The fields are:
 * ``deprecated_reason`` - If the enumeration is deprecated, the reason for its deprecation. May be
   empty.
 
+.. _communication-protocol-structures:
+
+Structures
+^^^^^^^^^^
+
+A structure is a compound value with named fields. Unlike a class, whose value on the wire is an
+identifier for an object that stays on the server, a structure's value is the values of its fields,
+sent inline. Details about each :csharp:attr:`KRPCStruct` are specified in a ``Struct`` message,
+with the format:
+
+.. code-block:: protobuf
+
+   message Struct {
+     string name = 1;
+     repeated StructField fields = 2;
+     string documentation = 3;
+     bool deprecated = 4;
+     string deprecated_reason = 5;
+   }
+
+   message StructField {
+     string name = 1;
+     Type type = 2;
+     string documentation = 3;
+     bool deprecated = 4;
+     string deprecated_reason = 5;
+   }
+
+The fields are:
+
+* ``name`` - The name of the structure.
+
+* ``fields`` - A list of ``StructField`` messages, one for each field of the structure, in the
+  order their values are encoded in. The fields are:
+
+  * ``name`` - The name of the field.
+
+  * ``type`` - The type of the field, as a :ref:`Type message
+    <communication-protocol-type>`. A field may have any type a parameter or return value may
+    have, including a class, a collection or another structure.
+
+  * ``documentation`` - Documentation for the field, as `C# XML documentation`_.
+
+  * ``deprecated`` - Whether the field is deprecated. Deprecated fields remain fully functional;
+    this field is informational.
+
+  * ``deprecated_reason`` - If the field is deprecated, the reason for its deprecation. May be
+    empty.
+
+* ``documentation`` - Documentation for the structure, as `C# XML documentation`_.
+
+* ``deprecated`` - Whether the structure is deprecated. Deprecated structures remain fully
+  functional; this field is informational.
+
+* ``deprecated_reason`` - If the structure is deprecated, the reason for its deprecation. May be
+  empty.
+
+A value of a structure type is encoded as a ``Tuple`` message whose items are the encoded values of
+the structure's fields, in the order the ``fields`` list gives them. This is the same encoding as a
+tuple of the field types, so a client can encode and decode a structure with the codec it already
+has for tuples, and the field names exist only in the definition above.
+
+Two rules follow from that encoding, and a client author should rely on them:
+
+* Fields are only ever appended to a structure. A value may therefore carry more items than the
+  fields a client knows about, when it was generated against an older definition of the structure,
+  and those extra items are to be ignored. Fewer items than the known fields means the definitions
+  do not match, and is an error.
+
+* A field is never null. Null is signaled out-of-band by the ``is_null`` field of the enclosing
+  ``Argument`` or ``ProcedureResult`` message, which can say that a whole structure value is null
+  but says nothing about its fields.
+
 Exceptions
 ^^^^^^^^^^
 
@@ -640,6 +717,7 @@ The ``GetServices`` procedure returns type information about parameters, return 
        // Objects
        CLASS = 100;
        ENUMERATION = 101;
+       STRUCT = 102;
 
        // Messages
        EVENT = 200;
@@ -659,9 +737,11 @@ The ``GetServices`` procedure returns type information about parameters, return 
 The ``code`` field specifies the type. ``NONE`` is used as the return type for procedures that do
 not return a value.
 
-For ``CLASS`` and ``ENUMERATION`` types the ``service`` and ``name`` fields specify the service that
-defines the class/enumeration and the name of the class/enumeration. For all other types these
-fields are empty.
+For ``CLASS``, ``ENUMERATION`` and ``STRUCT`` types the ``service`` and ``name`` fields specify the
+service that defines the class, enumeration or structure and its name. For all other types these
+fields are empty. A ``STRUCT`` type carries no more than that, so the fields of a structure have to
+be read from the :ref:`Struct message <communication-protocol-structures>` in the definition of the
+service that names it.
 
 For collection types the ``types`` repeated field will contain the sub-types:
 

--- a/doc/src/dictionary.txt
+++ b/doc/src/dictionary.txt
@@ -49,6 +49,7 @@ boolean
 circularization
 clickable
 clientgen
+codec
 collidable
 collinear
 combusting

--- a/doc/src/extending.rst
+++ b/doc/src/extending.rst
@@ -402,6 +402,82 @@ to add functionality to the kRPC server.
         conn = krpc.connect()
         state = conn.eva.FlagState.lowered
 
+.. csharp:attribute:: KRPCStruct (string Service)
+
+   :parameters:
+
+    * **Service** -- Optional name of the service to add this structure to. If omitted, the
+      structure is added to the service that contains its definition.
+
+   This `attribute <https://msdn.microsoft.com/en-us/library/aa287992.aspx>`_ is applied to a
+   ``struct``. It adds the structure and its fields to the server. A structure is a compound value
+   with named fields, whose value is sent to the client in full rather than as a reference to an
+   object that stays on the server.
+
+   The fields of the structure are its ``public`` instance properties that are annotated with
+   :csharp:attr:`KRPCProperty` and have both a getter and a setter, in the order they are declared.
+   A property that is not annotated is not a field, and is not visible to a client.
+
+   A :csharp:attr:`KRPCStruct` must be part of a service, just like a
+   :csharp:attr:`KRPCClass`. Similarly, a :csharp:attr:`KRPCStruct` can be declared outside of a
+   service if it has its ``Service`` parameter set to the name of the service that it is part of.
+
+   The struct type to which this attribute is applied must satisfy the following criteria:
+
+   * The struct must be ``public`` and must not be generic.
+
+   * The name of the struct must be a valid :ref:`kRPC identifier <service-api-identifiers>`.
+
+   * The struct must either be declared inside a :csharp:attr:`KRPCService`, or have its ``Service``
+     parameter set to the name of the service it is part of.
+
+   * It must have at least one field, and the type of every field must be a :ref:`serializable type
+     <service-api-serializable-types>`.
+
+   * A field must not be nullable and must not restrict the game scenes it is available in, so
+     neither the ``Nullable`` nor the ``GameScene`` parameter of its :csharp:attr:`KRPCProperty`
+     attribute may be set.
+
+   * The structure must not contain itself, whether directly or through the fields of another
+     structure that it contains.
+
+   Fields may only be **appended** to a structure. Reordering them, removing one or changing the
+   type of one is a breaking change for clients generated against the previous definition, as the
+   value of a structure is sent as the values of its fields in order.
+
+   **Choosing between a structure and a class.** A structure sends the values of all of its fields
+   whenever it is sent, in a single procedure call. Use one for compound data whose fields are
+   almost always wanted together, such as a position and a velocity. Use a
+   :csharp:attr:`KRPCClass` for something with mutable state, or whose members are expensive enough
+   that a client should be able to ask for them one at a time.
+
+   **Examples**
+
+   * Declare a structure with three fields:
+
+     .. code-block:: csharp
+
+        [KRPCStruct]
+        public struct LaunchSiteInfo {
+            [KRPCProperty]
+            public string Name { get; set; }
+
+            [KRPCProperty]
+            public CelestialBody Body { get; set; }
+
+            [KRPCProperty]
+            public double Latitude { get; set; }
+        }
+
+     This can be used from a python client as follows:
+
+     .. code-block:: python
+
+        import krpc
+        conn = krpc.connect()
+        site = conn.space_center.launch_sites[0]
+        print(site.name, site.latitude)
+
 .. csharp:attribute:: KRPCException (string Service, Type MappedException)
 
    :parameters:
@@ -524,6 +600,8 @@ following types are serializable:
 * Any type annotated with :csharp:attr:`KRPCClass`
 
 * Any type annotated with :csharp:attr:`KRPCEnum`
+
+* Any type annotated with :csharp:attr:`KRPCStruct`
 
 * Collections of serializable types:
 

--- a/protobuf/krpc.proto
+++ b/protobuf/krpc.proto
@@ -95,6 +95,7 @@ message Service {
   string documentation = 6;
   bool deprecated = 7;
   string deprecated_reason = 8;
+  repeated Struct structs = 9;
 }
 
 message Procedure {
@@ -160,6 +161,22 @@ message Exception {
   string deprecated_reason = 4;
 }
 
+message Struct {
+  string name = 1;
+  repeated StructField fields = 2;
+  string documentation = 3;
+  bool deprecated = 4;
+  string deprecated_reason = 5;
+}
+
+message StructField {
+  string name = 1;
+  Type type = 2;
+  string documentation = 3;
+  bool deprecated = 4;
+  string deprecated_reason = 5;
+}
+
 message Type {
   TypeCode code = 1;
   string service = 2;
@@ -183,6 +200,7 @@ message Type {
     // Objects
     CLASS = 100;
     ENUMERATION = 101;
+    STRUCT = 102;
 
     // Messages
     EVENT = 200;

--- a/tools/TestServer/src/TestService.cs
+++ b/tools/TestServer/src/TestService.cs
@@ -274,6 +274,110 @@ namespace TestServer
             return x;
         }
 
+        /// <summary>
+        /// Struct documentation string.
+        /// </summary>
+        [KRPCStruct]
+        public struct TestStruct
+        {
+            /// <summary>
+            /// Struct IntField documentation string.
+            /// </summary>
+            [KRPCProperty]
+            public int IntField { get; set; }
+
+            [KRPCProperty]
+            public string StringField { get; set; }
+
+            [KRPCProperty]
+            public TestEnum EnumField { get; set; }
+
+            [KRPCProperty]
+            public IList<int> ListField { get; set; }
+        }
+
+        /// <summary>
+        /// Nested struct documentation string.
+        /// </summary>
+        [KRPCStruct]
+        public struct TestNestedStruct
+        {
+            [KRPCProperty]
+            public TestStruct StructField { get; set; }
+
+            [KRPCProperty]
+            public TestClass ObjectField { get; set; }
+
+            [KRPCProperty]
+            public string StringField { get; set; }
+        }
+
+        [KRPCProcedure]
+        public static TestStruct StructEcho (TestStruct x)
+        {
+            return x;
+        }
+
+        [KRPCProcedure]
+        public static TestNestedStruct NestedStructEcho (TestNestedStruct x)
+        {
+            return x;
+        }
+
+        [KRPCProcedure]
+        public static IList<TestStruct> IncrementListOfStructs (IList<TestStruct> l)
+        {
+            if (l == null)
+                throw new ArgumentNullException (nameof (l));
+            return l.Select (x => new TestStruct {
+                IntField = x.IntField + 1,
+                StringField = x.StringField,
+                EnumField = x.EnumField,
+                ListField = x.ListField
+            }).ToList ();
+        }
+
+        public static class CreateStructDefault
+        {
+            public static object Create ()
+            {
+                return new TestStruct {
+                    IntField = 42,
+                    StringField = "jeb",
+                    EnumField = TestEnum.ValueB,
+                    ListField = new List<int> { 1, 2, 3 }
+                };
+            }
+        }
+
+        [KRPCProcedure]
+        public static TestStruct StructDefault (
+            [KRPCDefaultValue (typeof(CreateStructDefault))] TestStruct x)
+        {
+            return x;
+        }
+
+        [KRPCProcedure]
+        public static TestStruct? StructEchoNullable (TestStruct? x)
+        {
+            return x;
+        }
+
+        /// <summary>
+        /// Returns a struct whose IntField counts the number of times it has been called,
+        /// so that a stream on it changes on every update.
+        /// </summary>
+        [KRPCProcedure]
+        public static TestStruct CounterStruct (string id = "")
+        {
+            return new TestStruct {
+                IntField = Counter (id),
+                StringField = id,
+                EnumField = TestEnum.ValueA,
+                ListField = new List<int> ()
+            };
+        }
+
         [KRPCProcedure]
         public static int BlockingProcedure (int n, int sum = 0)
         {
@@ -635,6 +739,27 @@ namespace TestServer
             /// </summary>
             [Obsolete ("Use <see cref='ValueA'/> instead.")]
             ValueB
+        }
+
+        /// <summary>
+        /// Deprecated struct documentation string.
+        /// </summary>
+        [KRPCStruct]
+        [Obsolete ("Use the TestStruct struct instead.")]
+        public struct DeprecatedStruct
+        {
+            /// <summary>
+            /// Deprecated struct Value documentation string.
+            /// </summary>
+            [KRPCProperty]
+            public int Value { get; set; }
+
+            /// <summary>
+            /// Deprecated struct OldValue documentation string.
+            /// </summary>
+            [KRPCProperty]
+            [Obsolete ("Use the Value field instead.")]
+            public int OldValue { get; set; }
         }
 
         /// <summary>

--- a/tools/TestServer/src/TestService.cs
+++ b/tools/TestServer/src/TestService.cs
@@ -745,7 +745,7 @@ namespace TestServer
         /// Deprecated struct documentation string.
         /// </summary>
         [KRPCStruct]
-        [Obsolete ("Use the TestStruct struct instead.")]
+        [Obsolete ("Use <see cref='TestStruct'/> instead.")]
         public struct DeprecatedStruct
         {
             /// <summary>
@@ -758,7 +758,7 @@ namespace TestServer
             /// Deprecated struct OldValue documentation string.
             /// </summary>
             [KRPCProperty]
-            [Obsolete ("Use the Value field instead.")]
+            [Obsolete ("Use <see cref='Value'/> instead.")]
             public int OldValue { get; set; }
         }
 

--- a/tools/krpctools/CHANGELOG.md
+++ b/tools/krpctools/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## [v0.7.0] - unreleased
+- Generate and document the structure types a service defines, for every client (#1066)
 - **Breaking:** A generator module given to `krpc-clientgen` by path is constructed with
   the definitions of every service that was loaded, rather than with those of the single
   service it generates (#1044)

--- a/tools/krpctools/krpctools/clientgen/cnano.py
+++ b/tools/krpctools/krpctools/clientgen/cnano.py
@@ -7,6 +7,7 @@ from krpc.types import (
     ClassType,
     EnumerationType,
     MessageType,
+    StructType,
     TupleType,
     ListType,
     SetType,
@@ -56,6 +57,11 @@ class CnanoGenerator(Generator):
             ctype = "krpc_tuple_%s_t" % "_".join(
                 self.parse_type_name(t) for t in typ.value_types
             )
+        elif isinstance(typ, StructType):
+            ctype = "krpc_%s_%s_t" % (
+                typ.protobuf_type.service,
+                typ.protobuf_type.name,
+            )
         elif isinstance(typ, (ClassType, EnumerationType)):
             if in_collection:
                 if isinstance(typ, ClassType):
@@ -99,22 +105,32 @@ class CnanoGenerator(Generator):
         }
 
     def parse_collection_type(self, typ):
+        # A structure carries the values of its fields in order, which is the same encoding as
+        # a tuple of those values, so both are generated as a C struct holding one member per
+        # value. The members of a tuple are named for their position; those of a structure are
+        # named for the field they carry.
         result = self.parse_type(typ)
         if isinstance(typ, TupleType):
-            result.update(
-                {
-                    "value_types": [
-                        self._parse_type(t, in_collection=True) for t in typ.value_types
-                    ]
-                }
-            )
+            members = [self._parse_type(t, in_collection=True) for t in typ.value_types]
+            for i, member in enumerate(members):
+                member["member"] = "e%d" % i
+            result.update({"kind": "tuple", "value_types": members})
+        elif isinstance(typ, StructType):
+            members = [self._parse_type(t, in_collection=True) for t in typ.field_types]
+            for name, member in zip(typ.field_names, members):
+                member["member"] = self.parse_name(snake_case(name))
+            result.update({"kind": "struct", "value_types": members})
         elif isinstance(typ, (ListType, SetType)):
             result.update(
-                {"value_type": self._parse_type(typ.value_type, in_collection=True)}
+                {
+                    "kind": "list" if isinstance(typ, ListType) else "set",
+                    "value_type": self._parse_type(typ.value_type, in_collection=True),
+                }
             )
         elif isinstance(typ, DictionaryType):
             result.update(
                 {
+                    "kind": "dictionary",
                     "key_type": self._parse_type(typ.key_type, in_collection=True),
                     "value_type": self._parse_type(typ.value_type, in_collection=True),
                 }
@@ -141,6 +157,8 @@ class CnanoGenerator(Generator):
             return "tuple_%s" % "_".join(
                 self.parse_type_name(t) for t in typ.value_types
             )
+        if isinstance(typ, StructType):
+            return "%s_%s" % (typ.protobuf_type.service, typ.protobuf_type.name)
         if isinstance(typ, ClassType):
             return "object"
         if isinstance(typ, EnumerationType):

--- a/tools/krpctools/krpctools/clientgen/cnano.tmpl
+++ b/tools/krpctools/krpctools/clientgen/cnano.tmpl
@@ -93,20 +93,20 @@ typedef krpc_object_t krpc_{{ service_name }}_{{ class_name }}_t;
 #ifndef KRPC_TYPE_{{ typ.name | upper }}
 #define KRPC_TYPE_{{ typ.name | upper }}
 
-{% if typ.name.startswith('tuple_') %}
+{% if typ.kind in ('tuple', 'struct') %}
 typedef struct krpc_{{ typ.name }}_s krpc_{{ typ.name }}_t;
 struct krpc_{{ typ.name }}_s {
 {% for value_type in typ.value_types %}
-  {{ value_type.ctype }} e{{ loop.index0 }};
+  {{ value_type.ctype }} {{ value_type.member }};
 {% endfor %}
 };
-{% elif typ.name.startswith('list_') or typ.name.startswith('set_') %}
+{% elif typ.kind in ('list', 'set') %}
 typedef struct krpc_{{ typ.name }}_s krpc_{{ typ.name }}_t;
 struct krpc_{{ typ.name }}_s {
   size_t size;
   {{ typ.value_type.ctype }} * items;
 };
-{% elif typ.name.startswith('dictionary_') %}
+{% elif typ.kind == 'dictionary' %}
 typedef struct krpc_dictionary_entry_{{ typ.key_type.name }}_{{ typ.value_type.name }}_s krpc_dictionary_entry_{{ typ.key_type.name }}_{{ typ.value_type.name }}_t;
 struct krpc_dictionary_entry_{{ typ.key_type.name }}_{{ typ.value_type.name }}_s {
   {{ typ.key_type.ctype }} key;
@@ -193,7 +193,7 @@ static inline krpc_error_t krpc_{{ service_name }}_{{ class_name }}_{{ property_
 #ifndef KRPC_IMPL_TYPE_{{ typ.name | upper }}
 #define KRPC_IMPL_TYPE_{{ typ.name | upper }}
 
-{% if typ.name.startswith('tuple_') %}
+{% if typ.kind in ('tuple', 'struct') %}
 static inline bool krpc_encode_callback_items_{{ typ.name }}(
   pb_ostream_t * stream, const pb_field_t * field, void * const * arg) {
   const {{ typ.ctype }} * value = (const {{ typ.ctype }}*)(*arg);
@@ -202,15 +202,15 @@ static inline bool krpc_encode_callback_items_{{ typ.name }}(
     if (!pb_encode_tag_for_field(stream, field))
       KRPC_CALLBACK_RETURN_ERROR("encoding tag for tuple item");
     size_t size;
-    KRPC_CALLBACK_RETURN_ON_ERROR(krpc_encode_size_{{ value_type.name }}(&size, {{ value_type.structgetval }}value->e{{ loop.index0 }}));
+    KRPC_CALLBACK_RETURN_ON_ERROR(krpc_encode_size_{{ value_type.name }}(&size, {{ value_type.structgetval }}value->{{ value_type.member }}));
     if (!pb_encode_varint(stream, size))
       KRPC_CALLBACK_RETURN_ERROR("encoding size for tuple item");
-    KRPC_CALLBACK_RETURN_ON_ERROR(krpc_encode_{{ value_type.name }}(stream, {{ value_type.structgetval }}value->e{{ loop.index0 }}));
+    KRPC_CALLBACK_RETURN_ON_ERROR(krpc_encode_{{ value_type.name }}(stream, {{ value_type.structgetval }}value->{{ value_type.member }}));
   }
   {% endfor %}
   return true;
 }
-{% elif typ.name.startswith('list_') %}
+{% elif typ.kind == 'list' %}
 static inline bool krpc_encode_callback_items_{{ typ.name }}(
   pb_ostream_t * stream, const pb_field_t * field, void * const * arg) {
   const {{ typ.ctype }} * value = (const {{ typ.ctype }}*)(*arg);
@@ -226,7 +226,7 @@ static inline bool krpc_encode_callback_items_{{ typ.name }}(
   }
   return true;
 }
-{% elif typ.name.startswith('set_') %}
+{% elif typ.kind == 'set' %}
 static inline bool krpc_encode_callback_items_{{ typ.name }}(
   pb_ostream_t * stream, const pb_field_t * field, void * const * arg) {
   const {{ typ.ctype }} * value = (const {{ typ.ctype }}*)(*arg);
@@ -242,7 +242,7 @@ static inline bool krpc_encode_callback_items_{{ typ.name }}(
   }
   return true;
 }
-{% elif typ.name.startswith('dictionary_') %}
+{% elif typ.kind == 'dictionary' %}
 static inline bool krpc_encode_callback_key_{{ typ.name }}(
   pb_ostream_t * stream, const pb_field_t * field, void * const * arg) {
   if (!pb_encode_tag_for_field(stream, field))
@@ -293,22 +293,22 @@ static inline bool krpc_encode_callback_entry_{{ typ.name }}(
 
 static inline krpc_error_t krpc_encode_{{ typ.name }}(
   pb_ostream_t * stream, {{ typ.ccvtype }} value) {
-{% if typ.name.startswith('tuple_') %}
+{% if typ.kind in ('tuple', 'struct') %}
   krpc_schema_Tuple message = krpc_schema_Tuple_init_default;
   message.items.funcs.encode = &krpc_encode_callback_items_{{ typ.name }};
   message.items.arg = {{ typ.removeconst }}{{ typ.getptr }}value;
   KRPC_RETURN_ON_ERROR(krpc_encode_message_Tuple(stream, &message));
-{% elif typ.name.startswith('list_') %}
+{% elif typ.kind == 'list' %}
   krpc_schema_List message = krpc_schema_List_init_default;
   message.items.funcs.encode = &krpc_encode_callback_items_{{ typ.name }};
   message.items.arg = {{ typ.removeconst }}{{ typ.getptr }}value;
   KRPC_RETURN_ON_ERROR(krpc_encode_message_List(stream, &message));
-{% elif typ.name.startswith('set_') %}
+{% elif typ.kind == 'set' %}
   krpc_schema_Set message = krpc_schema_Set_init_default;
   message.items.funcs.encode = &krpc_encode_callback_items_{{ typ.name }};
   message.items.arg = {{ typ.removeconst }}{{ typ.getptr }}value;
   KRPC_RETURN_ON_ERROR(krpc_encode_message_Set(stream, &message));
-{% elif typ.name.startswith('dictionary_') %}
+{% elif typ.kind == 'dictionary' %}
   krpc_schema_Dictionary message = krpc_schema_Dictionary_init_default;
   message.entries.funcs.encode = &krpc_encode_callback_entry_{{ typ.name }};
   message.entries.arg = {{ typ.removeconst }}{{ typ.getptr }}value;
@@ -338,7 +338,7 @@ static inline bool krpc_encode_callback_{{ typ.name }}(
   return true;
 }
 
-{% if typ.name.startswith('tuple_') %}
+{% if typ.kind in ('tuple', 'struct') %}
 static inline bool krpc_decode_callback_item_{{ typ.name }}(
   pb_istream_t * stream, const pb_field_t * field, void ** arg) {
   typedef struct State {size_t pos; {{ typ.ctype }} * value;} State;
@@ -347,16 +347,24 @@ static inline bool krpc_decode_callback_item_{{ typ.name }}(
   switch (state->pos) {
   {% for value_type in typ.value_types %}
   case {{ loop.index0 }}:
-    KRPC_CALLBACK_RETURN_ON_ERROR(krpc_decode_{{ value_type.name }}(stream, {{ value_type.structgetptr }}value->e{{ loop.index0 }}));
+    KRPC_CALLBACK_RETURN_ON_ERROR(krpc_decode_{{ value_type.name }}(stream, {{ value_type.structgetptr }}value->{{ value_type.member }}));
     break;
   {% endfor %}
   default:
+{% if typ.kind == 'struct' %}
+    // Fields are only ever appended to a structure, so a value from a newer server may
+    // carry more items than this client knows about, and those are skipped
+    if (!pb_read(stream, NULL, stream->bytes_left))
+      KRPC_CALLBACK_RETURN_ERROR("skipping an appended struct field");
+    break;
+{% else %}
     KRPC_CALLBACK_RETURN_ERROR("unexpected tuple item");
+{% endif %}
   }
   state->pos++;
   return true;
 }
-{% elif typ.name.startswith('list_') or typ.name.startswith('set_') %}
+{% elif typ.kind in ('list', 'set') %}
 static inline bool krpc_decode_callback_item_{{ typ.name }}(
   pb_istream_t * stream, const pb_field_t * field, void ** arg) {
   typedef struct State { size_t capacity; {{ typ.ctype }} * value; } State;
@@ -370,7 +378,7 @@ static inline bool krpc_decode_callback_item_{{ typ.name }}(
   KRPC_CALLBACK_RETURN_ON_ERROR(krpc_decode_{{ typ.value_type.name }}(stream, {{ typ.value_type.structgetptr }}state->value->items[i]));
   return true;
 }
-{% elif typ.name.startswith('dictionary_') %}
+{% elif typ.kind == 'dictionary' %}
 static inline bool krpc_decode_callback_key_{{ typ.name }}(
   pb_istream_t * stream, const pb_field_t * field, void ** arg) {
   {{ typ.key_type.ctype }} * key = ({{ typ.key_type.ctype }}*)(*arg);
@@ -408,14 +416,18 @@ static inline bool krpc_decode_callback_entry_{{ typ.name }}(
 
 static inline krpc_error_t krpc_decode_{{ typ.name }}(
   pb_istream_t * stream, {{ typ.ctype }} * value) {
-{% if typ.name.startswith('tuple_') %}
+{% if typ.kind in ('tuple', 'struct') %}
   krpc_schema_Tuple message = krpc_schema_Tuple_init_default;
   message.items.funcs.decode = &krpc_decode_callback_item_{{ typ.name }};
   typedef struct State { size_t pos; {{ typ.ctype }} * value; } State;
   State state = { 0, value };
   message.items.arg = &state;
   KRPC_RETURN_ON_ERROR(krpc_decode_message_Tuple(stream, &message));
-{% elif typ.name.startswith('list_') or typ.name.startswith('set_') %}
+{% if typ.kind == 'struct' %}
+  if (state.pos < {{ typ.value_types | length }})
+    KRPC_RETURN_ERROR(DECODING_FAILED, "too few fields for a {{ typ.name }}");
+{% endif %}
+{% elif typ.kind in ('list', 'set') %}
   typedef struct State { size_t capacity; {{ typ.ctype }} * value; } State;
   State state = { 0, value };
   value->size = 0;
@@ -423,18 +435,18 @@ static inline krpc_error_t krpc_decode_{{ typ.name }}(
     value->items = ({{ typ.value_type.ctype }}*)krpc_calloc(KRPC_ALLOC_BLOCK_SIZE, sizeof({{ typ.value_type.ctype }}));
     state.capacity = KRPC_ALLOC_BLOCK_SIZE;
   }
-  {% if typ.name.startswith('list_') %}
+  {% if typ.kind == 'list' %}
   krpc_schema_List message = krpc_schema_List_init_default;
   message.items.funcs.decode = &krpc_decode_callback_item_{{ typ.name }};
   message.items.arg = &state;
   KRPC_RETURN_ON_ERROR(krpc_decode_message_List(stream, &message));
-  {% elif typ.name.startswith('set_') %}
+  {% elif typ.kind == 'set' %}
   krpc_schema_Set message = krpc_schema_Set_init_default;
   message.items.funcs.decode = &krpc_decode_callback_item_{{ typ.name }};
   message.items.arg = &state;
   KRPC_RETURN_ON_ERROR(krpc_decode_message_Set(stream, &message));
   {% endif %}
-{% elif typ.name.startswith('dictionary_') %}
+{% elif typ.kind == 'dictionary' %}
   typedef struct State { size_t capacity; {{ typ.ctype }} * value; } State;
   State state = { 0, value };
   value->size = 0;

--- a/tools/krpctools/krpctools/clientgen/cpp.py
+++ b/tools/krpctools/krpctools/clientgen/cpp.py
@@ -144,11 +144,14 @@ class CppGenerator(Generator):
             list(context["procedures"].values())
             + list(context["properties"].values())
             + list(context["enumerations"].values())
+            + list(context["structs"].values())
             + list(context["exceptions"].values())
             + list(context["classes"].values())
         )
         for enm in context["enumerations"].values():
             deprecatable += list(enm["values"])
+        for struct_info in context["structs"].values():
+            deprecatable += list(struct_info["fields"])
         for class_info in context["classes"].values():
             deprecatable += (
                 list(class_info["methods"].values())

--- a/tools/krpctools/krpctools/clientgen/cpp.tmpl
+++ b/tools/krpctools/krpctools/clientgen/cpp.tmpl
@@ -56,6 +56,13 @@ class {{ service_name }} : public Service {
   class {{ class_name }};
   {% endfor %}
   {% endif %}
+  {% if structs | length > 0 %}
+
+  // Structure forward declarations
+  {% for struct_name in structs.keys() %}
+  struct {{ struct_name }};
+  {% endfor %}
+  {% endif %}
   {% if exceptions | length > 0 %}
   {% for exception_name,exception in exceptions.items() %}
 
@@ -179,10 +186,35 @@ class {{ service_name }} : public Service {
     {% endfor %}
   };
   {% endfor %}
+  {% for struct_name,struct in structs.items() %}
+
+{% if struct.documentation %}{{ struct.documentation | indent(width=2) }}
+{% endif %}
+  struct {% if struct.deprecated %}[[deprecated{% if struct.deprecated_reason %}("{{ struct.deprecated_reason }}"){% endif %}]] {% endif %}{{ struct_name }} {
+    {% for field in struct['fields'] %}
+{% if field.documentation %}{{ field.documentation | indent(width=4) }}
+{% endif %}
+    {{ field.type }} {{ field.name }}{% if field.deprecated %} [[deprecated{% if field.deprecated_reason %}("{{ field.deprecated_reason }}"){% endif %}]]{% endif %};
+    {% endfor %}
+
+    {{ struct_name }}() : {% for field in struct['fields'] %}{{ field.name }}(){% if not loop.last %}, {% endif %}{% endfor %} {}
+
+    {{ struct_name }}({% for field in struct['fields'] %}{{ field.type }} {{ field.name }}{% if not loop.last %}, {% endif %}{% endfor %}) :
+      {% for field in struct['fields'] %}{{ field.name }}({{ field.name }}){% if not loop.last %}, {% endif %}{% endfor %} {}
+
+    bool operator==(const {{ struct_name }}& other) const {
+      return {% for field in struct['fields'] %}this->{{ field.name }} == other.{{ field.name }}{% if not loop.last %} && {% endif %}{% endfor %};
+    }
+
+    bool operator!=(const {{ struct_name }}& other) const {
+      return !(*this == other);
+    }
+  };
+  {% endfor %}
 };
 
 }  // namespace services
-{% if enumerations | length > 0 %}
+{% if enumerations | length > 0 or structs | length > 0 %}
 
 namespace encoder {
   {% for enum_name,enm in enumerations.items() %}
@@ -197,6 +229,31 @@ namespace encoder {
     return krpc::encoder::encode(static_cast<int32_t>(value));
   }
   {% if enm.deprecated %}
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
+  {% endif %}
+  {% endfor %}
+  {% for struct_name,struct in structs.items() %}
+
+  {% if struct.deprecated %}
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+  {% endif %}
+  // A structure is sent as the values of its fields in order, which is the same encoding as
+  // a tuple of those values. See the note on the collection encoders for why the message it
+  // is sent in is kept between calls.
+  inline std::string encode(const services::{{ service_name }}::{{ struct_name }}& value) {
+    static thread_local krpc::schema::Tuple structMessage;
+    structMessage.Clear();
+    {% for field in struct['fields'] %}
+    structMessage.add_items(encode(value.{{ field.name }}));
+    {% endfor %}
+    return krpc::encoder::encode(structMessage);
+  }
+  {% if struct.deprecated %}
 #if defined(__GNUC__)
 #pragma GCC diagnostic pop
 #endif
@@ -220,6 +277,31 @@ namespace decoder {
     value = static_cast<services::{{ service_name }}::{{ enum_name }}>(x);
   }
   {% if enm.deprecated %}
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
+  {% endif %}
+  {% endfor %}
+  {% for struct_name,struct in structs.items() %}
+
+  {% if struct.deprecated %}
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+  {% endif %}
+  // Fields are only ever appended to a structure, so a value from a newer server may carry
+  // more items than this client knows about, and those are ignored.
+  inline void decode(services::{{ service_name }}::{{ struct_name }}& value, const std::string& data, Client* client) {
+    static thread_local krpc::schema::Tuple structMessage;
+    if (!structMessage.ParseFromString(data)) throw EncodingError("Failed to decode message");
+    if (structMessage.items_size() < {{ struct['fields'] | length }})
+      throw EncodingError("Value for {{ struct_name }} does not have all of its fields");
+    {% for field in struct['fields'] %}
+    decode(value.{{ field.name }}, structMessage.items({{ loop.index0 }}), client);
+    {% endfor %}
+  }
+  {% if struct.deprecated %}
 #if defined(__GNUC__)
 #pragma GCC diagnostic pop
 #endif
@@ -250,6 +332,27 @@ namespace services {
     decoder::decode(value, data, client);
   }
   {% if enm.deprecated %}
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
+  {% endif %}
+  {% endfor %}
+  {% for struct_name,struct in structs.items() %}
+
+  {% if struct.deprecated %}
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+  {% endif %}
+  inline std::string encode(const {{ service_name }}::{{ struct_name }}& value) {
+    return encoder::encode(value);
+  }
+
+  inline void decode({{ service_name }}::{{ struct_name }}& value, const std::string& data, Client* client) {
+    decoder::decode(value, data, client);
+  }
+  {% if struct.deprecated %}
 #if defined(__GNUC__)
 #pragma GCC diagnostic pop
 #endif

--- a/tools/krpctools/krpctools/clientgen/csharp.py
+++ b/tools/krpctools/krpctools/clientgen/csharp.py
@@ -1,6 +1,6 @@
 # pylint: disable=no-name-in-module
 from krpc.schema.KRPC_pb2 import Type
-from krpc.types import ValueType, EnumerationType
+from krpc.types import ValueType, EnumerationType, StructType
 from .generator import Generator
 from ..lang.csharp import CsharpLanguage
 from ..utils import as_type
@@ -14,7 +14,7 @@ class CsharpGenerator(Generator):
     def _is_nullable_value_type(typ):
         # C# reference types (string, byte[], classes and collections) carry null
         # naturally; only genuine value types need the nullable form T?.
-        if isinstance(typ, EnumerationType):
+        if isinstance(typ, (EnumerationType, StructType)):
             return True
         if isinstance(typ, ValueType):
             return typ.protobuf_type.code not in (Type.STRING, Type.BYTES)
@@ -43,7 +43,18 @@ class CsharpGenerator(Generator):
                 continue
             ctype = parameter["type"]
             default_value = parameter["default_value"]
-            if (
+            if isinstance(typ, StructType):
+                # A structure is a value type, and its default value is not a compile-time
+                # constant, so the parameter takes the nullable form and the default is
+                # applied where the value is encoded
+                if not ctype.endswith("?"):
+                    parameter["type"] = ctype + "?"
+                parameter["name_value"] = "%s ?? %s" % (
+                    parameter["name"],
+                    default_value,
+                )
+                parameter["default_value"] = "null"
+            elif (
                 ctype.startswith("systemAlias::Tuple")
                 or ctype.startswith("global::System.Collections.Generic.IList")
                 or ctype.startswith("genericCollectionsAlias::ISet")

--- a/tools/krpctools/krpctools/clientgen/csharp.tmpl
+++ b/tools/krpctools/krpctools/clientgen/csharp.tmpl
@@ -144,6 +144,79 @@ namespace KRPC.Client.Services.{{ service_name }}
         {% endfor %}
     }
     {% endfor %}
+    {% for struct_name,struct in structs.items() %}
+
+{% if struct.documentation %}{{ struct.documentation | indent(width=4) }}
+{% endif %}
+    [Serializable]
+    [global::KRPC.Client.Attributes.KRPCStruct]
+{% if struct.deprecated %}    [global::System.Obsolete{% if struct.deprecated_reason %} ("{{ struct.deprecated_reason }}"){% endif %}]
+{% endif %}
+    public struct {{ struct_name }} : IEquatable<{{ struct_name }}>
+    {
+        /// <summary>
+        /// Construct a {{ struct_name }} from the values of its fields.
+        /// </summary>
+        public {{ struct_name }} ({% for field in struct['fields'] %}{{ field.type }} {{ field.name | lower_camel_case }}{% if not loop.last %}, {% endif %}{% endfor %}) : this ()
+        {
+            {% for field in struct['fields'] %}
+            {{ field.name }} = {{ field.name | lower_camel_case }};
+            {% endfor %}
+        }
+        {% for field in struct['fields'] %}
+
+{% if field.documentation %}{{ field.documentation | indent(width=8) }}
+{% endif %}
+{% if field.deprecated %}        [global::System.Obsolete{% if field.deprecated_reason %} ("{{ field.deprecated_reason }}"){% endif %}]
+{% endif %}
+        public {{ field.type }} {{ field.name }} { get; private set; }
+        {% endfor %}
+
+        /// <summary>
+        /// Returns true if this {{ struct_name }} is equal to the given object.
+        /// </summary>
+        public override bool Equals (object obj)
+        {
+            return obj is {{ struct_name }} && Equals (({{ struct_name }})obj);
+        }
+
+        /// <summary>
+        /// Returns true if this {{ struct_name }} is equal to the given one.
+        /// </summary>
+        public bool Equals ({{ struct_name }} other)
+        {
+            return {% for field in struct['fields'] %}global::KRPC.Client.ValueUtils.Equal ({{ field.name }}, other.{{ field.name }}){% if not loop.last %} && {% endif %}{% endfor %};
+        }
+
+        /// <summary>
+        /// Returns a hash code for this {{ struct_name }}.
+        /// </summary>
+        public override int GetHashCode ()
+        {
+            int hash = 17;
+            {% for field in struct['fields'] %}
+            hash = hash * 31 + global::KRPC.Client.ValueUtils.HashCode ({{ field.name }});
+            {% endfor %}
+            return hash;
+        }
+
+        /// <summary>
+        /// Returns true if the two {{ struct_name }} values are equal.
+        /// </summary>
+        public static bool operator == ({{ struct_name }} lhs, {{ struct_name }} rhs)
+        {
+            return lhs.Equals (rhs);
+        }
+
+        /// <summary>
+        /// Returns true if the two {{ struct_name }} values are not equal.
+        /// </summary>
+        public static bool operator != ({{ struct_name }} lhs, {{ struct_name }} rhs)
+        {
+            return !lhs.Equals (rhs);
+        }
+    }
+    {% endfor %}
     {% for exception_name,exception in exceptions.items() %}
 
 {% if exception.documentation %}{{ exception.documentation | indent(width=4) }}

--- a/tools/krpctools/krpctools/clientgen/generator.py
+++ b/tools/krpctools/krpctools/clientgen/generator.py
@@ -1,6 +1,14 @@
 import collections
 import jinja2
 from krpc.attributes import Attributes
+from krpc.definitions import topological_order
+from krpc.types import (
+    DictionaryType,
+    ListType,
+    SetType,
+    StructType,
+    TupleType,
+)
 from krpc.utils import snake_case
 from ..utils import lower_camel_case, indent, single_line, as_type, decode_default_value
 from .docparser import flatten_deprecation_reason
@@ -330,7 +338,9 @@ class Generator:
         context["procedures"] = sort_dict(context["procedures"])
         context["properties"] = sort_dict(context["properties"])
         context["enumerations"] = sort_dict(context["enumerations"])
-        context["structs"] = sort_dict(context["structs"])
+        context["structs"] = _ordered_structs(
+            sort_dict(context["structs"]), self.service_name
+        )
         context["classes"] = sort_dict(context["classes"])
         context["exceptions"] = sort_dict(context["exceptions"])
         for cls in context["classes"].values():
@@ -363,3 +373,37 @@ class Generator:
 
     def parse_default_value(self, value, typ):
         return self.language.parse_default_value(value, typ)
+
+
+def _ordered_structs(structs, service_name):
+    """The given structures, which are the ones the named service defines, ordered so that
+    each follows the ones its fields carry. A generated declaration of a structure names the
+    types of its fields, and C and C++ need a type to be declared before it is named."""
+
+    def dependencies(item):
+        _, struct = item
+        names = set()
+        for field in struct["fields"]:
+            names.update(_struct_names_in(field["krpc_type"]))
+        return [
+            (name, structs[name])
+            for service, name in sorted(names)
+            if service == service_name and name in structs
+        ]
+
+    ordered = topological_order(structs.items(), lambda item: item[0], dependencies)
+    return collections.OrderedDict(ordered)
+
+
+def _struct_names_in(typ):
+    """The service and name of every structure the given type is, or holds in a collection"""
+    if isinstance(typ, StructType):
+        yield (typ.protobuf_type.service, typ.protobuf_type.name)
+    elif isinstance(typ, TupleType):
+        for value_type in typ.value_types:
+            yield from _struct_names_in(value_type)
+    elif isinstance(typ, (ListType, SetType)):
+        yield from _struct_names_in(typ.value_type)
+    elif isinstance(typ, DictionaryType):
+        yield from _struct_names_in(typ.key_type)
+        yield from _struct_names_in(typ.value_type)

--- a/tools/krpctools/krpctools/clientgen/generator.py
+++ b/tools/krpctools/krpctools/clientgen/generator.py
@@ -103,6 +103,7 @@ class Generator:
             "properties": {},
             "classes": {},
             "enumerations": {},
+            "structs": {},
             "exceptions": {},
         }
 
@@ -136,6 +137,29 @@ class Generator:
                 "deprecated": enumeration.get("deprecated", False),
                 "deprecated_reason": self.parse_deprecation_reason(
                     enumeration.get("deprecated_reason", "")
+                ),
+            }
+
+        for name, struct in self._get_defs("structs"):
+            context["structs"][name] = {
+                "fields": [
+                    {
+                        "name": self.parse_name(x["name"]),
+                        "remote_name": x["name"],
+                        "krpc_type": self.as_type(x["type"]),
+                        "type": self.parse_type(self.as_type(x["type"])),
+                        "documentation": self.parse_documentation(x["documentation"]),
+                        "deprecated": x.get("deprecated", False),
+                        "deprecated_reason": self.parse_deprecation_reason(
+                            x.get("deprecated_reason", "")
+                        ),
+                    }
+                    for x in struct["fields"]
+                ],
+                "documentation": self.parse_documentation(struct["documentation"]),
+                "deprecated": struct.get("deprecated", False),
+                "deprecated_reason": self.parse_deprecation_reason(
+                    struct.get("deprecated_reason", "")
                 ),
             }
 
@@ -306,6 +330,7 @@ class Generator:
         context["procedures"] = sort_dict(context["procedures"])
         context["properties"] = sort_dict(context["properties"])
         context["enumerations"] = sort_dict(context["enumerations"])
+        context["structs"] = sort_dict(context["structs"])
         context["classes"] = sort_dict(context["classes"])
         context["exceptions"] = sort_dict(context["exceptions"])
         for cls in context["classes"].values():
@@ -314,6 +339,10 @@ class Generator:
             cls["properties"] = sort_dict(cls["properties"])
 
         return context
+
+    def as_type(self, type_info):
+        """Convert a type parsed from the service definitions into a type object"""
+        return as_type(self.types, type_info)
 
     def get_return_type(self, procedure):
         if "return_type" not in procedure:

--- a/tools/krpctools/krpctools/clientgen/java.py
+++ b/tools/krpctools/krpctools/clientgen/java.py
@@ -117,6 +117,14 @@ class JavaGenerator(Generator):
             "nullable": nullable,
         }
 
+    def add_struct_field_specifications(self, context):
+        """Add to every field of a structure the type specification and the accessor name its
+        generated declaration is written with"""
+        for struct_info in context["structs"].values():
+            for field in struct_info["fields"]:
+                field["spec"] = self.parse_type_specification(field["krpc_type"])
+                field["accessor_name"] = upper_camel_case(field["name"])
+
     def parse_context(self, context):
         # Expand service properties into get and set methods
         properties = collections.OrderedDict()
@@ -224,12 +232,7 @@ class JavaGenerator(Generator):
             for value in enm["values"]:
                 value["name"] = self.language.parse_const_name(value["name"])
 
-        # Add the type specification of every field of a structure, which its generated
-        # declaration needs to give the encoding the types of its fields
-        for struct_info in context["structs"].values():
-            for field in struct_info["fields"]:
-                field["spec"] = self.parse_type_specification(field["krpc_type"])
-                field["accessor_name"] = upper_camel_case(field["name"])
+        self.add_struct_field_specifications(context)
 
         # Add serial version UIDs to classes
         items = list(context["classes"].items()) + list(context["exceptions"].items())

--- a/tools/krpctools/krpctools/clientgen/java.py
+++ b/tools/krpctools/krpctools/clientgen/java.py
@@ -8,6 +8,7 @@ from krpc.types import (
     ValueType,
     ClassType,
     EnumerationType,
+    StructType,
     MessageType,
     TupleType,
     ListType,
@@ -48,6 +49,11 @@ class JavaGenerator(Generator):
             )
         if isinstance(typ, EnumerationType):
             return 'krpc.client.Types.createEnumeration("%s", "%s")' % (
+                typ.protobuf_type.service,
+                typ.protobuf_type.name,
+            )
+        if isinstance(typ, StructType):
+            return 'krpc.client.Types.createStruct("%s", "%s")' % (
                 typ.protobuf_type.service,
                 typ.protobuf_type.name,
             )
@@ -218,6 +224,13 @@ class JavaGenerator(Generator):
             for value in enm["values"]:
                 value["name"] = self.language.parse_const_name(value["name"])
 
+        # Add the type specification of every field of a structure, which its generated
+        # declaration needs to give the encoding the types of its fields
+        for struct_info in context["structs"].values():
+            for field in struct_info["fields"]:
+                field["spec"] = self.parse_type_specification(field["krpc_type"])
+                field["accessor_name"] = upper_camel_case(field["name"])
+
         # Add serial version UIDs to classes
         items = list(context["classes"].items()) + list(context["exceptions"].items())
         for class_name, cls in items:
@@ -230,11 +243,17 @@ class JavaGenerator(Generator):
             list(context["procedures"].values())
             + list(context["properties"].values())
             + list(context["enumerations"].values())
+            + list(context["structs"].values())
             + list(context["exceptions"].values())
             + list(context["classes"].values())
         )
         for enm in context["enumerations"].values():
             deprecatable += list(enm["values"])
+        deprecatable += [
+            field
+            for struct_info in context["structs"].values()
+            for field in struct_info["fields"]
+        ]
         for cls in context["classes"].values():
             deprecatable += (
                 list(cls["methods"].values())

--- a/tools/krpctools/krpctools/clientgen/java.tmpl
+++ b/tools/krpctools/krpctools/clientgen/java.tmpl
@@ -28,6 +28,7 @@ import krpc.client.Connection;
 import krpc.client.Encoder;
 import krpc.client.RemoteEnum;
 import krpc.client.RemoteObject;
+import krpc.client.RemoteStruct;
 import krpc.client.RPCInfo;
 import krpc.client.RPCException;
 import krpc.client.Types;
@@ -124,6 +125,83 @@ public class {{ service_name }} {
             {% endfor %}
             }
             return null;
+        }
+    }
+    {% endfor %}
+    {% for struct_name,struct in structs.items() %}
+
+{% if struct.documentation %}{{ struct.documentation | indent(width=4) }}
+{% endif %}
+{% if struct.deprecated %}    @Deprecated
+{% endif %}
+    public static class {{ struct_name }} implements RemoteStruct {
+        {% for field in struct['fields'] %}
+        private final {{ field.type }} {{ field.name }};
+        {% endfor %}
+
+        public {{ struct_name }}({% for field in struct['fields'] %}{{ field.type }} {{ field.name }}{% if not loop.last %}, {% endif %}{% endfor %}) {
+            {% for field in struct['fields'] %}
+            this.{{ field.name }} = {{ field.name }};
+            {% endfor %}
+        }
+        {% for field in struct['fields'] %}
+
+{% if field.documentation %}{{ field.documentation | indent(width=8) }}
+{% endif %}
+{% if field.deprecated %}        @Deprecated
+{% endif %}
+        public {{ field.type }} get{{ field.accessor_name }}() {
+            return {{ field.name }};
+        }
+        {% endfor %}
+
+        private static final java.util.List<krpc.schema.KRPC.Type> FIELD_TYPES =
+            java.util.Collections.unmodifiableList(java.util.Arrays.asList(
+                {% for field in struct['fields'] %}
+                {{ field.spec }}{% if not loop.last %},{% endif %}
+
+                {% endfor %}
+            ));
+
+        /** The types of the fields, in the order they are encoded in. */
+        public static java.util.List<krpc.schema.KRPC.Type> fieldTypes() {
+            return FIELD_TYPES;
+        }
+
+        /** Build a {{ struct_name }} from the values of its fields. */
+        @SuppressWarnings("unchecked")
+        public static {{ struct_name }} fromFieldValues(Object[] values) {
+            return new {{ struct_name }}(
+                {% for field in struct['fields'] %}
+                ({{ field.type }}) values[{{ loop.index0 }}]{% if not loop.last %},{% endif %}
+
+                {% endfor %}
+            );
+        }
+
+        @Override
+        public Object[] fieldValues() {
+            return new Object[] {
+                {% for field in struct['fields'] %}
+                {{ field.name }}{% if not loop.last %},{% endif %}
+
+                {% endfor %}
+            };
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (!(obj instanceof {{ struct_name }})) {
+                return false;
+            }
+            {{ struct_name }} other = ({{ struct_name }}) obj;
+            return {% for field in struct['fields'] %}java.util.Objects.equals(this.{{ field.name }}, other.{{ field.name }}){% if not loop.last %}
+                && {% endif %}{% endfor %};
+        }
+
+        @Override
+        public int hashCode() {
+            return java.util.Objects.hash({% for field in struct['fields'] %}{{ field.name }}{% if not loop.last %}, {% endif %}{% endfor %});
         }
     }
     {% endfor %}

--- a/tools/krpctools/krpctools/clientgen/python.py
+++ b/tools/krpctools/krpctools/clientgen/python.py
@@ -5,6 +5,7 @@ from krpc.types import (
     ClassType,
     EnumerationType,
     MessageType,
+    StructType,
     TupleType,
     ListType,
     SetType,
@@ -27,7 +28,7 @@ class StubLanguage(PythonLanguage):
         self.module = service
 
     def parse_type(self, typ):
-        if isinstance(typ, (ClassType, EnumerationType)):
+        if isinstance(typ, (ClassType, EnumerationType, StructType)):
             name = typ.protobuf_type.name
             if typ.protobuf_type.service != self.module:
                 name = typ.protobuf_type.service.lower() + "." + name
@@ -71,6 +72,11 @@ class PythonGenerator(Generator):
                 typ.protobuf_type.service,
                 typ.protobuf_type.name,
             )
+        if isinstance(typ, StructType):
+            return 'self._client._types.struct_type("%s", "%s")' % (
+                typ.protobuf_type.service,
+                typ.protobuf_type.name,
+            )
         if isinstance(typ, TupleType):
             return "self._client._types.tuple_type(%s)" % ", ".join(
                 self.parse_python_type(x) for x in typ.value_types
@@ -100,7 +106,7 @@ class PythonGenerator(Generator):
                 spec = "Event"
             else:
                 return "KRPC_pb2.%s" % typ.python_type.__name__
-        elif isinstance(typ, (ClassType, EnumerationType)):
+        elif isinstance(typ, (ClassType, EnumerationType, StructType)):
             spec = self.language.parse_type(typ)
         elif isinstance(typ, TupleType):
             spec = "Tuple[%s]" % ",".join(
@@ -234,7 +240,10 @@ class PythonGenerator(Generator):
                         and context["service_name"] != ptype["service"]
                     ):
                         dependencies.add(ptype["service"])
+        dependencies |= self.struct_field_dependencies(context)
         context["dependencies"] = dependencies
+
+        self.add_struct_field_specifications(context)
 
         # Add type specifications to types
         procedures = (
@@ -310,6 +319,24 @@ class PythonGenerator(Generator):
         self.add_deprecated_docstrings(context)
         return context
 
+    @staticmethod
+    def struct_field_dependencies(context):
+        """The other services whose types the fields of this service's structures name, which
+        the generated module has to import to name them"""
+        dependencies = set()
+        for struct_info in context["structs"].values():
+            for field in struct_info["fields"]:
+                service = field["krpc_type"].protobuf_type.service
+                if service and service != context["service_name"]:
+                    dependencies.add(service)
+        return dependencies
+
+    def add_struct_field_specifications(self, context):
+        """Add the type annotation each field of a structure is declared with"""
+        for struct_info in context["structs"].values():
+            for field in struct_info["fields"]:
+                field["spec"] = self.parse_type_specification(field["krpc_type"])
+
     @classmethod
     def add_deprecated_docstrings(cls, context):
         # Prepend a "Deprecated:" line to the docstring of every deprecated member/type
@@ -321,9 +348,12 @@ class PythonGenerator(Generator):
                 for accessor in property.values()
             ]
             + list(context["enumerations"].values())
+            + list(context["structs"].values())
             + list(context["exceptions"].values())
             + list(context["classes"].values())
         )
+        for struct_info in context["structs"].values():
+            deprecatable += list(struct_info["fields"])
         for class_info in context["classes"].values():
             deprecatable += list(class_info["methods"].values())
             deprecatable += list(class_info["static_methods"].values())

--- a/tools/krpctools/krpctools/clientgen/python.tmpl
+++ b/tools/krpctools/krpctools/clientgen/python.tmpl
@@ -1,7 +1,7 @@
 # pylint: disable=line-too-long,invalid-name,redefined-builtin,too-many-lines
 from __future__ import annotations
 import warnings
-from typing import Tuple, Set, Dict, List, Optional, TYPE_CHECKING
+from typing import Tuple, Set, Dict, List, NamedTuple, Optional, TYPE_CHECKING
 import krpc.limits
 import krpc.schema
 from krpc.schema import KRPC_pb2
@@ -29,6 +29,18 @@ class {{enum_name}}(DocEnum):
     {% for enum_value in enumeration['values'] %}
     {{enum_value['name']}} = {{enum_value['value']}}{% if enum_value.documentation %}, {{ enum_value.documentation }}{% endif %}
 
+    {% endfor %}
+
+
+{% endfor %}
+{% for struct_name, struct in structs.items() %}
+class {{struct_name}}(NamedTuple):
+{% if struct.documentation %}{{ struct.documentation | indent(width=4) }}
+{% endif %}
+    {% for field in struct['fields'] %}
+    {{field.name}}: {{ field.spec }}
+{% if field.documentation %}{{ field.documentation | indent(width=4) }}
+{% endif %}
     {% endfor %}
 
 
@@ -165,12 +177,13 @@ class {{ service_name }}:
 
     def __init__(self, client: Client) -> None:
         self._client = client
-        # The classes, enumerations and exceptions the service defines are put on the
-        # service here, so that reaching one is an ordinary attribute lookup and nothing
-        # has to intercept the lookups that do not name one - which is every call, as a
-        # call goes through a procedure or a property. A class is bound to the client it
-        # is reached through, so that its static methods use that client.
+        # The classes, enumerations, structures and exceptions the service defines are
+        # put on the service here, so that reaching one is an ordinary attribute lookup
+        # and nothing has to intercept the lookups that do not name one - which is every
+        # call, as a call goes through a procedure or a property. A class is bound to the
+        # client it is reached through, so that its static methods use that client.
         self.__dict__.update(self._enumerations)
+        self.__dict__.update(self._structs)
         self.__dict__.update(self._exceptions)
         for name, class_type in self._classes.items():
             self.__dict__[name] = WrappedClass(client, class_type)
@@ -199,6 +212,11 @@ class {{ service_name }}:
     _enumerations = {
     {% for enum_name in enumerations.keys() %}
         "{{ enum_name }}": {{ enum_name }},
+    {% endfor %}
+    }
+    _structs = {
+    {% for struct_name in structs.keys() %}
+        "{{ struct_name }}": {{ struct_name }},
     {% endfor %}
     }
     _exceptions = {

--- a/tools/krpctools/krpctools/definitions.py
+++ b/tools/krpctools/krpctools/definitions.py
@@ -7,7 +7,7 @@ from krpc.definitions import (
     register_all,
     topological_order,
 )
-from krpc.types import Types, TupleType, ListType, SetType, DictionaryType
+from krpc.types import Types, TupleType, ListType, SetType, DictionaryType, StructType
 from .utils import as_type, as_protobuf_type
 
 
@@ -39,8 +39,9 @@ class Definitions:
 
     @staticmethod
     def collection_types(types):
-        """The collection types among the given types, and the collection types they contain,
-        innermost first, so that a type always follows the types it is composed of."""
+        """The structural types among the given types, and the ones they contain, innermost
+        first, so that a type always follows the types it is composed of. A structure counts as
+        one, as it is composed of the types of its fields in the same way."""
         return topological_order(
             [typ for typ in types if _is_collection(typ)],
             lambda typ: typ.protobuf_type.SerializeToString(),
@@ -129,12 +130,14 @@ def _register_exception(service, name):
 
 
 def _is_collection(typ):
-    return isinstance(typ, (TupleType, ListType, SetType, DictionaryType))
+    return isinstance(typ, (TupleType, ListType, SetType, DictionaryType, StructType))
 
 
 def _contained_collection_types(typ):
     if isinstance(typ, TupleType):
         contained = typ.value_types
+    elif isinstance(typ, StructType):
+        contained = typ.field_types
     elif isinstance(typ, (ListType, SetType)):
         contained = [typ.value_type]
     elif isinstance(typ, DictionaryType):

--- a/tools/krpctools/krpctools/definitions.py
+++ b/tools/krpctools/krpctools/definitions.py
@@ -2,12 +2,13 @@ from krpc.definitions import (
     CLASS,
     ENUMERATION,
     EXCEPTION,
+    STRUCT,
     Definition,
     register_all,
     topological_order,
 )
 from krpc.types import Types, TupleType, ListType, SetType, DictionaryType
-from .utils import as_type
+from .utils import as_type, as_protobuf_type
 
 
 class Definitions:
@@ -70,6 +71,16 @@ def _definitions(services_info):
                 [],
                 _register_exception(service_name, name),
             )
+        for name, struct in info.get("structs", {}).items():
+            # A structure is registered after the definitions its field types name, as
+            # building its fields resolves those types
+            yield Definition(
+                STRUCT,
+                service_name,
+                name,
+                [as_protobuf_type(field["type"]) for field in struct["fields"]],
+                _register_struct(service_name, name, struct),
+            )
 
 
 def _register_class(service, name):
@@ -91,6 +102,21 @@ def _register_enumeration(service, name, enumeration):
 
     def register(types):
         types.enumeration_type(service, name).set_values(values)
+
+    return register
+
+
+def _register_struct(service, name, struct):
+    # The fields keep the names they are declared with, as each language names them its own way
+    fields = [(field["name"], field["type"]) for field in struct["fields"]]
+
+    def register(types):
+        types.struct_type(service, name).set_fields(
+            [
+                (field_name, as_type(types, type_info))
+                for field_name, type_info in fields
+            ]
+        )
 
     return register
 

--- a/tools/krpctools/krpctools/docgen/cnano.py
+++ b/tools/krpctools/krpctools/docgen/cnano.py
@@ -2,6 +2,7 @@ from krpc.types import (
     ValueType,
     ClassType,
     EnumerationType,
+    StructType,
     MessageType,
     TupleType,
     ListType,
@@ -18,6 +19,8 @@ from .nodes import (
     ClassProperty,
     Enumeration,
     EnumerationValue,
+    Struct,
+    StructField,
 )
 from ..lang.cnano import CnanoLanguage
 
@@ -61,6 +64,8 @@ class CnanoDomain(Domain):
             return "object"
         if isinstance(typ, EnumerationType):
             return "enum"
+        if isinstance(typ, StructType):
+            return "%s_%s" % (typ.protobuf_type.service, typ.protobuf_type.name)
         raise RuntimeError("Unknown type " + str(typ))
 
     def type(self, typ):
@@ -88,6 +93,8 @@ class CnanoDomain(Domain):
         elif isinstance(typ, (ClassType, EnumerationType)):
             ctype = "krpc_%s_%s_t" % (typ.protobuf_type.service, typ.protobuf_type.name)
             ptr = False
+        elif isinstance(typ, StructType):
+            ctype = "krpc_%s_%s_t" % (typ.protobuf_type.service, typ.protobuf_type.name)
         else:
             raise RuntimeError("Unknown type " + str(typ))
         # Note:
@@ -134,7 +141,7 @@ class CnanoDomain(Domain):
         ref = "krpc_" + "_".join(name)
         if isinstance(obj, EnumerationValue):
             ref = ref.upper()
-        elif isinstance(obj, (Class, Enumeration)):
+        elif isinstance(obj, (Class, Enumeration, Struct)):
             ref += "_t"
         return ref
 
@@ -147,8 +154,12 @@ class CnanoDomain(Domain):
             prefix = "type"
         elif isinstance(obj, Enumeration):
             prefix = "type"
+        elif isinstance(obj, Struct):
+            prefix = "type"
         elif isinstance(obj, EnumerationValue):
             prefix = "macro"
+        elif isinstance(obj, StructField):
+            prefix = "member"
         else:
             raise RuntimeError(str(obj))
         return ":%s:`%s`" % (prefix, self.ref(obj))

--- a/tools/krpctools/krpctools/docgen/cnano.py
+++ b/tools/krpctools/krpctools/docgen/cnano.py
@@ -1,3 +1,4 @@
+from krpc.utils import snake_case
 from krpc.types import (
     ValueType,
     ClassType,
@@ -138,6 +139,11 @@ class CnanoDomain(Domain):
 
     def ref(self, obj):
         name = obj.fullname.split(".")
+        if isinstance(obj, StructField):
+            # A field is documented inside the declaration of its structure, and the C
+            # domain addresses it through that declaration rather than by a name of its own
+            field = snake_case(name.pop())
+            return "krpc_" + "_".join(name) + "_t." + field
         ref = "krpc_" + "_".join(name)
         if isinstance(obj, EnumerationValue):
             ref = ref.upper()

--- a/tools/krpctools/krpctools/docgen/cnano.tmpl
+++ b/tools/krpctools/krpctools/docgen/cnano.tmpl
@@ -159,7 +159,7 @@
 
 {% if hasdoc(x.documentation, './remarks') %}{{ remarks(x.documentation) | indent }}{% endif %}
 {% for field in x.fields.values() %}{{ mark_documented(field) }}
-   .. member:: {{ domain.return_type(field.type) }} {{ field.name | snakecase }}
+   .. member:: {{ domain.type(field.type).ctype }} {{ field.name | snakecase }}
 
 {% if field.deprecated %}{{ deprecated(field) | indent(width=6) }}
 

--- a/tools/krpctools/krpctools/docgen/cnano.tmpl
+++ b/tools/krpctools/krpctools/docgen/cnano.tmpl
@@ -149,6 +149,25 @@
 {% endfor %}
 {% endmacro %}
 
+{% macro struct(x) %}{{ mark_documented(x) }}
+.. type:: krpc_{{ x.service_name }}_{{ x.name }}_t
+
+{% if x.deprecated %}{{ deprecated(x) | indent }}
+
+{% endif %}
+{{ gendoc(x.documentation) | indent }}
+
+{% if hasdoc(x.documentation, './remarks') %}{{ remarks(x.documentation) | indent }}{% endif %}
+{% for field in x.fields.values() %}{{ mark_documented(field) }}
+   .. member:: {{ domain.return_type(field.type) }} {{ field.name | snakecase }}
+
+{% if field.deprecated %}{{ deprecated(field) | indent(width=6) }}
+
+{% endif %}
+{{ gendoc(field.documentation) | indent(width=6) }}
+{% endfor %}
+{% endmacro %}
+
 {% macro exception(x) %}{{ mark_documented(x) }}
 Exception class {{ x.name }}
 

--- a/tools/krpctools/krpctools/docgen/cpp.py
+++ b/tools/krpctools/krpctools/docgen/cpp.py
@@ -2,6 +2,7 @@ from krpc.types import (
     ValueType,
     ClassType,
     EnumerationType,
+    StructType,
     MessageType,
     TupleType,
     ListType,
@@ -19,6 +20,8 @@ from .nodes import (
     ClassProperty,
     Enumeration,
     EnumerationValue,
+    Struct,
+    StructField,
 )
 from ..lang.cpp import CppLanguage
 
@@ -56,6 +59,8 @@ class CppDomain(Domain):
             return ":class:`%s`" % self.type(typ)
         if isinstance(typ, EnumerationType):
             return ":class:`%s`" % self.type(typ)
+        if isinstance(typ, StructType):
+            return ":class:`%s`" % self.type(typ)
         if isinstance(typ, ListType):
             return "std::vector<%s>" % self.type_description(typ.value_type)
         if isinstance(typ, DictionaryType):
@@ -82,6 +87,7 @@ class CppDomain(Domain):
                 ClassStaticMethod,
                 ClassProperty,
                 EnumerationValue,
+                StructField,
             )
         ):
             name[-1] = snake_case(name[-1])
@@ -100,6 +106,10 @@ class CppDomain(Domain):
             prefix = "enum"
         elif isinstance(obj, EnumerationValue):
             prefix = "enumerator"
+        elif isinstance(obj, Struct):
+            prefix = "struct"
+        elif isinstance(obj, StructField):
+            prefix = "member"
         else:
             raise RuntimeError(str(obj))
         return ":%s:`%s`" % (prefix, self.ref(obj))

--- a/tools/krpctools/krpctools/docgen/cpp.tmpl
+++ b/tools/krpctools/krpctools/docgen/cpp.tmpl
@@ -157,6 +157,26 @@
 {% endfor %}
 {% endmacro %}
 
+{% macro struct(x) %}{{ mark_documented(x) }}
+.. namespace:: krpc::services::{{ x.service_name }}
+.. struct:: {{ x.name }}
+
+{% if x.deprecated %}{{ deprecated(x) | indent }}
+
+{% endif %}
+{{ gendoc(x.documentation) | indent }}
+
+{% if hasdoc(x.documentation, './remarks') %}{{ remarks(x.documentation) | indent }}{% endif %}
+{% for field in x.fields.values() %}{{ mark_documented(field) }}
+   .. member:: {{ domain.return_type(field.type) }} {{ field.name | snakecase }}
+
+{% if field.deprecated %}{{ deprecated(field) | indent(width=6) }}
+
+{% endif %}
+{{ gendoc(field.documentation) | indent(width=6) }}
+{% endfor %}
+{% endmacro %}
+
 {% macro exception(x) %}{{ mark_documented(x) }}
 .. namespace:: krpc::services::{{ x.service_name }}
 .. class:: {{ x.name }}

--- a/tools/krpctools/krpctools/docgen/csharp.py
+++ b/tools/krpctools/krpctools/docgen/csharp.py
@@ -2,6 +2,7 @@ from krpc.types import (
     ValueType,
     ClassType,
     EnumerationType,
+    StructType,
     MessageType,
     TupleType,
     ListType,
@@ -18,6 +19,8 @@ from .nodes import (
     ClassProperty,
     Enumeration,
     EnumerationValue,
+    Struct,
+    StructField,
 )
 from ..lang.csharp import CsharpLanguage
 
@@ -41,7 +44,7 @@ class CsharpDomain(Domain):
             return self.language.type_map[typ.protobuf_type.code]
         if isinstance(typ, MessageType):
             return "KRPC.Schema.KRPC.%s" % typ.python_type.__name__
-        if isinstance(typ, (ClassType, EnumerationType)):
+        if isinstance(typ, (ClassType, EnumerationType, StructType)):
             return self.shorten_ref(
                 "%s.%s" % (typ.protobuf_type.service, typ.protobuf_type.name)
             )
@@ -61,6 +64,11 @@ class CsharpDomain(Domain):
         raise RuntimeError("Unknown type '%s'" % str(typ))
 
     def default_value(self, value, typ):
+        if isinstance(typ, StructType):
+            values = (
+                self.default_value(x, typ.field_types[i]) for i, x in enumerate(value)
+            )
+            return "new %s(%s)" % (self.type(typ), ", ".join(values))
         if isinstance(typ, EnumerationType):
             return "%s.%s" % (
                 self.type(typ),
@@ -102,9 +110,11 @@ class CsharpDomain(Domain):
             prefix = "prop"
         elif isinstance(obj, EnumerationValue):
             prefix = "enum"
+        elif isinstance(obj, StructField):
+            prefix = "prop"
         elif isinstance(obj, (Procedure, ClassMethod, ClassStaticMethod)):
             prefix = "meth"
-        elif isinstance(obj, (Class, Enumeration)):
+        elif isinstance(obj, (Class, Enumeration, Struct)):
             prefix = "type"
         else:
             raise RuntimeError(str(obj))

--- a/tools/krpctools/krpctools/docgen/csharp.tmpl
+++ b/tools/krpctools/krpctools/docgen/csharp.tmpl
@@ -154,6 +154,25 @@
 {% endfor %}
 {% endmacro %}
 
+{% macro struct(x) %}{{ mark_documented(x) }}
+.. struct:: {{ x.name }}
+
+{% if x.deprecated %}{{ deprecated(x) | indent }}
+
+{% endif %}
+{{ gendoc(x.documentation) | indent }}
+
+{% if hasdoc(x.documentation, './remarks') %}{{ remarks(x.documentation) | indent }}{% endif %}
+{% for field in x.fields.values() %}{{ mark_documented(field) }}
+   .. property:: {{ domain.return_type(field.type) }} {{ field.name }} {{'{'}} get; set; {{'}'}}
+
+{% if field.deprecated %}{{ deprecated(field) | indent(width=6) }}
+
+{% endif %}
+{{ gendoc(field.documentation) | indent(width=6) }}
+{% endfor %}
+{% endmacro %}
+
 {% macro exception(x) %}{{ mark_documented(x) }}
 .. class:: {{ x.name }}
 

--- a/tools/krpctools/krpctools/docgen/java.py
+++ b/tools/krpctools/krpctools/docgen/java.py
@@ -2,6 +2,7 @@ from krpc.types import (
     ValueType,
     ClassType,
     EnumerationType,
+    StructType,
     MessageType,
     TupleType,
     ListType,
@@ -19,6 +20,8 @@ from .nodes import (
     ClassProperty,
     Enumeration,
     EnumerationValue,
+    Struct,
+    StructField,
 )
 from ..utils import lower_camel_case
 from ..lang.java import JavaLanguage
@@ -53,7 +56,7 @@ class JavaDomain(Domain):
             return self.language.type_map_classes[typ.protobuf_type.code]
         if isinstance(typ, MessageType):
             return "krpc.schema.KRPC.%s" % typ.python_type.__name__
-        if isinstance(typ, (ClassType, EnumerationType)):
+        if isinstance(typ, (ClassType, EnumerationType, StructType)):
             return self.shorten_ref(
                 "%s.%s" % (typ.protobuf_type.service, typ.protobuf_type.name)
             )
@@ -83,6 +86,8 @@ class JavaDomain(Domain):
             return ":type:`%s`" % self.type(typ)
         if isinstance(typ, EnumerationType):
             return ":class:`%s`" % self.type(typ)
+        if isinstance(typ, StructType):
+            return ":type:`%s`" % self.type(typ)
         if isinstance(typ, ListType):
             return ":class:`java.util.List<%s>`" % self._type(typ.value_type, True)
         if isinstance(typ, DictionaryType):
@@ -123,6 +128,10 @@ class JavaDomain(Domain):
             name = name.split(".")
             name[-1] = snake_case(name[-1]).upper()
             name = ".".join(name)
+        elif isinstance(obj, StructField):
+            name = name.split(".")
+            name[-1] = "get" + name[-1] + "()"
+            name = ".".join(name)
         return self.shorten_ref(name)
 
     def see(self, obj):
@@ -135,10 +144,11 @@ class JavaDomain(Domain):
                 Property,
                 ClassProperty,
                 EnumerationValue,
+                StructField,
             )
         ):
             prefix = "meth"
-        elif any(isinstance(obj, cls) for cls in (Class, Enumeration)):
+        elif any(isinstance(obj, cls) for cls in (Class, Enumeration, Struct)):
             prefix = "type"
         else:
             raise RuntimeError(str(obj))

--- a/tools/krpctools/krpctools/docgen/java.tmpl
+++ b/tools/krpctools/krpctools/docgen/java.tmpl
@@ -161,6 +161,25 @@
 {% endfor %}
 {% endmacro %}
 
+{% macro struct(x) %}{{ mark_documented(x) }}
+.. type:: public class {{ x.name }}
+
+{% if x.deprecated %}{{ deprecated(x) | indent }}
+
+{% endif %}
+{{ gendoc(x.documentation) | indent }}
+
+{% if hasdoc(x.documentation, './remarks') %}{{ remarks(x.documentation) | indent }}{% endif %}
+{% for field in x.fields.values() %}{{ mark_documented(field) }}
+   .. method:: {{ domain.return_type(field.type) }} get{{ domain.method_name(field.name) }}()
+
+{% if field.deprecated %}{{ deprecated(field) | indent(width=6) }}
+
+{% endif %}
+{{ gendoc(field.documentation) | indent(width=6) }}
+{% endfor %}
+{% endmacro %}
+
 {% macro exception(x) %}{{ mark_documented(x) }}
 .. type:: public class {{ x.name }}
 

--- a/tools/krpctools/krpctools/docgen/lua.py
+++ b/tools/krpctools/krpctools/docgen/lua.py
@@ -2,6 +2,7 @@ from krpc.types import (
     ValueType,
     ClassType,
     EnumerationType,
+    StructType,
     MessageType,
     TupleType,
     ListType,
@@ -19,6 +20,8 @@ from .nodes import (
     ClassProperty,
     Enumeration,
     EnumerationValue,
+    Struct,
+    StructField,
 )
 from ..lang.lua import LuaLanguage
 
@@ -44,6 +47,8 @@ class LuaDomain(Domain):
             return ":class:`%s`" % self.type(typ)
         if isinstance(typ, EnumerationType):
             return ":class:`%s`" % self.type(typ)
+        if isinstance(typ, StructType):
+            return ":class:`%s`" % self.type(typ)
         if isinstance(typ, ListType):
             return "List"
         if isinstance(typ, DictionaryType):
@@ -65,6 +70,7 @@ class LuaDomain(Domain):
                 ClassStaticMethod,
                 ClassProperty,
                 EnumerationValue,
+                StructField,
             )
         ):
             name = name.split(".")
@@ -78,11 +84,11 @@ class LuaDomain(Domain):
         return name
 
     def see(self, obj):
-        if isinstance(obj, (Property, ClassProperty, EnumerationValue)):
+        if isinstance(obj, (Property, ClassProperty, EnumerationValue, StructField)):
             prefix = "attr"
         elif isinstance(obj, (Procedure, ClassMethod, ClassStaticMethod)):
             prefix = "meth"
-        elif isinstance(obj, (Class, Enumeration)):
+        elif isinstance(obj, (Class, Enumeration, Struct)):
             prefix = "class"
         else:
             raise RuntimeError(str(obj))

--- a/tools/krpctools/krpctools/docgen/lua.tmpl
+++ b/tools/krpctools/krpctools/docgen/lua.tmpl
@@ -163,6 +163,27 @@
 {% endfor %}
 {% endmacro %}
 
+{% macro struct(x) %}{{ mark_documented(x) }}
+.. class:: {{ x.name }}
+
+{% if x.deprecated %}{{ deprecated(x) | indent }}
+
+{% endif %}
+{{ gendoc(x.documentation) | indent }}
+
+{% if hasdoc(x.documentation, './remarks') %}{{ remarks(x.documentation) | indent }}{% endif %}
+{% for field in x.fields.values() %}{{ mark_documented(field) }}
+   .. attribute:: {{ field.name | snakecase }}: {{ domain.type(field.type) }}
+
+{% if field.deprecated %}{{ deprecated(field) | indent(width=6) }}
+
+{% endif %}
+{{ gendoc(field.documentation) | indent(width=6) }}
+
+      :rtype: {{ domain.type_description(field.type) }}
+{% endfor %}
+{% endmacro %}
+
 {% macro exception(x) %}{{ mark_documented(x) }}
 .. class:: {{ x.name }}
 

--- a/tools/krpctools/krpctools/docgen/nodes.py
+++ b/tools/krpctools/krpctools/docgen/nodes.py
@@ -16,6 +16,7 @@ class Appendable:
 
 
 class Service(Appendable):
+    # pylint: disable=too-many-arguments,too-many-locals
     def __init__(
         self,
         name,
@@ -26,6 +27,7 @@ class Service(Appendable):
         documentation,
         sort,
         types,
+        structs=None,
         deprecated=False,
         deprecated_reason="",
     ):
@@ -80,6 +82,10 @@ class Service(Appendable):
             ename: Enumeration(name, ename, sort=sort, **einfo)
             for (ename, einfo) in enumerations.items()
         }
+        self.structs = {
+            sname: Struct(name, sname, types=types, **sinfo)
+            for (sname, sinfo) in (structs or {}).items()
+        }
         self.exceptions = {
             ename: ExceptionNode(name, ename, **einfo)
             for (ename, einfo) in exceptions.items()
@@ -94,6 +100,8 @@ class Service(Appendable):
             del self.classes[member_name]
         if member_name in self.enumerations:
             del self.enumerations[member_name]
+        if member_name in self.structs:
+            del self.structs[member_name]
         if member_name in self.exceptions:
             del self.exceptions[member_name]
         del self.members[member_name]
@@ -408,6 +416,60 @@ class EnumerationValue(Appendable):
         self.deprecated = deprecated
         self.deprecated_reason = deprecated_reason
         self.cref = "M:%s.%s.%s" % (service_name, enum_name, name)
+
+
+class Struct(Appendable):
+    def __init__(
+        self,
+        service_name,
+        name,
+        fields,
+        documentation,
+        types,
+        deprecated=False,
+        deprecated_reason="",
+    ):
+        super().__init__()
+        self.types = types
+        self.service_name = service_name
+        self.name = name
+        self.fullname = service_name + "." + name
+        # The fields keep the order the structure declares them in, which is the order their
+        # values are encoded in, rather than being sorted like the members of a class
+        self.fields = OrderedDict(
+            (field["name"], StructField(service_name, name, types=types, **field))
+            for field in fields
+        )
+        self.documentation = documentation
+        self.deprecated = deprecated
+        self.deprecated_reason = deprecated_reason
+        self.cref = "T:%s.%s" % (service_name, name)
+
+
+class StructField(Appendable):
+    # pylint: disable=redefined-builtin
+    def __init__(
+        self,
+        service_name,
+        struct_name,
+        name,
+        type,
+        documentation,
+        types,
+        deprecated=False,
+        deprecated_reason="",
+    ):
+        super().__init__()
+        self.types = types
+        self.service_name = service_name
+        self.struct_name = struct_name
+        self.name = name
+        self.fullname = service_name + "." + struct_name + "." + name
+        self.type = as_type(self.types, type)
+        self.documentation = documentation
+        self.deprecated = deprecated
+        self.deprecated_reason = deprecated_reason
+        self.cref = "M:%s.%s.%s" % (service_name, struct_name, name)
 
 
 class ExceptionNode(Appendable):

--- a/tools/krpctools/krpctools/docgen/python.py
+++ b/tools/krpctools/krpctools/docgen/python.py
@@ -2,6 +2,7 @@ from krpc.types import (
     ValueType,
     ClassType,
     EnumerationType,
+    StructType,
     MessageType,
     TupleType,
     ListType,
@@ -18,7 +19,7 @@ from .nodes import (
     ClassStaticMethod,
     ClassProperty,
 )
-from .nodes import Enumeration, EnumerationValue
+from .nodes import Enumeration, EnumerationValue, Struct, StructField
 from ..lang.python import PythonLanguage
 
 
@@ -49,6 +50,8 @@ class PythonDomain(Domain):
             return ":class:`%s`" % self.type(typ)
         if isinstance(typ, EnumerationType):
             return ":class:`%s`" % self.type(typ)
+        if isinstance(typ, StructType):
+            return ":class:`%s`" % self.type(typ)
         if isinstance(typ, ListType):
             return "list(%s)" % self.type_description(typ.value_type)
         if isinstance(typ, DictionaryType):
@@ -75,6 +78,7 @@ class PythonDomain(Domain):
                 ClassStaticMethod,
                 ClassProperty,
                 EnumerationValue,
+                StructField,
             )
         ):
             name = name.split(".")
@@ -84,14 +88,15 @@ class PythonDomain(Domain):
 
     def see(self, obj):
         if any(
-            isinstance(obj, cls) for cls in (Property, ClassProperty, EnumerationValue)
+            isinstance(obj, cls)
+            for cls in (Property, ClassProperty, EnumerationValue, StructField)
         ):
             prefix = "attr"
         elif any(
             isinstance(obj, cls) for cls in (Procedure, ClassMethod, ClassStaticMethod)
         ):
             prefix = "meth"
-        elif any(isinstance(obj, cls) for cls in (Class, Enumeration)):
+        elif any(isinstance(obj, cls) for cls in (Class, Enumeration, Struct)):
             prefix = "class"
         else:
             raise RuntimeError(str(obj))

--- a/tools/krpctools/krpctools/docgen/python.tmpl
+++ b/tools/krpctools/krpctools/docgen/python.tmpl
@@ -167,6 +167,27 @@
 {% endfor %}
 {% endmacro %}
 
+{% macro struct(x) %}{{ mark_documented(x) }}
+.. class:: {{ x.name }}
+
+{% if x.deprecated %}{{ deprecated(x) | indent }}
+
+{% endif %}
+{{ gendoc(x.documentation) | indent }}
+
+{% if hasdoc(x.documentation, './remarks') %}{{ remarks(x.documentation) | indent }}{% endif %}
+{% for field in x.fields.values() %}{{ mark_documented(field) }}
+   .. attribute:: {{ field.name | snakecase }}
+
+{% if field.deprecated %}{{ deprecated(field) | indent(width=6) }}
+
+{% endif %}
+{{ gendoc(field.documentation) | indent(width=6) }}
+
+      :rtype: {{ domain.type_description(field.type) }}
+{% endfor %}
+{% endmacro %}
+
 {% macro exception(x) %}{{ mark_documented(x) }}
 .. class:: {{ x.name }}
 

--- a/tools/krpctools/krpctools/docgen/utils.py
+++ b/tools/krpctools/krpctools/docgen/utils.py
@@ -6,7 +6,10 @@ def lookup_cref(cref, services):
             objs.extend(service.members.values())
             objs.extend(service.classes.values())
             objs.extend(service.enumerations.values())
+            objs.extend(service.structs.values())
             objs.extend(service.exceptions.values())
+            for struct in service.structs.values():
+                objs.extend(struct.fields.values())
             for cls in service.classes.values():
                 objs.extend(cls.members.values())
             for enumeration in service.enumerations.values():

--- a/tools/krpctools/krpctools/lang/cpp.py
+++ b/tools/krpctools/krpctools/lang/cpp.py
@@ -4,6 +4,7 @@ from krpc.types import (
     ValueType,
     ClassType,
     EnumerationType,
+    StructType,
     MessageType,
     TupleType,
     ListType,
@@ -169,7 +170,7 @@ class CppLanguage(Language):
             return "std::tuple<%s>" % ", ".join(
                 self.parse_type(t) for t in typ.value_types
             )
-        if isinstance(typ, (ClassType, EnumerationType)):
+        if isinstance(typ, (ClassType, EnumerationType, StructType)):
             name = "%s.%s" % (typ.protobuf_type.service, typ.protobuf_type.name)
             return self.shorten_ref(name).replace(".", "::")
         raise RuntimeError("Unknown type '%s'" % str(typ))
@@ -196,6 +197,12 @@ class CppLanguage(Language):
         # A collection is written as a braced initializer list. Parentheses would name a
         # constructor instead, so std::vector<int32_t>(1, 2, 3) is not the vector of those
         # three values it appears to be.
+        if isinstance(typ, StructType):
+            values = (
+                self.parse_default_value(x, typ.field_types[i])
+                for i, x in enumerate(value)
+            )
+            return "%s{%s}" % (self.parse_type(typ), ", ".join(values))
         if isinstance(typ, TupleType):
             values = (
                 self.parse_default_value(x, typ.value_types[i])

--- a/tools/krpctools/krpctools/lang/csharp.py
+++ b/tools/krpctools/krpctools/lang/csharp.py
@@ -4,6 +4,7 @@ from krpc.types import (
     ValueType,
     ClassType,
     EnumerationType,
+    StructType,
     MessageType,
     TupleType,
     ListType,
@@ -171,7 +172,7 @@ class CsharpLanguage(Language):
                 self._parse_type(typ.key_type),
                 self._parse_type(typ.value_type),
             )
-        if isinstance(typ, (ClassType, EnumerationType)):
+        if isinstance(typ, (ClassType, EnumerationType, StructType)):
             return "global::KRPC.Client.Services.%s.%s" % (
                 typ.protobuf_type.service,
                 typ.protobuf_type.name,
@@ -197,6 +198,12 @@ class CsharpLanguage(Language):
             )
         if value is None:
             return "null"
+        if isinstance(typ, StructType):
+            values = (
+                self.parse_default_value(x, typ.field_types[i])
+                for i, x in enumerate(value)
+            )
+            return "new %s (%s)" % (self.parse_type(typ), ", ".join(values))
         if isinstance(typ, TupleType):
             values = (
                 self.parse_default_value(x, typ.value_types[i])

--- a/tools/krpctools/krpctools/lang/java.py
+++ b/tools/krpctools/krpctools/lang/java.py
@@ -4,6 +4,7 @@ from krpc.types import (
     ValueType,
     ClassType,
     EnumerationType,
+    StructType,
     MessageType,
     TupleType,
     ListType,
@@ -137,7 +138,7 @@ class JavaLanguage(Language):
             return "krpc.client.Event"
         if isinstance(typ, MessageType):
             return "krpc.schema.KRPC.%s" % typ.python_type.__name__
-        if isinstance(typ, (ClassType, EnumerationType)):
+        if isinstance(typ, (ClassType, EnumerationType, StructType)):
             return "krpc.client.services.%s.%s" % (
                 typ.protobuf_type.service,
                 typ.protobuf_type.name,

--- a/tools/krpctools/krpctools/lang/lua.py
+++ b/tools/krpctools/krpctools/lang/lua.py
@@ -4,6 +4,7 @@ from krpc.types import (
     ValueType,
     ClassType,
     EnumerationType,
+    StructType,
     MessageType,
     TupleType,
     ListType,
@@ -57,7 +58,7 @@ class LuaLanguage(Language):
             return self.type_map[typ.protobuf_type.code]
         if isinstance(typ, MessageType):
             return "krpc.schema.KRPC.%s" % typ.python_type.__name__
-        if isinstance(typ, (ClassType, EnumerationType)):
+        if isinstance(typ, (ClassType, EnumerationType, StructType)):
             return "%s.%s" % (typ.protobuf_type.service, typ.protobuf_type.name)
         if isinstance(typ, ListType):
             return "List"
@@ -87,6 +88,14 @@ class LuaLanguage(Language):
                 self.parse_type(typ),
                 self.parse_enum_value_name(value.name),
             )
+        if isinstance(typ, StructType):
+            # A structure is written as its field values in order, which is the form the
+            # client coerces to one
+            values = (
+                self.parse_default_value(x, typ.field_types[i])
+                for i, x in enumerate(value)
+            )
+            return "{%s}" % ", ".join(values)
         if isinstance(typ, TupleType):
             values = (
                 self.parse_default_value(x, typ.value_types[i])

--- a/tools/krpctools/krpctools/lang/python.py
+++ b/tools/krpctools/krpctools/lang/python.py
@@ -6,6 +6,7 @@ from krpc.types import (
     ValueType,
     ClassType,
     EnumerationType,
+    StructType,
     MessageType,
     TupleType,
     ListType,
@@ -60,7 +61,7 @@ class PythonLanguage(Language):
             return typ.python_type.__name__
         if isinstance(typ, MessageType):
             return "krpc.schema.KRPC.%s" % typ.python_type.__name__
-        if isinstance(typ, (ClassType, EnumerationType)):
+        if isinstance(typ, (ClassType, EnumerationType, StructType)):
             return self.shorten_ref(
                 "%s.%s" % (typ.protobuf_type.service, typ.protobuf_type.name)
             )
@@ -91,6 +92,12 @@ class PythonLanguage(Language):
                 self.parse_type(typ),
                 self.parse_enum_value_name(value.name),
             )
+        if isinstance(typ, StructType):
+            values = [
+                self.parse_default_value(x, typ.field_types[i])
+                for i, x in enumerate(value)
+            ]
+            return "%s(%s)" % (self.parse_type(typ), ", ".join(values))
         if isinstance(typ, TupleType):
             values = [
                 self.parse_default_value(x, typ.value_types[i])

--- a/tools/krpctools/krpctools/test/clientgen-Empty-java.txt
+++ b/tools/krpctools/krpctools/test/clientgen-Empty-java.txt
@@ -6,6 +6,7 @@ import krpc.client.Connection;
 import krpc.client.Encoder;
 import krpc.client.RemoteEnum;
 import krpc.client.RemoteObject;
+import krpc.client.RemoteStruct;
 import krpc.client.RPCInfo;
 import krpc.client.RPCException;
 import krpc.client.Types;

--- a/tools/krpctools/krpctools/test/clientgen-Empty-python.txt
+++ b/tools/krpctools/krpctools/test/clientgen-Empty-python.txt
@@ -1,7 +1,7 @@
 # pylint: disable=line-too-long,invalid-name,redefined-builtin,too-many-lines
 from __future__ import annotations
 import warnings
-from typing import Tuple, Set, Dict, List, Optional, TYPE_CHECKING
+from typing import Tuple, Set, Dict, List, NamedTuple, Optional, TYPE_CHECKING
 import krpc.limits
 import krpc.schema
 from krpc.schema import KRPC_pb2
@@ -15,12 +15,13 @@ class EmptyService:
 
     def __init__(self, client: Client) -> None:
         self._client = client
-        # The classes, enumerations and exceptions the service defines are put on the
-        # service here, so that reaching one is an ordinary attribute lookup and nothing
-        # has to intercept the lookups that do not name one - which is every call, as a
-        # call goes through a procedure or a property. A class is bound to the client it
-        # is reached through, so that its static methods use that client.
+        # The classes, enumerations, structures and exceptions the service defines are
+        # put on the service here, so that reaching one is an ordinary attribute lookup
+        # and nothing has to intercept the lookups that do not name one - which is every
+        # call, as a call goes through a procedure or a property. A class is bound to the
+        # client it is reached through, so that its static methods use that client.
         self.__dict__.update(self._enumerations)
+        self.__dict__.update(self._structs)
         self.__dict__.update(self._exceptions)
         for name, class_type in self._classes.items():
             self.__dict__[name] = WrappedClass(client, class_type)
@@ -44,6 +45,8 @@ class EmptyService:
     _classes = {
     }
     _enumerations = {
+    }
+    _structs = {
     }
     _exceptions = {
     }

--- a/tools/krpctools/krpctools/test/clientgen-Ordering-java.txt
+++ b/tools/krpctools/krpctools/test/clientgen-Ordering-java.txt
@@ -6,6 +6,7 @@ import krpc.client.Connection;
 import krpc.client.Encoder;
 import krpc.client.RemoteEnum;
 import krpc.client.RemoteObject;
+import krpc.client.RemoteStruct;
 import krpc.client.RPCInfo;
 import krpc.client.RPCException;
 import krpc.client.Types;

--- a/tools/krpctools/krpctools/test/clientgen-Ordering-python.txt
+++ b/tools/krpctools/krpctools/test/clientgen-Ordering-python.txt
@@ -1,7 +1,7 @@
 # pylint: disable=line-too-long,invalid-name,redefined-builtin,too-many-lines
 from __future__ import annotations
 import warnings
-from typing import Tuple, Set, Dict, List, Optional, TYPE_CHECKING
+from typing import Tuple, Set, Dict, List, NamedTuple, Optional, TYPE_CHECKING
 import krpc.limits
 import krpc.schema
 from krpc.schema import KRPC_pb2
@@ -19,12 +19,13 @@ class ServiceA:
 
     def __init__(self, client: Client) -> None:
         self._client = client
-        # The classes, enumerations and exceptions the service defines are put on the
-        # service here, so that reaching one is an ordinary attribute lookup and nothing
-        # has to intercept the lookups that do not name one - which is every call, as a
-        # call goes through a procedure or a property. A class is bound to the client it
-        # is reached through, so that its static methods use that client.
+        # The classes, enumerations, structures and exceptions the service defines are
+        # put on the service here, so that reaching one is an ordinary attribute lookup
+        # and nothing has to intercept the lookups that do not name one - which is every
+        # call, as a call goes through a procedure or a property. A class is bound to the
+        # client it is reached through, so that its static methods use that client.
         self.__dict__.update(self._enumerations)
+        self.__dict__.update(self._structs)
         self.__dict__.update(self._exceptions)
         for name, class_type in self._classes.items():
             self.__dict__[name] = WrappedClass(client, class_type)
@@ -48,6 +49,8 @@ class ServiceA:
     _classes = {
     }
     _enumerations = {
+    }
+    _structs = {
     }
     _exceptions = {
     }

--- a/tools/krpctools/krpctools/test/clientgen-TestService-cnano.txt
+++ b/tools/krpctools/krpctools/test/clientgen-TestService-cnano.txt
@@ -22,6 +22,69 @@ typedef krpc_object_t krpc_TestService_DeprecatedClass_t;
  */
 typedef krpc_object_t krpc_TestService_TestClass_t;
 
+#ifndef KRPC_TYPE_LIST_INT32
+#define KRPC_TYPE_LIST_INT32
+
+typedef struct krpc_list_int32_s krpc_list_int32_t;
+struct krpc_list_int32_s {
+  size_t size;
+  int32_t * items;
+};
+
+static inline krpc_error_t krpc_encode_list_int32(
+  pb_ostream_t * stream, const krpc_list_int32_t * value);
+static inline krpc_error_t krpc_encode_size_list_int32(
+  size_t * size, const krpc_list_int32_t * value);
+static inline bool krpc_encode_callback_list_int32(
+  pb_ostream_t * stream, const pb_field_t * field, void * const * arg);
+static inline krpc_error_t krpc_decode_list_int32(
+  pb_istream_t * stream, krpc_list_int32_t * value);
+
+#endif  // KRPC_TYPE_LIST_INT32
+
+#ifndef KRPC_TYPE_TESTSERVICE_TESTSTRUCT
+#define KRPC_TYPE_TESTSERVICE_TESTSTRUCT
+
+typedef struct krpc_TestService_TestStruct_s krpc_TestService_TestStruct_t;
+struct krpc_TestService_TestStruct_s {
+  int32_t int_field;
+  char * string_field;
+  krpc_enum_t enum_field;
+  krpc_list_int32_t list_field;
+};
+
+static inline krpc_error_t krpc_encode_TestService_TestStruct(
+  pb_ostream_t * stream, const krpc_TestService_TestStruct_t * value);
+static inline krpc_error_t krpc_encode_size_TestService_TestStruct(
+  size_t * size, const krpc_TestService_TestStruct_t * value);
+static inline bool krpc_encode_callback_TestService_TestStruct(
+  pb_ostream_t * stream, const pb_field_t * field, void * const * arg);
+static inline krpc_error_t krpc_decode_TestService_TestStruct(
+  pb_istream_t * stream, krpc_TestService_TestStruct_t * value);
+
+#endif  // KRPC_TYPE_TESTSERVICE_TESTSTRUCT
+
+#ifndef KRPC_TYPE_TESTSERVICE_TESTNESTEDSTRUCT
+#define KRPC_TYPE_TESTSERVICE_TESTNESTEDSTRUCT
+
+typedef struct krpc_TestService_TestNestedStruct_s krpc_TestService_TestNestedStruct_t;
+struct krpc_TestService_TestNestedStruct_s {
+  krpc_TestService_TestStruct_t struct_field;
+  krpc_object_t object_field;
+  char * string_field;
+};
+
+static inline krpc_error_t krpc_encode_TestService_TestNestedStruct(
+  pb_ostream_t * stream, const krpc_TestService_TestNestedStruct_t * value);
+static inline krpc_error_t krpc_encode_size_TestService_TestNestedStruct(
+  size_t * size, const krpc_TestService_TestNestedStruct_t * value);
+static inline bool krpc_encode_callback_TestService_TestNestedStruct(
+  pb_ostream_t * stream, const pb_field_t * field, void * const * arg);
+static inline krpc_error_t krpc_decode_TestService_TestNestedStruct(
+  pb_istream_t * stream, krpc_TestService_TestNestedStruct_t * value);
+
+#endif  // KRPC_TYPE_TESTSERVICE_TESTNESTEDSTRUCT
+
 #ifndef KRPC_TYPE_DICTIONARY_INT32_BOOL
 #define KRPC_TYPE_DICTIONARY_INT32_BOOL
 
@@ -74,26 +137,6 @@ static inline krpc_error_t krpc_decode_dictionary_string_int32(
 
 #endif  // KRPC_TYPE_DICTIONARY_STRING_INT32
 
-#ifndef KRPC_TYPE_LIST_INT32
-#define KRPC_TYPE_LIST_INT32
-
-typedef struct krpc_list_int32_s krpc_list_int32_t;
-struct krpc_list_int32_s {
-  size_t size;
-  int32_t * items;
-};
-
-static inline krpc_error_t krpc_encode_list_int32(
-  pb_ostream_t * stream, const krpc_list_int32_t * value);
-static inline krpc_error_t krpc_encode_size_list_int32(
-  size_t * size, const krpc_list_int32_t * value);
-static inline bool krpc_encode_callback_list_int32(
-  pb_ostream_t * stream, const pb_field_t * field, void * const * arg);
-static inline krpc_error_t krpc_decode_list_int32(
-  pb_istream_t * stream, krpc_list_int32_t * value);
-
-#endif  // KRPC_TYPE_LIST_INT32
-
 #ifndef KRPC_TYPE_DICTIONARY_STRING_LIST_INT32
 #define KRPC_TYPE_DICTIONARY_STRING_LIST_INT32
 
@@ -119,6 +162,26 @@ static inline krpc_error_t krpc_decode_dictionary_string_list_int32(
   pb_istream_t * stream, krpc_dictionary_string_list_int32_t * value);
 
 #endif  // KRPC_TYPE_DICTIONARY_STRING_LIST_INT32
+
+#ifndef KRPC_TYPE_LIST_TESTSERVICE_TESTSTRUCT
+#define KRPC_TYPE_LIST_TESTSERVICE_TESTSTRUCT
+
+typedef struct krpc_list_TestService_TestStruct_s krpc_list_TestService_TestStruct_t;
+struct krpc_list_TestService_TestStruct_s {
+  size_t size;
+  krpc_TestService_TestStruct_t * items;
+};
+
+static inline krpc_error_t krpc_encode_list_TestService_TestStruct(
+  pb_ostream_t * stream, const krpc_list_TestService_TestStruct_t * value);
+static inline krpc_error_t krpc_encode_size_list_TestService_TestStruct(
+  size_t * size, const krpc_list_TestService_TestStruct_t * value);
+static inline bool krpc_encode_callback_list_TestService_TestStruct(
+  pb_ostream_t * stream, const pb_field_t * field, void * const * arg);
+static inline krpc_error_t krpc_decode_list_TestService_TestStruct(
+  pb_istream_t * stream, krpc_list_TestService_TestStruct_t * value);
+
+#endif  // KRPC_TYPE_LIST_TESTSERVICE_TESTSTRUCT
 
 #ifndef KRPC_TYPE_LIST_DOUBLE
 #define KRPC_TYPE_LIST_DOUBLE
@@ -384,6 +447,12 @@ static inline krpc_error_t krpc_TestService_BytesToHexString(krpc_connection_t c
 
 static inline krpc_error_t krpc_TestService_Counter(krpc_connection_t connection, int32_t * returnValue, const char * id, int32_t divisor);
 
+/**
+ * Returns a struct whose IntField counts the number of times it has been called,
+ * so that a stream on it changes on every update.
+ */
+static inline krpc_error_t krpc_TestService_CounterStruct(krpc_connection_t connection, krpc_TestService_TestStruct_t * returnValue, const char * id);
+
 static inline krpc_error_t krpc_TestService_CreateTestObject(krpc_connection_t connection, krpc_TestService_TestClass_t * returnValue, const char * value);
 
 /**
@@ -440,6 +509,8 @@ static inline krpc_error_t krpc_TestService_IncrementDictionary(krpc_connection_
 
 static inline krpc_error_t krpc_TestService_IncrementList(krpc_connection_t connection, krpc_list_int32_t * returnValue, const krpc_list_int32_t * l);
 
+static inline krpc_error_t krpc_TestService_IncrementListOfStructs(krpc_connection_t connection, krpc_list_TestService_TestStruct_t * returnValue, const krpc_list_TestService_TestStruct_t * l);
+
 static inline krpc_error_t krpc_TestService_IncrementNestedCollection(krpc_connection_t connection, krpc_dictionary_string_list_int32_t * returnValue, const krpc_dictionary_string_list_int32_t * d);
 
 static inline krpc_error_t krpc_TestService_IncrementSet(krpc_connection_t connection, krpc_set_int32_t * returnValue, const krpc_set_int32_t * h);
@@ -462,6 +533,8 @@ static inline krpc_error_t krpc_TestService_Int64ToString(krpc_connection_t conn
 
 static inline krpc_error_t krpc_TestService_ListDefault(krpc_connection_t connection, krpc_list_int32_t * returnValue, const krpc_list_int32_t * x);
 
+static inline krpc_error_t krpc_TestService_NestedStructEcho(krpc_connection_t connection, krpc_TestService_TestNestedStruct_t * returnValue, const krpc_TestService_TestNestedStruct_t * x);
+
 static inline krpc_error_t krpc_TestService_NotNullableObject(krpc_connection_t connection, krpc_TestService_TestClass_t * returnValue, krpc_TestService_TestClass_t value);
 
 static inline krpc_error_t krpc_TestService_OnTimer(krpc_connection_t connection, krpc_schema_Event * returnValue, uint32_t milliseconds, uint32_t repeats);
@@ -479,6 +552,12 @@ static inline krpc_error_t krpc_TestService_ReturnNullWhenNotAllowed(krpc_connec
 static inline krpc_error_t krpc_TestService_SetDefault(krpc_connection_t connection, krpc_set_int32_t * returnValue, const krpc_set_int32_t * x);
 
 static inline krpc_error_t krpc_TestService_StringToInt32(krpc_connection_t connection, int32_t * returnValue, const char * value);
+
+static inline krpc_error_t krpc_TestService_StructDefault(krpc_connection_t connection, krpc_TestService_TestStruct_t * returnValue, const krpc_TestService_TestStruct_t * x);
+
+static inline krpc_error_t krpc_TestService_StructEcho(krpc_connection_t connection, krpc_TestService_TestStruct_t * returnValue, const krpc_TestService_TestStruct_t * x);
+
+static inline krpc_error_t krpc_TestService_StructEchoNullable(krpc_connection_t connection, krpc_TestService_TestStruct_t * returnValue, bool * returnValueIsNull, const krpc_TestService_TestStruct_t * x);
 
 static inline krpc_error_t krpc_TestService_ThrowArgumentException(krpc_connection_t connection, int32_t * returnValue);
 
@@ -582,6 +661,313 @@ static inline krpc_error_t krpc_TestService_TestClass_set_StringPropertyPrivateG
 static inline krpc_error_t krpc_TestService_TestClass_StringPropertyPrivateSet(krpc_connection_t connection, char * * returnValue, krpc_TestService_TestClass_t instance);
 
 // Implementation
+
+#ifndef KRPC_IMPL_TYPE_LIST_INT32
+#define KRPC_IMPL_TYPE_LIST_INT32
+
+static inline bool krpc_encode_callback_items_list_int32(
+  pb_ostream_t * stream, const pb_field_t * field, void * const * arg) {
+  const krpc_list_int32_t * value = (const krpc_list_int32_t*)(*arg);
+  size_t i = 0;
+  for (; i < value->size; i++) {
+    if (!pb_encode_tag_for_field(stream, field))
+      KRPC_CALLBACK_RETURN_ERROR("encoding tag for list item");
+    size_t size;
+    KRPC_CALLBACK_RETURN_ON_ERROR(krpc_encode_size_int32(&size, value->items[i]));
+    if (!pb_encode_varint(stream, size))
+      KRPC_CALLBACK_RETURN_ERROR("encoding size for list item");
+    KRPC_CALLBACK_RETURN_ON_ERROR(krpc_encode_int32(stream, value->items[i]));
+  }
+  return true;
+}
+
+static inline krpc_error_t krpc_encode_list_int32(
+  pb_ostream_t * stream, const krpc_list_int32_t * value) {
+  krpc_schema_List message = krpc_schema_List_init_default;
+  message.items.funcs.encode = &krpc_encode_callback_items_list_int32;
+  message.items.arg = (krpc_list_int32_t*)value;
+  KRPC_RETURN_ON_ERROR(krpc_encode_message_List(stream, &message));
+  return KRPC_OK;
+}
+
+static inline krpc_error_t krpc_encode_size_list_int32(
+  size_t * size, const krpc_list_int32_t * value) {
+  pb_ostream_t stream = PB_OSTREAM_SIZING;
+  KRPC_RETURN_ON_ERROR(krpc_encode_list_int32(&stream, value));
+  *size = stream.bytes_written;
+  return KRPC_OK;
+}
+
+static inline bool krpc_encode_callback_list_int32(
+  pb_ostream_t * stream, const pb_field_t * field, void * const * arg) {
+  if (!pb_encode_tag_for_field(stream, field))
+    KRPC_CALLBACK_RETURN_ERROR("encoding tag for list_int32");
+  krpc_list_int32_t * value = (krpc_list_int32_t*)(*arg);
+  size_t size;
+  KRPC_CALLBACK_RETURN_ON_ERROR(krpc_encode_size_list_int32(&size, value));
+  if (!pb_encode_varint(stream, size))
+    KRPC_CALLBACK_RETURN_ERROR("encoding size for list_int32");
+  KRPC_CALLBACK_RETURN_ON_ERROR(krpc_encode_list_int32(stream, value));
+  return true;
+}
+
+static inline bool krpc_decode_callback_item_list_int32(
+  pb_istream_t * stream, const pb_field_t * field, void ** arg) {
+  typedef struct State { size_t capacity; krpc_list_int32_t * value; } State;
+  State * state = (State*)(*arg);
+  size_t i = state->value->size;
+  state->value->size++;
+  if (state->capacity > 0 && state->value->size > state->capacity) {
+    state->value->items = (int32_t*)krpc_recalloc(state->value->items, state->capacity, KRPC_ALLOC_BLOCK_SIZE, sizeof(int32_t));
+    state->capacity += KRPC_ALLOC_BLOCK_SIZE;
+  }
+  KRPC_CALLBACK_RETURN_ON_ERROR(krpc_decode_int32(stream, &state->value->items[i]));
+  return true;
+}
+
+static inline krpc_error_t krpc_decode_list_int32(
+  pb_istream_t * stream, krpc_list_int32_t * value) {
+  typedef struct State { size_t capacity; krpc_list_int32_t * value; } State;
+  State state = { 0, value };
+  value->size = 0;
+  if (value->items == NULL) {
+    value->items = (int32_t*)krpc_calloc(KRPC_ALLOC_BLOCK_SIZE, sizeof(int32_t));
+    state.capacity = KRPC_ALLOC_BLOCK_SIZE;
+  }
+  krpc_schema_List message = krpc_schema_List_init_default;
+  message.items.funcs.decode = &krpc_decode_callback_item_list_int32;
+  message.items.arg = &state;
+  KRPC_RETURN_ON_ERROR(krpc_decode_message_List(stream, &message));
+  return KRPC_OK;
+}
+
+#endif  // KRPC_IMPL_TYPE_LIST_INT32
+
+#ifndef KRPC_IMPL_TYPE_TESTSERVICE_TESTSTRUCT
+#define KRPC_IMPL_TYPE_TESTSERVICE_TESTSTRUCT
+
+static inline bool krpc_encode_callback_items_TestService_TestStruct(
+  pb_ostream_t * stream, const pb_field_t * field, void * const * arg) {
+  const krpc_TestService_TestStruct_t * value = (const krpc_TestService_TestStruct_t*)(*arg);
+  {
+    if (!pb_encode_tag_for_field(stream, field))
+      KRPC_CALLBACK_RETURN_ERROR("encoding tag for tuple item");
+    size_t size;
+    KRPC_CALLBACK_RETURN_ON_ERROR(krpc_encode_size_int32(&size, value->int_field));
+    if (!pb_encode_varint(stream, size))
+      KRPC_CALLBACK_RETURN_ERROR("encoding size for tuple item");
+    KRPC_CALLBACK_RETURN_ON_ERROR(krpc_encode_int32(stream, value->int_field));
+  }
+  {
+    if (!pb_encode_tag_for_field(stream, field))
+      KRPC_CALLBACK_RETURN_ERROR("encoding tag for tuple item");
+    size_t size;
+    KRPC_CALLBACK_RETURN_ON_ERROR(krpc_encode_size_string(&size, value->string_field));
+    if (!pb_encode_varint(stream, size))
+      KRPC_CALLBACK_RETURN_ERROR("encoding size for tuple item");
+    KRPC_CALLBACK_RETURN_ON_ERROR(krpc_encode_string(stream, value->string_field));
+  }
+  {
+    if (!pb_encode_tag_for_field(stream, field))
+      KRPC_CALLBACK_RETURN_ERROR("encoding tag for tuple item");
+    size_t size;
+    KRPC_CALLBACK_RETURN_ON_ERROR(krpc_encode_size_enum(&size, value->enum_field));
+    if (!pb_encode_varint(stream, size))
+      KRPC_CALLBACK_RETURN_ERROR("encoding size for tuple item");
+    KRPC_CALLBACK_RETURN_ON_ERROR(krpc_encode_enum(stream, value->enum_field));
+  }
+  {
+    if (!pb_encode_tag_for_field(stream, field))
+      KRPC_CALLBACK_RETURN_ERROR("encoding tag for tuple item");
+    size_t size;
+    KRPC_CALLBACK_RETURN_ON_ERROR(krpc_encode_size_list_int32(&size, &value->list_field));
+    if (!pb_encode_varint(stream, size))
+      KRPC_CALLBACK_RETURN_ERROR("encoding size for tuple item");
+    KRPC_CALLBACK_RETURN_ON_ERROR(krpc_encode_list_int32(stream, &value->list_field));
+  }
+  return true;
+}
+
+static inline krpc_error_t krpc_encode_TestService_TestStruct(
+  pb_ostream_t * stream, const krpc_TestService_TestStruct_t * value) {
+  krpc_schema_Tuple message = krpc_schema_Tuple_init_default;
+  message.items.funcs.encode = &krpc_encode_callback_items_TestService_TestStruct;
+  message.items.arg = (krpc_TestService_TestStruct_t*)value;
+  KRPC_RETURN_ON_ERROR(krpc_encode_message_Tuple(stream, &message));
+  return KRPC_OK;
+}
+
+static inline krpc_error_t krpc_encode_size_TestService_TestStruct(
+  size_t * size, const krpc_TestService_TestStruct_t * value) {
+  pb_ostream_t stream = PB_OSTREAM_SIZING;
+  KRPC_RETURN_ON_ERROR(krpc_encode_TestService_TestStruct(&stream, value));
+  *size = stream.bytes_written;
+  return KRPC_OK;
+}
+
+static inline bool krpc_encode_callback_TestService_TestStruct(
+  pb_ostream_t * stream, const pb_field_t * field, void * const * arg) {
+  if (!pb_encode_tag_for_field(stream, field))
+    KRPC_CALLBACK_RETURN_ERROR("encoding tag for TestService_TestStruct");
+  krpc_TestService_TestStruct_t * value = (krpc_TestService_TestStruct_t*)(*arg);
+  size_t size;
+  KRPC_CALLBACK_RETURN_ON_ERROR(krpc_encode_size_TestService_TestStruct(&size, value));
+  if (!pb_encode_varint(stream, size))
+    KRPC_CALLBACK_RETURN_ERROR("encoding size for TestService_TestStruct");
+  KRPC_CALLBACK_RETURN_ON_ERROR(krpc_encode_TestService_TestStruct(stream, value));
+  return true;
+}
+
+static inline bool krpc_decode_callback_item_TestService_TestStruct(
+  pb_istream_t * stream, const pb_field_t * field, void ** arg) {
+  typedef struct State {size_t pos; krpc_TestService_TestStruct_t * value;} State;
+  State * state = (State*)(*arg);
+  krpc_TestService_TestStruct_t * value = state->value;
+  switch (state->pos) {
+  case 0:
+    KRPC_CALLBACK_RETURN_ON_ERROR(krpc_decode_int32(stream, &value->int_field));
+    break;
+  case 1:
+    KRPC_CALLBACK_RETURN_ON_ERROR(krpc_decode_string(stream, &value->string_field));
+    break;
+  case 2:
+    KRPC_CALLBACK_RETURN_ON_ERROR(krpc_decode_enum(stream, &value->enum_field));
+    break;
+  case 3:
+    KRPC_CALLBACK_RETURN_ON_ERROR(krpc_decode_list_int32(stream, &value->list_field));
+    break;
+  default:
+    // Fields are only ever appended to a structure, so a value from a newer server may
+    // carry more items than this client knows about, and those are skipped
+    if (!pb_read(stream, NULL, stream->bytes_left))
+      KRPC_CALLBACK_RETURN_ERROR("skipping an appended struct field");
+    break;
+  }
+  state->pos++;
+  return true;
+}
+
+static inline krpc_error_t krpc_decode_TestService_TestStruct(
+  pb_istream_t * stream, krpc_TestService_TestStruct_t * value) {
+  krpc_schema_Tuple message = krpc_schema_Tuple_init_default;
+  message.items.funcs.decode = &krpc_decode_callback_item_TestService_TestStruct;
+  typedef struct State { size_t pos; krpc_TestService_TestStruct_t * value; } State;
+  State state = { 0, value };
+  message.items.arg = &state;
+  KRPC_RETURN_ON_ERROR(krpc_decode_message_Tuple(stream, &message));
+  if (state.pos < 4)
+    KRPC_RETURN_ERROR(DECODING_FAILED, "too few fields for a TestService_TestStruct");
+  return KRPC_OK;
+}
+
+#endif  // KRPC_IMPL_TYPE_TESTSERVICE_TESTSTRUCT
+
+#ifndef KRPC_IMPL_TYPE_TESTSERVICE_TESTNESTEDSTRUCT
+#define KRPC_IMPL_TYPE_TESTSERVICE_TESTNESTEDSTRUCT
+
+static inline bool krpc_encode_callback_items_TestService_TestNestedStruct(
+  pb_ostream_t * stream, const pb_field_t * field, void * const * arg) {
+  const krpc_TestService_TestNestedStruct_t * value = (const krpc_TestService_TestNestedStruct_t*)(*arg);
+  {
+    if (!pb_encode_tag_for_field(stream, field))
+      KRPC_CALLBACK_RETURN_ERROR("encoding tag for tuple item");
+    size_t size;
+    KRPC_CALLBACK_RETURN_ON_ERROR(krpc_encode_size_TestService_TestStruct(&size, &value->struct_field));
+    if (!pb_encode_varint(stream, size))
+      KRPC_CALLBACK_RETURN_ERROR("encoding size for tuple item");
+    KRPC_CALLBACK_RETURN_ON_ERROR(krpc_encode_TestService_TestStruct(stream, &value->struct_field));
+  }
+  {
+    if (!pb_encode_tag_for_field(stream, field))
+      KRPC_CALLBACK_RETURN_ERROR("encoding tag for tuple item");
+    size_t size;
+    KRPC_CALLBACK_RETURN_ON_ERROR(krpc_encode_size_object(&size, value->object_field));
+    if (!pb_encode_varint(stream, size))
+      KRPC_CALLBACK_RETURN_ERROR("encoding size for tuple item");
+    KRPC_CALLBACK_RETURN_ON_ERROR(krpc_encode_object(stream, value->object_field));
+  }
+  {
+    if (!pb_encode_tag_for_field(stream, field))
+      KRPC_CALLBACK_RETURN_ERROR("encoding tag for tuple item");
+    size_t size;
+    KRPC_CALLBACK_RETURN_ON_ERROR(krpc_encode_size_string(&size, value->string_field));
+    if (!pb_encode_varint(stream, size))
+      KRPC_CALLBACK_RETURN_ERROR("encoding size for tuple item");
+    KRPC_CALLBACK_RETURN_ON_ERROR(krpc_encode_string(stream, value->string_field));
+  }
+  return true;
+}
+
+static inline krpc_error_t krpc_encode_TestService_TestNestedStruct(
+  pb_ostream_t * stream, const krpc_TestService_TestNestedStruct_t * value) {
+  krpc_schema_Tuple message = krpc_schema_Tuple_init_default;
+  message.items.funcs.encode = &krpc_encode_callback_items_TestService_TestNestedStruct;
+  message.items.arg = (krpc_TestService_TestNestedStruct_t*)value;
+  KRPC_RETURN_ON_ERROR(krpc_encode_message_Tuple(stream, &message));
+  return KRPC_OK;
+}
+
+static inline krpc_error_t krpc_encode_size_TestService_TestNestedStruct(
+  size_t * size, const krpc_TestService_TestNestedStruct_t * value) {
+  pb_ostream_t stream = PB_OSTREAM_SIZING;
+  KRPC_RETURN_ON_ERROR(krpc_encode_TestService_TestNestedStruct(&stream, value));
+  *size = stream.bytes_written;
+  return KRPC_OK;
+}
+
+static inline bool krpc_encode_callback_TestService_TestNestedStruct(
+  pb_ostream_t * stream, const pb_field_t * field, void * const * arg) {
+  if (!pb_encode_tag_for_field(stream, field))
+    KRPC_CALLBACK_RETURN_ERROR("encoding tag for TestService_TestNestedStruct");
+  krpc_TestService_TestNestedStruct_t * value = (krpc_TestService_TestNestedStruct_t*)(*arg);
+  size_t size;
+  KRPC_CALLBACK_RETURN_ON_ERROR(krpc_encode_size_TestService_TestNestedStruct(&size, value));
+  if (!pb_encode_varint(stream, size))
+    KRPC_CALLBACK_RETURN_ERROR("encoding size for TestService_TestNestedStruct");
+  KRPC_CALLBACK_RETURN_ON_ERROR(krpc_encode_TestService_TestNestedStruct(stream, value));
+  return true;
+}
+
+static inline bool krpc_decode_callback_item_TestService_TestNestedStruct(
+  pb_istream_t * stream, const pb_field_t * field, void ** arg) {
+  typedef struct State {size_t pos; krpc_TestService_TestNestedStruct_t * value;} State;
+  State * state = (State*)(*arg);
+  krpc_TestService_TestNestedStruct_t * value = state->value;
+  switch (state->pos) {
+  case 0:
+    KRPC_CALLBACK_RETURN_ON_ERROR(krpc_decode_TestService_TestStruct(stream, &value->struct_field));
+    break;
+  case 1:
+    KRPC_CALLBACK_RETURN_ON_ERROR(krpc_decode_object(stream, &value->object_field));
+    break;
+  case 2:
+    KRPC_CALLBACK_RETURN_ON_ERROR(krpc_decode_string(stream, &value->string_field));
+    break;
+  default:
+    // Fields are only ever appended to a structure, so a value from a newer server may
+    // carry more items than this client knows about, and those are skipped
+    if (!pb_read(stream, NULL, stream->bytes_left))
+      KRPC_CALLBACK_RETURN_ERROR("skipping an appended struct field");
+    break;
+  }
+  state->pos++;
+  return true;
+}
+
+static inline krpc_error_t krpc_decode_TestService_TestNestedStruct(
+  pb_istream_t * stream, krpc_TestService_TestNestedStruct_t * value) {
+  krpc_schema_Tuple message = krpc_schema_Tuple_init_default;
+  message.items.funcs.decode = &krpc_decode_callback_item_TestService_TestNestedStruct;
+  typedef struct State { size_t pos; krpc_TestService_TestNestedStruct_t * value; } State;
+  State state = { 0, value };
+  message.items.arg = &state;
+  KRPC_RETURN_ON_ERROR(krpc_decode_message_Tuple(stream, &message));
+  if (state.pos < 3)
+    KRPC_RETURN_ERROR(DECODING_FAILED, "too few fields for a TestService_TestNestedStruct");
+  return KRPC_OK;
+}
+
+#endif  // KRPC_IMPL_TYPE_TESTSERVICE_TESTNESTEDSTRUCT
 
 #ifndef KRPC_IMPL_TYPE_DICTIONARY_INT32_BOOL
 #define KRPC_IMPL_TYPE_DICTIONARY_INT32_BOOL
@@ -847,87 +1233,6 @@ static inline krpc_error_t krpc_decode_dictionary_string_int32(
 
 #endif  // KRPC_IMPL_TYPE_DICTIONARY_STRING_INT32
 
-#ifndef KRPC_IMPL_TYPE_LIST_INT32
-#define KRPC_IMPL_TYPE_LIST_INT32
-
-static inline bool krpc_encode_callback_items_list_int32(
-  pb_ostream_t * stream, const pb_field_t * field, void * const * arg) {
-  const krpc_list_int32_t * value = (const krpc_list_int32_t*)(*arg);
-  size_t i = 0;
-  for (; i < value->size; i++) {
-    if (!pb_encode_tag_for_field(stream, field))
-      KRPC_CALLBACK_RETURN_ERROR("encoding tag for list item");
-    size_t size;
-    KRPC_CALLBACK_RETURN_ON_ERROR(krpc_encode_size_int32(&size, value->items[i]));
-    if (!pb_encode_varint(stream, size))
-      KRPC_CALLBACK_RETURN_ERROR("encoding size for list item");
-    KRPC_CALLBACK_RETURN_ON_ERROR(krpc_encode_int32(stream, value->items[i]));
-  }
-  return true;
-}
-
-static inline krpc_error_t krpc_encode_list_int32(
-  pb_ostream_t * stream, const krpc_list_int32_t * value) {
-  krpc_schema_List message = krpc_schema_List_init_default;
-  message.items.funcs.encode = &krpc_encode_callback_items_list_int32;
-  message.items.arg = (krpc_list_int32_t*)value;
-  KRPC_RETURN_ON_ERROR(krpc_encode_message_List(stream, &message));
-  return KRPC_OK;
-}
-
-static inline krpc_error_t krpc_encode_size_list_int32(
-  size_t * size, const krpc_list_int32_t * value) {
-  pb_ostream_t stream = PB_OSTREAM_SIZING;
-  KRPC_RETURN_ON_ERROR(krpc_encode_list_int32(&stream, value));
-  *size = stream.bytes_written;
-  return KRPC_OK;
-}
-
-static inline bool krpc_encode_callback_list_int32(
-  pb_ostream_t * stream, const pb_field_t * field, void * const * arg) {
-  if (!pb_encode_tag_for_field(stream, field))
-    KRPC_CALLBACK_RETURN_ERROR("encoding tag for list_int32");
-  krpc_list_int32_t * value = (krpc_list_int32_t*)(*arg);
-  size_t size;
-  KRPC_CALLBACK_RETURN_ON_ERROR(krpc_encode_size_list_int32(&size, value));
-  if (!pb_encode_varint(stream, size))
-    KRPC_CALLBACK_RETURN_ERROR("encoding size for list_int32");
-  KRPC_CALLBACK_RETURN_ON_ERROR(krpc_encode_list_int32(stream, value));
-  return true;
-}
-
-static inline bool krpc_decode_callback_item_list_int32(
-  pb_istream_t * stream, const pb_field_t * field, void ** arg) {
-  typedef struct State { size_t capacity; krpc_list_int32_t * value; } State;
-  State * state = (State*)(*arg);
-  size_t i = state->value->size;
-  state->value->size++;
-  if (state->capacity > 0 && state->value->size > state->capacity) {
-    state->value->items = (int32_t*)krpc_recalloc(state->value->items, state->capacity, KRPC_ALLOC_BLOCK_SIZE, sizeof(int32_t));
-    state->capacity += KRPC_ALLOC_BLOCK_SIZE;
-  }
-  KRPC_CALLBACK_RETURN_ON_ERROR(krpc_decode_int32(stream, &state->value->items[i]));
-  return true;
-}
-
-static inline krpc_error_t krpc_decode_list_int32(
-  pb_istream_t * stream, krpc_list_int32_t * value) {
-  typedef struct State { size_t capacity; krpc_list_int32_t * value; } State;
-  State state = { 0, value };
-  value->size = 0;
-  if (value->items == NULL) {
-    value->items = (int32_t*)krpc_calloc(KRPC_ALLOC_BLOCK_SIZE, sizeof(int32_t));
-    state.capacity = KRPC_ALLOC_BLOCK_SIZE;
-  }
-  krpc_schema_List message = krpc_schema_List_init_default;
-  message.items.funcs.decode = &krpc_decode_callback_item_list_int32;
-  message.items.arg = &state;
-  KRPC_RETURN_ON_ERROR(krpc_decode_message_List(stream, &message));
-  return KRPC_OK;
-}
-
-#endif  // KRPC_IMPL_TYPE_LIST_INT32
-
 #ifndef KRPC_IMPL_TYPE_DICTIONARY_STRING_LIST_INT32
 #define KRPC_IMPL_TYPE_DICTIONARY_STRING_LIST_INT32
 
@@ -1059,6 +1364,87 @@ static inline krpc_error_t krpc_decode_dictionary_string_list_int32(
 }
 
 #endif  // KRPC_IMPL_TYPE_DICTIONARY_STRING_LIST_INT32
+
+#ifndef KRPC_IMPL_TYPE_LIST_TESTSERVICE_TESTSTRUCT
+#define KRPC_IMPL_TYPE_LIST_TESTSERVICE_TESTSTRUCT
+
+static inline bool krpc_encode_callback_items_list_TestService_TestStruct(
+  pb_ostream_t * stream, const pb_field_t * field, void * const * arg) {
+  const krpc_list_TestService_TestStruct_t * value = (const krpc_list_TestService_TestStruct_t*)(*arg);
+  size_t i = 0;
+  for (; i < value->size; i++) {
+    if (!pb_encode_tag_for_field(stream, field))
+      KRPC_CALLBACK_RETURN_ERROR("encoding tag for list item");
+    size_t size;
+    KRPC_CALLBACK_RETURN_ON_ERROR(krpc_encode_size_TestService_TestStruct(&size, &value->items[i]));
+    if (!pb_encode_varint(stream, size))
+      KRPC_CALLBACK_RETURN_ERROR("encoding size for list item");
+    KRPC_CALLBACK_RETURN_ON_ERROR(krpc_encode_TestService_TestStruct(stream, &value->items[i]));
+  }
+  return true;
+}
+
+static inline krpc_error_t krpc_encode_list_TestService_TestStruct(
+  pb_ostream_t * stream, const krpc_list_TestService_TestStruct_t * value) {
+  krpc_schema_List message = krpc_schema_List_init_default;
+  message.items.funcs.encode = &krpc_encode_callback_items_list_TestService_TestStruct;
+  message.items.arg = (krpc_list_TestService_TestStruct_t*)value;
+  KRPC_RETURN_ON_ERROR(krpc_encode_message_List(stream, &message));
+  return KRPC_OK;
+}
+
+static inline krpc_error_t krpc_encode_size_list_TestService_TestStruct(
+  size_t * size, const krpc_list_TestService_TestStruct_t * value) {
+  pb_ostream_t stream = PB_OSTREAM_SIZING;
+  KRPC_RETURN_ON_ERROR(krpc_encode_list_TestService_TestStruct(&stream, value));
+  *size = stream.bytes_written;
+  return KRPC_OK;
+}
+
+static inline bool krpc_encode_callback_list_TestService_TestStruct(
+  pb_ostream_t * stream, const pb_field_t * field, void * const * arg) {
+  if (!pb_encode_tag_for_field(stream, field))
+    KRPC_CALLBACK_RETURN_ERROR("encoding tag for list_TestService_TestStruct");
+  krpc_list_TestService_TestStruct_t * value = (krpc_list_TestService_TestStruct_t*)(*arg);
+  size_t size;
+  KRPC_CALLBACK_RETURN_ON_ERROR(krpc_encode_size_list_TestService_TestStruct(&size, value));
+  if (!pb_encode_varint(stream, size))
+    KRPC_CALLBACK_RETURN_ERROR("encoding size for list_TestService_TestStruct");
+  KRPC_CALLBACK_RETURN_ON_ERROR(krpc_encode_list_TestService_TestStruct(stream, value));
+  return true;
+}
+
+static inline bool krpc_decode_callback_item_list_TestService_TestStruct(
+  pb_istream_t * stream, const pb_field_t * field, void ** arg) {
+  typedef struct State { size_t capacity; krpc_list_TestService_TestStruct_t * value; } State;
+  State * state = (State*)(*arg);
+  size_t i = state->value->size;
+  state->value->size++;
+  if (state->capacity > 0 && state->value->size > state->capacity) {
+    state->value->items = (krpc_TestService_TestStruct_t*)krpc_recalloc(state->value->items, state->capacity, KRPC_ALLOC_BLOCK_SIZE, sizeof(krpc_TestService_TestStruct_t));
+    state->capacity += KRPC_ALLOC_BLOCK_SIZE;
+  }
+  KRPC_CALLBACK_RETURN_ON_ERROR(krpc_decode_TestService_TestStruct(stream, &state->value->items[i]));
+  return true;
+}
+
+static inline krpc_error_t krpc_decode_list_TestService_TestStruct(
+  pb_istream_t * stream, krpc_list_TestService_TestStruct_t * value) {
+  typedef struct State { size_t capacity; krpc_list_TestService_TestStruct_t * value; } State;
+  State state = { 0, value };
+  value->size = 0;
+  if (value->items == NULL) {
+    value->items = (krpc_TestService_TestStruct_t*)krpc_calloc(KRPC_ALLOC_BLOCK_SIZE, sizeof(krpc_TestService_TestStruct_t));
+    state.capacity = KRPC_ALLOC_BLOCK_SIZE;
+  }
+  krpc_schema_List message = krpc_schema_List_init_default;
+  message.items.funcs.decode = &krpc_decode_callback_item_list_TestService_TestStruct;
+  message.items.arg = &state;
+  KRPC_RETURN_ON_ERROR(krpc_decode_message_List(stream, &message));
+  return KRPC_OK;
+}
+
+#endif  // KRPC_IMPL_TYPE_LIST_TESTSERVICE_TESTSTRUCT
 
 #ifndef KRPC_IMPL_TYPE_LIST_DOUBLE
 #define KRPC_IMPL_TYPE_LIST_DOUBLE
@@ -1989,7 +2375,7 @@ static inline krpc_error_t krpc_TestService_AddMultipleValues(krpc_connection_t 
 static inline krpc_error_t krpc_TestService_AddToObjectList(krpc_connection_t connection, krpc_list_object_t * returnValue, const krpc_list_object_t * l, const char * value) {
   krpc_call_t _call;
   krpc_argument_t _arguments[2];
-  KRPC_CHECK(krpc_call(&_call, 9999, 32, 2, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 38, 2, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_list_object, l));
   KRPC_CHECK(krpc_add_argument(&_call, 1, &krpc_encode_callback_string, &value));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
@@ -2007,7 +2393,7 @@ static inline krpc_error_t krpc_TestService_AddToObjectList(krpc_connection_t co
 static inline krpc_error_t krpc_TestService_BlockingProcedure(krpc_connection_t connection, int32_t * returnValue, int32_t n, int32_t sum) {
   krpc_call_t _call;
   krpc_argument_t _arguments[2];
-  KRPC_CHECK(krpc_call(&_call, 9999, 20, 2, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 26, 2, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_int32, &n));
   KRPC_CHECK(krpc_add_argument(&_call, 1, &krpc_encode_callback_int32, &sum));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
@@ -2059,7 +2445,7 @@ static inline krpc_error_t krpc_TestService_BytesToHexString(krpc_connection_t c
 static inline krpc_error_t krpc_TestService_Counter(krpc_connection_t connection, int32_t * returnValue, const char * id, int32_t divisor) {
   krpc_call_t _call;
   krpc_argument_t _arguments[2];
-  KRPC_CHECK(krpc_call(&_call, 9999, 33, 2, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 39, 2, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_string, &id));
   KRPC_CHECK(krpc_add_argument(&_call, 1, &krpc_encode_callback_int32, &divisor));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
@@ -2069,6 +2455,23 @@ static inline krpc_error_t krpc_TestService_Counter(krpc_connection_t connection
     pb_istream_t _stream;
     KRPC_CHECK(krpc_get_return_value(&_result, &_stream));
     KRPC_CHECK(krpc_decode_int32(&_stream, returnValue));
+  }
+  KRPC_CHECK(krpc_free_result(&_result));
+  return KRPC_OK;
+}
+
+static inline krpc_error_t krpc_TestService_CounterStruct(krpc_connection_t connection, krpc_TestService_TestStruct_t * returnValue, const char * id) {
+  krpc_call_t _call;
+  krpc_argument_t _arguments[1];
+  KRPC_CHECK(krpc_call(&_call, 9999, 25, 1, _arguments));
+  KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_string, &id));
+  krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
+  KRPC_CHECK(krpc_init_result(&_result));
+  KRPC_CHECK(krpc_invoke(connection, &_result.message, &_call.message));
+  if (returnValue) {
+    pb_istream_t _stream;
+    KRPC_CHECK(krpc_get_return_value(&_result, &_stream));
+    KRPC_CHECK(krpc_decode_TestService_TestStruct(&_stream, returnValue));
   }
   KRPC_CHECK(krpc_free_result(&_result));
   return KRPC_OK;
@@ -2094,7 +2497,7 @@ static inline krpc_error_t krpc_TestService_CreateTestObject(krpc_connection_t c
 static inline krpc_error_t krpc_TestService_DeprecatedProcedure(krpc_connection_t connection, char * * returnValue, float value) {
   krpc_call_t _call;
   krpc_argument_t _arguments[1];
-  KRPC_CHECK(krpc_call(&_call, 9999, 45, 1, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 51, 1, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_float, &value));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
@@ -2111,7 +2514,7 @@ static inline krpc_error_t krpc_TestService_DeprecatedProcedure(krpc_connection_
 static inline krpc_error_t krpc_TestService_DeprecatedProcedureNoMessage(krpc_connection_t connection, char * * returnValue, float value) {
   krpc_call_t _call;
   krpc_argument_t _arguments[1];
-  KRPC_CHECK(krpc_call(&_call, 9999, 46, 1, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 52, 1, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_float, &value));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
@@ -2128,7 +2531,7 @@ static inline krpc_error_t krpc_TestService_DeprecatedProcedureNoMessage(krpc_co
 static inline krpc_error_t krpc_TestService_DictionaryDefault(krpc_connection_t connection, krpc_dictionary_int32_bool_t * returnValue, const krpc_dictionary_int32_bool_t * x) {
   krpc_call_t _call;
   krpc_argument_t _arguments[1];
-  KRPC_CHECK(krpc_call(&_call, 9999, 29, 1, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 35, 1, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_dictionary_int32_bool, x));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
@@ -2145,7 +2548,7 @@ static inline krpc_error_t krpc_TestService_DictionaryDefault(krpc_connection_t 
 static inline krpc_error_t krpc_TestService_DoubleSpecialDefaults(krpc_connection_t connection, krpc_list_double_t * returnValue, double nan, double infinity, double negativeInfinity, double maximum, double lowest) {
   krpc_call_t _call;
   krpc_argument_t _arguments[5];
-  KRPC_CHECK(krpc_call(&_call, 9999, 47, 5, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 53, 5, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_double, &nan));
   KRPC_CHECK(krpc_add_argument(&_call, 1, &krpc_encode_callback_double, &infinity));
   KRPC_CHECK(krpc_add_argument(&_call, 2, &krpc_encode_callback_double, &negativeInfinity));
@@ -2292,7 +2695,7 @@ static inline krpc_error_t krpc_TestService_EchoTestObject(krpc_connection_t con
 static inline krpc_error_t krpc_TestService_EmptyListDefault(krpc_connection_t connection, krpc_list_string_t * returnValue, const krpc_list_string_t * x) {
   krpc_call_t _call;
   krpc_argument_t _arguments[1];
-  KRPC_CHECK(krpc_call(&_call, 9999, 31, 1, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 37, 1, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_list_string, x));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
@@ -2343,7 +2746,7 @@ static inline krpc_error_t krpc_TestService_EnumEcho(krpc_connection_t connectio
 static inline krpc_error_t krpc_TestService_EnumListDefault(krpc_connection_t connection, krpc_list_enum_t * returnValue, const krpc_list_enum_t * x) {
   krpc_call_t _call;
   krpc_argument_t _arguments[1];
-  KRPC_CHECK(krpc_call(&_call, 9999, 30, 1, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 36, 1, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_list_enum, x));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
@@ -2375,7 +2778,7 @@ static inline krpc_error_t krpc_TestService_EnumReturn(krpc_connection_t connect
 static inline krpc_error_t krpc_TestService_FloatSpecialDefaults(krpc_connection_t connection, krpc_list_float_t * returnValue, float nan, float infinity, float negativeInfinity, float maximum, float lowest, float fraction) {
   krpc_call_t _call;
   krpc_argument_t _arguments[6];
-  KRPC_CHECK(krpc_call(&_call, 9999, 48, 6, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 54, 6, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_float, &nan));
   KRPC_CHECK(krpc_add_argument(&_call, 1, &krpc_encode_callback_float, &infinity));
   KRPC_CHECK(krpc_add_argument(&_call, 2, &krpc_encode_callback_float, &negativeInfinity));
@@ -2414,7 +2817,7 @@ static inline krpc_error_t krpc_TestService_FloatToString(krpc_connection_t conn
 static inline krpc_error_t krpc_TestService_IncrementDictionary(krpc_connection_t connection, krpc_dictionary_string_int32_t * returnValue, const krpc_dictionary_string_int32_t * d) {
   krpc_call_t _call;
   krpc_argument_t _arguments[1];
-  KRPC_CHECK(krpc_call(&_call, 9999, 22, 1, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 28, 1, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_dictionary_string_int32, d));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
@@ -2431,7 +2834,7 @@ static inline krpc_error_t krpc_TestService_IncrementDictionary(krpc_connection_
 static inline krpc_error_t krpc_TestService_IncrementList(krpc_connection_t connection, krpc_list_int32_t * returnValue, const krpc_list_int32_t * l) {
   krpc_call_t _call;
   krpc_argument_t _arguments[1];
-  KRPC_CHECK(krpc_call(&_call, 9999, 21, 1, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 27, 1, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_list_int32, l));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
@@ -2445,10 +2848,27 @@ static inline krpc_error_t krpc_TestService_IncrementList(krpc_connection_t conn
   return KRPC_OK;
 }
 
+static inline krpc_error_t krpc_TestService_IncrementListOfStructs(krpc_connection_t connection, krpc_list_TestService_TestStruct_t * returnValue, const krpc_list_TestService_TestStruct_t * l) {
+  krpc_call_t _call;
+  krpc_argument_t _arguments[1];
+  KRPC_CHECK(krpc_call(&_call, 9999, 22, 1, _arguments));
+  KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_list_TestService_TestStruct, l));
+  krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
+  KRPC_CHECK(krpc_init_result(&_result));
+  KRPC_CHECK(krpc_invoke(connection, &_result.message, &_call.message));
+  if (returnValue) {
+    pb_istream_t _stream;
+    KRPC_CHECK(krpc_get_return_value(&_result, &_stream));
+    KRPC_CHECK(krpc_decode_list_TestService_TestStruct(&_stream, returnValue));
+  }
+  KRPC_CHECK(krpc_free_result(&_result));
+  return KRPC_OK;
+}
+
 static inline krpc_error_t krpc_TestService_IncrementNestedCollection(krpc_connection_t connection, krpc_dictionary_string_list_int32_t * returnValue, const krpc_dictionary_string_list_int32_t * d) {
   krpc_call_t _call;
   krpc_argument_t _arguments[1];
-  KRPC_CHECK(krpc_call(&_call, 9999, 25, 1, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 31, 1, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_dictionary_string_list_int32, d));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
@@ -2465,7 +2885,7 @@ static inline krpc_error_t krpc_TestService_IncrementNestedCollection(krpc_conne
 static inline krpc_error_t krpc_TestService_IncrementSet(krpc_connection_t connection, krpc_set_int32_t * returnValue, const krpc_set_int32_t * h) {
   krpc_call_t _call;
   krpc_argument_t _arguments[1];
-  KRPC_CHECK(krpc_call(&_call, 9999, 23, 1, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 29, 1, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_set_int32, h));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
@@ -2482,7 +2902,7 @@ static inline krpc_error_t krpc_TestService_IncrementSet(krpc_connection_t conne
 static inline krpc_error_t krpc_TestService_IncrementTuple(krpc_connection_t connection, krpc_tuple_int32_int64_t * returnValue, const krpc_tuple_int32_int64_t * t) {
   krpc_call_t _call;
   krpc_argument_t _arguments[1];
-  KRPC_CHECK(krpc_call(&_call, 9999, 24, 1, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 30, 1, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_tuple_int32_int64, t));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
@@ -2499,7 +2919,7 @@ static inline krpc_error_t krpc_TestService_IncrementTuple(krpc_connection_t con
 static inline krpc_error_t krpc_TestService_Int32SpecialDefaults(krpc_connection_t connection, krpc_list_int32_t * returnValue, int32_t maximum, int32_t minimum) {
   krpc_call_t _call;
   krpc_argument_t _arguments[2];
-  KRPC_CHECK(krpc_call(&_call, 9999, 49, 2, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 55, 2, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_int32, &maximum));
   KRPC_CHECK(krpc_add_argument(&_call, 1, &krpc_encode_callback_int32, &minimum));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
@@ -2534,7 +2954,7 @@ static inline krpc_error_t krpc_TestService_Int32ToString(krpc_connection_t conn
 static inline krpc_error_t krpc_TestService_Int64SpecialDefaults(krpc_connection_t connection, krpc_list_int64_t * returnValue, int64_t maximum, int64_t minimum) {
   krpc_call_t _call;
   krpc_argument_t _arguments[2];
-  KRPC_CHECK(krpc_call(&_call, 9999, 50, 2, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 56, 2, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_int64, &maximum));
   KRPC_CHECK(krpc_add_argument(&_call, 1, &krpc_encode_callback_int64, &minimum));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
@@ -2569,7 +2989,7 @@ static inline krpc_error_t krpc_TestService_Int64ToString(krpc_connection_t conn
 static inline krpc_error_t krpc_TestService_ListDefault(krpc_connection_t connection, krpc_list_int32_t * returnValue, const krpc_list_int32_t * x) {
   krpc_call_t _call;
   krpc_argument_t _arguments[1];
-  KRPC_CHECK(krpc_call(&_call, 9999, 27, 1, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 33, 1, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_list_int32, x));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
@@ -2578,6 +2998,23 @@ static inline krpc_error_t krpc_TestService_ListDefault(krpc_connection_t connec
     pb_istream_t _stream;
     KRPC_CHECK(krpc_get_return_value(&_result, &_stream));
     KRPC_CHECK(krpc_decode_list_int32(&_stream, returnValue));
+  }
+  KRPC_CHECK(krpc_free_result(&_result));
+  return KRPC_OK;
+}
+
+static inline krpc_error_t krpc_TestService_NestedStructEcho(krpc_connection_t connection, krpc_TestService_TestNestedStruct_t * returnValue, const krpc_TestService_TestNestedStruct_t * x) {
+  krpc_call_t _call;
+  krpc_argument_t _arguments[1];
+  KRPC_CHECK(krpc_call(&_call, 9999, 21, 1, _arguments));
+  KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_TestService_TestNestedStruct, x));
+  krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
+  KRPC_CHECK(krpc_init_result(&_result));
+  KRPC_CHECK(krpc_invoke(connection, &_result.message, &_call.message));
+  if (returnValue) {
+    pb_istream_t _stream;
+    KRPC_CHECK(krpc_get_return_value(&_result, &_stream));
+    KRPC_CHECK(krpc_decode_TestService_TestNestedStruct(&_stream, returnValue));
   }
   KRPC_CHECK(krpc_free_result(&_result));
   return KRPC_OK;
@@ -2603,7 +3040,7 @@ static inline krpc_error_t krpc_TestService_NotNullableObject(krpc_connection_t 
 static inline krpc_error_t krpc_TestService_OnTimer(krpc_connection_t connection, krpc_schema_Event * returnValue, uint32_t milliseconds, uint32_t repeats) {
   krpc_call_t _call;
   krpc_argument_t _arguments[2];
-  KRPC_CHECK(krpc_call(&_call, 9999, 43, 2, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 49, 2, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_uint32, &milliseconds));
   KRPC_CHECK(krpc_add_argument(&_call, 1, &krpc_encode_callback_uint32, &repeats));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
@@ -2621,7 +3058,7 @@ static inline krpc_error_t krpc_TestService_OnTimer(krpc_connection_t connection
 static inline krpc_error_t krpc_TestService_OnTimerUsingLambda(krpc_connection_t connection, krpc_schema_Event * returnValue, uint32_t milliseconds) {
   krpc_call_t _call;
   krpc_argument_t _arguments[1];
-  KRPC_CHECK(krpc_call(&_call, 9999, 44, 1, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 50, 1, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_uint32, &milliseconds));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
@@ -2661,7 +3098,7 @@ static inline krpc_error_t krpc_TestService_OptionalArguments(krpc_connection_t 
 
 static inline krpc_error_t krpc_TestService_ResetCustomExceptionLater(krpc_connection_t connection) {
   krpc_call_t _call;
-  KRPC_CHECK(krpc_call(&_call, 9999, 41, 0, NULL));
+  KRPC_CHECK(krpc_call(&_call, 9999, 47, 0, NULL));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
   KRPC_CHECK(krpc_invoke(connection, &_result.message, &_call.message));
@@ -2671,7 +3108,7 @@ static inline krpc_error_t krpc_TestService_ResetCustomExceptionLater(krpc_conne
 
 static inline krpc_error_t krpc_TestService_ResetInvalidOperationExceptionLater(krpc_connection_t connection) {
   krpc_call_t _call;
-  KRPC_CHECK(krpc_call(&_call, 9999, 35, 0, NULL));
+  KRPC_CHECK(krpc_call(&_call, 9999, 41, 0, NULL));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
   KRPC_CHECK(krpc_invoke(connection, &_result.message, &_call.message));
@@ -2697,7 +3134,7 @@ static inline krpc_error_t krpc_TestService_ReturnNullWhenNotAllowed(krpc_connec
 static inline krpc_error_t krpc_TestService_SetDefault(krpc_connection_t connection, krpc_set_int32_t * returnValue, const krpc_set_int32_t * x) {
   krpc_call_t _call;
   krpc_argument_t _arguments[1];
-  KRPC_CHECK(krpc_call(&_call, 9999, 28, 1, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 34, 1, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_set_int32, x));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
@@ -2728,9 +3165,71 @@ static inline krpc_error_t krpc_TestService_StringToInt32(krpc_connection_t conn
   return KRPC_OK;
 }
 
+static inline krpc_error_t krpc_TestService_StructDefault(krpc_connection_t connection, krpc_TestService_TestStruct_t * returnValue, const krpc_TestService_TestStruct_t * x) {
+  krpc_call_t _call;
+  krpc_argument_t _arguments[1];
+  KRPC_CHECK(krpc_call(&_call, 9999, 23, 1, _arguments));
+  KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_TestService_TestStruct, x));
+  krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
+  KRPC_CHECK(krpc_init_result(&_result));
+  KRPC_CHECK(krpc_invoke(connection, &_result.message, &_call.message));
+  if (returnValue) {
+    pb_istream_t _stream;
+    KRPC_CHECK(krpc_get_return_value(&_result, &_stream));
+    KRPC_CHECK(krpc_decode_TestService_TestStruct(&_stream, returnValue));
+  }
+  KRPC_CHECK(krpc_free_result(&_result));
+  return KRPC_OK;
+}
+
+static inline krpc_error_t krpc_TestService_StructEcho(krpc_connection_t connection, krpc_TestService_TestStruct_t * returnValue, const krpc_TestService_TestStruct_t * x) {
+  krpc_call_t _call;
+  krpc_argument_t _arguments[1];
+  KRPC_CHECK(krpc_call(&_call, 9999, 20, 1, _arguments));
+  KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_TestService_TestStruct, x));
+  krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
+  KRPC_CHECK(krpc_init_result(&_result));
+  KRPC_CHECK(krpc_invoke(connection, &_result.message, &_call.message));
+  if (returnValue) {
+    pb_istream_t _stream;
+    KRPC_CHECK(krpc_get_return_value(&_result, &_stream));
+    KRPC_CHECK(krpc_decode_TestService_TestStruct(&_stream, returnValue));
+  }
+  KRPC_CHECK(krpc_free_result(&_result));
+  return KRPC_OK;
+}
+
+static inline krpc_error_t krpc_TestService_StructEchoNullable(krpc_connection_t connection, krpc_TestService_TestStruct_t * returnValue, bool * returnValueIsNull, const krpc_TestService_TestStruct_t * x) {
+  krpc_call_t _call;
+  krpc_argument_t _arguments[1];
+  KRPC_CHECK(krpc_call(&_call, 9999, 24, 1, _arguments));
+  if (x == NULL) {
+    KRPC_CHECK(krpc_add_null_argument(&_call, 0));
+  } else {
+    KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_TestService_TestStruct, x));
+  }
+  krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
+  KRPC_CHECK(krpc_init_result(&_result));
+  KRPC_CHECK(krpc_invoke(connection, &_result.message, &_call.message));
+  if (returnValue) {
+    if (_result.message.is_null) {
+      if (returnValueIsNull)
+        *returnValueIsNull = true;
+    } else {
+      if (returnValueIsNull)
+        *returnValueIsNull = false;
+      pb_istream_t _stream;
+      KRPC_CHECK(krpc_get_return_value(&_result, &_stream));
+      KRPC_CHECK(krpc_decode_TestService_TestStruct(&_stream, returnValue));
+    }
+  }
+  KRPC_CHECK(krpc_free_result(&_result));
+  return KRPC_OK;
+}
+
 static inline krpc_error_t krpc_TestService_ThrowArgumentException(krpc_connection_t connection, int32_t * returnValue) {
   krpc_call_t _call;
-  KRPC_CHECK(krpc_call(&_call, 9999, 37, 0, NULL));
+  KRPC_CHECK(krpc_call(&_call, 9999, 43, 0, NULL));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
   KRPC_CHECK(krpc_invoke(connection, &_result.message, &_call.message));
@@ -2746,7 +3245,7 @@ static inline krpc_error_t krpc_TestService_ThrowArgumentException(krpc_connecti
 static inline krpc_error_t krpc_TestService_ThrowArgumentNullException(krpc_connection_t connection, int32_t * returnValue, const char * foo) {
   krpc_call_t _call;
   krpc_argument_t _arguments[1];
-  KRPC_CHECK(krpc_call(&_call, 9999, 38, 1, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 44, 1, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_string, &foo));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
@@ -2763,7 +3262,7 @@ static inline krpc_error_t krpc_TestService_ThrowArgumentNullException(krpc_conn
 static inline krpc_error_t krpc_TestService_ThrowArgumentOutOfRangeException(krpc_connection_t connection, int32_t * returnValue, int32_t foo) {
   krpc_call_t _call;
   krpc_argument_t _arguments[1];
-  KRPC_CHECK(krpc_call(&_call, 9999, 39, 1, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 45, 1, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_int32, &foo));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
@@ -2779,7 +3278,7 @@ static inline krpc_error_t krpc_TestService_ThrowArgumentOutOfRangeException(krp
 
 static inline krpc_error_t krpc_TestService_ThrowCustomException(krpc_connection_t connection, int32_t * returnValue) {
   krpc_call_t _call;
-  KRPC_CHECK(krpc_call(&_call, 9999, 40, 0, NULL));
+  KRPC_CHECK(krpc_call(&_call, 9999, 46, 0, NULL));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
   KRPC_CHECK(krpc_invoke(connection, &_result.message, &_call.message));
@@ -2794,7 +3293,7 @@ static inline krpc_error_t krpc_TestService_ThrowCustomException(krpc_connection
 
 static inline krpc_error_t krpc_TestService_ThrowCustomExceptionLater(krpc_connection_t connection, int32_t * returnValue) {
   krpc_call_t _call;
-  KRPC_CHECK(krpc_call(&_call, 9999, 42, 0, NULL));
+  KRPC_CHECK(krpc_call(&_call, 9999, 48, 0, NULL));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
   KRPC_CHECK(krpc_invoke(connection, &_result.message, &_call.message));
@@ -2809,7 +3308,7 @@ static inline krpc_error_t krpc_TestService_ThrowCustomExceptionLater(krpc_conne
 
 static inline krpc_error_t krpc_TestService_ThrowInvalidOperationException(krpc_connection_t connection, int32_t * returnValue) {
   krpc_call_t _call;
-  KRPC_CHECK(krpc_call(&_call, 9999, 34, 0, NULL));
+  KRPC_CHECK(krpc_call(&_call, 9999, 40, 0, NULL));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
   KRPC_CHECK(krpc_invoke(connection, &_result.message, &_call.message));
@@ -2824,7 +3323,7 @@ static inline krpc_error_t krpc_TestService_ThrowInvalidOperationException(krpc_
 
 static inline krpc_error_t krpc_TestService_ThrowInvalidOperationExceptionLater(krpc_connection_t connection, int32_t * returnValue) {
   krpc_call_t _call;
-  KRPC_CHECK(krpc_call(&_call, 9999, 36, 0, NULL));
+  KRPC_CHECK(krpc_call(&_call, 9999, 42, 0, NULL));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
   KRPC_CHECK(krpc_invoke(connection, &_result.message, &_call.message));
@@ -2840,7 +3339,7 @@ static inline krpc_error_t krpc_TestService_ThrowInvalidOperationExceptionLater(
 static inline krpc_error_t krpc_TestService_TupleDefault(krpc_connection_t connection, krpc_tuple_int32_bool_t * returnValue, const krpc_tuple_int32_bool_t * x) {
   krpc_call_t _call;
   krpc_argument_t _arguments[1];
-  KRPC_CHECK(krpc_call(&_call, 9999, 26, 1, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 32, 1, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_tuple_int32_bool, x));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
@@ -2857,7 +3356,7 @@ static inline krpc_error_t krpc_TestService_TupleDefault(krpc_connection_t conne
 static inline krpc_error_t krpc_TestService_Uint32SpecialDefaults(krpc_connection_t connection, krpc_list_uint32_t * returnValue, uint32_t maximum) {
   krpc_call_t _call;
   krpc_argument_t _arguments[1];
-  KRPC_CHECK(krpc_call(&_call, 9999, 51, 1, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 57, 1, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_uint32, &maximum));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
@@ -2874,7 +3373,7 @@ static inline krpc_error_t krpc_TestService_Uint32SpecialDefaults(krpc_connectio
 static inline krpc_error_t krpc_TestService_Uint64SpecialDefaults(krpc_connection_t connection, krpc_list_uint64_t * returnValue, uint64_t maximum) {
   krpc_call_t _call;
   krpc_argument_t _arguments[1];
-  KRPC_CHECK(krpc_call(&_call, 9999, 52, 1, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 58, 1, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_uint64, &maximum));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
@@ -2890,7 +3389,7 @@ static inline krpc_error_t krpc_TestService_Uint64SpecialDefaults(krpc_connectio
 
 static inline krpc_error_t krpc_TestService_DeprecatedProperty(krpc_connection_t connection, char * * returnValue) {
   krpc_call_t _call;
-  KRPC_CHECK(krpc_call(&_call, 9999, 61, 0, NULL));
+  KRPC_CHECK(krpc_call(&_call, 9999, 67, 0, NULL));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
   KRPC_CHECK(krpc_invoke(connection, &_result.message, &_call.message));
@@ -2906,7 +3405,7 @@ static inline krpc_error_t krpc_TestService_DeprecatedProperty(krpc_connection_t
 static inline krpc_error_t krpc_TestService_set_DeprecatedProperty(krpc_connection_t connection, const char * value) {
   krpc_call_t _call;
   krpc_argument_t _arguments[1];
-  KRPC_CHECK(krpc_call(&_call, 9999, 62, 1, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 68, 1, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_string, &value));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
@@ -2917,7 +3416,7 @@ static inline krpc_error_t krpc_TestService_set_DeprecatedProperty(krpc_connecti
 
 static inline krpc_error_t krpc_TestService_NullableObject(krpc_connection_t connection, krpc_TestService_TestClass_t * returnValue) {
   krpc_call_t _call;
-  KRPC_CHECK(krpc_call(&_call, 9999, 59, 0, NULL));
+  KRPC_CHECK(krpc_call(&_call, 9999, 65, 0, NULL));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
   KRPC_CHECK(krpc_invoke(connection, &_result.message, &_call.message));
@@ -2937,7 +3436,7 @@ static inline krpc_error_t krpc_TestService_NullableObject(krpc_connection_t con
 static inline krpc_error_t krpc_TestService_set_NullableObject(krpc_connection_t connection, krpc_TestService_TestClass_t value) {
   krpc_call_t _call;
   krpc_argument_t _arguments[1];
-  KRPC_CHECK(krpc_call(&_call, 9999, 60, 1, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 66, 1, _arguments));
   if (value == KRPC_NULL) {
     KRPC_CHECK(krpc_add_null_argument(&_call, 0));
   } else {
@@ -2952,7 +3451,7 @@ static inline krpc_error_t krpc_TestService_set_NullableObject(krpc_connection_t
 
 static inline krpc_error_t krpc_TestService_ObjectProperty(krpc_connection_t connection, krpc_TestService_TestClass_t * returnValue) {
   krpc_call_t _call;
-  KRPC_CHECK(krpc_call(&_call, 9999, 57, 0, NULL));
+  KRPC_CHECK(krpc_call(&_call, 9999, 63, 0, NULL));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
   KRPC_CHECK(krpc_invoke(connection, &_result.message, &_call.message));
@@ -2972,7 +3471,7 @@ static inline krpc_error_t krpc_TestService_ObjectProperty(krpc_connection_t con
 static inline krpc_error_t krpc_TestService_set_ObjectProperty(krpc_connection_t connection, krpc_TestService_TestClass_t value) {
   krpc_call_t _call;
   krpc_argument_t _arguments[1];
-  KRPC_CHECK(krpc_call(&_call, 9999, 58, 1, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 64, 1, _arguments));
   if (value == KRPC_NULL) {
     KRPC_CHECK(krpc_add_null_argument(&_call, 0));
   } else {
@@ -2987,7 +3486,7 @@ static inline krpc_error_t krpc_TestService_set_ObjectProperty(krpc_connection_t
 
 static inline krpc_error_t krpc_TestService_StringProperty(krpc_connection_t connection, char * * returnValue) {
   krpc_call_t _call;
-  KRPC_CHECK(krpc_call(&_call, 9999, 53, 0, NULL));
+  KRPC_CHECK(krpc_call(&_call, 9999, 59, 0, NULL));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
   KRPC_CHECK(krpc_invoke(connection, &_result.message, &_call.message));
@@ -3003,7 +3502,7 @@ static inline krpc_error_t krpc_TestService_StringProperty(krpc_connection_t con
 static inline krpc_error_t krpc_TestService_set_StringProperty(krpc_connection_t connection, const char * value) {
   krpc_call_t _call;
   krpc_argument_t _arguments[1];
-  KRPC_CHECK(krpc_call(&_call, 9999, 54, 1, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 60, 1, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_string, &value));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
@@ -3015,7 +3514,7 @@ static inline krpc_error_t krpc_TestService_set_StringProperty(krpc_connection_t
 static inline krpc_error_t krpc_TestService_set_StringPropertyPrivateGet(krpc_connection_t connection, const char * value) {
   krpc_call_t _call;
   krpc_argument_t _arguments[1];
-  KRPC_CHECK(krpc_call(&_call, 9999, 55, 1, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 61, 1, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_string, &value));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
@@ -3026,7 +3525,7 @@ static inline krpc_error_t krpc_TestService_set_StringPropertyPrivateGet(krpc_co
 
 static inline krpc_error_t krpc_TestService_StringPropertyPrivateSet(krpc_connection_t connection, char * * returnValue) {
   krpc_call_t _call;
-  KRPC_CHECK(krpc_call(&_call, 9999, 56, 0, NULL));
+  KRPC_CHECK(krpc_call(&_call, 9999, 62, 0, NULL));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
   KRPC_CHECK(krpc_invoke(connection, &_result.message, &_call.message));
@@ -3042,7 +3541,7 @@ static inline krpc_error_t krpc_TestService_StringPropertyPrivateSet(krpc_connec
 static inline krpc_error_t krpc_TestService_DeprecatedClass_DeprecatedMethod(krpc_connection_t connection, char * * returnValue, krpc_TestService_DeprecatedClass_t instance) {
   krpc_call_t _call;
   krpc_argument_t _arguments[1];
-  KRPC_CHECK(krpc_call(&_call, 9999, 76, 1, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 82, 1, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_uint64, &instance));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
@@ -3059,7 +3558,7 @@ static inline krpc_error_t krpc_TestService_DeprecatedClass_DeprecatedMethod(krp
 static inline krpc_error_t krpc_TestService_TestClass_EchoNullableObject(krpc_connection_t connection, krpc_TestService_TestClass_t * returnValue, krpc_TestService_TestClass_t instance, krpc_TestService_TestClass_t value) {
   krpc_call_t _call;
   krpc_argument_t _arguments[2];
-  KRPC_CHECK(krpc_call(&_call, 9999, 66, 2, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 72, 2, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_uint64, &instance));
   if (value == KRPC_NULL) {
     KRPC_CHECK(krpc_add_null_argument(&_call, 1));
@@ -3085,7 +3584,7 @@ static inline krpc_error_t krpc_TestService_TestClass_EchoNullableObject(krpc_co
 static inline krpc_error_t krpc_TestService_TestClass_FloatToString(krpc_connection_t connection, char * * returnValue, krpc_TestService_TestClass_t instance, float x) {
   krpc_call_t _call;
   krpc_argument_t _arguments[2];
-  KRPC_CHECK(krpc_call(&_call, 9999, 64, 2, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 70, 2, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_uint64, &instance));
   KRPC_CHECK(krpc_add_argument(&_call, 1, &krpc_encode_callback_float, &x));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
@@ -3103,7 +3602,7 @@ static inline krpc_error_t krpc_TestService_TestClass_FloatToString(krpc_connect
 static inline krpc_error_t krpc_TestService_TestClass_GetValue(krpc_connection_t connection, char * * returnValue, krpc_TestService_TestClass_t instance) {
   krpc_call_t _call;
   krpc_argument_t _arguments[1];
-  KRPC_CHECK(krpc_call(&_call, 9999, 63, 1, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 69, 1, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_uint64, &instance));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
@@ -3120,7 +3619,7 @@ static inline krpc_error_t krpc_TestService_TestClass_GetValue(krpc_connection_t
 static inline krpc_error_t krpc_TestService_TestClass_ObjectToString(krpc_connection_t connection, char * * returnValue, krpc_TestService_TestClass_t instance, krpc_TestService_TestClass_t other) {
   krpc_call_t _call;
   krpc_argument_t _arguments[2];
-  KRPC_CHECK(krpc_call(&_call, 9999, 65, 2, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 71, 2, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_uint64, &instance));
   if (other == KRPC_NULL) {
     KRPC_CHECK(krpc_add_null_argument(&_call, 1));
@@ -3142,7 +3641,7 @@ static inline krpc_error_t krpc_TestService_TestClass_ObjectToString(krpc_connec
 static inline krpc_error_t krpc_TestService_TestClass_OptionalArguments(krpc_connection_t connection, char * * returnValue, krpc_TestService_TestClass_t instance, const char * x, const char * y, const char * z, krpc_TestService_TestClass_t obj) {
   krpc_call_t _call;
   krpc_argument_t _arguments[5];
-  KRPC_CHECK(krpc_call(&_call, 9999, 67, 5, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 73, 5, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_uint64, &instance));
   KRPC_CHECK(krpc_add_argument(&_call, 1, &krpc_encode_callback_string, &x));
   KRPC_CHECK(krpc_add_argument(&_call, 2, &krpc_encode_callback_string, &y));
@@ -3167,7 +3666,7 @@ static inline krpc_error_t krpc_TestService_TestClass_OptionalArguments(krpc_con
 static inline krpc_error_t krpc_TestService_TestClass_IntProperty(krpc_connection_t connection, int32_t * returnValue, krpc_TestService_TestClass_t instance) {
   krpc_call_t _call;
   krpc_argument_t _arguments[1];
-  KRPC_CHECK(krpc_call(&_call, 9999, 70, 1, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 76, 1, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_uint64, &instance));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
@@ -3184,7 +3683,7 @@ static inline krpc_error_t krpc_TestService_TestClass_IntProperty(krpc_connectio
 static inline krpc_error_t krpc_TestService_TestClass_set_IntProperty(krpc_connection_t connection, krpc_TestService_TestClass_t instance, int32_t value) {
   krpc_call_t _call;
   krpc_argument_t _arguments[2];
-  KRPC_CHECK(krpc_call(&_call, 9999, 71, 2, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 77, 2, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_uint64, &instance));
   KRPC_CHECK(krpc_add_argument(&_call, 1, &krpc_encode_callback_int32, &value));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
@@ -3197,7 +3696,7 @@ static inline krpc_error_t krpc_TestService_TestClass_set_IntProperty(krpc_conne
 static inline krpc_error_t krpc_TestService_TestClass_ObjectProperty(krpc_connection_t connection, krpc_TestService_TestClass_t * returnValue, krpc_TestService_TestClass_t instance) {
   krpc_call_t _call;
   krpc_argument_t _arguments[1];
-  KRPC_CHECK(krpc_call(&_call, 9999, 72, 1, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 78, 1, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_uint64, &instance));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
@@ -3218,7 +3717,7 @@ static inline krpc_error_t krpc_TestService_TestClass_ObjectProperty(krpc_connec
 static inline krpc_error_t krpc_TestService_TestClass_set_ObjectProperty(krpc_connection_t connection, krpc_TestService_TestClass_t instance, krpc_TestService_TestClass_t value) {
   krpc_call_t _call;
   krpc_argument_t _arguments[2];
-  KRPC_CHECK(krpc_call(&_call, 9999, 73, 2, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 79, 2, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_uint64, &instance));
   if (value == KRPC_NULL) {
     KRPC_CHECK(krpc_add_null_argument(&_call, 1));
@@ -3235,7 +3734,7 @@ static inline krpc_error_t krpc_TestService_TestClass_set_ObjectProperty(krpc_co
 static inline krpc_error_t krpc_TestService_TestClass_set_StringPropertyPrivateGet(krpc_connection_t connection, krpc_TestService_TestClass_t instance, const char * value) {
   krpc_call_t _call;
   krpc_argument_t _arguments[2];
-  KRPC_CHECK(krpc_call(&_call, 9999, 74, 2, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 80, 2, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_uint64, &instance));
   KRPC_CHECK(krpc_add_argument(&_call, 1, &krpc_encode_callback_string, &value));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
@@ -3248,7 +3747,7 @@ static inline krpc_error_t krpc_TestService_TestClass_set_StringPropertyPrivateG
 static inline krpc_error_t krpc_TestService_TestClass_StringPropertyPrivateSet(krpc_connection_t connection, char * * returnValue, krpc_TestService_TestClass_t instance) {
   krpc_call_t _call;
   krpc_argument_t _arguments[1];
-  KRPC_CHECK(krpc_call(&_call, 9999, 75, 1, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 81, 1, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_uint64, &instance));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
@@ -3265,7 +3764,7 @@ static inline krpc_error_t krpc_TestService_TestClass_StringPropertyPrivateSet(k
 static inline krpc_error_t krpc_TestService_TestClass_StaticMethod(krpc_connection_t connection, char * * returnValue, const char * a, const char * b) {
   krpc_call_t _call;
   krpc_argument_t _arguments[2];
-  KRPC_CHECK(krpc_call(&_call, 9999, 68, 2, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 74, 2, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_string, &a));
   KRPC_CHECK(krpc_add_argument(&_call, 1, &krpc_encode_callback_string, &b));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
@@ -3283,7 +3782,7 @@ static inline krpc_error_t krpc_TestService_TestClass_StaticMethod(krpc_connecti
 static inline krpc_error_t krpc_TestService_TestClass_StaticNullableObject(krpc_connection_t connection, krpc_TestService_TestClass_t * returnValue, krpc_TestService_TestClass_t value) {
   krpc_call_t _call;
   krpc_argument_t _arguments[1];
-  KRPC_CHECK(krpc_call(&_call, 9999, 69, 1, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 75, 1, _arguments));
   if (value == KRPC_NULL) {
     KRPC_CHECK(krpc_add_null_argument(&_call, 0));
   } else {

--- a/tools/krpctools/krpctools/test/clientgen-TestService-cpp.txt
+++ b/tools/krpctools/krpctools/test/clientgen-TestService-cpp.txt
@@ -26,6 +26,11 @@ class TestService : public Service {
   class DeprecatedClass;
   class TestClass;
 
+  // Structure forward declarations
+  struct DeprecatedStruct;
+  struct TestStruct;
+  struct TestNestedStruct;
+
   class CustomException : public ::krpc::RPCError {
    public:
     inline explicit CustomException(const std::string& msg) : ::krpc::RPCError(msg) {}
@@ -89,6 +94,12 @@ class TestService : public Service {
 
   int32_t counter(std::string id, int32_t divisor);
 
+  /**
+   * Returns a struct whose IntField counts the number of times it has been called,
+   * so that a stream on it changes on every update.
+   */
+  TestService::TestStruct counter_struct(std::string id);
+
   TestService::TestClass create_test_object(std::string value);
 
   /**
@@ -147,6 +158,8 @@ class TestService : public Service {
 
   std::vector<int32_t> increment_list(std::vector<int32_t> l);
 
+  std::vector<TestService::TestStruct> increment_list_of_structs(std::vector<TestService::TestStruct> l);
+
   std::map<std::string, std::vector<int32_t> > increment_nested_collection(std::map<std::string, std::vector<int32_t> > d);
 
   std::set<int32_t> increment_set(std::set<int32_t> h);
@@ -169,6 +182,8 @@ class TestService : public Service {
 
   std::vector<int32_t> list_default(std::vector<int32_t> x);
 
+  TestService::TestNestedStruct nested_struct_echo(TestService::TestNestedStruct x);
+
   TestService::TestClass not_nullable_object(TestService::TestClass value);
 
   ::krpc::Event on_timer(uint32_t milliseconds, uint32_t repeats);
@@ -186,6 +201,12 @@ class TestService : public Service {
   std::set<int32_t> set_default(std::set<int32_t> x);
 
   int32_t string_to_int32(std::string value);
+
+  TestService::TestStruct struct_default(TestService::TestStruct x);
+
+  TestService::TestStruct struct_echo(TestService::TestStruct x);
+
+  std::optional<TestService::TestStruct> struct_echo_nullable(std::optional<TestService::TestStruct> x);
 
   int32_t throw_argument_exception();
 
@@ -263,6 +284,8 @@ class TestService : public Service {
 
   ::krpc::Stream<int32_t> counter_stream(std::string id, int32_t divisor);
 
+  ::krpc::Stream<TestService::TestStruct> counter_struct_stream(std::string id);
+
   ::krpc::Stream<TestService::TestClass> create_test_object_stream(std::string value);
 
   ::krpc::Stream<std::string> deprecated_procedure_stream(float value);
@@ -301,6 +324,8 @@ class TestService : public Service {
 
   ::krpc::Stream<std::vector<int32_t>> increment_list_stream(std::vector<int32_t> l);
 
+  ::krpc::Stream<std::vector<TestService::TestStruct>> increment_list_of_structs_stream(std::vector<TestService::TestStruct> l);
+
   ::krpc::Stream<std::map<std::string, std::vector<int32_t> >> increment_nested_collection_stream(std::map<std::string, std::vector<int32_t> > d);
 
   ::krpc::Stream<std::set<int32_t>> increment_set_stream(std::set<int32_t> h);
@@ -317,6 +342,8 @@ class TestService : public Service {
 
   ::krpc::Stream<std::vector<int32_t>> list_default_stream(std::vector<int32_t> x);
 
+  ::krpc::Stream<TestService::TestNestedStruct> nested_struct_echo_stream(TestService::TestNestedStruct x);
+
   ::krpc::Stream<TestService::TestClass> not_nullable_object_stream(TestService::TestClass value);
 
   ::krpc::Stream<::krpc::Event> on_timer_stream(uint32_t milliseconds, uint32_t repeats);
@@ -330,6 +357,12 @@ class TestService : public Service {
   ::krpc::Stream<std::set<int32_t>> set_default_stream(std::set<int32_t> x);
 
   ::krpc::Stream<int32_t> string_to_int32_stream(std::string value);
+
+  ::krpc::Stream<TestService::TestStruct> struct_default_stream(TestService::TestStruct x);
+
+  ::krpc::Stream<TestService::TestStruct> struct_echo_stream(TestService::TestStruct x);
+
+  ::krpc::Stream<std::optional<TestService::TestStruct>> struct_echo_nullable_stream(std::optional<TestService::TestStruct> x);
 
   ::krpc::Stream<int32_t> throw_argument_exception_stream();
 
@@ -373,6 +406,8 @@ class TestService : public Service {
 
   ::krpc::schema::ProcedureCall counter_call(std::string id, int32_t divisor);
 
+  ::krpc::schema::ProcedureCall counter_struct_call(std::string id);
+
   ::krpc::schema::ProcedureCall create_test_object_call(std::string value);
 
   ::krpc::schema::ProcedureCall deprecated_procedure_call(float value);
@@ -411,6 +446,8 @@ class TestService : public Service {
 
   ::krpc::schema::ProcedureCall increment_list_call(std::vector<int32_t> l);
 
+  ::krpc::schema::ProcedureCall increment_list_of_structs_call(std::vector<TestService::TestStruct> l);
+
   ::krpc::schema::ProcedureCall increment_nested_collection_call(std::map<std::string, std::vector<int32_t> > d);
 
   ::krpc::schema::ProcedureCall increment_set_call(std::set<int32_t> h);
@@ -426,6 +463,8 @@ class TestService : public Service {
   ::krpc::schema::ProcedureCall int64_to_string_call(int64_t value);
 
   ::krpc::schema::ProcedureCall list_default_call(std::vector<int32_t> x);
+
+  ::krpc::schema::ProcedureCall nested_struct_echo_call(TestService::TestNestedStruct x);
 
   ::krpc::schema::ProcedureCall not_nullable_object_call(TestService::TestClass value);
 
@@ -444,6 +483,12 @@ class TestService : public Service {
   ::krpc::schema::ProcedureCall set_default_call(std::set<int32_t> x);
 
   ::krpc::schema::ProcedureCall string_to_int32_call(std::string value);
+
+  ::krpc::schema::ProcedureCall struct_default_call(TestService::TestStruct x);
+
+  ::krpc::schema::ProcedureCall struct_echo_call(TestService::TestStruct x);
+
+  ::krpc::schema::ProcedureCall struct_echo_nullable_call(std::optional<TestService::TestStruct> x);
 
   ::krpc::schema::ProcedureCall throw_argument_exception_call();
 
@@ -595,6 +640,85 @@ class TestService : public Service {
 
     ::krpc::schema::ProcedureCall string_property_private_set_call();
   };
+
+  /**
+   * Deprecated struct documentation string.
+   *
+   * \deprecated Use the TestStruct struct instead.
+   */
+  struct [[deprecated("Use the TestStruct struct instead.")]] DeprecatedStruct {
+    /**
+     * Deprecated struct Value documentation string.
+     */
+    int32_t value;
+    /**
+     * Deprecated struct OldValue documentation string.
+     *
+     * \deprecated Use the Value field instead.
+     */
+    int32_t old_value [[deprecated("Use the Value field instead.")]];
+
+    DeprecatedStruct() : value(), old_value() {}
+
+    DeprecatedStruct(int32_t value, int32_t old_value) :
+value(value), old_value(old_value) {}
+
+    bool operator==(const DeprecatedStruct& other) const {
+      return this->value == other.value && this->old_value == other.old_value;
+    }
+
+    bool operator!=(const DeprecatedStruct& other) const {
+      return !(*this == other);
+    }
+  };
+
+  /**
+   * Struct documentation string.
+   */
+  struct TestStruct {
+    /**
+     * Struct IntField documentation string.
+     */
+    int32_t int_field;
+    std::string string_field;
+    TestService::TestEnum enum_field;
+    std::vector<int32_t> list_field;
+
+    TestStruct() : int_field(), string_field(), enum_field(), list_field() {}
+
+    TestStruct(int32_t int_field, std::string string_field, TestService::TestEnum enum_field, std::vector<int32_t> list_field) :
+int_field(int_field), string_field(string_field), enum_field(enum_field), list_field(list_field) {}
+
+    bool operator==(const TestStruct& other) const {
+      return this->int_field == other.int_field && this->string_field == other.string_field && this->enum_field == other.enum_field && this->list_field == other.list_field;
+    }
+
+    bool operator!=(const TestStruct& other) const {
+      return !(*this == other);
+    }
+  };
+
+  /**
+   * Nested struct documentation string.
+   */
+  struct TestNestedStruct {
+    TestService::TestStruct struct_field;
+    TestService::TestClass object_field;
+    std::string string_field;
+
+    TestNestedStruct() : struct_field(), object_field(), string_field() {}
+
+    TestNestedStruct(TestService::TestStruct struct_field, TestService::TestClass object_field, std::string string_field) :
+struct_field(struct_field), object_field(object_field), string_field(string_field) {}
+
+    bool operator==(const TestNestedStruct& other) const {
+      return this->struct_field == other.struct_field && this->object_field == other.object_field && this->string_field == other.string_field;
+    }
+
+    bool operator!=(const TestNestedStruct& other) const {
+      return !(*this == other);
+    }
+  };
 };
 
 }  // namespace services
@@ -614,6 +738,49 @@ namespace encoder {
 
   inline std::string encode(const services::TestService::TestEnum& value) {
     return krpc::encoder::encode(static_cast<int32_t>(value));
+  }
+
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+  // A structure is sent as the values of its fields in order, which is the same encoding as
+  // a tuple of those values. See the note on the collection encoders for why the message it
+  // is sent in is kept between calls.
+  inline std::string encode(const services::TestService::DeprecatedStruct& value) {
+    static thread_local krpc::schema::Tuple structMessage;
+    structMessage.Clear();
+    structMessage.add_items(encode(value.value));
+    structMessage.add_items(encode(value.old_value));
+    return krpc::encoder::encode(structMessage);
+  }
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
+
+  // A structure is sent as the values of its fields in order, which is the same encoding as
+  // a tuple of those values. See the note on the collection encoders for why the message it
+  // is sent in is kept between calls.
+  inline std::string encode(const services::TestService::TestStruct& value) {
+    static thread_local krpc::schema::Tuple structMessage;
+    structMessage.Clear();
+    structMessage.add_items(encode(value.int_field));
+    structMessage.add_items(encode(value.string_field));
+    structMessage.add_items(encode(value.enum_field));
+    structMessage.add_items(encode(value.list_field));
+    return krpc::encoder::encode(structMessage);
+  }
+
+  // A structure is sent as the values of its fields in order, which is the same encoding as
+  // a tuple of those values. See the note on the collection encoders for why the message it
+  // is sent in is kept between calls.
+  inline std::string encode(const services::TestService::TestNestedStruct& value) {
+    static thread_local krpc::schema::Tuple structMessage;
+    structMessage.Clear();
+    structMessage.add_items(encode(value.struct_field));
+    structMessage.add_items(encode(value.object_field));
+    structMessage.add_items(encode(value.string_field));
+    return krpc::encoder::encode(structMessage);
   }
 
 }  // namespace encoder
@@ -637,6 +804,49 @@ namespace decoder {
     int32_t x;
     decode(x, data, client);
     value = static_cast<services::TestService::TestEnum>(x);
+  }
+
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+  // Fields are only ever appended to a structure, so a value from a newer server may carry
+  // more items than this client knows about, and those are ignored.
+  inline void decode(services::TestService::DeprecatedStruct& value, const std::string& data, Client* client) {
+    static thread_local krpc::schema::Tuple structMessage;
+    if (!structMessage.ParseFromString(data)) throw EncodingError("Failed to decode message");
+    if (structMessage.items_size() < 2)
+      throw EncodingError("Value for DeprecatedStruct does not have all of its fields");
+    decode(value.value, structMessage.items(0), client);
+    decode(value.old_value, structMessage.items(1), client);
+  }
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
+
+  // Fields are only ever appended to a structure, so a value from a newer server may carry
+  // more items than this client knows about, and those are ignored.
+  inline void decode(services::TestService::TestStruct& value, const std::string& data, Client* client) {
+    static thread_local krpc::schema::Tuple structMessage;
+    if (!structMessage.ParseFromString(data)) throw EncodingError("Failed to decode message");
+    if (structMessage.items_size() < 4)
+      throw EncodingError("Value for TestStruct does not have all of its fields");
+    decode(value.int_field, structMessage.items(0), client);
+    decode(value.string_field, structMessage.items(1), client);
+    decode(value.enum_field, structMessage.items(2), client);
+    decode(value.list_field, structMessage.items(3), client);
+  }
+
+  // Fields are only ever appended to a structure, so a value from a newer server may carry
+  // more items than this client knows about, and those are ignored.
+  inline void decode(services::TestService::TestNestedStruct& value, const std::string& data, Client* client) {
+    static thread_local krpc::schema::Tuple structMessage;
+    if (!structMessage.ParseFromString(data)) throw EncodingError("Failed to decode message");
+    if (structMessage.items_size() < 3)
+      throw EncodingError("Value for TestNestedStruct does not have all of its fields");
+    decode(value.struct_field, structMessage.items(0), client);
+    decode(value.object_field, structMessage.items(1), client);
+    decode(value.string_field, structMessage.items(2), client);
   }
 
 }  // namespace decoder
@@ -668,6 +878,37 @@ namespace services {
   }
 
   inline void decode(TestService::TestEnum& value, const std::string& data, Client* client) {
+    decoder::decode(value, data, client);
+  }
+
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+  inline std::string encode(const TestService::DeprecatedStruct& value) {
+    return encoder::encode(value);
+  }
+
+  inline void decode(TestService::DeprecatedStruct& value, const std::string& data, Client* client) {
+    decoder::decode(value, data, client);
+  }
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
+
+  inline std::string encode(const TestService::TestStruct& value) {
+    return encoder::encode(value);
+  }
+
+  inline void decode(TestService::TestStruct& value, const std::string& data, Client* client) {
+    decoder::decode(value, data, client);
+  }
+
+  inline std::string encode(const TestService::TestNestedStruct& value) {
+    return encoder::encode(value);
+  }
+
+  inline void decode(TestService::TestNestedStruct& value, const std::string& data, Client* client) {
     decoder::decode(value, data, client);
   }
 
@@ -758,6 +999,17 @@ inline int32_t TestService::counter(std::string id = "", int32_t divisor = 1) {
   _args.push_back(encoder::encode(divisor));
   auto _data = this->_client->invoke("TestService", "Counter", _args);
   int32_t _result{};
+  if (!_data.is_null())
+    decoder::decode(_result, _data.value(), this->_client);
+  return _result;
+}
+
+inline TestService::TestStruct TestService::counter_struct(std::string id = "") {
+  std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
+  _args.push_back(encoder::encode(id));
+  auto _data = this->_client->invoke("TestService", "CounterStruct", _args);
+  TestService::TestStruct _result{};
   if (!_data.is_null())
     decoder::decode(_result, _data.value(), this->_client);
   return _result;
@@ -978,6 +1230,17 @@ inline std::vector<int32_t> TestService::increment_list(std::vector<int32_t> l) 
   return _result;
 }
 
+inline std::vector<TestService::TestStruct> TestService::increment_list_of_structs(std::vector<TestService::TestStruct> l) {
+  std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
+  _args.push_back(encoder::encode(l));
+  auto _data = this->_client->invoke("TestService", "IncrementListOfStructs", _args);
+  std::vector<TestService::TestStruct> _result{};
+  if (!_data.is_null())
+    decoder::decode(_result, _data.value(), this->_client);
+  return _result;
+}
+
 inline std::map<std::string, std::vector<int32_t> > TestService::increment_nested_collection(std::map<std::string, std::vector<int32_t> > d) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(1);
@@ -1068,6 +1331,17 @@ inline std::vector<int32_t> TestService::list_default(std::vector<int32_t> x = s
   return _result;
 }
 
+inline TestService::TestNestedStruct TestService::nested_struct_echo(TestService::TestNestedStruct x) {
+  std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
+  _args.push_back(encoder::encode(x));
+  auto _data = this->_client->invoke("TestService", "NestedStructEcho", _args);
+  TestService::TestNestedStruct _result{};
+  if (!_data.is_null())
+    decoder::decode(_result, _data.value(), this->_client);
+  return _result;
+}
+
 inline TestService::TestClass TestService::not_nullable_object(TestService::TestClass value) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(1);
@@ -1149,6 +1423,39 @@ inline int32_t TestService::string_to_int32(std::string value) {
   _args.push_back(encoder::encode(value));
   auto _data = this->_client->invoke("TestService", "StringToInt32", _args);
   int32_t _result{};
+  if (!_data.is_null())
+    decoder::decode(_result, _data.value(), this->_client);
+  return _result;
+}
+
+inline TestService::TestStruct TestService::struct_default(TestService::TestStruct x = TestService::TestStruct{42, "jeb", TestService::TestEnum::value_b, std::vector<int32_t>{1, 2, 3}}) {
+  std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
+  _args.push_back(encoder::encode(x));
+  auto _data = this->_client->invoke("TestService", "StructDefault", _args);
+  TestService::TestStruct _result{};
+  if (!_data.is_null())
+    decoder::decode(_result, _data.value(), this->_client);
+  return _result;
+}
+
+inline TestService::TestStruct TestService::struct_echo(TestService::TestStruct x) {
+  std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
+  _args.push_back(encoder::encode(x));
+  auto _data = this->_client->invoke("TestService", "StructEcho", _args);
+  TestService::TestStruct _result{};
+  if (!_data.is_null())
+    decoder::decode(_result, _data.value(), this->_client);
+  return _result;
+}
+
+inline std::optional<TestService::TestStruct> TestService::struct_echo_nullable(std::optional<TestService::TestStruct> x) {
+  std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
+  _args.push_back(encoder::encode_nullable(x));
+  auto _data = this->_client->invoke("TestService", "StructEchoNullable", _args);
+  std::optional<TestService::TestStruct> _result{};
   if (!_data.is_null())
     decoder::decode(_result, _data.value(), this->_client);
   return _result;
@@ -1371,6 +1678,13 @@ inline ::krpc::Stream<int32_t> TestService::counter_stream(std::string id = "", 
   return ::krpc::Stream<int32_t>(this->_client, this->_client->build_call("TestService", "Counter", _args));
 }
 
+inline ::krpc::Stream<TestService::TestStruct> TestService::counter_struct_stream(std::string id = "") {
+  std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
+  _args.push_back(encoder::encode(id));
+  return ::krpc::Stream<TestService::TestStruct>(this->_client, this->_client->build_call("TestService", "CounterStruct", _args));
+}
+
 inline ::krpc::Stream<TestService::TestClass> TestService::create_test_object_stream(std::string value) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(1);
@@ -1510,6 +1824,13 @@ inline ::krpc::Stream<std::vector<int32_t>> TestService::increment_list_stream(s
   return ::krpc::Stream<std::vector<int32_t>>(this->_client, this->_client->build_call("TestService", "IncrementList", _args));
 }
 
+inline ::krpc::Stream<std::vector<TestService::TestStruct>> TestService::increment_list_of_structs_stream(std::vector<TestService::TestStruct> l) {
+  std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
+  _args.push_back(encoder::encode(l));
+  return ::krpc::Stream<std::vector<TestService::TestStruct>>(this->_client, this->_client->build_call("TestService", "IncrementListOfStructs", _args));
+}
+
 inline ::krpc::Stream<std::map<std::string, std::vector<int32_t> >> TestService::increment_nested_collection_stream(std::map<std::string, std::vector<int32_t> > d) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(1);
@@ -1568,6 +1889,13 @@ inline ::krpc::Stream<std::vector<int32_t>> TestService::list_default_stream(std
   return ::krpc::Stream<std::vector<int32_t>>(this->_client, this->_client->build_call("TestService", "ListDefault", _args));
 }
 
+inline ::krpc::Stream<TestService::TestNestedStruct> TestService::nested_struct_echo_stream(TestService::TestNestedStruct x) {
+  std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
+  _args.push_back(encoder::encode(x));
+  return ::krpc::Stream<TestService::TestNestedStruct>(this->_client, this->_client->build_call("TestService", "NestedStructEcho", _args));
+}
+
 inline ::krpc::Stream<TestService::TestClass> TestService::not_nullable_object_stream(TestService::TestClass value) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(1);
@@ -1616,6 +1944,27 @@ inline ::krpc::Stream<int32_t> TestService::string_to_int32_stream(std::string v
   _args.reserve(1);
   _args.push_back(encoder::encode(value));
   return ::krpc::Stream<int32_t>(this->_client, this->_client->build_call("TestService", "StringToInt32", _args));
+}
+
+inline ::krpc::Stream<TestService::TestStruct> TestService::struct_default_stream(TestService::TestStruct x = TestService::TestStruct{42, "jeb", TestService::TestEnum::value_b, std::vector<int32_t>{1, 2, 3}}) {
+  std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
+  _args.push_back(encoder::encode(x));
+  return ::krpc::Stream<TestService::TestStruct>(this->_client, this->_client->build_call("TestService", "StructDefault", _args));
+}
+
+inline ::krpc::Stream<TestService::TestStruct> TestService::struct_echo_stream(TestService::TestStruct x) {
+  std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
+  _args.push_back(encoder::encode(x));
+  return ::krpc::Stream<TestService::TestStruct>(this->_client, this->_client->build_call("TestService", "StructEcho", _args));
+}
+
+inline ::krpc::Stream<std::optional<TestService::TestStruct>> TestService::struct_echo_nullable_stream(std::optional<TestService::TestStruct> x) {
+  std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
+  _args.push_back(encoder::encode_nullable(x));
+  return ::krpc::Stream<std::optional<TestService::TestStruct>>(this->_client, this->_client->build_call("TestService", "StructEchoNullable", _args));
 }
 
 inline ::krpc::Stream<int32_t> TestService::throw_argument_exception_stream() {
@@ -1738,6 +2087,13 @@ inline ::krpc::schema::ProcedureCall TestService::counter_call(std::string id = 
   _args.push_back(encoder::encode(id));
   _args.push_back(encoder::encode(divisor));
   return this->_client->build_call("TestService", "Counter", _args);
+}
+
+inline ::krpc::schema::ProcedureCall TestService::counter_struct_call(std::string id = "") {
+  std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
+  _args.push_back(encoder::encode(id));
+  return this->_client->build_call("TestService", "CounterStruct", _args);
 }
 
 inline ::krpc::schema::ProcedureCall TestService::create_test_object_call(std::string value) {
@@ -1879,6 +2235,13 @@ inline ::krpc::schema::ProcedureCall TestService::increment_list_call(std::vecto
   return this->_client->build_call("TestService", "IncrementList", _args);
 }
 
+inline ::krpc::schema::ProcedureCall TestService::increment_list_of_structs_call(std::vector<TestService::TestStruct> l) {
+  std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
+  _args.push_back(encoder::encode(l));
+  return this->_client->build_call("TestService", "IncrementListOfStructs", _args);
+}
+
 inline ::krpc::schema::ProcedureCall TestService::increment_nested_collection_call(std::map<std::string, std::vector<int32_t> > d) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(1);
@@ -1937,6 +2300,13 @@ inline ::krpc::schema::ProcedureCall TestService::list_default_call(std::vector<
   return this->_client->build_call("TestService", "ListDefault", _args);
 }
 
+inline ::krpc::schema::ProcedureCall TestService::nested_struct_echo_call(TestService::TestNestedStruct x) {
+  std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
+  _args.push_back(encoder::encode(x));
+  return this->_client->build_call("TestService", "NestedStructEcho", _args);
+}
+
 inline ::krpc::schema::ProcedureCall TestService::not_nullable_object_call(TestService::TestClass value) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(1);
@@ -1993,6 +2363,27 @@ inline ::krpc::schema::ProcedureCall TestService::string_to_int32_call(std::stri
   _args.reserve(1);
   _args.push_back(encoder::encode(value));
   return this->_client->build_call("TestService", "StringToInt32", _args);
+}
+
+inline ::krpc::schema::ProcedureCall TestService::struct_default_call(TestService::TestStruct x = TestService::TestStruct{42, "jeb", TestService::TestEnum::value_b, std::vector<int32_t>{1, 2, 3}}) {
+  std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
+  _args.push_back(encoder::encode(x));
+  return this->_client->build_call("TestService", "StructDefault", _args);
+}
+
+inline ::krpc::schema::ProcedureCall TestService::struct_echo_call(TestService::TestStruct x) {
+  std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
+  _args.push_back(encoder::encode(x));
+  return this->_client->build_call("TestService", "StructEcho", _args);
+}
+
+inline ::krpc::schema::ProcedureCall TestService::struct_echo_nullable_call(std::optional<TestService::TestStruct> x) {
+  std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
+  _args.push_back(encoder::encode_nullable(x));
+  return this->_client->build_call("TestService", "StructEchoNullable", _args);
 }
 
 inline ::krpc::schema::ProcedureCall TestService::throw_argument_exception_call() {

--- a/tools/krpctools/krpctools/test/clientgen-TestService-cpp.txt
+++ b/tools/krpctools/krpctools/test/clientgen-TestService-cpp.txt
@@ -644,9 +644,9 @@ class TestService : public Service {
   /**
    * Deprecated struct documentation string.
    *
-   * \deprecated Use the TestStruct struct instead.
+   * \deprecated Use TestStruct instead.
    */
-  struct [[deprecated("Use the TestStruct struct instead.")]] DeprecatedStruct {
+  struct [[deprecated("Use TestStruct instead.")]] DeprecatedStruct {
     /**
      * Deprecated struct Value documentation string.
      */
@@ -654,9 +654,9 @@ class TestService : public Service {
     /**
      * Deprecated struct OldValue documentation string.
      *
-     * \deprecated Use the Value field instead.
+     * \deprecated Use DeprecatedStruct::value instead.
      */
-    int32_t old_value [[deprecated("Use the Value field instead.")]];
+    int32_t old_value [[deprecated("Use DeprecatedStruct::value instead.")]];
 
     DeprecatedStruct() : value(), old_value() {}
 

--- a/tools/krpctools/krpctools/test/clientgen-TestService-csharp.txt
+++ b/tools/krpctools/krpctools/test/clientgen-TestService-csharp.txt
@@ -793,7 +793,7 @@ namespace KRPC.Client.Services.TestService
     /// </summary>
     [Serializable]
     [global::KRPC.Client.Attributes.KRPCStruct]
-    [global::System.Obsolete ("Use the TestStruct struct instead.")]
+    [global::System.Obsolete ("Use TestStruct instead.")]
     public struct DeprecatedStruct : IEquatable<DeprecatedStruct>
     {
         /// <summary>
@@ -813,7 +813,7 @@ namespace KRPC.Client.Services.TestService
         /// <summary>
         /// Deprecated struct OldValue documentation string.
         /// </summary>
-        [global::System.Obsolete ("Use the Value field instead.")]
+        [global::System.Obsolete ("Use DeprecatedStruct.Value instead.")]
         public int OldValue { get; private set; }
 
         /// <summary>

--- a/tools/krpctools/krpctools/test/clientgen-TestService-csharp.txt
+++ b/tools/krpctools/krpctools/test/clientgen-TestService-csharp.txt
@@ -115,6 +115,20 @@ namespace KRPC.Client.Services.TestService
             return (int)global::KRPC.Client.Encoder.Decode (_result.Value, typeof(int), connection);
         }
 
+        /// <summary>
+        /// Returns a struct whose IntField counts the number of times it has been called,
+        /// so that a stream on it changes on every update.
+        /// </summary>
+        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "CounterStruct")]
+        public global::KRPC.Client.Services.TestService.TestStruct CounterStruct (string id = "")
+        {
+            var _args = new ByteString[] {
+                global::KRPC.Client.Encoder.Encode (id, typeof(string))
+            };
+            var _result = connection.Invoke ("TestService", "CounterStruct", _args);
+            return (global::KRPC.Client.Services.TestService.TestStruct)global::KRPC.Client.Encoder.Decode (_result.Value, typeof(global::KRPC.Client.Services.TestService.TestStruct), connection);
+        }
+
         [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "CreateTestObject")]
         public global::KRPC.Client.Services.TestService.TestClass CreateTestObject (string value)
         {
@@ -337,6 +351,16 @@ namespace KRPC.Client.Services.TestService
             return (global::System.Collections.Generic.IList<int>)global::KRPC.Client.Encoder.Decode (_result.Value, typeof(global::System.Collections.Generic.IList<int>), connection);
         }
 
+        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "IncrementListOfStructs")]
+        public global::System.Collections.Generic.IList<global::KRPC.Client.Services.TestService.TestStruct> IncrementListOfStructs (global::System.Collections.Generic.IList<global::KRPC.Client.Services.TestService.TestStruct> l)
+        {
+            var _args = new ByteString[] {
+                global::KRPC.Client.Encoder.Encode (l, typeof(global::System.Collections.Generic.IList<global::KRPC.Client.Services.TestService.TestStruct>))
+            };
+            var _result = connection.Invoke ("TestService", "IncrementListOfStructs", _args);
+            return (global::System.Collections.Generic.IList<global::KRPC.Client.Services.TestService.TestStruct>)global::KRPC.Client.Encoder.Decode (_result.Value, typeof(global::System.Collections.Generic.IList<global::KRPC.Client.Services.TestService.TestStruct>), connection);
+        }
+
         [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "IncrementNestedCollection")]
         public global::System.Collections.Generic.IDictionary<string,global::System.Collections.Generic.IList<int>> IncrementNestedCollection (global::System.Collections.Generic.IDictionary<string,global::System.Collections.Generic.IList<int>> d)
         {
@@ -425,6 +449,16 @@ namespace KRPC.Client.Services.TestService
             return (global::System.Collections.Generic.IList<int>)global::KRPC.Client.Encoder.Decode (_result.Value, typeof(global::System.Collections.Generic.IList<int>), connection);
         }
 
+        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "NestedStructEcho")]
+        public global::KRPC.Client.Services.TestService.TestNestedStruct NestedStructEcho (global::KRPC.Client.Services.TestService.TestNestedStruct x)
+        {
+            var _args = new ByteString[] {
+                global::KRPC.Client.Encoder.Encode (x, typeof(global::KRPC.Client.Services.TestService.TestNestedStruct))
+            };
+            var _result = connection.Invoke ("TestService", "NestedStructEcho", _args);
+            return (global::KRPC.Client.Services.TestService.TestNestedStruct)global::KRPC.Client.Encoder.Decode (_result.Value, typeof(global::KRPC.Client.Services.TestService.TestNestedStruct), connection);
+        }
+
         [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "NotNullableObject")]
         public global::KRPC.Client.Services.TestService.TestClass NotNullableObject (global::KRPC.Client.Services.TestService.TestClass value)
         {
@@ -506,6 +540,38 @@ namespace KRPC.Client.Services.TestService
             };
             var _result = connection.Invoke ("TestService", "StringToInt32", _args);
             return (int)global::KRPC.Client.Encoder.Decode (_result.Value, typeof(int), connection);
+        }
+
+        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "StructDefault")]
+        public global::KRPC.Client.Services.TestService.TestStruct StructDefault (global::KRPC.Client.Services.TestService.TestStruct? x = null)
+        {
+            var _args = new ByteString[] {
+                global::KRPC.Client.Encoder.Encode (x ?? new global::KRPC.Client.Services.TestService.TestStruct (42, "jeb", global::KRPC.Client.Services.TestService.TestEnum.ValueB, new global::System.Collections.Generic.List<int> { 1, 2, 3 }), typeof(global::KRPC.Client.Services.TestService.TestStruct?))
+            };
+            var _result = connection.Invoke ("TestService", "StructDefault", _args);
+            return (global::KRPC.Client.Services.TestService.TestStruct)global::KRPC.Client.Encoder.Decode (_result.Value, typeof(global::KRPC.Client.Services.TestService.TestStruct), connection);
+        }
+
+        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "StructEcho")]
+        public global::KRPC.Client.Services.TestService.TestStruct StructEcho (global::KRPC.Client.Services.TestService.TestStruct x)
+        {
+            var _args = new ByteString[] {
+                global::KRPC.Client.Encoder.Encode (x, typeof(global::KRPC.Client.Services.TestService.TestStruct))
+            };
+            var _result = connection.Invoke ("TestService", "StructEcho", _args);
+            return (global::KRPC.Client.Services.TestService.TestStruct)global::KRPC.Client.Encoder.Decode (_result.Value, typeof(global::KRPC.Client.Services.TestService.TestStruct), connection);
+        }
+
+        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "StructEchoNullable")]
+        public global::KRPC.Client.Services.TestService.TestStruct? StructEchoNullable (global::KRPC.Client.Services.TestService.TestStruct? x)
+        {
+            var _args = new ByteString[] {
+                global::KRPC.Client.Encoder.Encode (x, typeof(global::KRPC.Client.Services.TestService.TestStruct?))
+            };
+            var _result = connection.Invoke ("TestService", "StructEchoNullable", _args);
+            if (_result.IsNull)
+                return null;
+            return (global::KRPC.Client.Services.TestService.TestStruct?)global::KRPC.Client.Encoder.Decode (_result.Value, typeof(global::KRPC.Client.Services.TestService.TestStruct?), connection);
         }
 
         [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "ThrowArgumentException")]
@@ -720,6 +786,221 @@ namespace KRPC.Client.Services.TestService
         /// Enum ValueC documentation string.
         /// </summary>
         ValueC = 2
+    }
+
+    /// <summary>
+    /// Deprecated struct documentation string.
+    /// </summary>
+    [Serializable]
+    [global::KRPC.Client.Attributes.KRPCStruct]
+    [global::System.Obsolete ("Use the TestStruct struct instead.")]
+    public struct DeprecatedStruct : IEquatable<DeprecatedStruct>
+    {
+        /// <summary>
+        /// Construct a DeprecatedStruct from the values of its fields.
+        /// </summary>
+        public DeprecatedStruct (int value, int oldValue) : this ()
+        {
+            Value = value;
+            OldValue = oldValue;
+        }
+
+        /// <summary>
+        /// Deprecated struct Value documentation string.
+        /// </summary>
+        public int Value { get; private set; }
+
+        /// <summary>
+        /// Deprecated struct OldValue documentation string.
+        /// </summary>
+        [global::System.Obsolete ("Use the Value field instead.")]
+        public int OldValue { get; private set; }
+
+        /// <summary>
+        /// Returns true if this DeprecatedStruct is equal to the given object.
+        /// </summary>
+        public override bool Equals (object obj)
+        {
+            return obj is DeprecatedStruct && Equals ((DeprecatedStruct)obj);
+        }
+
+        /// <summary>
+        /// Returns true if this DeprecatedStruct is equal to the given one.
+        /// </summary>
+        public bool Equals (DeprecatedStruct other)
+        {
+            return global::KRPC.Client.ValueUtils.Equal (Value, other.Value) && global::KRPC.Client.ValueUtils.Equal (OldValue, other.OldValue);
+        }
+
+        /// <summary>
+        /// Returns a hash code for this DeprecatedStruct.
+        /// </summary>
+        public override int GetHashCode ()
+        {
+            int hash = 17;
+            hash = hash * 31 + global::KRPC.Client.ValueUtils.HashCode (Value);
+            hash = hash * 31 + global::KRPC.Client.ValueUtils.HashCode (OldValue);
+            return hash;
+        }
+
+        /// <summary>
+        /// Returns true if the two DeprecatedStruct values are equal.
+        /// </summary>
+        public static bool operator == (DeprecatedStruct lhs, DeprecatedStruct rhs)
+        {
+            return lhs.Equals (rhs);
+        }
+
+        /// <summary>
+        /// Returns true if the two DeprecatedStruct values are not equal.
+        /// </summary>
+        public static bool operator != (DeprecatedStruct lhs, DeprecatedStruct rhs)
+        {
+            return !lhs.Equals (rhs);
+        }
+    }
+
+    /// <summary>
+    /// Nested struct documentation string.
+    /// </summary>
+    [Serializable]
+    [global::KRPC.Client.Attributes.KRPCStruct]
+    public struct TestNestedStruct : IEquatable<TestNestedStruct>
+    {
+        /// <summary>
+        /// Construct a TestNestedStruct from the values of its fields.
+        /// </summary>
+        public TestNestedStruct (global::KRPC.Client.Services.TestService.TestStruct structField, global::KRPC.Client.Services.TestService.TestClass objectField, string stringField) : this ()
+        {
+            StructField = structField;
+            ObjectField = objectField;
+            StringField = stringField;
+        }
+
+        public global::KRPC.Client.Services.TestService.TestStruct StructField { get; private set; }
+
+        public global::KRPC.Client.Services.TestService.TestClass ObjectField { get; private set; }
+
+        public string StringField { get; private set; }
+
+        /// <summary>
+        /// Returns true if this TestNestedStruct is equal to the given object.
+        /// </summary>
+        public override bool Equals (object obj)
+        {
+            return obj is TestNestedStruct && Equals ((TestNestedStruct)obj);
+        }
+
+        /// <summary>
+        /// Returns true if this TestNestedStruct is equal to the given one.
+        /// </summary>
+        public bool Equals (TestNestedStruct other)
+        {
+            return global::KRPC.Client.ValueUtils.Equal (StructField, other.StructField) && global::KRPC.Client.ValueUtils.Equal (ObjectField, other.ObjectField) && global::KRPC.Client.ValueUtils.Equal (StringField, other.StringField);
+        }
+
+        /// <summary>
+        /// Returns a hash code for this TestNestedStruct.
+        /// </summary>
+        public override int GetHashCode ()
+        {
+            int hash = 17;
+            hash = hash * 31 + global::KRPC.Client.ValueUtils.HashCode (StructField);
+            hash = hash * 31 + global::KRPC.Client.ValueUtils.HashCode (ObjectField);
+            hash = hash * 31 + global::KRPC.Client.ValueUtils.HashCode (StringField);
+            return hash;
+        }
+
+        /// <summary>
+        /// Returns true if the two TestNestedStruct values are equal.
+        /// </summary>
+        public static bool operator == (TestNestedStruct lhs, TestNestedStruct rhs)
+        {
+            return lhs.Equals (rhs);
+        }
+
+        /// <summary>
+        /// Returns true if the two TestNestedStruct values are not equal.
+        /// </summary>
+        public static bool operator != (TestNestedStruct lhs, TestNestedStruct rhs)
+        {
+            return !lhs.Equals (rhs);
+        }
+    }
+
+    /// <summary>
+    /// Struct documentation string.
+    /// </summary>
+    [Serializable]
+    [global::KRPC.Client.Attributes.KRPCStruct]
+    public struct TestStruct : IEquatable<TestStruct>
+    {
+        /// <summary>
+        /// Construct a TestStruct from the values of its fields.
+        /// </summary>
+        public TestStruct (int intField, string stringField, global::KRPC.Client.Services.TestService.TestEnum enumField, global::System.Collections.Generic.IList<int> listField) : this ()
+        {
+            IntField = intField;
+            StringField = stringField;
+            EnumField = enumField;
+            ListField = listField;
+        }
+
+        /// <summary>
+        /// Struct IntField documentation string.
+        /// </summary>
+        public int IntField { get; private set; }
+
+        public string StringField { get; private set; }
+
+        public global::KRPC.Client.Services.TestService.TestEnum EnumField { get; private set; }
+
+        public global::System.Collections.Generic.IList<int> ListField { get; private set; }
+
+        /// <summary>
+        /// Returns true if this TestStruct is equal to the given object.
+        /// </summary>
+        public override bool Equals (object obj)
+        {
+            return obj is TestStruct && Equals ((TestStruct)obj);
+        }
+
+        /// <summary>
+        /// Returns true if this TestStruct is equal to the given one.
+        /// </summary>
+        public bool Equals (TestStruct other)
+        {
+            return global::KRPC.Client.ValueUtils.Equal (IntField, other.IntField) && global::KRPC.Client.ValueUtils.Equal (StringField, other.StringField) && global::KRPC.Client.ValueUtils.Equal (EnumField, other.EnumField) && global::KRPC.Client.ValueUtils.Equal (ListField, other.ListField);
+        }
+
+        /// <summary>
+        /// Returns a hash code for this TestStruct.
+        /// </summary>
+        public override int GetHashCode ()
+        {
+            int hash = 17;
+            hash = hash * 31 + global::KRPC.Client.ValueUtils.HashCode (IntField);
+            hash = hash * 31 + global::KRPC.Client.ValueUtils.HashCode (StringField);
+            hash = hash * 31 + global::KRPC.Client.ValueUtils.HashCode (EnumField);
+            hash = hash * 31 + global::KRPC.Client.ValueUtils.HashCode (ListField);
+            return hash;
+        }
+
+        /// <summary>
+        /// Returns true if the two TestStruct values are equal.
+        /// </summary>
+        public static bool operator == (TestStruct lhs, TestStruct rhs)
+        {
+            return lhs.Equals (rhs);
+        }
+
+        /// <summary>
+        /// Returns true if the two TestStruct values are not equal.
+        /// </summary>
+        public static bool operator != (TestStruct lhs, TestStruct rhs)
+        {
+            return !lhs.Equals (rhs);
+        }
     }
 
     [Serializable]

--- a/tools/krpctools/krpctools/test/clientgen-TestService-csharp.txt
+++ b/tools/krpctools/krpctools/test/clientgen-TestService-csharp.txt
@@ -861,74 +861,6 @@ namespace KRPC.Client.Services.TestService
     }
 
     /// <summary>
-    /// Nested struct documentation string.
-    /// </summary>
-    [Serializable]
-    [global::KRPC.Client.Attributes.KRPCStruct]
-    public struct TestNestedStruct : IEquatable<TestNestedStruct>
-    {
-        /// <summary>
-        /// Construct a TestNestedStruct from the values of its fields.
-        /// </summary>
-        public TestNestedStruct (global::KRPC.Client.Services.TestService.TestStruct structField, global::KRPC.Client.Services.TestService.TestClass objectField, string stringField) : this ()
-        {
-            StructField = structField;
-            ObjectField = objectField;
-            StringField = stringField;
-        }
-
-        public global::KRPC.Client.Services.TestService.TestStruct StructField { get; private set; }
-
-        public global::KRPC.Client.Services.TestService.TestClass ObjectField { get; private set; }
-
-        public string StringField { get; private set; }
-
-        /// <summary>
-        /// Returns true if this TestNestedStruct is equal to the given object.
-        /// </summary>
-        public override bool Equals (object obj)
-        {
-            return obj is TestNestedStruct && Equals ((TestNestedStruct)obj);
-        }
-
-        /// <summary>
-        /// Returns true if this TestNestedStruct is equal to the given one.
-        /// </summary>
-        public bool Equals (TestNestedStruct other)
-        {
-            return global::KRPC.Client.ValueUtils.Equal (StructField, other.StructField) && global::KRPC.Client.ValueUtils.Equal (ObjectField, other.ObjectField) && global::KRPC.Client.ValueUtils.Equal (StringField, other.StringField);
-        }
-
-        /// <summary>
-        /// Returns a hash code for this TestNestedStruct.
-        /// </summary>
-        public override int GetHashCode ()
-        {
-            int hash = 17;
-            hash = hash * 31 + global::KRPC.Client.ValueUtils.HashCode (StructField);
-            hash = hash * 31 + global::KRPC.Client.ValueUtils.HashCode (ObjectField);
-            hash = hash * 31 + global::KRPC.Client.ValueUtils.HashCode (StringField);
-            return hash;
-        }
-
-        /// <summary>
-        /// Returns true if the two TestNestedStruct values are equal.
-        /// </summary>
-        public static bool operator == (TestNestedStruct lhs, TestNestedStruct rhs)
-        {
-            return lhs.Equals (rhs);
-        }
-
-        /// <summary>
-        /// Returns true if the two TestNestedStruct values are not equal.
-        /// </summary>
-        public static bool operator != (TestNestedStruct lhs, TestNestedStruct rhs)
-        {
-            return !lhs.Equals (rhs);
-        }
-    }
-
-    /// <summary>
     /// Struct documentation string.
     /// </summary>
     [Serializable]
@@ -998,6 +930,74 @@ namespace KRPC.Client.Services.TestService
         /// Returns true if the two TestStruct values are not equal.
         /// </summary>
         public static bool operator != (TestStruct lhs, TestStruct rhs)
+        {
+            return !lhs.Equals (rhs);
+        }
+    }
+
+    /// <summary>
+    /// Nested struct documentation string.
+    /// </summary>
+    [Serializable]
+    [global::KRPC.Client.Attributes.KRPCStruct]
+    public struct TestNestedStruct : IEquatable<TestNestedStruct>
+    {
+        /// <summary>
+        /// Construct a TestNestedStruct from the values of its fields.
+        /// </summary>
+        public TestNestedStruct (global::KRPC.Client.Services.TestService.TestStruct structField, global::KRPC.Client.Services.TestService.TestClass objectField, string stringField) : this ()
+        {
+            StructField = structField;
+            ObjectField = objectField;
+            StringField = stringField;
+        }
+
+        public global::KRPC.Client.Services.TestService.TestStruct StructField { get; private set; }
+
+        public global::KRPC.Client.Services.TestService.TestClass ObjectField { get; private set; }
+
+        public string StringField { get; private set; }
+
+        /// <summary>
+        /// Returns true if this TestNestedStruct is equal to the given object.
+        /// </summary>
+        public override bool Equals (object obj)
+        {
+            return obj is TestNestedStruct && Equals ((TestNestedStruct)obj);
+        }
+
+        /// <summary>
+        /// Returns true if this TestNestedStruct is equal to the given one.
+        /// </summary>
+        public bool Equals (TestNestedStruct other)
+        {
+            return global::KRPC.Client.ValueUtils.Equal (StructField, other.StructField) && global::KRPC.Client.ValueUtils.Equal (ObjectField, other.ObjectField) && global::KRPC.Client.ValueUtils.Equal (StringField, other.StringField);
+        }
+
+        /// <summary>
+        /// Returns a hash code for this TestNestedStruct.
+        /// </summary>
+        public override int GetHashCode ()
+        {
+            int hash = 17;
+            hash = hash * 31 + global::KRPC.Client.ValueUtils.HashCode (StructField);
+            hash = hash * 31 + global::KRPC.Client.ValueUtils.HashCode (ObjectField);
+            hash = hash * 31 + global::KRPC.Client.ValueUtils.HashCode (StringField);
+            return hash;
+        }
+
+        /// <summary>
+        /// Returns true if the two TestNestedStruct values are equal.
+        /// </summary>
+        public static bool operator == (TestNestedStruct lhs, TestNestedStruct rhs)
+        {
+            return lhs.Equals (rhs);
+        }
+
+        /// <summary>
+        /// Returns true if the two TestNestedStruct values are not equal.
+        /// </summary>
+        public static bool operator != (TestNestedStruct lhs, TestNestedStruct rhs)
         {
             return !lhs.Equals (rhs);
         }

--- a/tools/krpctools/krpctools/test/clientgen-TestService-java.txt
+++ b/tools/krpctools/krpctools/test/clientgen-TestService-java.txt
@@ -6,6 +6,7 @@ import krpc.client.Connection;
 import krpc.client.Encoder;
 import krpc.client.RemoteEnum;
 import krpc.client.RemoteObject;
+import krpc.client.RemoteStruct;
 import krpc.client.RPCInfo;
 import krpc.client.RPCException;
 import krpc.client.Types;
@@ -124,6 +125,20 @@ public class TestService {
         };
         krpc.schema.KRPC.ProcedureResult _data = this.connection.invoke("TestService", "Counter", _args);
         return (int) Encoder.decode(_data.getValue(), krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.SINT32), this.connection);
+    }
+
+    /**
+     * Returns a struct whose IntField counts the number of times it has been called,
+     * so that a stream on it changes on every update.
+     */
+    @SuppressWarnings({ "unchecked" })
+    @RPCInfo(service = "TestService", procedure = "CounterStruct", types = _Types.class)
+    public krpc.client.services.TestService.TestStruct counterStruct(String id) throws RPCException {
+        ByteString[] _args = new ByteString[] {
+            Encoder.encode(id, krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.STRING))
+        };
+        krpc.schema.KRPC.ProcedureResult _data = this.connection.invoke("TestService", "CounterStruct", _args);
+        return (krpc.client.services.TestService.TestStruct) Encoder.decode(_data.getValue(), krpc.client.Types.createStruct("TestService", "TestStruct"), this.connection);
     }
 
     @SuppressWarnings({ "unchecked" })
@@ -355,6 +370,16 @@ public class TestService {
     }
 
     @SuppressWarnings({ "unchecked" })
+    @RPCInfo(service = "TestService", procedure = "IncrementListOfStructs", types = _Types.class)
+    public java.util.List<krpc.client.services.TestService.TestStruct> incrementListOfStructs(java.util.List<krpc.client.services.TestService.TestStruct> l) throws RPCException {
+        ByteString[] _args = new ByteString[] {
+            Encoder.encode(l, krpc.client.Types.createList(krpc.client.Types.createStruct("TestService", "TestStruct")))
+        };
+        krpc.schema.KRPC.ProcedureResult _data = this.connection.invoke("TestService", "IncrementListOfStructs", _args);
+        return (java.util.List<krpc.client.services.TestService.TestStruct>) Encoder.decode(_data.getValue(), krpc.client.Types.createList(krpc.client.Types.createStruct("TestService", "TestStruct")), this.connection);
+    }
+
+    @SuppressWarnings({ "unchecked" })
     @RPCInfo(service = "TestService", procedure = "IncrementNestedCollection", types = _Types.class)
     public java.util.Map<String,java.util.List<Integer>> incrementNestedCollection(java.util.Map<String,java.util.List<Integer>> d) throws RPCException {
         ByteString[] _args = new ByteString[] {
@@ -443,6 +468,16 @@ public class TestService {
     }
 
     @SuppressWarnings({ "unchecked" })
+    @RPCInfo(service = "TestService", procedure = "NestedStructEcho", types = _Types.class)
+    public krpc.client.services.TestService.TestNestedStruct nestedStructEcho(krpc.client.services.TestService.TestNestedStruct x) throws RPCException {
+        ByteString[] _args = new ByteString[] {
+            Encoder.encode(x, krpc.client.Types.createStruct("TestService", "TestNestedStruct"))
+        };
+        krpc.schema.KRPC.ProcedureResult _data = this.connection.invoke("TestService", "NestedStructEcho", _args);
+        return (krpc.client.services.TestService.TestNestedStruct) Encoder.decode(_data.getValue(), krpc.client.Types.createStruct("TestService", "TestNestedStruct"), this.connection);
+    }
+
+    @SuppressWarnings({ "unchecked" })
     @RPCInfo(service = "TestService", procedure = "NotNullableObject", types = _Types.class)
     public krpc.client.services.TestService.TestClass notNullableObject(krpc.client.services.TestService.TestClass value) throws RPCException {
         ByteString[] _args = new ByteString[] {
@@ -523,6 +558,39 @@ public class TestService {
         };
         krpc.schema.KRPC.ProcedureResult _data = this.connection.invoke("TestService", "StringToInt32", _args);
         return (int) Encoder.decode(_data.getValue(), krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.SINT32), this.connection);
+    }
+
+    @SuppressWarnings({ "unchecked" })
+    @RPCInfo(service = "TestService", procedure = "StructDefault", types = _Types.class)
+    public krpc.client.services.TestService.TestStruct structDefault(krpc.client.services.TestService.TestStruct x) throws RPCException {
+        ByteString[] _args = new ByteString[] {
+            Encoder.encode(x, krpc.client.Types.createStruct("TestService", "TestStruct"))
+        };
+        krpc.schema.KRPC.ProcedureResult _data = this.connection.invoke("TestService", "StructDefault", _args);
+        return (krpc.client.services.TestService.TestStruct) Encoder.decode(_data.getValue(), krpc.client.Types.createStruct("TestService", "TestStruct"), this.connection);
+    }
+
+    @SuppressWarnings({ "unchecked" })
+    @RPCInfo(service = "TestService", procedure = "StructEcho", types = _Types.class)
+    public krpc.client.services.TestService.TestStruct structEcho(krpc.client.services.TestService.TestStruct x) throws RPCException {
+        ByteString[] _args = new ByteString[] {
+            Encoder.encode(x, krpc.client.Types.createStruct("TestService", "TestStruct"))
+        };
+        krpc.schema.KRPC.ProcedureResult _data = this.connection.invoke("TestService", "StructEcho", _args);
+        return (krpc.client.services.TestService.TestStruct) Encoder.decode(_data.getValue(), krpc.client.Types.createStruct("TestService", "TestStruct"), this.connection);
+    }
+
+    @SuppressWarnings({ "unchecked" })
+    @RPCInfo(service = "TestService", procedure = "StructEchoNullable", types = _Types.class)
+    public krpc.client.services.TestService.TestStruct structEchoNullable(krpc.client.services.TestService.TestStruct x) throws RPCException {
+        ByteString[] _args = new ByteString[] {
+            Encoder.encode(x, krpc.client.Types.createStruct("TestService", "TestStruct"))
+        };
+        krpc.schema.KRPC.ProcedureResult _data = this.connection.invoke("TestService", "StructEchoNullable", _args);
+        if (_data.getIsNull()) {
+          return null;
+        }
+        return (krpc.client.services.TestService.TestStruct) Encoder.decode(_data.getValue(), krpc.client.Types.createStruct("TestService", "TestStruct"), this.connection);
     }
 
     @SuppressWarnings({ "unchecked" })
@@ -806,6 +874,237 @@ public class TestService {
     }
 
     /**
+     * Deprecated struct documentation string.
+     *
+     * @deprecated Use the TestStruct struct instead.
+     */
+    @Deprecated
+    public static class DeprecatedStruct implements RemoteStruct {
+        private final int value;
+        private final int oldValue;
+
+        public DeprecatedStruct(int value, int oldValue) {
+            this.value = value;
+            this.oldValue = oldValue;
+        }
+
+        /**
+         * Deprecated struct Value documentation string.
+         */
+        public int getValue() {
+            return value;
+        }
+
+        /**
+         * Deprecated struct OldValue documentation string.
+         *
+         * @deprecated Use the Value field instead.
+         */
+        @Deprecated
+        public int getOldValue() {
+            return oldValue;
+        }
+
+        private static final java.util.List<krpc.schema.KRPC.Type> FIELD_TYPES =
+            java.util.Collections.unmodifiableList(java.util.Arrays.asList(
+                krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.SINT32),
+                krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.SINT32)
+            ));
+
+        /** The types of the fields, in the order they are encoded in. */
+        public static java.util.List<krpc.schema.KRPC.Type> fieldTypes() {
+            return FIELD_TYPES;
+        }
+
+        /** Build a DeprecatedStruct from the values of its fields. */
+        @SuppressWarnings("unchecked")
+        public static DeprecatedStruct fromFieldValues(Object[] values) {
+            return new DeprecatedStruct(
+                (int) values[0],
+                (int) values[1]
+            );
+        }
+
+        @Override
+        public Object[] fieldValues() {
+            return new Object[] {
+                value,
+                oldValue
+            };
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (!(obj instanceof DeprecatedStruct)) {
+                return false;
+            }
+            DeprecatedStruct other = (DeprecatedStruct) obj;
+            return java.util.Objects.equals(this.value, other.value)                && java.util.Objects.equals(this.oldValue, other.oldValue);
+        }
+
+        @Override
+        public int hashCode() {
+            return java.util.Objects.hash(value, oldValue);
+        }
+    }
+
+    /**
+     * Struct documentation string.
+     */
+    public static class TestStruct implements RemoteStruct {
+        private final int intField;
+        private final String stringField;
+        private final krpc.client.services.TestService.TestEnum enumField;
+        private final java.util.List<Integer> listField;
+
+        public TestStruct(int intField, String stringField, krpc.client.services.TestService.TestEnum enumField, java.util.List<Integer> listField) {
+            this.intField = intField;
+            this.stringField = stringField;
+            this.enumField = enumField;
+            this.listField = listField;
+        }
+
+        /**
+         * Struct IntField documentation string.
+         */
+        public int getIntField() {
+            return intField;
+        }
+
+        public String getStringField() {
+            return stringField;
+        }
+
+        public krpc.client.services.TestService.TestEnum getEnumField() {
+            return enumField;
+        }
+
+        public java.util.List<Integer> getListField() {
+            return listField;
+        }
+
+        private static final java.util.List<krpc.schema.KRPC.Type> FIELD_TYPES =
+            java.util.Collections.unmodifiableList(java.util.Arrays.asList(
+                krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.SINT32),
+                krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.STRING),
+                krpc.client.Types.createEnumeration("TestService", "TestEnum"),
+                krpc.client.Types.createList(krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.SINT32))
+            ));
+
+        /** The types of the fields, in the order they are encoded in. */
+        public static java.util.List<krpc.schema.KRPC.Type> fieldTypes() {
+            return FIELD_TYPES;
+        }
+
+        /** Build a TestStruct from the values of its fields. */
+        @SuppressWarnings("unchecked")
+        public static TestStruct fromFieldValues(Object[] values) {
+            return new TestStruct(
+                (int) values[0],
+                (String) values[1],
+                (krpc.client.services.TestService.TestEnum) values[2],
+                (java.util.List<Integer>) values[3]
+            );
+        }
+
+        @Override
+        public Object[] fieldValues() {
+            return new Object[] {
+                intField,
+                stringField,
+                enumField,
+                listField
+            };
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (!(obj instanceof TestStruct)) {
+                return false;
+            }
+            TestStruct other = (TestStruct) obj;
+            return java.util.Objects.equals(this.intField, other.intField)                && java.util.Objects.equals(this.stringField, other.stringField)                && java.util.Objects.equals(this.enumField, other.enumField)                && java.util.Objects.equals(this.listField, other.listField);
+        }
+
+        @Override
+        public int hashCode() {
+            return java.util.Objects.hash(intField, stringField, enumField, listField);
+        }
+    }
+
+    /**
+     * Nested struct documentation string.
+     */
+    public static class TestNestedStruct implements RemoteStruct {
+        private final krpc.client.services.TestService.TestStruct structField;
+        private final krpc.client.services.TestService.TestClass objectField;
+        private final String stringField;
+
+        public TestNestedStruct(krpc.client.services.TestService.TestStruct structField, krpc.client.services.TestService.TestClass objectField, String stringField) {
+            this.structField = structField;
+            this.objectField = objectField;
+            this.stringField = stringField;
+        }
+
+        public krpc.client.services.TestService.TestStruct getStructField() {
+            return structField;
+        }
+
+        public krpc.client.services.TestService.TestClass getObjectField() {
+            return objectField;
+        }
+
+        public String getStringField() {
+            return stringField;
+        }
+
+        private static final java.util.List<krpc.schema.KRPC.Type> FIELD_TYPES =
+            java.util.Collections.unmodifiableList(java.util.Arrays.asList(
+                krpc.client.Types.createStruct("TestService", "TestStruct"),
+                krpc.client.Types.createClass("TestService", "TestClass"),
+                krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.STRING)
+            ));
+
+        /** The types of the fields, in the order they are encoded in. */
+        public static java.util.List<krpc.schema.KRPC.Type> fieldTypes() {
+            return FIELD_TYPES;
+        }
+
+        /** Build a TestNestedStruct from the values of its fields. */
+        @SuppressWarnings("unchecked")
+        public static TestNestedStruct fromFieldValues(Object[] values) {
+            return new TestNestedStruct(
+                (krpc.client.services.TestService.TestStruct) values[0],
+                (krpc.client.services.TestService.TestClass) values[1],
+                (String) values[2]
+            );
+        }
+
+        @Override
+        public Object[] fieldValues() {
+            return new Object[] {
+                structField,
+                objectField,
+                stringField
+            };
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (!(obj instanceof TestNestedStruct)) {
+                return false;
+            }
+            TestNestedStruct other = (TestNestedStruct) obj;
+            return java.util.Objects.equals(this.structField, other.structField)                && java.util.Objects.equals(this.objectField, other.objectField)                && java.util.Objects.equals(this.stringField, other.stringField);
+        }
+
+        @Override
+        public int hashCode() {
+            return java.util.Objects.hash(structField, objectField, stringField);
+        }
+    }
+
+    /**
      * Deprecated class documentation string.
      *
      * @deprecated Use TestClass instead.
@@ -1046,6 +1345,8 @@ public class TestService {
             PARAMETER_TYPES.put("BytesToHexString", new krpc.schema.KRPC.Type[] { krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.BYTES) });
             RETURN_TYPES.put("Counter", krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.SINT32));
             PARAMETER_TYPES.put("Counter", new krpc.schema.KRPC.Type[] { krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.STRING), krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.SINT32) });
+            RETURN_TYPES.put("CounterStruct", krpc.client.Types.createStruct("TestService", "TestStruct"));
+            PARAMETER_TYPES.put("CounterStruct", new krpc.schema.KRPC.Type[] { krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.STRING) });
             RETURN_TYPES.put("CreateTestObject", krpc.client.Types.createClass("TestService", "TestClass"));
             PARAMETER_TYPES.put("CreateTestObject", new krpc.schema.KRPC.Type[] { krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.STRING) });
             RETURN_TYPES.put("DeprecatedProcedure", krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.STRING));
@@ -1084,6 +1385,8 @@ public class TestService {
             PARAMETER_TYPES.put("IncrementDictionary", new krpc.schema.KRPC.Type[] { krpc.client.Types.createDictionary(krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.STRING), krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.SINT32)) });
             RETURN_TYPES.put("IncrementList", krpc.client.Types.createList(krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.SINT32)));
             PARAMETER_TYPES.put("IncrementList", new krpc.schema.KRPC.Type[] { krpc.client.Types.createList(krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.SINT32)) });
+            RETURN_TYPES.put("IncrementListOfStructs", krpc.client.Types.createList(krpc.client.Types.createStruct("TestService", "TestStruct")));
+            PARAMETER_TYPES.put("IncrementListOfStructs", new krpc.schema.KRPC.Type[] { krpc.client.Types.createList(krpc.client.Types.createStruct("TestService", "TestStruct")) });
             RETURN_TYPES.put("IncrementNestedCollection", krpc.client.Types.createDictionary(krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.STRING), krpc.client.Types.createList(krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.SINT32))));
             PARAMETER_TYPES.put("IncrementNestedCollection", new krpc.schema.KRPC.Type[] { krpc.client.Types.createDictionary(krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.STRING), krpc.client.Types.createList(krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.SINT32))) });
             RETURN_TYPES.put("IncrementSet", krpc.client.Types.createSet(krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.SINT32)));
@@ -1100,6 +1403,8 @@ public class TestService {
             PARAMETER_TYPES.put("Int64ToString", new krpc.schema.KRPC.Type[] { krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.SINT64) });
             RETURN_TYPES.put("ListDefault", krpc.client.Types.createList(krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.SINT32)));
             PARAMETER_TYPES.put("ListDefault", new krpc.schema.KRPC.Type[] { krpc.client.Types.createList(krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.SINT32)) });
+            RETURN_TYPES.put("NestedStructEcho", krpc.client.Types.createStruct("TestService", "TestNestedStruct"));
+            PARAMETER_TYPES.put("NestedStructEcho", new krpc.schema.KRPC.Type[] { krpc.client.Types.createStruct("TestService", "TestNestedStruct") });
             RETURN_TYPES.put("NotNullableObject", krpc.client.Types.createClass("TestService", "TestClass"));
             PARAMETER_TYPES.put("NotNullableObject", new krpc.schema.KRPC.Type[] { krpc.client.Types.createClass("TestService", "TestClass") });
             RETURN_TYPES.put("OnTimer", krpc.client.Types.createMessage(krpc.schema.KRPC.Type.TypeCode.EVENT));
@@ -1118,10 +1423,19 @@ public class TestService {
             PARAMETER_TYPES.put("SetDefault", new krpc.schema.KRPC.Type[] { krpc.client.Types.createSet(krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.SINT32)) });
             RETURN_TYPES.put("StringToInt32", krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.SINT32));
             PARAMETER_TYPES.put("StringToInt32", new krpc.schema.KRPC.Type[] { krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.STRING) });
+            RETURN_TYPES.put("StructDefault", krpc.client.Types.createStruct("TestService", "TestStruct"));
+            PARAMETER_TYPES.put("StructDefault", new krpc.schema.KRPC.Type[] { krpc.client.Types.createStruct("TestService", "TestStruct") });
+            RETURN_TYPES.put("StructEcho", krpc.client.Types.createStruct("TestService", "TestStruct"));
+            PARAMETER_TYPES.put("StructEcho", new krpc.schema.KRPC.Type[] { krpc.client.Types.createStruct("TestService", "TestStruct") });
+            RETURN_TYPES.put("StructEchoNullable", krpc.client.Types.createStruct("TestService", "TestStruct"));
+            PARAMETER_TYPES.put("StructEchoNullable", new krpc.schema.KRPC.Type[] { krpc.client.Types.createStruct("TestService", "TestStruct") });
             RETURN_TYPES.put("ThrowArgumentException", krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.SINT32));
             PARAMETER_TYPES.put("ThrowArgumentException", new krpc.schema.KRPC.Type[] {  });
             RETURN_TYPES.put("ThrowArgumentNullException", krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.SINT32));
             PARAMETER_TYPES.put("ThrowArgumentNullException", new krpc.schema.KRPC.Type[] { krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.STRING) });
+        }
+
+        private static void initTypes1() {
             RETURN_TYPES.put("ThrowArgumentOutOfRangeException", krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.SINT32));
             PARAMETER_TYPES.put("ThrowArgumentOutOfRangeException", new krpc.schema.KRPC.Type[] { krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.SINT32) });
             RETURN_TYPES.put("ThrowCustomException", krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.SINT32));
@@ -1134,9 +1448,6 @@ public class TestService {
             PARAMETER_TYPES.put("ThrowInvalidOperationExceptionLater", new krpc.schema.KRPC.Type[] {  });
             RETURN_TYPES.put("TupleDefault", krpc.client.Types.createTuple(krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.SINT32),krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.BOOL)));
             PARAMETER_TYPES.put("TupleDefault", new krpc.schema.KRPC.Type[] { krpc.client.Types.createTuple(krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.SINT32),krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.BOOL)) });
-        }
-
-        private static void initTypes1() {
             RETURN_TYPES.put("Uint32SpecialDefaults", krpc.client.Types.createList(krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.UINT32)));
             PARAMETER_TYPES.put("Uint32SpecialDefaults", new krpc.schema.KRPC.Type[] { krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.UINT32) });
             RETURN_TYPES.put("Uint64SpecialDefaults", krpc.client.Types.createList(krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.UINT64)));

--- a/tools/krpctools/krpctools/test/clientgen-TestService-java.txt
+++ b/tools/krpctools/krpctools/test/clientgen-TestService-java.txt
@@ -876,7 +876,7 @@ public class TestService {
     /**
      * Deprecated struct documentation string.
      *
-     * @deprecated Use the TestStruct struct instead.
+     * @deprecated Use TestStruct instead.
      */
     @Deprecated
     public static class DeprecatedStruct implements RemoteStruct {
@@ -898,7 +898,7 @@ public class TestService {
         /**
          * Deprecated struct OldValue documentation string.
          *
-         * @deprecated Use the Value field instead.
+         * @deprecated Use DeprecatedStruct.value instead.
          */
         @Deprecated
         public int getOldValue() {

--- a/tools/krpctools/krpctools/test/clientgen-TestService-python.txt
+++ b/tools/krpctools/krpctools/test/clientgen-TestService-python.txt
@@ -42,7 +42,7 @@ Enum ValueC documentation string.
 
 class DeprecatedStruct(NamedTuple):
     """
-    Deprecated. Use the TestStruct struct instead.
+    Deprecated. Use TestStruct instead.
 
     Deprecated struct documentation string.
     """
@@ -52,7 +52,7 @@ class DeprecatedStruct(NamedTuple):
     """
     old_value: int
     """
-    Deprecated. Use the Value field instead.
+    Deprecated. Use DeprecatedStruct.value instead.
 
     Deprecated struct OldValue documentation string.
     """

--- a/tools/krpctools/krpctools/test/clientgen-TestService-python.txt
+++ b/tools/krpctools/krpctools/test/clientgen-TestService-python.txt
@@ -58,15 +58,6 @@ class DeprecatedStruct(NamedTuple):
     """
 
 
-class TestNestedStruct(NamedTuple):
-    """
-    Nested struct documentation string.
-    """
-    struct_field: TestStruct
-    object_field: TestClass
-    string_field: str
-
-
 class TestStruct(NamedTuple):
     """
     Struct documentation string.
@@ -78,6 +69,15 @@ class TestStruct(NamedTuple):
     string_field: str
     enum_field: TestEnum
     list_field: List[int]
+
+
+class TestNestedStruct(NamedTuple):
+    """
+    Nested struct documentation string.
+    """
+    struct_field: TestStruct
+    object_field: TestClass
+    string_field: str
 
 
 class CustomException(RuntimeError):
@@ -443,8 +443,8 @@ class TestService:
     }
     _structs = {
         "DeprecatedStruct": DeprecatedStruct,
-        "TestNestedStruct": TestNestedStruct,
         "TestStruct": TestStruct,
+        "TestNestedStruct": TestNestedStruct,
     }
     _exceptions = {
         "CustomException": CustomException,

--- a/tools/krpctools/krpctools/test/clientgen-TestService-python.txt
+++ b/tools/krpctools/krpctools/test/clientgen-TestService-python.txt
@@ -1,7 +1,7 @@
 # pylint: disable=line-too-long,invalid-name,redefined-builtin,too-many-lines
 from __future__ import annotations
 import warnings
-from typing import Tuple, Set, Dict, List, Optional, TYPE_CHECKING
+from typing import Tuple, Set, Dict, List, NamedTuple, Optional, TYPE_CHECKING
 import krpc.limits
 import krpc.schema
 from krpc.schema import KRPC_pb2
@@ -366,12 +366,13 @@ class TestService:
 
     def __init__(self, client: Client) -> None:
         self._client = client
-        # The classes, enumerations and exceptions the service defines are put on the
-        # service here, so that reaching one is an ordinary attribute lookup and nothing
-        # has to intercept the lookups that do not name one - which is every call, as a
-        # call goes through a procedure or a property. A class is bound to the client it
-        # is reached through, so that its static methods use that client.
+        # The classes, enumerations, structures and exceptions the service defines are
+        # put on the service here, so that reaching one is an ordinary attribute lookup
+        # and nothing has to intercept the lookups that do not name one - which is every
+        # call, as a call goes through a procedure or a property. A class is bound to the
+        # client it is reached through, so that its static methods use that client.
         self.__dict__.update(self._enumerations)
+        self.__dict__.update(self._structs)
         self.__dict__.update(self._exceptions)
         for name, class_type in self._classes.items():
             self.__dict__[name] = WrappedClass(client, class_type)
@@ -399,6 +400,8 @@ class TestService:
     _enumerations = {
         "DeprecatedEnum": DeprecatedEnum,
         "TestEnum": TestEnum,
+    }
+    _structs = {
     }
     _exceptions = {
         "CustomException": CustomException,

--- a/tools/krpctools/krpctools/test/clientgen-TestService-python.txt
+++ b/tools/krpctools/krpctools/test/clientgen-TestService-python.txt
@@ -40,6 +40,46 @@ Enum ValueC documentation string.
 """
 
 
+class DeprecatedStruct(NamedTuple):
+    """
+    Deprecated. Use the TestStruct struct instead.
+
+    Deprecated struct documentation string.
+    """
+    value: int
+    """
+    Deprecated struct Value documentation string.
+    """
+    old_value: int
+    """
+    Deprecated. Use the Value field instead.
+
+    Deprecated struct OldValue documentation string.
+    """
+
+
+class TestNestedStruct(NamedTuple):
+    """
+    Nested struct documentation string.
+    """
+    struct_field: TestStruct
+    object_field: TestClass
+    string_field: str
+
+
+class TestStruct(NamedTuple):
+    """
+    Struct documentation string.
+    """
+    int_field: int
+    """
+    Struct IntField documentation string.
+    """
+    string_field: str
+    enum_field: TestEnum
+    list_field: List[int]
+
+
 class CustomException(RuntimeError):
     pass
 
@@ -402,6 +442,9 @@ class TestService:
         "TestEnum": TestEnum,
     }
     _structs = {
+        "DeprecatedStruct": DeprecatedStruct,
+        "TestNestedStruct": TestNestedStruct,
+        "TestStruct": TestStruct,
     }
     _exceptions = {
         "CustomException": CustomException,
@@ -706,6 +749,31 @@ class TestService:
             [id, divisor],
             [self._client._types.string_type, self._client._types.sint32_type],
             self._client._types.sint32_type
+        )
+
+    def counter_struct(self, id: str = '') -> TestStruct:
+        """
+        Returns a struct whose IntField counts the number of times it has been called,
+        so that a stream on it changes on every update.
+        """
+        return self._client._invoke(
+            "TestService",
+            "CounterStruct",
+            [id],
+            [self._client._types.string_type],
+            self._client._types.struct_type("TestService", "TestStruct")
+        )
+
+    def _return_type_counter_struct(self) -> TypeBase:
+        return self._client._types.struct_type("TestService", "TestStruct")
+
+    def _build_call_counter_struct(self, id: str = '') -> KRPC_pb2.ProcedureCall:
+        return self._client._build_call(
+            "TestService",
+            "CounterStruct",
+            [id],
+            [self._client._types.string_type],
+            self._client._types.struct_type("TestService", "TestStruct")
         )
 
     def create_test_object(self, value: str) -> TestClass:
@@ -1129,6 +1197,27 @@ class TestService:
             self._client._types.list_type(self._client._types.sint32_type)
         )
 
+    def increment_list_of_structs(self, l: List[TestStruct]) -> List[TestStruct]:
+        return self._client._invoke(
+            "TestService",
+            "IncrementListOfStructs",
+            [l],
+            [self._client._types.list_type(self._client._types.struct_type("TestService", "TestStruct"))],
+            self._client._types.list_type(self._client._types.struct_type("TestService", "TestStruct"))
+        )
+
+    def _return_type_increment_list_of_structs(self) -> TypeBase:
+        return self._client._types.list_type(self._client._types.struct_type("TestService", "TestStruct"))
+
+    def _build_call_increment_list_of_structs(self, l: List[TestStruct]) -> KRPC_pb2.ProcedureCall:
+        return self._client._build_call(
+            "TestService",
+            "IncrementListOfStructs",
+            [l],
+            [self._client._types.list_type(self._client._types.struct_type("TestService", "TestStruct"))],
+            self._client._types.list_type(self._client._types.struct_type("TestService", "TestStruct"))
+        )
+
     def increment_nested_collection(self, d: Dict[str, List[int]]) -> Dict[str, List[int]]:
         return self._client._invoke(
             "TestService",
@@ -1301,6 +1390,27 @@ class TestService:
             [x],
             [self._client._types.list_type(self._client._types.sint32_type)],
             self._client._types.list_type(self._client._types.sint32_type)
+        )
+
+    def nested_struct_echo(self, x: TestNestedStruct) -> TestNestedStruct:
+        return self._client._invoke(
+            "TestService",
+            "NestedStructEcho",
+            [x],
+            [self._client._types.struct_type("TestService", "TestNestedStruct")],
+            self._client._types.struct_type("TestService", "TestNestedStruct")
+        )
+
+    def _return_type_nested_struct_echo(self) -> TypeBase:
+        return self._client._types.struct_type("TestService", "TestNestedStruct")
+
+    def _build_call_nested_struct_echo(self, x: TestNestedStruct) -> KRPC_pb2.ProcedureCall:
+        return self._client._build_call(
+            "TestService",
+            "NestedStructEcho",
+            [x],
+            [self._client._types.struct_type("TestService", "TestNestedStruct")],
+            self._client._types.struct_type("TestService", "TestNestedStruct")
         )
 
     def not_nullable_object(self, value: TestClass) -> TestClass:
@@ -1490,6 +1600,69 @@ class TestService:
             [value],
             [self._client._types.string_type],
             self._client._types.sint32_type
+        )
+
+    def struct_default(self, x: TestStruct = TestStruct(42, 'jeb', TestEnum.value_b, [1, 2, 3])) -> TestStruct:
+        return self._client._invoke(
+            "TestService",
+            "StructDefault",
+            [x],
+            [self._client._types.struct_type("TestService", "TestStruct")],
+            self._client._types.struct_type("TestService", "TestStruct")
+        )
+
+    def _return_type_struct_default(self) -> TypeBase:
+        return self._client._types.struct_type("TestService", "TestStruct")
+
+    def _build_call_struct_default(self, x: TestStruct = TestStruct(42, 'jeb', TestEnum.value_b, [1, 2, 3])) -> KRPC_pb2.ProcedureCall:
+        return self._client._build_call(
+            "TestService",
+            "StructDefault",
+            [x],
+            [self._client._types.struct_type("TestService", "TestStruct")],
+            self._client._types.struct_type("TestService", "TestStruct")
+        )
+
+    def struct_echo(self, x: TestStruct) -> TestStruct:
+        return self._client._invoke(
+            "TestService",
+            "StructEcho",
+            [x],
+            [self._client._types.struct_type("TestService", "TestStruct")],
+            self._client._types.struct_type("TestService", "TestStruct")
+        )
+
+    def _return_type_struct_echo(self) -> TypeBase:
+        return self._client._types.struct_type("TestService", "TestStruct")
+
+    def _build_call_struct_echo(self, x: TestStruct) -> KRPC_pb2.ProcedureCall:
+        return self._client._build_call(
+            "TestService",
+            "StructEcho",
+            [x],
+            [self._client._types.struct_type("TestService", "TestStruct")],
+            self._client._types.struct_type("TestService", "TestStruct")
+        )
+
+    def struct_echo_nullable(self, x: Optional[TestStruct]) -> Optional[TestStruct]:
+        return self._client._invoke(
+            "TestService",
+            "StructEchoNullable",
+            [x],
+            [self._client._types.struct_type("TestService", "TestStruct")],
+            self._client._types.struct_type("TestService", "TestStruct")
+        )
+
+    def _return_type_struct_echo_nullable(self) -> TypeBase:
+        return self._client._types.struct_type("TestService", "TestStruct")
+
+    def _build_call_struct_echo_nullable(self, x: Optional[TestStruct]) -> KRPC_pb2.ProcedureCall:
+        return self._client._build_call(
+            "TestService",
+            "StructEchoNullable",
+            [x],
+            [self._client._types.struct_type("TestService", "TestStruct")],
+            self._client._types.struct_type("TestService", "TestStruct")
         )
 
     def throw_argument_exception(self) -> int:

--- a/tools/krpctools/krpctools/test/clientgentest.py
+++ b/tools/krpctools/krpctools/test/clientgentest.py
@@ -49,6 +49,33 @@ class ClientGenTestCase:
     def test_ordering(self):
         self.run_test("ServiceA", "Ordering")
 
+    def test_struct_of_the_same_name_in_another_service(self):
+        # A field whose type is a structure of the same name in another service refers to
+        # that one, not to the structure that holds it
+        struct = {
+            "documentation": "",
+            "fields": [
+                {
+                    "name": "Other",
+                    "type": {"code": "STRUCT", "service": "ServiceB", "name": "Thing"},
+                    "documentation": "",
+                }
+            ],
+        }
+        service = {
+            "id": 1,
+            "documentation": "",
+            "procedures": {},
+            "classes": {},
+            "enumerations": {},
+            "exceptions": {},
+            "structs": {"Thing": struct},
+        }
+        other = dict(
+            service, id=2, structs={"Thing": {"documentation": "", "fields": []}}
+        )
+        self.generate("ServiceA", {"ServiceA": service, "ServiceB": other})
+
     def test_service_that_is_not_defined(self):
         defs = self.load("Ordering")
         del defs["ServiceB"]

--- a/tools/krpctools/krpctools/test/docgen-TestService-cnano.rst
+++ b/tools/krpctools/krpctools/test/docgen-TestService-cnano.rst
@@ -1024,7 +1024,7 @@ Service documentation string.
 
 .. type:: krpc_TestService_DeprecatedStruct_t
 
-   .. warning:: Deprecated. Use the TestStruct struct instead.
+   .. warning:: Deprecated. Use :type:`krpc_TestService_TestStruct_t` instead.
 
    Deprecated struct documentation string.
 
@@ -1035,7 +1035,7 @@ Service documentation string.
 
    .. member:: int32_t old_value
 
-      .. warning:: Deprecated. Use the Value field instead.
+      .. warning:: Deprecated. Use :member:`krpc_TestService_DeprecatedStruct_t.value` instead.
 
       Deprecated struct OldValue documentation string.
 

--- a/tools/krpctools/krpctools/test/docgen-TestService-cnano.rst
+++ b/tools/krpctools/krpctools/test/docgen-TestService-cnano.rst
@@ -90,6 +90,20 @@ Service documentation string.
 
 
 
+.. function:: krpc_error_t krpc_TestService_CounterStruct(krpc_connection_t connection, krpc_TestService_TestStruct_t * result, const char * id)
+
+   Returns a struct whose IntField counts the number of times it has been called,
+   so that a stream on it changes on every update.
+
+   :Parameters:
+
+
+
+   
+
+
+
+
 .. function:: krpc_error_t krpc_TestService_CreateTestObject(krpc_connection_t connection, krpc_TestService_TestClass_t * result, const char * value)
 
 
@@ -360,6 +374,19 @@ Service documentation string.
 
 
 
+.. function:: krpc_error_t krpc_TestService_IncrementListOfStructs(krpc_connection_t connection, krpc_list_TestService_TestStruct_t * result, const krpc_list_TestService_TestStruct_t * l)
+
+
+
+   :Parameters:
+
+
+
+   
+
+
+
+
 .. function:: krpc_error_t krpc_TestService_IncrementNestedCollection(krpc_connection_t connection, krpc_dictionary_string_list_int32_t * result, const krpc_dictionary_string_list_int32_t * d)
 
 
@@ -454,6 +481,19 @@ Service documentation string.
 
 
 .. function:: krpc_error_t krpc_TestService_ListDefault(krpc_connection_t connection, krpc_list_int32_t * result, const krpc_list_int32_t * x)
+
+
+
+   :Parameters:
+
+
+
+   
+
+
+
+
+.. function:: krpc_error_t krpc_TestService_NestedStructEcho(krpc_connection_t connection, krpc_TestService_TestNestedStruct_t * result, const krpc_TestService_TestNestedStruct_t * x)
 
 
 
@@ -614,6 +654,45 @@ Service documentation string.
 
 
 .. function:: krpc_error_t krpc_TestService_StringToInt32(krpc_connection_t connection, int32_t * result, const char * value)
+
+
+
+   :Parameters:
+
+
+
+   
+
+
+
+
+.. function:: krpc_error_t krpc_TestService_StructDefault(krpc_connection_t connection, krpc_TestService_TestStruct_t * result, const krpc_TestService_TestStruct_t * x)
+
+
+
+   :Parameters:
+
+
+
+   
+
+
+
+
+.. function:: krpc_error_t krpc_TestService_StructEcho(krpc_connection_t connection, krpc_TestService_TestStruct_t * result, const krpc_TestService_TestStruct_t * x)
+
+
+
+   :Parameters:
+
+
+
+   
+
+
+
+
+.. function:: krpc_error_t krpc_TestService_StructEchoNullable(krpc_connection_t connection, krpc_TestService_TestStruct_t * result, const krpc_TestService_TestStruct_t * x)
 
 
 
@@ -901,6 +980,64 @@ Service documentation string.
 
       Deprecated enum ValueB documentation string.
 
+
+
+.. type:: krpc_TestService_TestStruct_t
+
+   Struct documentation string.
+
+
+   .. member:: int32_t int_field
+
+      Struct IntField documentation string.
+
+   .. member:: char * string_field
+
+
+
+   .. member:: krpc_TestService_TestEnum_t enum_field
+
+
+
+   .. member:: krpc_list_int32_t list_field
+
+
+
+
+.. type:: krpc_TestService_TestNestedStruct_t
+
+   Nested struct documentation string.
+
+
+   .. member:: krpc_TestService_TestStruct_t struct_field
+
+
+
+   .. member:: krpc_TestService_TestClass_t object_field
+
+
+
+   .. member:: char * string_field
+
+
+
+
+.. type:: krpc_TestService_DeprecatedStruct_t
+
+   .. warning:: Deprecated. Use the TestStruct struct instead.
+
+   Deprecated struct documentation string.
+
+
+   .. member:: int32_t value
+
+      Deprecated struct Value documentation string.
+
+   .. member:: int32_t old_value
+
+      .. warning:: Deprecated. Use the Value field instead.
+
+      Deprecated struct OldValue documentation string.
 
 
 Exception class CustomException

--- a/tools/krpctools/krpctools/test/docgen-TestService-cpp.rst
+++ b/tools/krpctools/krpctools/test/docgen-TestService-cpp.rst
@@ -844,7 +844,7 @@
 .. namespace:: krpc::services::TestService
 .. struct:: DeprecatedStruct
 
-   .. warning:: Deprecated. Use the TestStruct struct instead.
+   .. warning:: Deprecated. Use :struct:`TestStruct` instead.
 
    Deprecated struct documentation string.
 
@@ -855,7 +855,7 @@
 
    .. member:: int32_t old_value
 
-      .. warning:: Deprecated. Use the Value field instead.
+      .. warning:: Deprecated. Use :member:`DeprecatedStruct::value` instead.
 
       Deprecated struct OldValue documentation string.
 

--- a/tools/krpctools/krpctools/test/docgen-TestService-cpp.rst
+++ b/tools/krpctools/krpctools/test/docgen-TestService-cpp.rst
@@ -78,6 +78,17 @@
 
    
 
+   .. function:: TestStruct counter_struct(std::string id = "")
+
+      Returns a struct whose IntField counts the number of times it has been called,
+      so that a stream on it changes on every update.
+
+      :Parameters:
+
+
+
+   
+
    .. function:: TestClass create_test_object(std::string value)
 
 
@@ -288,6 +299,16 @@
 
    
 
+   .. function:: std::vector<TestStruct> increment_list_of_structs(std::vector<TestStruct> l)
+
+
+
+      :Parameters:
+
+
+
+   
+
    .. function:: std::map<std::string, std::vector<int32_t>> increment_nested_collection(std::map<std::string, std::vector<int32_t>> d)
 
 
@@ -361,6 +382,16 @@
    
 
    .. function:: std::vector<int32_t> list_default(std::vector<int32_t> x = std::vector<int32_t>{1, 2, 3})
+
+
+
+      :Parameters:
+
+
+
+   
+
+   .. function:: TestNestedStruct nested_struct_echo(TestNestedStruct x)
 
 
 
@@ -479,6 +510,36 @@
    
 
    .. function:: int32_t string_to_int32(std::string value)
+
+
+
+      :Parameters:
+
+
+
+   
+
+   .. function:: TestStruct struct_default(TestStruct x = TestStruct{42, "jeb", TestEnum::value_b, std::vector<int32_t>{1, 2, 3}})
+
+
+
+      :Parameters:
+
+
+
+   
+
+   .. function:: TestStruct struct_echo(TestStruct x)
+
+
+
+      :Parameters:
+
+
+
+   
+
+   .. function:: TestStruct struct_echo_nullable(TestStruct x)
 
 
 
@@ -736,6 +797,67 @@
 
       Deprecated enum ValueB documentation string.
 
+
+
+.. namespace:: krpc::services::TestService
+.. struct:: TestStruct
+
+   Struct documentation string.
+
+
+   .. member:: int32_t int_field
+
+      Struct IntField documentation string.
+
+   .. member:: std::string string_field
+
+
+
+   .. member:: TestEnum enum_field
+
+
+
+   .. member:: std::vector<int32_t> list_field
+
+
+
+
+.. namespace:: krpc::services::TestService
+.. struct:: TestNestedStruct
+
+   Nested struct documentation string.
+
+
+   .. member:: TestStruct struct_field
+
+
+
+   .. member:: TestClass object_field
+
+
+
+   .. member:: std::string string_field
+
+
+
+
+.. namespace:: krpc::services::TestService
+.. struct:: DeprecatedStruct
+
+   .. warning:: Deprecated. Use the TestStruct struct instead.
+
+   Deprecated struct documentation string.
+
+
+   .. member:: int32_t value
+
+      Deprecated struct Value documentation string.
+
+   .. member:: int32_t old_value
+
+      .. warning:: Deprecated. Use the Value field instead.
+
+      Deprecated struct OldValue documentation string.
 
 
 .. namespace:: krpc::services::TestService

--- a/tools/krpctools/krpctools/test/docgen-TestService-csharp.rst
+++ b/tools/krpctools/krpctools/test/docgen-TestService-csharp.rst
@@ -73,6 +73,17 @@
 
       :Game Scenes: All
 
+   .. method:: TestStruct CounterStruct(string id = "")
+
+      Returns a struct whose IntField counts the number of times it has been called,
+      so that a stream on it changes on every update.
+
+      :parameters:
+
+
+
+      :Game Scenes: All
+
    .. method:: TestClass CreateTestObject(string value)
 
 
@@ -282,6 +293,16 @@
 
       :Game Scenes: All
 
+   .. method:: System.Collections.Generic.IList<TestStruct> IncrementListOfStructs(System.Collections.Generic.IList<TestStruct> l)
+
+
+
+      :parameters:
+
+
+
+      :Game Scenes: All
+
    .. method:: System.Collections.Generic.IDictionary<string,System.Collections.Generic.IList<int>> IncrementNestedCollection(System.Collections.Generic.IDictionary<string,System.Collections.Generic.IList<int>> d)
 
 
@@ -355,6 +376,16 @@
       :Game Scenes: All
 
    .. method:: System.Collections.Generic.IList<int> ListDefault(System.Collections.Generic.IList<int> x = { 1, 2, 3 })
+
+
+
+      :parameters:
+
+
+
+      :Game Scenes: All
+
+   .. method:: TestNestedStruct NestedStructEcho(TestNestedStruct x)
 
 
 
@@ -470,6 +501,36 @@
       :Game Scenes: All
 
    .. method:: int StringToInt32(string value)
+
+
+
+      :parameters:
+
+
+
+      :Game Scenes: All
+
+   .. method:: TestStruct StructDefault(TestStruct x = new TestStruct(42, "jeb", TestEnum.ValueB, { 1, 2, 3 }))
+
+
+
+      :parameters:
+
+
+
+      :Game Scenes: All
+
+   .. method:: TestStruct StructEcho(TestStruct x)
+
+
+
+      :parameters:
+
+
+
+      :Game Scenes: All
+
+   .. method:: TestStruct StructEchoNullable(TestStruct x)
 
 
 
@@ -723,6 +784,64 @@
 
       Deprecated enum ValueB documentation string.
 
+
+
+.. struct:: TestStruct
+
+   Struct documentation string.
+
+
+   .. property:: int IntField { get; set; }
+
+      Struct IntField documentation string.
+
+   .. property:: string StringField { get; set; }
+
+
+
+   .. property:: TestEnum EnumField { get; set; }
+
+
+
+   .. property:: System.Collections.Generic.IList<int> ListField { get; set; }
+
+
+
+
+.. struct:: TestNestedStruct
+
+   Nested struct documentation string.
+
+
+   .. property:: TestStruct StructField { get; set; }
+
+
+
+   .. property:: TestClass ObjectField { get; set; }
+
+
+
+   .. property:: string StringField { get; set; }
+
+
+
+
+.. struct:: DeprecatedStruct
+
+   .. warning:: Deprecated. Use the TestStruct struct instead.
+
+   Deprecated struct documentation string.
+
+
+   .. property:: int Value { get; set; }
+
+      Deprecated struct Value documentation string.
+
+   .. property:: int OldValue { get; set; }
+
+      .. warning:: Deprecated. Use the Value field instead.
+
+      Deprecated struct OldValue documentation string.
 
 
 .. class:: CustomException

--- a/tools/krpctools/krpctools/test/docgen-TestService-csharp.rst
+++ b/tools/krpctools/krpctools/test/docgen-TestService-csharp.rst
@@ -828,7 +828,7 @@
 
 .. struct:: DeprecatedStruct
 
-   .. warning:: Deprecated. Use the TestStruct struct instead.
+   .. warning:: Deprecated. Use :type:`TestStruct` instead.
 
    Deprecated struct documentation string.
 
@@ -839,7 +839,7 @@
 
    .. property:: int OldValue { get; set; }
 
-      .. warning:: Deprecated. Use the Value field instead.
+      .. warning:: Deprecated. Use :prop:`DeprecatedStruct.Value` instead.
 
       Deprecated struct OldValue documentation string.
 

--- a/tools/krpctools/krpctools/test/docgen-TestService-java.rst
+++ b/tools/krpctools/krpctools/test/docgen-TestService-java.rst
@@ -666,7 +666,7 @@
 
 .. type:: public class DeprecatedStruct
 
-   .. warning:: Deprecated. Use the TestStruct struct instead.
+   .. warning:: Deprecated. Use :type:`TestStruct` instead.
 
    Deprecated struct documentation string.
 
@@ -677,7 +677,7 @@
 
    .. method:: int getOldValue()
 
-      .. warning:: Deprecated. Use the Value field instead.
+      .. warning:: Deprecated. Use :meth:`DeprecatedStruct.getValue()` instead.
 
       Deprecated struct OldValue documentation string.
 

--- a/tools/krpctools/krpctools/test/docgen-TestService-java.rst
+++ b/tools/krpctools/krpctools/test/docgen-TestService-java.rst
@@ -55,6 +55,14 @@
       :param int divisor:
    
 
+   .. method:: TestStruct counterStruct(String id)
+
+      Returns a struct whose IntField counts the number of times it has been called,
+      so that a stream on it changes on every update.
+
+      :param String id:
+   
+
    .. method:: TestClass createTestObject(String value)
 
 
@@ -211,6 +219,13 @@
       :param java.util.List<Integer> l:
    
 
+   .. method:: java.util.List<TestStruct> incrementListOfStructs(java.util.List<TestStruct> l)
+
+
+
+      :param java.util.List<TestStruct> l:
+   
+
    .. method:: java.util.Map<String,java.util.List<Integer>> incrementNestedCollection(java.util.Map<String,java.util.List<Integer>> d)
 
 
@@ -267,6 +282,13 @@
 
 
       :param java.util.List<Integer> x:
+   
+
+   .. method:: TestNestedStruct nestedStructEcho(TestNestedStruct x)
+
+
+
+      :param TestNestedStruct x:
    
 
    .. method:: TestClass notNullableObject(TestClass value)
@@ -368,6 +390,27 @@
 
 
       :param String value:
+   
+
+   .. method:: TestStruct structDefault(TestStruct x)
+
+
+
+      :param TestStruct x:
+   
+
+   .. method:: TestStruct structEcho(TestStruct x)
+
+
+
+      :param TestStruct x:
+   
+
+   .. method:: TestStruct structEchoNullable(TestStruct x)
+
+
+
+      :param TestStruct x:
    
 
    .. method:: int throwArgumentException()
@@ -579,6 +622,64 @@
 
       Deprecated enum ValueB documentation string.
 
+
+
+.. type:: public class TestStruct
+
+   Struct documentation string.
+
+
+   .. method:: int getIntField()
+
+      Struct IntField documentation string.
+
+   .. method:: String getStringField()
+
+
+
+   .. method:: TestEnum getEnumField()
+
+
+
+   .. method:: java.util.List<Integer> getListField()
+
+
+
+
+.. type:: public class TestNestedStruct
+
+   Nested struct documentation string.
+
+
+   .. method:: TestStruct getStructField()
+
+
+
+   .. method:: TestClass getObjectField()
+
+
+
+   .. method:: String getStringField()
+
+
+
+
+.. type:: public class DeprecatedStruct
+
+   .. warning:: Deprecated. Use the TestStruct struct instead.
+
+   Deprecated struct documentation string.
+
+
+   .. method:: int getValue()
+
+      Deprecated struct Value documentation string.
+
+   .. method:: int getOldValue()
+
+      .. warning:: Deprecated. Use the Value field instead.
+
+      Deprecated struct OldValue documentation string.
 
 
 .. type:: public class CustomException

--- a/tools/krpctools/krpctools/test/docgen-TestService-lua.rst
+++ b/tools/krpctools/krpctools/test/docgen-TestService-lua.rst
@@ -866,7 +866,7 @@ Service documentation string.
 
 .. class:: DeprecatedStruct
 
-   .. warning:: Deprecated. Use the TestStruct struct instead.
+   .. warning:: Deprecated. Use :class:`TestService.TestStruct` instead.
 
    Deprecated struct documentation string.
 
@@ -879,7 +879,7 @@ Service documentation string.
 
    .. attribute:: old_value: number
 
-      .. warning:: Deprecated. Use the Value field instead.
+      .. warning:: Deprecated. Use :attr:`TestService.DeprecatedStruct.value` instead.
 
       Deprecated struct OldValue documentation string.
 

--- a/tools/krpctools/krpctools/test/docgen-TestService-lua.rst
+++ b/tools/krpctools/krpctools/test/docgen-TestService-lua.rst
@@ -74,6 +74,17 @@ Service documentation string.
 
 
 
+.. staticmethod:: counter_struct([id = ''])
+
+   Returns a struct whose IntField counts the number of times it has been called,
+   so that a stream on it changes on every update.
+
+   :param string id:
+   :rtype: :class:`TestService.TestStruct`
+
+
+
+
 .. staticmethod:: create_test_object(value)
 
 
@@ -289,6 +300,16 @@ Service documentation string.
 
 
 
+.. staticmethod:: increment_list_of_structs(l)
+
+
+
+   :param List l:
+   :rtype: List
+
+
+
+
 .. staticmethod:: increment_nested_collection(d)
 
 
@@ -367,6 +388,16 @@ Service documentation string.
 
    :param List x:
    :rtype: List
+
+
+
+
+.. staticmethod:: nested_struct_echo(x)
+
+
+
+   :param TestService.TestNestedStruct x:
+   :rtype: :class:`TestService.TestNestedStruct`
 
 
 
@@ -506,6 +537,36 @@ Service documentation string.
 
    :param string value:
    :rtype: number
+
+
+
+
+.. staticmethod:: struct_default([x = {42, 'jeb', TestService.TestEnum.value_b, {1, 2, 3}}])
+
+
+
+   :param TestService.TestStruct x:
+   :rtype: :class:`TestService.TestStruct`
+
+
+
+
+.. staticmethod:: struct_echo(x)
+
+
+
+   :param TestService.TestStruct x:
+   :rtype: :class:`TestService.TestStruct`
+
+
+
+
+.. staticmethod:: struct_echo_nullable(x)
+
+
+
+   :param TestService.TestStruct x:
+   :rtype: :class:`TestService.TestStruct`
 
 
 
@@ -747,6 +808,82 @@ Service documentation string.
 
       Deprecated enum ValueB documentation string.
 
+
+
+.. class:: TestStruct
+
+   Struct documentation string.
+
+
+   .. attribute:: int_field: number
+
+      Struct IntField documentation string.
+
+      :rtype: number
+
+   .. attribute:: string_field: string
+
+
+
+      :rtype: string
+
+   .. attribute:: enum_field: TestService.TestEnum
+
+
+
+      :rtype: :class:`TestService.TestEnum`
+
+   .. attribute:: list_field: List
+
+
+
+      :rtype: List
+
+
+.. class:: TestNestedStruct
+
+   Nested struct documentation string.
+
+
+   .. attribute:: struct_field: TestService.TestStruct
+
+
+
+      :rtype: :class:`TestService.TestStruct`
+
+   .. attribute:: object_field: TestService.TestClass
+
+
+
+      :rtype: :class:`TestService.TestClass`
+
+   .. attribute:: string_field: string
+
+
+
+      :rtype: string
+
+
+.. class:: DeprecatedStruct
+
+   .. warning:: Deprecated. Use the TestStruct struct instead.
+
+   Deprecated struct documentation string.
+
+
+   .. attribute:: value: number
+
+      Deprecated struct Value documentation string.
+
+      :rtype: number
+
+   .. attribute:: old_value: number
+
+      .. warning:: Deprecated. Use the Value field instead.
+
+      Deprecated struct OldValue documentation string.
+
+      :rtype: number
 
 
 .. class:: CustomException

--- a/tools/krpctools/krpctools/test/docgen-TestService-python.rst
+++ b/tools/krpctools/krpctools/test/docgen-TestService-python.rst
@@ -80,6 +80,18 @@ Service documentation string.
 
 
 
+.. staticmethod:: counter_struct([id = ''])
+
+   Returns a struct whose IntField counts the number of times it has been called,
+   so that a stream on it changes on every update.
+
+   :param str id:
+   :rtype: :class:`TestStruct`
+   
+
+
+
+
 .. staticmethod:: create_test_object(value)
 
 
@@ -315,6 +327,17 @@ Service documentation string.
 
 
 
+.. staticmethod:: increment_list_of_structs(l)
+
+
+
+   :param list l:
+   :rtype: list(:class:`TestStruct`)
+   
+
+
+
+
 .. staticmethod:: increment_nested_collection(d)
 
 
@@ -400,6 +423,17 @@ Service documentation string.
 
    :param list x:
    :rtype: list(int)
+   
+
+
+
+
+.. staticmethod:: nested_struct_echo(x)
+
+
+
+   :param TestNestedStruct x:
+   :rtype: :class:`TestNestedStruct`
    
 
 
@@ -553,6 +587,39 @@ Service documentation string.
 
    :param str value:
    :rtype: int
+   
+
+
+
+
+.. staticmethod:: struct_default([x = TestStruct(42, 'jeb', TestEnum.value_b, [1, 2, 3])])
+
+
+
+   :param TestStruct x:
+   :rtype: :class:`TestStruct`
+   
+
+
+
+
+.. staticmethod:: struct_echo(x)
+
+
+
+   :param TestStruct x:
+   :rtype: :class:`TestStruct`
+   
+
+
+
+
+.. staticmethod:: struct_echo_nullable(x)
+
+
+
+   :param TestStruct x:
+   :rtype: :class:`TestStruct`
    
 
 
@@ -817,6 +884,82 @@ Service documentation string.
 
       Deprecated enum ValueB documentation string.
 
+
+
+.. class:: TestStruct
+
+   Struct documentation string.
+
+
+   .. attribute:: int_field
+
+      Struct IntField documentation string.
+
+      :rtype: int
+
+   .. attribute:: string_field
+
+
+
+      :rtype: str
+
+   .. attribute:: enum_field
+
+
+
+      :rtype: :class:`TestEnum`
+
+   .. attribute:: list_field
+
+
+
+      :rtype: list(int)
+
+
+.. class:: TestNestedStruct
+
+   Nested struct documentation string.
+
+
+   .. attribute:: struct_field
+
+
+
+      :rtype: :class:`TestStruct`
+
+   .. attribute:: object_field
+
+
+
+      :rtype: :class:`TestClass`
+
+   .. attribute:: string_field
+
+
+
+      :rtype: str
+
+
+.. class:: DeprecatedStruct
+
+   .. warning:: Deprecated. Use the TestStruct struct instead.
+
+   Deprecated struct documentation string.
+
+
+   .. attribute:: value
+
+      Deprecated struct Value documentation string.
+
+      :rtype: int
+
+   .. attribute:: old_value
+
+      .. warning:: Deprecated. Use the Value field instead.
+
+      Deprecated struct OldValue documentation string.
+
+      :rtype: int
 
 
 .. class:: CustomException

--- a/tools/krpctools/krpctools/test/docgen-TestService-python.rst
+++ b/tools/krpctools/krpctools/test/docgen-TestService-python.rst
@@ -942,7 +942,7 @@ Service documentation string.
 
 .. class:: DeprecatedStruct
 
-   .. warning:: Deprecated. Use the TestStruct struct instead.
+   .. warning:: Deprecated. Use :class:`TestStruct` instead.
 
    Deprecated struct documentation string.
 
@@ -955,7 +955,7 @@ Service documentation string.
 
    .. attribute:: old_value
 
-      .. warning:: Deprecated. Use the Value field instead.
+      .. warning:: Deprecated. Use :attr:`DeprecatedStruct.value` instead.
 
       Deprecated struct OldValue documentation string.
 

--- a/tools/krpctools/krpctools/test/docgentest.py
+++ b/tools/krpctools/krpctools/test/docgentest.py
@@ -62,6 +62,11 @@ class DocGenTestCase:
                 "{{ macros.enumeration(services['%s'].enumerations['%s']) }}"
                 % (service_name, enm)
             )
+        for struct in defs[service_name].get("structs", {}).keys():
+            rst_content.append(
+                "{{ macros.struct(services['%s'].structs['%s']) }}"
+                % (service_name, struct)
+            )
         for exn in defs[service_name]["exceptions"].keys():
             rst_content.append(
                 "{{ macros.exception(services['%s'].exceptions['%s']) }}"

--- a/tools/krpctools/krpctools/utils.py
+++ b/tools/krpctools/krpctools/utils.py
@@ -38,10 +38,12 @@ def single_line(string):
 def as_type(types, type_info):
     """Convert a type parsed from a JSON service definitions file
     into a type object"""
-    return types.as_type(_as_protobuf_type(types, type_info))
+    return types.as_type(as_protobuf_type(type_info))
 
 
-def _as_protobuf_type(types, type_info):
+def as_protobuf_type(type_info):
+    """Convert a type parsed from a JSON service definitions file
+    into a protocol buffer type"""
     protobuf_type = Type()
     protobuf_type.code = getattr(Type, type_info["code"])
     if "service" in type_info:
@@ -49,9 +51,7 @@ def _as_protobuf_type(types, type_info):
     if "name" in type_info:
         protobuf_type.name = type_info["name"]
     if "types" in type_info:
-        protobuf_type.types.extend(
-            [_as_protobuf_type(types, t) for t in type_info["types"]]
-        )
+        protobuf_type.types.extend([as_protobuf_type(t) for t in type_info["types"]])
     return protobuf_type
 
 


### PR DESCRIPTION
**The problem.** kRPC has two ways to return compound data, and neither suits a value that a caller almost always wants in full: a `KRPCClass` costs a round trip per field, and a tuple is positional with no names.

**The change.** `KRPCStruct` on a C# struct makes its `KRPCProperty` annotated properties the fields of a structure type, whose value is sent inline as the values of those fields in the order the structure declares them. That is the same encoding as a tuple of the field types, so each client reads and writes one with the codec it already has, and the field names live only in the service definition.

Two rules follow from that encoding, and every implementation relies on them: fields are only ever appended to a structure, so a value carrying more items than the reader knows about has the extra ones ignored while fewer is an error; and a field is never null, since null is signaled out of band for a whole value.

**Forward compatibility.** The python and lua clients build a service at runtime from the definitions the server sends. A definition naming a type code they do not know about, which is what one from a newer server looks like, now skips the member that names it with a warning rather than failing to create the service at all.

No service defines a structure yet. The protocol documentation covers the encoding of a structure value and the definition messages that describe one, so that a third party client can implement support.

Fixes #866
