### PR TITLE
Order and hash structure values

### DIFF
--- a/client/cpp/BUILD.bazel
+++ b/client/cpp/BUILD.bazel
@@ -190,6 +190,7 @@ cc_test(
         "test/test_decoder.cpp",
         "test/test_encode_decode.cpp",
         "test/test_encoder.cpp",
+        "test/test_hash.cpp",
         ":services-test-service",
     ],
     includes = ["test"],

--- a/client/cpp/CHANGELOG.md
+++ b/client/cpp/CHANGELOG.md
@@ -1,7 +1,13 @@
 ## [v0.7.0] - unreleased
 - Support structure types, which a service defines as a compound value with named fields. One
   is generated as a `struct` carrying its fields as members, with a constructor taking them in
-  the order the structure declares them and equality over them (#1066)
+  the order the structure declares them, and equality, ordering and a `std::hash` over them,
+  comparing its fields in turn as a `std::tuple` of the same values does (#1066)
+- Add `krpc::hash_value` and the `krpc::hash` function object, which hash any type the client
+  carries. The standard library hashes neither `std::tuple` nor its containers, which is what a
+  kRPC tuple and the collection types are, so a tuple could not be the key of an unordered
+  container: `std::unordered_set<std::tuple<double, double, double>, krpc::hash>` now can be
+  (#1067)
 - **Breaking:** Support null for any nullable type; nullable non-class values use
   `std::optional`, changing generated signatures (#1017)
 - Add `krpc::connect_local`, which connects to a server on the same machine over unix

--- a/client/cpp/include/krpc.hpp
+++ b/client/cpp/include/krpc.hpp
@@ -5,6 +5,7 @@
 
 #include "krpc/client.hpp"   // IWYU pragma: export
 #include "krpc/error.hpp"    // IWYU pragma: export
+#include "krpc/hash.hpp"     // IWYU pragma: export
 #include "krpc/krpc.pb.hpp"  // IWYU pragma: export
 #include "krpc/object.hpp"   // IWYU pragma: export
 

--- a/client/cpp/include/krpc/hash.hpp
+++ b/client/cpp/include/krpc/hash.hpp
@@ -1,0 +1,128 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <map>
+#include <optional>
+#include <set>
+#include <string>
+#include <tuple>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+namespace krpc {
+
+template <typename T>
+class Object;
+
+/** Mix a hash into a running one. The constant and the shifts are the ones boost::hash_combine
+    uses, which spread the bits of each value it is given across the result. */
+inline void hash_combine(std::size_t* seed, std::size_t value) {
+  *seed ^= value + 0x9e3779b9 + (*seed << 6) + (*seed >> 2);
+}
+
+/** The hash of a value of any type kRPC carries.
+
+    The standard library hashes the arithmetic types, std::string and enumerations, but not
+    std::tuple nor any of its containers, which is what a kRPC tuple and the collection types
+    are. Specializing std::hash for those is not allowed: a program may only add a
+    specialization of a standard template for a type of its own, and std::tuple<double, double>
+    is not one. So the hash of everything the client carries is written here instead, and
+    krpc::hash below is the function object to give a standard container that needs one.
+
+    A service that defines a structure type is generated with an overload of its own, in the
+    namespace enclosing the structure, which argument dependent lookup finds from the ones
+    below in the same way as the encoder and decoder find theirs. The overloads are all
+    declared before any is defined, so that a collection finds the hash of what it holds
+    however the two are nested. */
+template <typename T, typename std::enable_if<
+                          std::is_arithmetic<T>::value || std::is_enum<T>::value, int>::type = 0>
+std::size_t hash_value(const T& value);
+std::size_t hash_value(const std::string& value);
+template <typename T>
+std::size_t hash_value(const Object<T>& object);
+template <typename T>
+std::size_t hash_value(const std::optional<T>& value);
+template <typename T>
+std::size_t hash_value(const std::vector<T>& list);
+template <typename T>
+std::size_t hash_value(const std::set<T>& set);
+template <typename K, typename V>
+std::size_t hash_value(const std::map<K, V>& dictionary);
+template <typename... Ts>
+std::size_t hash_value(const std::tuple<Ts...>& tuple);
+
+template <typename T, typename std::enable_if<
+                          std::is_arithmetic<T>::value || std::is_enum<T>::value, int>::type>
+inline std::size_t hash_value(const T& value) {
+  return std::hash<T>()(value);
+}
+
+inline std::size_t hash_value(const std::string& value) { return std::hash<std::string>()(value); }
+
+/** An object is a handle to something on the server, and is equal to another handle to the
+    same thing, so its identifier is what it hashes as. */
+template <typename T>
+inline std::size_t hash_value(const Object<T>& object) {
+  return std::hash<uint64_t>()(object._id);
+}
+
+/** An optional holding a value hashes as if it were the one value it holds; an empty one
+    hashes as an empty collection does. */
+template <typename T>
+inline std::size_t hash_value(const std::optional<T>& value) {
+  std::size_t seed = 0;
+  if (value) hash_combine(&seed, hash_value(*value));
+  return seed;
+}
+
+template <typename T>
+inline std::size_t hash_value(const std::vector<T>& list) {
+  std::size_t seed = 0;
+  for (typename std::vector<T>::const_iterator x = list.begin(); x != list.end(); ++x)
+    hash_combine(&seed, hash_value(*x));
+  return seed;
+}
+
+template <typename T>
+inline std::size_t hash_value(const std::set<T>& set) {
+  std::size_t seed = 0;
+  for (typename std::set<T>::const_iterator x = set.begin(); x != set.end(); ++x)
+    hash_combine(&seed, hash_value(*x));
+  return seed;
+}
+
+template <typename K, typename V>
+inline std::size_t hash_value(const std::map<K, V>& dictionary) {
+  std::size_t seed = 0;
+  for (typename std::map<K, V>::const_iterator x = dictionary.begin(); x != dictionary.end(); ++x) {
+    hash_combine(&seed, hash_value(x->first));
+    hash_combine(&seed, hash_value(x->second));
+  }
+  return seed;
+}
+
+template <typename... Ts>
+inline std::size_t hash_value(const std::tuple<Ts...>& tuple) {
+  std::size_t seed = 0;
+  std::apply([&](const Ts&... args) { (hash_combine(&seed, hash_value(args)), ...); }, tuple);
+  return seed;
+}
+
+/** Hashes a value of any type kRPC carries, for a standard container that takes the hash as a
+    template argument:
+
+        std::unordered_set<std::tuple<double, double, double>, krpc::hash> points;
+
+    A structure type is also given a std::hash of its own, so a container of one needs nothing
+    here. */
+struct hash {
+  template <typename T>
+  std::size_t operator()(const T& value) const {
+    return hash_value(value);
+  }
+};
+
+}  // namespace krpc

--- a/client/cpp/test/test_client.cpp
+++ b/client/cpp/test/test_client.cpp
@@ -14,6 +14,7 @@
 #include <string>
 #include <thread>  // NOLINT(build/c++11)
 #include <tuple>
+#include <unordered_set>
 #include <vector>
 
 #include "gtest/gtest.h"
@@ -399,6 +400,33 @@ TEST_F(test_client, test_struct_default_value) {
   krpc::services::TestService::TestStruct value(
       42, "jeb", krpc::services::TestService::TestEnum::value_b, {1, 2, 3});
   ASSERT_EQ(value, test_service.struct_default());
+}
+
+TEST_F(test_client, test_struct_comparison) {
+  typedef krpc::services::TestService::TestStruct Struct;
+  Struct a(1, "jeb", krpc::services::TestService::TestEnum::value_a, {1, 2});
+  Struct b(1, "jeb", krpc::services::TestService::TestEnum::value_a, {1, 2});
+  Struct c(2, "jeb", krpc::services::TestService::TestEnum::value_a, {1, 2});
+
+  ASSERT_EQ(a, b);
+  ASSERT_NE(a, c);
+  // Ordered by the fields in turn, as a tuple of the same values is
+  ASSERT_LT(a, c);
+  ASSERT_GT(c, a);
+  ASSERT_LE(a, b);
+  ASSERT_GE(a, b);
+
+  std::set<Struct> set{c, a, b};
+  ASSERT_EQ(2u, set.size());
+  ASSERT_EQ(a, *set.begin());
+
+  // A structure is a type of our own, so it gets a std::hash and needs nothing further to be
+  // the key of an unordered container
+  std::unordered_set<Struct> hashed{a, b, c};
+  ASSERT_EQ(2u, hashed.size());
+  ASSERT_EQ(std::hash<Struct>()(a), std::hash<Struct>()(b));
+  // A collection of structures hashes too, through krpc::hash
+  ASSERT_EQ(krpc::hash_value(std::vector<Struct>{a}), krpc::hash_value(std::vector<Struct>{b}));
 }
 
 TEST_F(test_client, test_collections_default_values) {

--- a/client/cpp/test/test_hash.cpp
+++ b/client/cpp/test/test_hash.cpp
@@ -1,0 +1,73 @@
+#include <gtest/gtest.h>
+
+#include <map>
+#include <optional>
+#include <set>
+#include <string>
+#include <tuple>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+#include "krpc/hash.hpp"
+
+namespace {
+
+TEST(test_hash, values) {
+  ASSERT_EQ(krpc::hash_value(42), krpc::hash_value(42));
+  ASSERT_EQ(krpc::hash_value(std::string("jeb")), krpc::hash_value(std::string("jeb")));
+  ASSERT_NE(krpc::hash_value(std::string("jeb")), krpc::hash_value(std::string("bob")));
+}
+
+TEST(test_hash, tuple) {
+  std::tuple<int32_t, std::string, bool> x(1, "jeb", false);
+  std::tuple<int32_t, std::string, bool> y(1, "jeb", false);
+  std::tuple<int32_t, std::string, bool> z(2, "jeb", false);
+  ASSERT_EQ(krpc::hash_value(x), krpc::hash_value(y));
+  ASSERT_NE(krpc::hash_value(x), krpc::hash_value(z));
+}
+
+TEST(test_hash, collections) {
+  ASSERT_EQ(krpc::hash_value(std::vector<int32_t>{1, 2, 3}),
+            krpc::hash_value(std::vector<int32_t>{1, 2, 3}));
+  ASSERT_NE(krpc::hash_value(std::vector<int32_t>{1, 2, 3}),
+            krpc::hash_value(std::vector<int32_t>{3, 2, 1}));
+  ASSERT_EQ(krpc::hash_value(std::set<int32_t>{1, 2}), krpc::hash_value(std::set<int32_t>{2, 1}));
+  ASSERT_EQ(krpc::hash_value(std::map<std::string, int32_t>{{"a", 1}}),
+            krpc::hash_value(std::map<std::string, int32_t>{{"a", 1}}));
+  ASSERT_NE(krpc::hash_value(std::map<std::string, int32_t>{{"a", 1}}),
+            krpc::hash_value(std::map<std::string, int32_t>{{"a", 2}}));
+}
+
+TEST(test_hash, optional) {
+  ASSERT_EQ(krpc::hash_value(std::optional<int32_t>(1)),
+            krpc::hash_value(std::optional<int32_t>(1)));
+  ASSERT_NE(krpc::hash_value(std::optional<int32_t>(1)),
+            krpc::hash_value(std::optional<int32_t>(2)));
+  ASSERT_NE(krpc::hash_value(std::optional<int32_t>(1)),
+            krpc::hash_value(std::optional<int32_t>()));
+  ASSERT_EQ(krpc::hash_value(std::optional<int32_t>()), krpc::hash_value(std::optional<int32_t>()));
+}
+
+TEST(test_hash, nested_collections) {
+  std::vector<std::tuple<int32_t, std::string>> x{{1, "jeb"}, {2, "bob"}};
+  std::vector<std::tuple<int32_t, std::string>> y{{1, "jeb"}, {2, "bob"}};
+  ASSERT_EQ(krpc::hash_value(x), krpc::hash_value(y));
+}
+
+TEST(test_hash, as_a_container_hash) {
+  // What the hash is for: a standard container keyed by a type the standard library does not
+  // hash on its own
+  std::unordered_set<std::tuple<double, double, double>, krpc::hash> points;
+  points.insert(std::make_tuple(1.0, 2.0, 3.0));
+  points.insert(std::make_tuple(1.0, 2.0, 3.0));
+  ASSERT_EQ(1u, points.size());
+  ASSERT_EQ(1u, points.count(std::make_tuple(1.0, 2.0, 3.0)));
+  ASSERT_EQ(0u, points.count(std::make_tuple(1.0, 2.0, 4.0)));
+
+  std::unordered_map<std::vector<int32_t>, std::string, krpc::hash> names;
+  names[std::vector<int32_t>{1, 2}] = "jeb";
+  ASSERT_EQ("jeb", names[std::vector<int32_t>({1, 2})]);
+}
+
+}  // namespace

--- a/client/csharp/CHANGELOG.md
+++ b/client/csharp/CHANGELOG.md
@@ -1,7 +1,9 @@
 ## [v0.7.0] - unreleased
 - Support structure types, which a service defines as a compound value with named fields. One
   is generated as a `struct` carrying its fields as properties, with a constructor taking them
-  in the order the structure declares them and equality over them (#1066)
+  in the order the structure declares them. It implements `IEquatable` and `IComparable` and
+  carries the equality and relational operators, ordering by its fields in turn as a
+  `System.Tuple` of the same values does (#1066)
 - **Breaking:** Support `null` for any nullable type; nullable value types use the nullable
   form (`int?`) (#1017)
 - Add `Connection.ConnectLocal`, which connects to a server on the same machine over unix

--- a/client/csharp/test/ConnectionTest.cs
+++ b/client/csharp/test/ConnectionTest.cs
@@ -414,6 +414,64 @@ namespace KRPC.Client.Test
         }
 
         [Test]
+        public void StructComparison ()
+        {
+            var items = new List<int> ();
+            var a = new TestStruct (1, "jeb", TestEnum.ValueA, items);
+            var b = new TestStruct (1, "jeb", TestEnum.ValueA, items);
+            var c = new TestStruct (2, "jeb", TestEnum.ValueA, items);
+
+            Assert.IsTrue (a.Equals (b));
+            Assert.IsTrue (a == b);
+            Assert.IsTrue (a != c);
+            Assert.AreEqual (a.GetHashCode (), b.GetHashCode ());
+
+            // Ordered by the fields in turn, as a tuple of the same values is
+            Assert.IsTrue (a < c);
+            Assert.IsTrue (c > a);
+            Assert.IsTrue (a <= b);
+            Assert.IsTrue (a >= b);
+            Assert.AreEqual (0, a.CompareTo (b));
+            Assert.Less (a.CompareTo (c), 0);
+
+            var sorted = new List<TestStruct> { c, a };
+            sorted.Sort ();
+            Assert.AreEqual (a, sorted [0]);
+
+            var set = new HashSet<TestStruct> { a, b, c };
+            Assert.AreEqual (2, set.Count);
+        }
+
+        [Test]
+        public void StructEqualityOfACollectionFieldIsByContents ()
+        {
+            // A collection field is equal to one holding the same items, whatever object
+            // each of them is
+            // Asserted through Equals rather than through Assert.AreEqual, which compares
+            // collections structurally with a comparer of NUnit's own
+            var x = new TestStruct (1, "jeb", TestEnum.ValueA, new List<int> { 1 });
+            var y = new TestStruct (1, "jeb", TestEnum.ValueA, new List<int> { 1 });
+            var z = new TestStruct (1, "jeb", TestEnum.ValueA, new List<int> { 2 });
+            Assert.IsTrue (x.Equals (y));
+            Assert.AreEqual (x.GetHashCode (), y.GetHashCode ());
+            Assert.IsFalse (x.Equals (z));
+        }
+
+        [Test]
+        public void StructComparisonOfACollectionFieldThrows ()
+        {
+            // A collection has no ordering, so comparing two structures whose collection
+            // fields are different objects throws, as comparing two such tuples does
+            var a = new TestStruct (1, "jeb", TestEnum.ValueA, new List<int> { 1 });
+            var b = new TestStruct (1, "jeb", TestEnum.ValueA, new List<int> { 2 });
+            Assert.Throws<System.ArgumentException> (() => a.CompareTo (b));
+            Assert.Throws<System.ArgumentException> (
+                () => Comparer<Tuple<int, IList<int>>>.Default.Compare (
+                    new Tuple<int, IList<int>> (1, new List<int> { 1 }),
+                    new Tuple<int, IList<int>> (1, new List<int> { 2 })));
+        }
+
+        [Test]
         public void CollectionsDefaultValues ()
         {
             Assert.AreEqual (new Tuple<int,bool> (1, false), Connection.TestService ().TupleDefault ());

--- a/client/java/CHANGELOG.md
+++ b/client/java/CHANGELOG.md
@@ -1,7 +1,8 @@
 ## [v0.7.0] - unreleased
 - Support structure types, which a service defines as a compound value with named fields. One
   is generated as a class carrying its fields, with a constructor taking them in the order the
-  structure declares them, getters and equality over them (#1066)
+  structure declares them, getters, `equals`, `hashCode` and `Comparable`, comparing its fields
+  in turn as a javatuples tuple of the same values does (#1066)
 - **Breaking:** Requires Java 17 or later, up from Java 9, for the unix domain sockets the
   local socket protocol is carried over (#1065)
 - **Breaking:** Support `null` for any nullable type; nullable value types use the boxed type

--- a/client/java/src/krpc/client/RemoteStruct.java
+++ b/client/java/src/krpc/client/RemoteStruct.java
@@ -11,4 +11,25 @@ package krpc.client;
 public interface RemoteStruct {
   /** Returns the values of the fields, in the order they are encoded in. */
   public Object[] fieldValues();
+
+  /**
+   * Compare the values two structures hold for the same field, which a generated structure
+   * calls for each of its fields in turn. A field whose type has no ordering, such as a
+   * collection, throws a {@link ClassCastException} unless the two values are the same
+   * object, exactly as comparing two tuples holding such an item does, so two structures
+   * that are equal can still throw here.
+   */
+  @SuppressWarnings({"unchecked", "rawtypes"})
+  public static int compareFields(Object lhs, Object rhs) {
+    if (lhs == rhs) {
+      return 0;
+    }
+    if (lhs == null) {
+      return -1;
+    }
+    if (rhs == null) {
+      return 1;
+    }
+    return ((Comparable) lhs).compareTo(rhs);
+  }
 }

--- a/client/java/test/krpc/client/ConnectionTest.java
+++ b/client/java/test/krpc/client/ConnectionTest.java
@@ -296,6 +296,48 @@ public class ConnectionTest {
   }
 
   @Test
+  public void testStructComparison() {
+    java.util.List<Integer> items = new ArrayList<Integer>();
+    TestService.TestStruct a =
+        new TestService.TestStruct(1, "jeb", TestService.TestEnum.VALUE_A, items);
+    TestService.TestStruct b =
+        new TestService.TestStruct(1, "jeb", TestService.TestEnum.VALUE_A, items);
+    final TestService.TestStruct c =
+        new TestService.TestStruct(2, "jeb", TestService.TestEnum.VALUE_A, items);
+
+    assertEquals(a, b);
+    assertEquals(a.hashCode(), b.hashCode());
+
+    // Ordered by the fields in turn, as a tuple of the same values is
+    assertEquals(0, a.compareTo(b));
+    assertTrue(a.compareTo(c) < 0);
+    assertTrue(c.compareTo(a) > 0);
+
+    java.util.List<TestService.TestStruct> sorted = new ArrayList<>(Arrays.asList(c, a));
+    java.util.Collections.sort(sorted);
+    assertEquals(a, sorted.get(0));
+
+    assertEquals(2, new HashSet<>(Arrays.asList(a, b, c)).size());
+  }
+
+  @Test
+  public void testStructComparisonOfCollectionFieldThrows() {
+    // A collection has no ordering, so comparing two structures whose collection fields
+    // differ throws, exactly as comparing two such tuples does
+    TestService.TestStruct a = new TestService.TestStruct(
+        1, "jeb", TestService.TestEnum.VALUE_A, Arrays.asList(new Integer[] { 1 }));
+    TestService.TestStruct b = new TestService.TestStruct(
+        1, "jeb", TestService.TestEnum.VALUE_A, Arrays.asList(new Integer[] { 2 }));
+    assertThrows(ClassCastException.class, () -> a.compareTo(b));
+    assertThrows(
+        ClassCastException.class,
+        () -> new Pair<Integer, java.util.List<Integer>>(1, Arrays.asList(new Integer[] { 1 }))
+            .compareTo(
+                new Pair<Integer, java.util.List<Integer>>(
+                    1, Arrays.asList(new Integer[] { 2 }))));
+  }
+
+  @Test
   @SuppressWarnings("serial")
   public void testCollectionsNested() throws RPCException {
     assertEquals(new HashMap<String, List<Integer>>(),

--- a/client/lua/CHANGELOG.md
+++ b/client/lua/CHANGELOG.md
@@ -1,7 +1,8 @@
 ## [v0.7.0] - unreleased
 - Support structure types, which a service defines as a compound value with named fields. A
   value of one is built from the values of its fields in order and gives them named access; a
-  list with one element per field is accepted where one is expected (#1066)
+  list with one element per field is accepted where one is expected. It compares for
+  equality and orders by its fields in turn (#1066)
 - A service definition that names a type this client does not know about, as one from a newer
   server may, now skips the member that names it with a warning, rather than failing to
   connect (#1066)

--- a/client/lua/krpc/test/test_client.lua
+++ b/client/lua/krpc/test/test_client.lua
@@ -309,6 +309,25 @@ function TestClient:test_struct_default_value()
     service.struct_default())
 end
 
+function TestClient:test_struct_comparison()
+  local service = self.conn.test_service
+  local a = service.TestStruct(1, 'jeb', service.TestEnum.value_a, List{})
+  local b = service.TestStruct(1, 'jeb', service.TestEnum.value_a, List{})
+  local c = service.TestStruct(2, 'jeb', service.TestEnum.value_a, List{})
+
+  luaunit.assertEquals(a, b)
+  -- Ordered by the fields in turn
+  luaunit.assertTrue(a < c)
+  luaunit.assertTrue(c > a)
+  luaunit.assertTrue(a <= b)
+  luaunit.assertTrue(a >= b)
+  luaunit.assertFalse(c < a)
+
+  local values = {c, a}
+  table.sort(values)
+  luaunit.assertEquals(a, values[1])
+end
+
 function TestClient:test_collections_default_values()
   luaunit.assertEquals(List{1, false}, self.conn.test_service.tuple_default())
   luaunit.assertEquals(List{1, 2, 3}, self.conn.test_service.list_default())

--- a/client/lua/krpc/test/test_types.lua
+++ b/client/lua/krpc/test/test_types.lua
@@ -210,6 +210,34 @@ function TestTypes:test_coerce_to()
   luaunit.assertError(types.coerce_to, types, List{1}, types:tuple_type({types:string_type()}))
 end
 
+function TestTypes:test_struct_comparison()
+  local types = Types()
+  local typ = types:struct_type('ServiceName', 'ComparableStruct')
+  typ:set_fields({{'count', types:uint32_type()}, {'name', types:string_type()}})
+  local one = typ.lua_type(1, 'jeb')
+  local same = typ.lua_type(1, 'jeb')
+  local two = typ.lua_type(2, 'jeb')
+  luaunit.assertTrue(one == same)
+  luaunit.assertTrue(one ~= two)
+  -- Ordered by the fields in turn
+  luaunit.assertTrue(one < two)
+  luaunit.assertTrue(two > one)
+  luaunit.assertTrue(one <= same)
+  luaunit.assertTrue(one >= same)
+  luaunit.assertFalse(two < one)
+end
+
+function TestTypes:test_struct_ordering_of_a_field_that_orders_neither_way()
+  local types = Types()
+  local typ = types:struct_type('ServiceName', 'NanStruct')
+  typ:set_fields({{'value', types:double_type()}, {'count', types:uint32_type()}})
+  -- A NaN is unequal to itself and orders neither way, so ordering moves on to the next
+  -- field rather than calling the two values ordered
+  local nan = 0/0
+  luaunit.assertTrue(typ.lua_type(nan, 1) < typ.lua_type(nan, 2))
+  luaunit.assertFalse(typ.lua_type(nan, 2) < typ.lua_type(nan, 1))
+end
+
 function TestTypes:test_none()
   luaunit.assertEquals(tostring(Types.none), 'none')
   luaunit.assertTrue(Types.none == Types.none)

--- a/client/lua/krpc/types.lua
+++ b/client/lua/krpc/types.lua
@@ -600,6 +600,28 @@ function Types.StructBase:__eq(other)
   return true
 end
 
+--- Ordered by the fields in turn, which is how a tuple of the same values would be ordered
+--- if Lua ordered tables. A field whose type Lua does not order, such as a collection or an
+--- enumeration value, raises when the two values differ. Two values that are unequal but
+--- order neither way, as two NaNs are, move on to the next field.
+function Types.StructBase:__lt(other)
+  for _, name in ipairs(self._field_names) do
+    if self[name] ~= other[name] then
+      if self[name] < other[name] then
+        return true
+      end
+      if other[name] < self[name] then
+        return false
+      end
+    end
+  end
+  return false
+end
+
+function Types.StructBase:__le(other)
+  return not (other < self)
+end
+
 function Types.StructBase:__tostring()
   local parts = {}
   for i, name in ipairs(self._field_names) do

--- a/client/python/CHANGELOG.md
+++ b/client/python/CHANGELOG.md
@@ -1,8 +1,8 @@
 ## [v0.7.0] - unreleased
 - Support structure types, which a service defines as a compound value with named fields. A
   value of one is a named tuple, so its fields can be read by name and it is also the tuple of
-  their values; a tuple or list with one element per field is accepted where one is expected
-  (#1066)
+  their values; a tuple or list with one element per field is accepted where one is expected.
+  It compares, orders and hashes as the tuple of its field values does (#1066)
 - A service definition that names a type this client does not know about, as one from a newer
   server may, now skips the member that names it with a warning, rather than failing to
   connect (#1066)

--- a/client/python/krpc/test/test_client.py
+++ b/client/python/krpc/test/test_client.py
@@ -500,6 +500,20 @@ class TestClient(ServerTestCase, unittest.TestCase):
             service.struct_default(),
         )
 
+    def test_struct_comparison(self) -> None:
+        service = self.conn.test_service
+        value = service.TestStruct(
+            int_field=42,
+            string_field="jeb",
+            enum_field=service.TestEnum.value_b,
+            list_field=[1, 2, 3],
+        )
+        result = service.struct_echo(value)
+        other = service.struct_echo(value._replace(int_field=43))
+        self.assertEqual(value, result)
+        self.assertLess(result, other)
+        self.assertEqual([result, other], sorted([other, result]))
+
     def test_colllections_default_values(self) -> None:
         self.assertEqual((1, False), self.conn.test_service.tuple_default())
         self.assertEqual([1, 2, 3], self.conn.test_service.list_default())

--- a/client/python/krpc/test/test_types.py
+++ b/client/python/krpc/test/test_types.py
@@ -227,6 +227,35 @@ class TestTypes(unittest.TestCase):
         self.assertEqual(int, typ.value_type.python_type)
         self.check_protobuf_type(Type.UINT32, "", "", 0, typ.value_type.protobuf_type)
 
+    def test_struct_comparison(self) -> None:
+        types = Types()
+        typ = types.struct_type("ServiceName", "ComparableStruct")
+        typ.set_fields([("count", types.uint32_type), ("name", types.string_type)])
+        one = typ.python_type(1, "jeb")
+        same = typ.python_type(1, "jeb")
+        two = typ.python_type(2, "jeb")
+        self.assertEqual(one, same)
+        self.assertNotEqual(one, two)
+        # A structure is ordered and hashed as the tuple of its field values is, and equals
+        # that tuple
+        self.assertEqual((1, "jeb"), one)
+        self.assertLess(one, two)
+        self.assertGreater(two, one)
+        self.assertEqual([one, two], sorted([two, one]))
+        self.assertEqual(hash(one), hash(same))
+        self.assertEqual({one, two}, {one, same, two})
+
+    def test_struct_holding_an_unhashable_value(self) -> None:
+        types = Types()
+        typ = types.struct_type("ServiceName", "UnhashableStruct")
+        typ.set_fields([("items", types.list_type(types.sint32_type))])
+        value = typ.python_type([1, 2])
+        self.assertEqual(typ.python_type([1, 2]), value)
+        # A list cannot be hashed, so neither can a structure holding one, exactly as a
+        # tuple holding one cannot
+        self.assertRaises(TypeError, hash, value)
+        self.assertRaises(TypeError, hash, ([1, 2],))
+
     def test_coerce_to_struct(self) -> None:
         types = Types()
         typ = types.struct_type("ServiceName", "StructName")

--- a/doc/src/cpp/client.rst
+++ b/doc/src/cpp/client.rst
@@ -505,3 +505,20 @@ Client API Reference
    .. function:: operator bool()
 
       Returns whether the event object is bound to a stream.
+
+.. function:: template <typename T> std::size_t hash_value(const T& value)
+
+   Returns a hash of a value of any type the client carries: the arithmetic types, strings,
+   enumerations, class objects, tuples, and the list, set and dictionary collection types,
+   nested however deeply. A structure is also hashed by this function, and is given a
+   ``std::hash`` of its own, so an unordered container keyed by one needs nothing further.
+
+.. class:: hash
+
+   A function object that calls :func:`hash_value`, to give a standard container that takes
+   its hash as a template argument. The standard library hashes neither ``std::tuple`` nor
+   any of the collection types, so a container keyed by one needs this:
+
+   .. code-block:: cpp
+
+      std::unordered_set<std::tuple<double, double, double>, krpc::hash> points;

--- a/tools/krpctools/krpctools/clientgen/cpp.tmpl
+++ b/tools/krpctools/krpctools/clientgen/cpp.tmpl
@@ -28,6 +28,8 @@ return {% if is_static %}_client.{% else %}this->_client->{% endif %}build_call(
 {% for x in parameters %}{{x.type}} {{x.name}}{% if 'default_value' in x %} = {{x.default_value}}{%- endif %}{% if not loop.last %}, {% endif %}{% endfor %}
 {% endmacro %}
 
+#include <cstddef>
+#include <functional>
 #include <limits>
 #include <map>
 #include <set>
@@ -39,6 +41,7 @@ return {% if is_static %}_client.{% else %}this->_client->{% endif %}build_call(
 #include <krpc/encoder.hpp>
 #include <krpc/error.hpp>
 #include <krpc/event.hpp>
+#include <krpc/hash.hpp>
 #include <krpc/object.hpp>
 #include <krpc/service.hpp>
 #include <krpc/stream.hpp>
@@ -209,6 +212,31 @@ class {{ service_name }} : public Service {
     bool operator!=(const {{ struct_name }}& other) const {
       return !(*this == other);
     }
+
+    // Ordered by the fields in turn, which is how a tuple of the same values orders
+    bool operator<(const {{ struct_name }}& other) const {
+      {% for field in struct['fields'] %}
+      if ({{ field.name }} < other.{{ field.name }})
+        return true;
+      {% if not loop.last %}
+      if (other.{{ field.name }} < {{ field.name }})
+        return false;
+      {% endif %}
+      {% endfor %}
+      return false;
+    }
+
+    bool operator>(const {{ struct_name }}& other) const {
+      return other < *this;
+    }
+
+    bool operator<=(const {{ struct_name }}& other) const {
+      return !(other < *this);
+    }
+
+    bool operator>=(const {{ struct_name }}& other) const {
+      return !(*this < other);
+    }
   };
   {% endfor %}
 };
@@ -309,7 +337,30 @@ namespace decoder {
   {% endfor %}
 
 }  // namespace decoder
+{% if structs | length > 0 %}
 
+{% for struct_name,struct in structs.items() %}
+{% if struct.deprecated %}
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+{% endif %}
+inline std::size_t hash_value(const services::{{ service_name }}::{{ struct_name }}& value) {
+  std::size_t seed = 0;
+  {% for field in struct['fields'] %}
+  hash_combine(&seed, hash_value(value.{{ field.name }}));
+  {% endfor %}
+  return seed;
+}
+{% if struct.deprecated %}
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
+{% endif %}
+
+{% endfor %}
+{% endif %}
 // The encoder and decoder for a collection call encode and decode on the type it
 // contains without qualifying them, so the ones above, which are declared after those
 // templates, are only reachable through argument dependent lookup. That searches the
@@ -351,6 +402,10 @@ namespace services {
 
   inline void decode({{ service_name }}::{{ struct_name }}& value, const std::string& data, Client* client) {
     decoder::decode(value, data, client);
+  }
+
+  inline std::size_t hash_value(const {{ service_name }}::{{ struct_name }}& value) {
+    return krpc::hash_value(value);
   }
   {% if struct.deprecated %}
 #if defined(__GNUC__)
@@ -472,3 +527,31 @@ inline ::krpc::schema::ProcedureCall {{ service_name }}::{{ class_name }}::{{ me
 }  // namespace services
 
 }  // namespace krpc
+{% if structs | length > 0 %}
+
+// A structure is a type of this program's own, so unlike a tuple it can be given a std::hash,
+// and an unordered container of one needs nothing further.
+namespace std {
+{% for struct_name,struct in structs.items() %}
+
+{% if struct.deprecated %}
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+{% endif %}
+template <>
+struct hash<krpc::services::{{ service_name }}::{{ struct_name }}> {
+  std::size_t operator()(const krpc::services::{{ service_name }}::{{ struct_name }}& value) const {
+    return krpc::hash_value(value);
+  }
+};
+{% if struct.deprecated %}
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
+{% endif %}
+{% endfor %}
+
+}  // namespace std
+{% endif %}

--- a/tools/krpctools/krpctools/clientgen/csharp.tmpl
+++ b/tools/krpctools/krpctools/clientgen/csharp.tmpl
@@ -152,7 +152,7 @@ namespace KRPC.Client.Services.{{ service_name }}
     [global::KRPC.Client.Attributes.KRPCStruct]
 {% if struct.deprecated %}    [global::System.Obsolete{% if struct.deprecated_reason %} ("{{ struct.deprecated_reason }}"){% endif %}]
 {% endif %}
-    public struct {{ struct_name }} : IEquatable<{{ struct_name }}>
+    public struct {{ struct_name }} : IEquatable<{{ struct_name }}>, IComparable<{{ struct_name }}>
     {
         /// <summary>
         /// Construct a {{ struct_name }} from the values of its fields.
@@ -214,6 +214,55 @@ namespace KRPC.Client.Services.{{ service_name }}
         public static bool operator != ({{ struct_name }} lhs, {{ struct_name }} rhs)
         {
             return !lhs.Equals (rhs);
+        }
+
+        /// <summary>
+        /// Compares this {{ struct_name }} with the given one, by its fields in turn, which is
+        /// how a tuple of the same values compares. A field whose type has no ordering, such as
+        /// a collection, throws unless the two values are the same object, as it does in a
+        /// tuple, so two {{ struct_name }}s that are equal can still throw here.
+        /// </summary>
+        public int CompareTo ({{ struct_name }} other)
+        {
+            int result;
+            {% for field in struct['fields'] %}
+            result = global::System.Collections.Generic.Comparer<{{ field.type }}>.Default.Compare ({{ field.name }}, other.{{ field.name }});
+            if (result != 0)
+                return result;
+            {% endfor %}
+            return 0;
+        }
+
+        /// <summary>
+        /// Returns true if the first {{ struct_name }} orders before the second.
+        /// </summary>
+        public static bool operator < ({{ struct_name }} lhs, {{ struct_name }} rhs)
+        {
+            return lhs.CompareTo (rhs) < 0;
+        }
+
+        /// <summary>
+        /// Returns true if the first {{ struct_name }} orders after the second.
+        /// </summary>
+        public static bool operator > ({{ struct_name }} lhs, {{ struct_name }} rhs)
+        {
+            return lhs.CompareTo (rhs) > 0;
+        }
+
+        /// <summary>
+        /// Returns true if the first {{ struct_name }} does not order after the second.
+        /// </summary>
+        public static bool operator <= ({{ struct_name }} lhs, {{ struct_name }} rhs)
+        {
+            return lhs.CompareTo (rhs) <= 0;
+        }
+
+        /// <summary>
+        /// Returns true if the first {{ struct_name }} does not order before the second.
+        /// </summary>
+        public static bool operator >= ({{ struct_name }} lhs, {{ struct_name }} rhs)
+        {
+            return lhs.CompareTo (rhs) >= 0;
         }
     }
     {% endfor %}

--- a/tools/krpctools/krpctools/clientgen/java.tmpl
+++ b/tools/krpctools/krpctools/clientgen/java.tmpl
@@ -134,7 +134,7 @@ public class {{ service_name }} {
 {% endif %}
 {% if struct.deprecated %}    @Deprecated
 {% endif %}
-    public static class {{ struct_name }} implements RemoteStruct {
+    public static class {{ struct_name }} implements RemoteStruct, Comparable<{{ struct_name }}> {
         {% for field in struct['fields'] %}
         private final {{ field.type }} {{ field.name }};
         {% endfor %}
@@ -202,6 +202,22 @@ public class {{ service_name }} {
         @Override
         public int hashCode() {
             return java.util.Objects.hash({% for field in struct['fields'] %}{{ field.name }}{% if not loop.last %}, {% endif %}{% endfor %});
+        }
+
+        /**
+         * Compares this {{ struct_name }} with the given one, by its fields in turn, which is
+         * how a tuple of the same values compares.
+         */
+        @Override
+        public int compareTo({{ struct_name }} other) {
+            int result;
+            {% for field in struct['fields'] %}
+            result = RemoteStruct.compareFields({{ field.name }}, other.{{ field.name }});
+            if (result != 0) {
+                return result;
+            }
+            {% endfor %}
+            return 0;
         }
     }
     {% endfor %}

--- a/tools/krpctools/krpctools/test/clientgen-Empty-cpp.txt
+++ b/tools/krpctools/krpctools/test/clientgen-Empty-cpp.txt
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <cstddef>
+#include <functional>
 #include <limits>
 #include <map>
 #include <set>
@@ -11,6 +13,7 @@
 #include <krpc/encoder.hpp>
 #include <krpc/error.hpp>
 #include <krpc/event.hpp>
+#include <krpc/hash.hpp>
 #include <krpc/object.hpp>
 #include <krpc/service.hpp>
 #include <krpc/stream.hpp>

--- a/tools/krpctools/krpctools/test/clientgen-Ordering-cpp.txt
+++ b/tools/krpctools/krpctools/test/clientgen-Ordering-cpp.txt
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <cstddef>
+#include <functional>
 #include <limits>
 #include <map>
 #include <set>
@@ -11,6 +13,7 @@
 #include <krpc/encoder.hpp>
 #include <krpc/error.hpp>
 #include <krpc/event.hpp>
+#include <krpc/hash.hpp>
 #include <krpc/object.hpp>
 #include <krpc/service.hpp>
 #include <krpc/stream.hpp>

--- a/tools/krpctools/krpctools/test/clientgen-TestService-cpp.txt
+++ b/tools/krpctools/krpctools/test/clientgen-TestService-cpp.txt
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <cstddef>
+#include <functional>
 #include <limits>
 #include <map>
 #include <set>
@@ -11,6 +13,7 @@
 #include <krpc/encoder.hpp>
 #include <krpc/error.hpp>
 #include <krpc/event.hpp>
+#include <krpc/hash.hpp>
 #include <krpc/object.hpp>
 #include <krpc/service.hpp>
 #include <krpc/stream.hpp>
@@ -670,6 +673,29 @@ value(value), old_value(old_value) {}
     bool operator!=(const DeprecatedStruct& other) const {
       return !(*this == other);
     }
+
+    // Ordered by the fields in turn, which is how a tuple of the same values orders
+    bool operator<(const DeprecatedStruct& other) const {
+      if (value < other.value)
+        return true;
+      if (other.value < value)
+        return false;
+      if (old_value < other.old_value)
+        return true;
+      return false;
+    }
+
+    bool operator>(const DeprecatedStruct& other) const {
+      return other < *this;
+    }
+
+    bool operator<=(const DeprecatedStruct& other) const {
+      return !(other < *this);
+    }
+
+    bool operator>=(const DeprecatedStruct& other) const {
+      return !(*this < other);
+    }
   };
 
   /**
@@ -696,6 +722,37 @@ int_field(int_field), string_field(string_field), enum_field(enum_field), list_f
     bool operator!=(const TestStruct& other) const {
       return !(*this == other);
     }
+
+    // Ordered by the fields in turn, which is how a tuple of the same values orders
+    bool operator<(const TestStruct& other) const {
+      if (int_field < other.int_field)
+        return true;
+      if (other.int_field < int_field)
+        return false;
+      if (string_field < other.string_field)
+        return true;
+      if (other.string_field < string_field)
+        return false;
+      if (enum_field < other.enum_field)
+        return true;
+      if (other.enum_field < enum_field)
+        return false;
+      if (list_field < other.list_field)
+        return true;
+      return false;
+    }
+
+    bool operator>(const TestStruct& other) const {
+      return other < *this;
+    }
+
+    bool operator<=(const TestStruct& other) const {
+      return !(other < *this);
+    }
+
+    bool operator>=(const TestStruct& other) const {
+      return !(*this < other);
+    }
   };
 
   /**
@@ -717,6 +774,33 @@ struct_field(struct_field), object_field(object_field), string_field(string_fiel
 
     bool operator!=(const TestNestedStruct& other) const {
       return !(*this == other);
+    }
+
+    // Ordered by the fields in turn, which is how a tuple of the same values orders
+    bool operator<(const TestNestedStruct& other) const {
+      if (struct_field < other.struct_field)
+        return true;
+      if (other.struct_field < struct_field)
+        return false;
+      if (object_field < other.object_field)
+        return true;
+      if (other.object_field < object_field)
+        return false;
+      if (string_field < other.string_field)
+        return true;
+      return false;
+    }
+
+    bool operator>(const TestNestedStruct& other) const {
+      return other < *this;
+    }
+
+    bool operator<=(const TestNestedStruct& other) const {
+      return !(other < *this);
+    }
+
+    bool operator>=(const TestNestedStruct& other) const {
+      return !(*this < other);
     }
   };
 };
@@ -851,6 +935,37 @@ namespace decoder {
 
 }  // namespace decoder
 
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+inline std::size_t hash_value(const services::TestService::DeprecatedStruct& value) {
+  std::size_t seed = 0;
+  hash_combine(&seed, hash_value(value.value));
+  hash_combine(&seed, hash_value(value.old_value));
+  return seed;
+}
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
+
+inline std::size_t hash_value(const services::TestService::TestStruct& value) {
+  std::size_t seed = 0;
+  hash_combine(&seed, hash_value(value.int_field));
+  hash_combine(&seed, hash_value(value.string_field));
+  hash_combine(&seed, hash_value(value.enum_field));
+  hash_combine(&seed, hash_value(value.list_field));
+  return seed;
+}
+
+inline std::size_t hash_value(const services::TestService::TestNestedStruct& value) {
+  std::size_t seed = 0;
+  hash_combine(&seed, hash_value(value.struct_field));
+  hash_combine(&seed, hash_value(value.object_field));
+  hash_combine(&seed, hash_value(value.string_field));
+  return seed;
+}
+
 // The encoder and decoder for a collection call encode and decode on the type it
 // contains without qualifying them, so the ones above, which are declared after those
 // templates, are only reachable through argument dependent lookup. That searches the
@@ -892,6 +1007,10 @@ namespace services {
   inline void decode(TestService::DeprecatedStruct& value, const std::string& data, Client* client) {
     decoder::decode(value, data, client);
   }
+
+  inline std::size_t hash_value(const TestService::DeprecatedStruct& value) {
+    return krpc::hash_value(value);
+  }
 #if defined(__GNUC__)
 #pragma GCC diagnostic pop
 #endif
@@ -904,12 +1023,20 @@ namespace services {
     decoder::decode(value, data, client);
   }
 
+  inline std::size_t hash_value(const TestService::TestStruct& value) {
+    return krpc::hash_value(value);
+  }
+
   inline std::string encode(const TestService::TestNestedStruct& value) {
     return encoder::encode(value);
   }
 
   inline void decode(TestService::TestNestedStruct& value, const std::string& data, Client* client) {
     decoder::decode(value, data, client);
+  }
+
+  inline std::size_t hash_value(const TestService::TestNestedStruct& value) {
+    return krpc::hash_value(value);
   }
 
 }  // namespace services
@@ -2851,3 +2978,37 @@ inline ::krpc::schema::ProcedureCall TestService::TestClass::static_nullable_obj
 }  // namespace services
 
 }  // namespace krpc
+
+// A structure is a type of this program's own, so unlike a tuple it can be given a std::hash,
+// and an unordered container of one needs nothing further.
+namespace std {
+
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+template <>
+struct hash<krpc::services::TestService::DeprecatedStruct> {
+  std::size_t operator()(const krpc::services::TestService::DeprecatedStruct& value) const {
+    return krpc::hash_value(value);
+  }
+};
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
+
+template <>
+struct hash<krpc::services::TestService::TestStruct> {
+  std::size_t operator()(const krpc::services::TestService::TestStruct& value) const {
+    return krpc::hash_value(value);
+  }
+};
+
+template <>
+struct hash<krpc::services::TestService::TestNestedStruct> {
+  std::size_t operator()(const krpc::services::TestService::TestNestedStruct& value) const {
+    return krpc::hash_value(value);
+  }
+};
+
+}  // namespace std

--- a/tools/krpctools/krpctools/test/clientgen-TestService-csharp.txt
+++ b/tools/krpctools/krpctools/test/clientgen-TestService-csharp.txt
@@ -794,7 +794,7 @@ namespace KRPC.Client.Services.TestService
     [Serializable]
     [global::KRPC.Client.Attributes.KRPCStruct]
     [global::System.Obsolete ("Use TestStruct instead.")]
-    public struct DeprecatedStruct : IEquatable<DeprecatedStruct>
+    public struct DeprecatedStruct : IEquatable<DeprecatedStruct>, IComparable<DeprecatedStruct>
     {
         /// <summary>
         /// Construct a DeprecatedStruct from the values of its fields.
@@ -858,6 +858,56 @@ namespace KRPC.Client.Services.TestService
         {
             return !lhs.Equals (rhs);
         }
+
+        /// <summary>
+        /// Compares this DeprecatedStruct with the given one, by its fields in turn, which is
+        /// how a tuple of the same values compares. A field whose type has no ordering, such as
+        /// a collection, throws unless the two values are the same object, as it does in a
+        /// tuple, so two DeprecatedStructs that are equal can still throw here.
+        /// </summary>
+        public int CompareTo (DeprecatedStruct other)
+        {
+            int result;
+            result = global::System.Collections.Generic.Comparer<int>.Default.Compare (Value, other.Value);
+            if (result != 0)
+                return result;
+            result = global::System.Collections.Generic.Comparer<int>.Default.Compare (OldValue, other.OldValue);
+            if (result != 0)
+                return result;
+            return 0;
+        }
+
+        /// <summary>
+        /// Returns true if the first DeprecatedStruct orders before the second.
+        /// </summary>
+        public static bool operator < (DeprecatedStruct lhs, DeprecatedStruct rhs)
+        {
+            return lhs.CompareTo (rhs) < 0;
+        }
+
+        /// <summary>
+        /// Returns true if the first DeprecatedStruct orders after the second.
+        /// </summary>
+        public static bool operator > (DeprecatedStruct lhs, DeprecatedStruct rhs)
+        {
+            return lhs.CompareTo (rhs) > 0;
+        }
+
+        /// <summary>
+        /// Returns true if the first DeprecatedStruct does not order after the second.
+        /// </summary>
+        public static bool operator <= (DeprecatedStruct lhs, DeprecatedStruct rhs)
+        {
+            return lhs.CompareTo (rhs) <= 0;
+        }
+
+        /// <summary>
+        /// Returns true if the first DeprecatedStruct does not order before the second.
+        /// </summary>
+        public static bool operator >= (DeprecatedStruct lhs, DeprecatedStruct rhs)
+        {
+            return lhs.CompareTo (rhs) >= 0;
+        }
     }
 
     /// <summary>
@@ -865,7 +915,7 @@ namespace KRPC.Client.Services.TestService
     /// </summary>
     [Serializable]
     [global::KRPC.Client.Attributes.KRPCStruct]
-    public struct TestStruct : IEquatable<TestStruct>
+    public struct TestStruct : IEquatable<TestStruct>, IComparable<TestStruct>
     {
         /// <summary>
         /// Construct a TestStruct from the values of its fields.
@@ -933,6 +983,62 @@ namespace KRPC.Client.Services.TestService
         {
             return !lhs.Equals (rhs);
         }
+
+        /// <summary>
+        /// Compares this TestStruct with the given one, by its fields in turn, which is
+        /// how a tuple of the same values compares. A field whose type has no ordering, such as
+        /// a collection, throws unless the two values are the same object, as it does in a
+        /// tuple, so two TestStructs that are equal can still throw here.
+        /// </summary>
+        public int CompareTo (TestStruct other)
+        {
+            int result;
+            result = global::System.Collections.Generic.Comparer<int>.Default.Compare (IntField, other.IntField);
+            if (result != 0)
+                return result;
+            result = global::System.Collections.Generic.Comparer<string>.Default.Compare (StringField, other.StringField);
+            if (result != 0)
+                return result;
+            result = global::System.Collections.Generic.Comparer<global::KRPC.Client.Services.TestService.TestEnum>.Default.Compare (EnumField, other.EnumField);
+            if (result != 0)
+                return result;
+            result = global::System.Collections.Generic.Comparer<global::System.Collections.Generic.IList<int>>.Default.Compare (ListField, other.ListField);
+            if (result != 0)
+                return result;
+            return 0;
+        }
+
+        /// <summary>
+        /// Returns true if the first TestStruct orders before the second.
+        /// </summary>
+        public static bool operator < (TestStruct lhs, TestStruct rhs)
+        {
+            return lhs.CompareTo (rhs) < 0;
+        }
+
+        /// <summary>
+        /// Returns true if the first TestStruct orders after the second.
+        /// </summary>
+        public static bool operator > (TestStruct lhs, TestStruct rhs)
+        {
+            return lhs.CompareTo (rhs) > 0;
+        }
+
+        /// <summary>
+        /// Returns true if the first TestStruct does not order after the second.
+        /// </summary>
+        public static bool operator <= (TestStruct lhs, TestStruct rhs)
+        {
+            return lhs.CompareTo (rhs) <= 0;
+        }
+
+        /// <summary>
+        /// Returns true if the first TestStruct does not order before the second.
+        /// </summary>
+        public static bool operator >= (TestStruct lhs, TestStruct rhs)
+        {
+            return lhs.CompareTo (rhs) >= 0;
+        }
     }
 
     /// <summary>
@@ -940,7 +1046,7 @@ namespace KRPC.Client.Services.TestService
     /// </summary>
     [Serializable]
     [global::KRPC.Client.Attributes.KRPCStruct]
-    public struct TestNestedStruct : IEquatable<TestNestedStruct>
+    public struct TestNestedStruct : IEquatable<TestNestedStruct>, IComparable<TestNestedStruct>
     {
         /// <summary>
         /// Construct a TestNestedStruct from the values of its fields.
@@ -1000,6 +1106,59 @@ namespace KRPC.Client.Services.TestService
         public static bool operator != (TestNestedStruct lhs, TestNestedStruct rhs)
         {
             return !lhs.Equals (rhs);
+        }
+
+        /// <summary>
+        /// Compares this TestNestedStruct with the given one, by its fields in turn, which is
+        /// how a tuple of the same values compares. A field whose type has no ordering, such as
+        /// a collection, throws unless the two values are the same object, as it does in a
+        /// tuple, so two TestNestedStructs that are equal can still throw here.
+        /// </summary>
+        public int CompareTo (TestNestedStruct other)
+        {
+            int result;
+            result = global::System.Collections.Generic.Comparer<global::KRPC.Client.Services.TestService.TestStruct>.Default.Compare (StructField, other.StructField);
+            if (result != 0)
+                return result;
+            result = global::System.Collections.Generic.Comparer<global::KRPC.Client.Services.TestService.TestClass>.Default.Compare (ObjectField, other.ObjectField);
+            if (result != 0)
+                return result;
+            result = global::System.Collections.Generic.Comparer<string>.Default.Compare (StringField, other.StringField);
+            if (result != 0)
+                return result;
+            return 0;
+        }
+
+        /// <summary>
+        /// Returns true if the first TestNestedStruct orders before the second.
+        /// </summary>
+        public static bool operator < (TestNestedStruct lhs, TestNestedStruct rhs)
+        {
+            return lhs.CompareTo (rhs) < 0;
+        }
+
+        /// <summary>
+        /// Returns true if the first TestNestedStruct orders after the second.
+        /// </summary>
+        public static bool operator > (TestNestedStruct lhs, TestNestedStruct rhs)
+        {
+            return lhs.CompareTo (rhs) > 0;
+        }
+
+        /// <summary>
+        /// Returns true if the first TestNestedStruct does not order after the second.
+        /// </summary>
+        public static bool operator <= (TestNestedStruct lhs, TestNestedStruct rhs)
+        {
+            return lhs.CompareTo (rhs) <= 0;
+        }
+
+        /// <summary>
+        /// Returns true if the first TestNestedStruct does not order before the second.
+        /// </summary>
+        public static bool operator >= (TestNestedStruct lhs, TestNestedStruct rhs)
+        {
+            return lhs.CompareTo (rhs) >= 0;
         }
     }
 

--- a/tools/krpctools/krpctools/test/clientgen-TestService-java.txt
+++ b/tools/krpctools/krpctools/test/clientgen-TestService-java.txt
@@ -879,7 +879,7 @@ public class TestService {
      * @deprecated Use TestStruct instead.
      */
     @Deprecated
-    public static class DeprecatedStruct implements RemoteStruct {
+    public static class DeprecatedStruct implements RemoteStruct, Comparable<DeprecatedStruct> {
         private final int value;
         private final int oldValue;
 
@@ -946,12 +946,30 @@ public class TestService {
         public int hashCode() {
             return java.util.Objects.hash(value, oldValue);
         }
+
+        /**
+         * Compares this DeprecatedStruct with the given one, by its fields in turn, which is
+         * how a tuple of the same values compares.
+         */
+        @Override
+        public int compareTo(DeprecatedStruct other) {
+            int result;
+            result = RemoteStruct.compareFields(value, other.value);
+            if (result != 0) {
+                return result;
+            }
+            result = RemoteStruct.compareFields(oldValue, other.oldValue);
+            if (result != 0) {
+                return result;
+            }
+            return 0;
+        }
     }
 
     /**
      * Struct documentation string.
      */
-    public static class TestStruct implements RemoteStruct {
+    public static class TestStruct implements RemoteStruct, Comparable<TestStruct> {
         private final int intField;
         private final String stringField;
         private final krpc.client.services.TestService.TestEnum enumField;
@@ -1030,12 +1048,38 @@ public class TestService {
         public int hashCode() {
             return java.util.Objects.hash(intField, stringField, enumField, listField);
         }
+
+        /**
+         * Compares this TestStruct with the given one, by its fields in turn, which is
+         * how a tuple of the same values compares.
+         */
+        @Override
+        public int compareTo(TestStruct other) {
+            int result;
+            result = RemoteStruct.compareFields(intField, other.intField);
+            if (result != 0) {
+                return result;
+            }
+            result = RemoteStruct.compareFields(stringField, other.stringField);
+            if (result != 0) {
+                return result;
+            }
+            result = RemoteStruct.compareFields(enumField, other.enumField);
+            if (result != 0) {
+                return result;
+            }
+            result = RemoteStruct.compareFields(listField, other.listField);
+            if (result != 0) {
+                return result;
+            }
+            return 0;
+        }
     }
 
     /**
      * Nested struct documentation string.
      */
-    public static class TestNestedStruct implements RemoteStruct {
+    public static class TestNestedStruct implements RemoteStruct, Comparable<TestNestedStruct> {
         private final krpc.client.services.TestService.TestStruct structField;
         private final krpc.client.services.TestService.TestClass objectField;
         private final String stringField;
@@ -1101,6 +1145,28 @@ public class TestService {
         @Override
         public int hashCode() {
             return java.util.Objects.hash(structField, objectField, stringField);
+        }
+
+        /**
+         * Compares this TestNestedStruct with the given one, by its fields in turn, which is
+         * how a tuple of the same values compares.
+         */
+        @Override
+        public int compareTo(TestNestedStruct other) {
+            int result;
+            result = RemoteStruct.compareFields(structField, other.structField);
+            if (result != 0) {
+                return result;
+            }
+            result = RemoteStruct.compareFields(objectField, other.objectField);
+            if (result != 0) {
+                return result;
+            }
+            result = RemoteStruct.compareFields(stringField, other.stringField);
+            if (result != 0) {
+                return result;
+            }
+            return 0;
         }
     }
 


### PR DESCRIPTION
A structure value already compared equal in every client; it now also orders, by its fields in turn, which is how a tuple of the same values orders. So structures can be sorted, and where ordering is what keys a container, be the key of one. Python needed no change, a structure being a named tuple already, and the tests pin what it does.

**C++ hashing.** The C++ client gains `krpc::hash_value` and the `krpc::hash` function object, which hash every type the client carries. The standard library hashes neither `std::tuple` nor its containers, which is what a kRPC tuple and the collection types are, so until now a tuple could not be the key of an unordered container. A structure is a type of the client's own, unlike a tuple, so it is also given a `std::hash` and needs nothing further.

**Fields with no ordering.** Comparing two structures with such a field, a collection for instance, throws in C# and Java unless the two values are the same object, and raises in Lua when they differ. That is what comparing a pair of tuples holding one already does, so two structures that are equal can still throw.
