### PR TITLE
Key the lua type cache on what a type names

### DIFF
--- a/client/lua/CHANGELOG.md
+++ b/client/lua/CHANGELOG.md
@@ -24,6 +24,8 @@
   the size of a message is read directly rather than by handing each byte to a decoder until it
   stops raising an error, and the client connection disables Nagle's algorithm (#1056)
 - Require luasocket 3.0 or later (#1060)
+- Fix a type occasionally being built a second time rather than reused, which could leave
+  an enumeration or class type in a service unusable (#1068)
 
 ## [v0.6.0]
 - Fix `attributes` module to always return boolean for `is_a_class_member` and `is_a_class_property_accessor` (#850)

--- a/client/lua/krpc/types.lua
+++ b/client/lua/krpc/types.lua
@@ -118,11 +118,23 @@ function _set_protobuf_type(src, dst)
   end
 end
 
+-- The key a type is cached under, built from the type code, the names and the types nested
+-- inside it in turn. It is built here rather than by serializing the message, as the protobuf
+-- library writes the fields of a message in the order its own table happens to hold them,
+-- which is not the same order every time.
+local function _type_key(protobuf_type)
+  local parts = { protobuf_type.code, protobuf_type.service, protobuf_type.name }
+  for _, typ in ipairs(protobuf_type.types) do
+    parts[#parts + 1] = '(' .. _type_key(typ) .. ')'
+  end
+  return table.concat(parts, ',')
+end
+
 function Types:as_type(protobuf_type)
   -- Return a type object given a protocol buffer type
 
   -- Get cached type
-  local key = protobuf_type:SerializeToString()
+  local key = _type_key(protobuf_type)
   if self._types:get(key) then
     return self._types:get(key)
   end


### PR DESCRIPTION
**Root cause.** `Types.as_type` cached a type object under the bytes of the protobuf message describing it. The library serializes a message by iterating the table holding its fields, so the order of the fields in those bytes follows the addresses of the field descriptors, and reading a repeated field of a message inserts into that table, which can move a field already in it. The same message can then serialize differently before and after being read from, and a type already built gets built a second time. The duplicate is unusable: an enumeration type has no values until `set_values` is called on it, and a class or structure type is a different Lua class from the one the service exposes.

**Fix.** The key is built from the type itself: its code, the service and type names, and the types nested inside it.

**Testing.** `test_class_types` and `test_enum_types` already assert that a type is reused, and are the tests that flaked on Windows. Reloading the schema module so the descriptors land at fresh addresses and repeating what those tests do, the old key changed on 14 of 3000 layouts and the new one on none.
