### PR TITLE
Physics tick synchronization

### DIFF
--- a/client/lua/krpc/test/test_client.lua
+++ b/client/lua/krpc/test/test_client.lua
@@ -415,6 +415,7 @@ function TestClient:test_krpc_service_members()
      'get_services',
      'get_status',
      'hold_tick',
+     'next_tick',
      'release_tick',
      'remove_stream',
      'set_game_scene',

--- a/client/lua/krpc/test/test_client.lua
+++ b/client/lua/krpc/test/test_client.lua
@@ -414,6 +414,8 @@ function TestClient:test_krpc_service_members()
      'get_paused',
      'get_services',
      'get_status',
+     'hold_tick',
+     'release_tick',
      'remove_stream',
      'set_game_scene',
      'set_paused',

--- a/client/python/krpc/test/test_client.py
+++ b/client/python/krpc/test/test_client.py
@@ -658,6 +658,8 @@ class TestClient(ServerTestCase, unittest.TestCase):
                     "set_stream_rate",
                     "remove_stream",
                     "add_event",
+                    "hold_tick",
+                    "release_tick",
                     "game_scene",
                     "current_game_scene",
                     "GameScene",

--- a/client/python/krpc/test/test_client.py
+++ b/client/python/krpc/test/test_client.py
@@ -660,6 +660,7 @@ class TestClient(ServerTestCase, unittest.TestCase):
                     "add_event",
                     "hold_tick",
                     "release_tick",
+                    "next_tick",
                     "game_scene",
                     "current_game_scene",
                     "GameScene",

--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -10,6 +10,15 @@
   around 20% more of them per physics update, and around 35% more when the values are large.
   A client that makes one call and then waits is unaffected, as the wait is governed by the
   game's update rate. Available on Linux, macOS, and Windows 10 1803 and later (#1065)
+- Add `KRPC.HoldTick` and `KRPC.ReleaseTick`, which hold the game on its current physics tick so
+  that a program can read the game state, compute with it and write the result back without the
+  game advancing in between. Intended for control loops, which are otherwise served one RPC per
+  tick whenever they spend longer than the receive timeout between calls. The game runs no
+  physics and draws no frame while a tick is held, and a hold ends by itself after
+  `TickHoldTimeout` (#1070)
+- Add `KRPC.NextTick`, which releases the tick being held and holds the one after it, so that a
+  loop acts on consecutive physics ticks. A release and a hold made as two calls leave the
+  server free to advance between them; this closes that gap (#1070)
 - Fix the game freezing for as long as a serial connection takes to carry an RPC; serial ports are
   now read and written on their own threads rather than on the thread that runs the game. Data
   waiting to be sent is buffered up to 1 MB, beyond which the connection is dropped (#1035)

--- a/core/src/Configuration.cs
+++ b/core/src/Configuration.cs
@@ -47,6 +47,7 @@ namespace KRPC
             AdaptiveRateControl = true;
             BlockingRecv = true;
             RecvTimeout = 1000;
+            TickHoldTimeout = 1000000;
         }
 
         /// <summary>
@@ -257,6 +258,12 @@ namespace KRPC
         /// Timeout when waiting for data from a client
         /// </summary>
         public uint RecvTimeout { get; set; }
+
+        /// <summary>
+        /// How long a client may hold the game on one physics tick before the server takes
+        /// the tick back
+        /// </summary>
+        public uint TickHoldTimeout { get; set; }
 
         /// <summary>
         /// Whether debug logging is enable

--- a/core/src/Core.cs
+++ b/core/src/Core.cs
@@ -704,6 +704,20 @@ namespace KRPC
         }
 
         /// <summary>
+        /// Let the game move on from the current tick and hold the one after it, so that a
+        /// client works on consecutive ticks rather than on whichever it manages to ask for in
+        /// time. The hold on the next tick is taken by the yield the second call makes: the
+        /// caller's continuation waits in the server and is carried on at the start of the next
+        /// update, ahead of anything the server has to be polled for, so there is no window for
+        /// the game to advance through.
+        /// </summary>
+        internal void NextTick (IClient rpcClient)
+        {
+            ReleaseTick (rpcClient);
+            HoldTick (rpcClient);
+        }
+
+        /// <summary>
         /// Whether a client is holding the game on this tick. A hold that has run out of time,
         /// or whose client has gone away, ends here: the client cannot end it itself, and an
         /// update must not be left waiting for one that will never end.

--- a/core/src/Core.cs
+++ b/core/src/Core.cs
@@ -95,6 +95,17 @@ namespace KRPC
         /// </summary>
         public event EventHandler<ClientDisconnectedEventArgs> OnClientDisconnected;
 
+        /// <summary>
+        /// Event triggered at the start of an update, before it executes any calls.
+        /// </summary>
+        public event EventHandler OnBeforeCalls;
+
+        /// <summary>
+        /// Event triggered once an update has executed the calls it received, before it
+        /// produces stream updates.
+        /// </summary>
+        public event EventHandler OnAfterCalls;
+
         internal void RPCClientConnected (IClient<Request,Response> client)
         {
             rpcClients [client.Guid] = client;
@@ -382,7 +393,13 @@ namespace KRPC
             ulong startBytesRead = BytesRead;
             ulong startBytesWritten = BytesWritten;
 
+            // The events bracket the call phase rather than being raised from inside it, so that
+            // they are raised exactly once per update whatever the update does: the poll loop
+            // runs many times over while a client holds the tick. Raising OnAfterCalls before
+            // the stream update also means streams observe whatever the handlers did.
+            EventHandlerExtensions.Invoke (OnBeforeCalls, this);
             RPCServerUpdate ();
+            EventHandlerExtensions.Invoke (OnAfterCalls, this);
             StreamServerUpdate ();
 
             var timeElapsed = updateTimer.ElapsedSeconds ();

--- a/core/src/Core.cs
+++ b/core/src/Core.cs
@@ -30,6 +30,22 @@ namespace KRPC
         Dictionary<ulong, IClient<NoMessage, StreamUpdate>> removeStreams = new Dictionary<ulong, IClient<NoMessage, StreamUpdate>> ();
         ulong nextStreamId = 0;
 
+        /// <summary>
+        /// The client holding the game on the current tick, and the timestamp its hold runs
+        /// out at. One client at a time: what a hold offers is that nothing else happens,
+        /// which two clients cannot both be given.
+        /// </summary>
+        IClient<Request,Response> tickHoldClient;
+        long tickHoldDeadline;
+
+        /// <summary>
+        /// Whether the update is executing calls a client made. A hold only means anything
+        /// while it is: a call made by a stream or an event runs after the update has finished
+        /// with the calls, so a hold taken there would be found in force by the next update
+        /// with no client waiting to release it, and be taken again before that one ended too.
+        /// </summary>
+        bool executingRPCs;
+
         static Core instance;
 
         /// <summary>
@@ -89,6 +105,9 @@ namespace KRPC
         internal void RPCClientDisconnected (IClient<Request,Response> client)
         {
             rpcClients.Remove (client.Guid);
+            // A client that goes away while holding the tick does not get to keep holding it.
+            if (tickHoldClient != null && tickHoldClient.Guid == client.Guid)
+                ReleaseTickHold ();
             clientScheduler.Remove (client);
             EventHandlerExtensions.Invoke (OnClientDisconnected, this, new ClientDisconnectedEventArgs (client));
         }
@@ -383,7 +402,11 @@ namespace KRPC
             // This prevents MaxTimePerUpdate from being set to a high value when the server is idle, which would
             // cause a drop in framerate if a large burst of RPCs are received.
             var config = Configuration.Instance;
-            if (config.AdaptiveRateControl) {
+            // An update that a client held the tick through ran for as long as that client
+            // asked it to. Adapting to it would read the client's own work as the server
+            // spending too long on RPCs, and wind the limit down to its floor for every other
+            // client as well.
+            if (config.AdaptiveRateControl && !heldTick) {
                 var targetTicks = Stopwatch.Frequency / 59;
                 if (ticksElapsed > targetTicks) {
                     if (config.MaxTimePerUpdate > 1000)
@@ -399,6 +422,14 @@ namespace KRPC
             }
         }
 
+        /// <summary>
+        /// Whether a client held the tick during the update that just ran. Two things read it:
+        /// the tick gets held once per update and no more, and an update that was held took as
+        /// long as the client it was waiting for, which is not a measurement the frame rate
+        /// should be adapted to.
+        /// </summary>
+        bool heldTick;
+
         Stopwatch rpcTimer = new Stopwatch ();
         Stopwatch rpcPollTimeout = new Stopwatch ();
         Stopwatch rpcPollTimer = new Stopwatch ();
@@ -413,6 +444,9 @@ namespace KRPC
         /// If NonBlockingUpdate is false, this call will block waiting for new RPCs for up to
         /// MaxPollTimePerUpdate microseconds. If NonBlockingUpdate is true, a single non-blocking call
         /// will be made to check for new RPCs.
+        /// While a client holds the tick, none of those limits apply: its RPCs are waited for and
+        /// executed until it releases the tick or its hold runs out of time, so that a program can
+        /// read the game state, compute with it and write the result back within one tick.
         /// </summary>
         void RPCServerUpdate ()
         {
@@ -421,6 +455,7 @@ namespace KRPC
             rpcPollTimeout.Reset ();
             rpcPollTimer.Reset ();
             rpcExecTimer.Reset ();
+            heldTick = false;
             var config = Configuration.Instance;
             long maxTimePerUpdateTicks = StopwatchExtensions.MicrosecondsToTicks (config.MaxTimePerUpdate);
             long recvTimeoutTicks = StopwatchExtensions.MicrosecondsToTicks (config.RecvTimeout);
@@ -438,13 +473,21 @@ namespace KRPC
                 rpcPollTimeout.Start ();
                 while (true) {
                     PollRequests (rpcYieldedContinuations);
+                    if (rpcContinuations.Count > 0)
+                        break;
+                    // A client holding the tick is waited for until it releases it, so that a
+                    // call it makes after seeing the result of an earlier one is executed in
+                    // this update rather than the next. The hold ending is the only thing that
+                    // ends this wait, which is why it is asked about every time around.
+                    if (TickHeld) {
+                        heldTick = true;
+                        continue;
+                    }
                     if (!config.BlockingRecv)
                         break;
                     if (rpcPollTimeout.ElapsedTicks > recvTimeoutTicks)
                         break;
                     if (rpcTimer.ElapsedTicks > maxTimePerUpdateTicks)
-                        break;
-                    if (rpcContinuations.Count > 0)
                         break;
                 }
                 rpcPollTimer.Stop ();
@@ -454,6 +497,7 @@ namespace KRPC
 
                 // Execute RPCs
                 rpcExecTimer.Start ();
+                executingRPCs = true;
                 for (int i = 0; i < rpcContinuations.Count; i++) {
                     var continuation = rpcContinuations [i];
 
@@ -461,8 +505,9 @@ namespace KRPC
                     if (!continuation.Client.Connected)
                         continue;
 
-                    // Max exec time exceeded, delay to next update
-                    if (rpcTimer.ElapsedTicks > maxTimePerUpdateTicks) {
+                    // Max exec time exceeded, delay to next update. An update holding a tick
+                    // runs for as long as the hold lasts instead.
+                    if (!TickHeld && rpcTimer.ElapsedTicks > maxTimePerUpdateTicks) {
                         rpcYieldedContinuations.Add (continuation);
                         continue;
                     }
@@ -472,11 +517,23 @@ namespace KRPC
                         ExecuteContinuation (continuation);
                     } catch (YieldException<RequestContinuation> e) {
                         rpcYieldedContinuations.Add (e.Value);
+                        ReleaseTickToYield (e.Value.Client);
                     }
                     rpcsExecuted++;
                 }
+                executingRPCs = false;
                 rpcContinuations.Clear ();
                 rpcExecTimer.Stop ();
+
+                if (TickHeld) {
+                    heldTick = true;
+                    continue;
+                }
+
+                // Exit if a hold on the tick ended during this update, so that the game takes
+                // the tick it was held back from before another hold can defer it again.
+                if (heldTick)
+                    break;
 
                 // Exit if only execute one RPC per update
                 if (config.OneRPCPerUpdate)
@@ -485,6 +542,17 @@ namespace KRPC
                 // Exit if max exec time exceeded
                 if (rpcTimer.ElapsedTicks > maxTimePerUpdateTicks)
                     break;
+            }
+
+            // Nothing leaves the loop while a client holds the tick, so a hold still in force
+            // here belongs to an update that failed part way through. Which is also the only
+            // way calls can still be marked as executing.
+            executingRPCs = false;
+            if (tickHoldClient != null) {
+                Logger.WriteLine (
+                    "Ending a hold on the tick left behind by client " + tickHoldClient.Address,
+                    Logger.Severity.Error);
+                ReleaseTickHold ();
             }
 
             // Run yielded continuations on the next update
@@ -580,6 +648,112 @@ namespace KRPC
             streamTimer.Stop ();
             StreamRPCsExecuted += rpcsExecuted;
             TimePerStreamUpdate = (float)streamTimer.ElapsedSeconds ();
+        }
+
+        /// <summary>
+        /// Hold the game on the current tick for a client, so that the calls it makes next are
+        /// executed in this tick rather than in later ones. Yields to the next tick if this one
+        /// has already been held and let go.
+        /// </summary>
+        internal void HoldTick (IClient rpcClient)
+        {
+            if (rpcClient == null)
+                throw new ArgumentNullException (nameof (rpcClient));
+            if (!executingRPCs)
+                throw new InvalidOperationException (
+                    "The tick can only be held by a client making a call, " +
+                    "not by a stream or an event");
+            IClient<Request,Response> client;
+            if (!rpcClients.TryGetValue (rpcClient.Guid, out client))
+                throw new InvalidOperationException (
+                    "No RPC client is connected with this identifier");
+            // Taking a hold that is already held would let a client renew its own before it ran
+            // out of time, and so hold the game for as long as it liked.
+            if (TickHeld)
+                throw new InvalidOperationException (
+                    tickHoldClient.Guid == rpcClient.Guid
+                    ? "This client is already holding the tick"
+                    : "Another client is holding the tick");
+            // One hold per tick, whoever asks for it. A tick that has already been held and let
+            // go has done its waiting, and holding it again would defer it a second time; a
+            // client looping on hold and release, or two passing it between them, could defer it
+            // for as long as they kept asking. The call waits for the next tick instead, which
+            // is where the work it is about to do belongs.
+            if (heldTick)
+                throw new YieldException<Action> (() => HoldTick (rpcClient));
+            tickHoldClient = client;
+            tickHoldDeadline = Stopwatch.GetTimestamp () +
+                StopwatchExtensions.MicrosecondsToTicks (Configuration.Instance.TickHoldTimeout);
+            Logger.WriteLine ("Client " + client.Address + " is holding the tick",
+                              Logger.Severity.Debug);
+        }
+
+        /// <summary>
+        /// Let the game move on from the current tick. Does nothing if the client is not
+        /// holding it, which is what a client whose hold has already ended sees.
+        /// </summary>
+        internal void ReleaseTick (IClient rpcClient)
+        {
+            if (rpcClient == null)
+                throw new ArgumentNullException (nameof (rpcClient));
+            if (tickHoldClient == null || tickHoldClient.Guid != rpcClient.Guid)
+                return;
+            Logger.WriteLine ("Client " + tickHoldClient.Address + " released the tick",
+                              Logger.Severity.Debug);
+            ReleaseTickHold ();
+        }
+
+        /// <summary>
+        /// Whether a client is holding the game on this tick. A hold that has run out of time,
+        /// or whose client has gone away, ends here: the client cannot end it itself, and an
+        /// update must not be left waiting for one that will never end.
+        /// </summary>
+        bool TickHeld {
+            get {
+                if (tickHoldClient == null)
+                    return false;
+                if (Stopwatch.GetTimestamp () >= tickHoldDeadline) {
+                    Logger.WriteLine (
+                        "Client " + tickHoldClient.Address + " held the tick for longer than the " +
+                        "timeout allows, so the game has moved on without it",
+                        Logger.Severity.Warning);
+                    ReleaseTickHold ();
+                    return false;
+                }
+                // Clients that have gone away are only reconciled between updates, so an update
+                // holding a tick has to notice for itself that the client it waits for has left.
+                if (!rpcClients.ContainsKey (tickHoldClient.Guid) || !tickHoldClient.Connected) {
+                    Logger.WriteLine (
+                        "Client " + tickHoldClient.Address + " disconnected while holding the tick",
+                        Logger.Severity.Warning);
+                    ReleaseTickHold ();
+                    return false;
+                }
+                return true;
+            }
+        }
+
+        /// <summary>
+        /// End a client's hold on the tick because a call it made needs another update to
+        /// finish. Only a later update can carry on such a call, which is exactly what the hold
+        /// prevents, so waiting the hold out would leave the client and the game waiting for
+        /// each other until the timeout.
+        /// </summary>
+        void ReleaseTickToYield (IClient<Request,Response> client)
+        {
+            if (tickHoldClient == null || tickHoldClient.Guid != client.Guid)
+                return;
+            Logger.WriteLine (
+                "Client " + client.Address + " called a procedure that takes more than one " +
+                "update to finish while holding the tick, so the hold has ended",
+                Logger.Severity.Warning);
+            ReleaseTickHold ();
+        }
+
+        void ReleaseTickHold ()
+        {
+            tickHoldClient = null;
+            tickHoldDeadline = 0;
         }
 
         /// <summary>

--- a/core/src/Service/KRPC/KRPC.cs
+++ b/core/src/Service/KRPC/KRPC.cs
@@ -279,5 +279,43 @@ namespace KRPC.Service.KRPC
             var func = LinqExpression.Lambda<Func<bool>>(expression).Compile();
             return new Event((evnt) => func()).Message;
         }
+
+        /// <summary>
+        /// Hold the game on its current physics tick until <see cref="ReleaseTick" /> is called
+        /// or the hold times out. Every call made in between is executed before the game moves
+        /// on, so that a program which reads the game state, computes with it and writes the
+        /// result back does all three in the state of a single tick.
+        ///
+        /// A tick is held once and no more, so this waits for the next tick when the current
+        /// one has already been held and let go.
+        /// </summary>
+        /// <remarks>
+        /// The game renders no frame, takes no input and runs no physics while the tick is
+        /// held, so a hold should be as short as the program can make it, and should be
+        /// released even when the code between the two calls fails. Only one client can hold
+        /// the tick at a time, and only a client making a call can hold it: the tick cannot be
+        /// held by a stream or an event. A hold ends by itself when it times out, when the
+        /// client disconnects, or when the client calls a procedure that takes more than one
+        /// tick to finish, such as staging or warping, since such a call can only finish in the
+        /// tick the hold is holding back. Waiting for a stream or an event while holding the
+        /// tick therefore waits out the timeout, as stream updates are only sent once the tick
+        /// has been let go.
+        /// </remarks>
+        [KRPCProcedure]
+        public static void HoldTick ()
+        {
+            Core.Instance.HoldTick (CallContext.Client);
+        }
+
+        /// <summary>
+        /// Let the game move on from the tick that <see cref="HoldTick" /> held it on. Does
+        /// nothing if the tick is not being held, which is what a client whose hold has already
+        /// ended sees.
+        /// </summary>
+        [KRPCProcedure]
+        public static void ReleaseTick ()
+        {
+            Core.Instance.ReleaseTick (CallContext.Client);
+        }
     }
 }

--- a/core/src/Service/KRPC/KRPC.cs
+++ b/core/src/Service/KRPC/KRPC.cs
@@ -317,5 +317,29 @@ namespace KRPC.Service.KRPC
         {
             Core.Instance.ReleaseTick (CallContext.Client);
         }
+
+        /// <summary>
+        /// Let the game move on from the tick being held and hold the one after it, so that a
+        /// program acts on consecutive physics ticks. Holds the soonest tick it can if no tick
+        /// is currently being held.
+        /// </summary>
+        /// <remarks>
+        /// A release and a hold made as two separate calls leave the server free to advance
+        /// between them, since the hold is a call it has to be waiting for when it looks. This
+        /// takes the next tick without that gap, so it is the call a loop that has to act on
+        /// every tick is built around: call it at the top of the loop, work, and come back to
+        /// it. The game advances one tick per call and no faster, so it runs at the rate of the
+        /// loop for as long as the loop runs, and the loop ends by calling
+        /// <see cref="ReleaseTick" />.
+        ///
+        /// Every other limit of <see cref="HoldTick" /> applies unchanged, the timeout
+        /// included. A hold lost to the timeout is not reported: the next call simply takes
+        /// whatever tick it lands on.
+        /// </remarks>
+        [KRPCProcedure]
+        public static void NextTick ()
+        {
+            Core.Instance.NextTick (CallContext.Client);
+        }
     }
 }

--- a/core/test/KRPC.Core.Test.csproj
+++ b/core/test/KRPC.Core.Test.csproj
@@ -40,6 +40,8 @@
     </Compile>
     <Compile Include="ConfigurationTest.cs" />
     <Compile Include="CoreTest.cs" />
+    <Compile Include="ScriptedClient.cs" />
+    <Compile Include="TickHoldTest.cs" />
     <Compile Include="Server\ClientRequestingConnectionArgsTest.cs" />
     <Compile Include="Server\HTTP\RequestTest.cs" />
     <Compile Include="Server\HTTP\ResponseTest.cs" />

--- a/core/test/KRPC.Core.Test.csproj
+++ b/core/test/KRPC.Core.Test.csproj
@@ -42,6 +42,7 @@
     <Compile Include="CoreTest.cs" />
     <Compile Include="ScriptedClient.cs" />
     <Compile Include="TickHoldTest.cs" />
+    <Compile Include="UpdateEventsTest.cs" />
     <Compile Include="Server\ClientRequestingConnectionArgsTest.cs" />
     <Compile Include="Server\HTTP\RequestTest.cs" />
     <Compile Include="Server\HTTP\ResponseTest.cs" />

--- a/core/test/ScriptedClient.cs
+++ b/core/test/ScriptedClient.cs
@@ -1,0 +1,168 @@
+using System;
+using System.Collections.Generic;
+using KRPC.Server;
+using KRPC.Service.Messages;
+
+namespace KRPC.Test
+{
+    // A client whose requests are handed over one at a time, and only once the server has
+    // polled for them often enough. Polling stands in for the time a real client spends
+    // deciding what to call next, so that what is measured is how many updates the calls
+    // are spread over rather than how long anything took.
+    sealed class ScriptedClient : IClient<Request,Response>
+    {
+        sealed class ScriptedStream : IStream<Request,Response>
+        {
+            readonly Queue<Request> pending;
+            readonly int pollsBeforeReady;
+            readonly Action onPollsBeforeGone;
+            readonly int pollsBeforeGone;
+            int polls;
+
+            public ScriptedStream (IEnumerable<Request> requests, int pollsBeforeReady,
+                                   int pollsBeforeGone, Action onPollsBeforeGone)
+            {
+                pending = new Queue<Request> (requests);
+                this.pollsBeforeReady = pollsBeforeReady;
+                this.pollsBeforeGone = pollsBeforeGone;
+                this.onPollsBeforeGone = onPollsBeforeGone;
+            }
+
+            public IList<Response> Written { get; } = new List<Response> ();
+
+            public bool DataAvailable {
+                get {
+                    // Counted here, since polling for a request is what the server does
+                    // while it waits for one.
+                    polls++;
+                    if (pollsBeforeGone > 0 && polls > pollsBeforeGone)
+                        onPollsBeforeGone ();
+                    if (pending.Count == 0)
+                        return false;
+                    return polls > pollsBeforeReady;
+                }
+            }
+
+            public Request Read ()
+            {
+                polls = 0;
+                return pending.Dequeue ();
+            }
+
+            public void Write (Response value)
+            {
+                Written.Add (value);
+            }
+
+            public ulong BytesRead { get { return 0; } }
+
+            public ulong BytesWritten { get { return 0; } }
+
+            public void ClearStats ()
+            {
+            }
+
+            public void Close ()
+            {
+            }
+
+            public int Read (Request[] buffer, int offset)
+            {
+                throw new NotSupportedException ();
+            }
+
+            public int Read (Request[] buffer, int offset, int size)
+            {
+                throw new NotSupportedException ();
+            }
+
+            public void Write (Response[] buffer)
+            {
+                throw new NotSupportedException ();
+            }
+
+            public void Write (Response[] buffer, int offset, int size)
+            {
+                throw new NotSupportedException ();
+            }
+        }
+
+        readonly ScriptedStream stream;
+
+        public ScriptedClient (int pollsBeforeReady, int pollsBeforeGone,
+                               params string[] procedures)
+            : this (pollsBeforeReady, pollsBeforeGone, OnePerRequest (procedures))
+        {
+        }
+
+        ScriptedClient (int pollsBeforeReady, int pollsBeforeGone, IEnumerable<Request> requests)
+        {
+            stream = new ScriptedStream (requests, pollsBeforeReady, pollsBeforeGone,
+                                         () => Connected = false);
+            Guid = Guid.NewGuid ();
+            Connected = true;
+        }
+
+        /// <summary>
+        /// A client whose script is grouped into requests, each inner array being the calls of
+        /// one request. Calls sent together are executed together, in one continuation.
+        /// </summary>
+        public static ScriptedClient Batched (int pollsBeforeReady, int pollsBeforeGone,
+                                              params string[][] requests)
+        {
+            var scripted = new List<Request> ();
+            foreach (var procedures in requests) {
+                var request = new Request ();
+                foreach (var procedure in procedures)
+                    request.Calls.Add (new ProcedureCall ("KRPC", procedure));
+                scripted.Add (request);
+            }
+            return new ScriptedClient (pollsBeforeReady, pollsBeforeGone, scripted);
+        }
+
+        static IEnumerable<Request> OnePerRequest (IEnumerable<string> procedures)
+        {
+            var requests = new List<Request> ();
+            foreach (var procedure in procedures) {
+                var request = new Request ();
+                request.Calls.Add (new ProcedureCall ("KRPC", procedure));
+                requests.Add (request);
+            }
+            return requests;
+        }
+
+        public IList<Response> Written { get { return stream.Written; } }
+
+        public string Name { get { return "ScriptedClient"; } }
+
+        public Guid Guid { get; private set; }
+
+        public string Address { get { return "scripted"; } }
+
+        public bool Connected { get; set; }
+
+        public IStream<Request,Response> Stream { get { return stream; } }
+
+        public void Close ()
+        {
+            Connected = false;
+        }
+
+        // The round robin scheduler and the set of clients already being served both
+        // compare clients, so identity has to come from the identifier.
+        public bool Equals (IClient<Request,Response> other)
+        {
+            return other != null && Guid == other.Guid;
+        }
+
+        public override bool Equals (object obj)
+        {
+            return Equals (obj as IClient<Request,Response>);
+        }
+
+        public override int GetHashCode ()
+        {
+            return Guid.GetHashCode ();
+        }
+    }
+}

--- a/core/test/Service/KRPC/KRPCTest.cs
+++ b/core/test/Service/KRPC/KRPCTest.cs
@@ -30,7 +30,7 @@ namespace KRPC.Test.Service.KRPC
             Assert.AreEqual (5, services.ServicesList.Count);
 
             var service = services.ServicesList.First (x => x.Name == "KRPC");
-            Assert.AreEqual (71, service.Procedures.Count);
+            Assert.AreEqual (72, service.Procedures.Count);
             Assert.AreEqual (2, service.Classes.Count);
             Assert.AreEqual (1, service.Enumerations.Count);
 
@@ -82,6 +82,10 @@ namespace KRPC.Test.Service.KRPC
                     MessageAssert.HasNoReturnType (proc);
                     MessageAssert.HasNoParameters (proc);
                     MessageAssert.HasDocumentation (proc);
+                } else if (proc.Name == "NextTick") {
+                    MessageAssert.HasNoReturnType (proc);
+                    MessageAssert.HasNoParameters (proc);
+                    MessageAssert.HasDocumentation (proc);
                 } else if (proc.Name == "get_Clients") {
                     MessageAssert.HasReturnType (proc, typeof(IList<Tuple<byte[],string,string>>));
                     MessageAssert.HasNoParameters (proc);
@@ -105,7 +109,7 @@ namespace KRPC.Test.Service.KRPC
                 }
                 foundProcedures++;
             }
-            Assert.AreEqual (14, foundProcedures);
+            Assert.AreEqual (15, foundProcedures);
 
             bool foundEnumeration = false;
             foreach (var enumeration in service.Enumerations) {

--- a/core/test/Service/KRPC/KRPCTest.cs
+++ b/core/test/Service/KRPC/KRPCTest.cs
@@ -30,7 +30,7 @@ namespace KRPC.Test.Service.KRPC
             Assert.AreEqual (5, services.ServicesList.Count);
 
             var service = services.ServicesList.First (x => x.Name == "KRPC");
-            Assert.AreEqual (69, service.Procedures.Count);
+            Assert.AreEqual (71, service.Procedures.Count);
             Assert.AreEqual (2, service.Classes.Count);
             Assert.AreEqual (1, service.Enumerations.Count);
 
@@ -74,6 +74,14 @@ namespace KRPC.Test.Service.KRPC
                     MessageAssert.HasParameters (proc, 1);
                     MessageAssert.HasParameter (proc, 0, typeof(ulong), "id");
                     MessageAssert.HasDocumentation (proc);
+                } else if (proc.Name == "HoldTick") {
+                    MessageAssert.HasNoReturnType (proc);
+                    MessageAssert.HasNoParameters (proc);
+                    MessageAssert.HasDocumentation (proc);
+                } else if (proc.Name == "ReleaseTick") {
+                    MessageAssert.HasNoReturnType (proc);
+                    MessageAssert.HasNoParameters (proc);
+                    MessageAssert.HasDocumentation (proc);
                 } else if (proc.Name == "get_Clients") {
                     MessageAssert.HasReturnType (proc, typeof(IList<Tuple<byte[],string,string>>));
                     MessageAssert.HasNoParameters (proc);
@@ -97,7 +105,7 @@ namespace KRPC.Test.Service.KRPC
                 }
                 foundProcedures++;
             }
-            Assert.AreEqual (12, foundProcedures);
+            Assert.AreEqual (14, foundProcedures);
 
             bool foundEnumeration = false;
             foreach (var enumeration in service.Enumerations) {

--- a/core/test/TickHoldTest.cs
+++ b/core/test/TickHoldTest.cs
@@ -1,0 +1,181 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using KRPC.Server;
+using KRPC.Service;
+using KRPC.Service.Messages;
+using NUnit.Framework;
+
+namespace KRPC.Test
+{
+    [TestFixture]
+    public class TickHoldTest
+    {
+        Core core;
+        bool blockingRecv;
+        uint tickHoldTimeout;
+        readonly List<ScriptedClient> clients = new List<ScriptedClient> ();
+
+        [SetUp]
+        public void SetUp ()
+        {
+            core = Core.Instance;
+            // Procedures are gated on the game scene, so the calls these tests script only run
+            // in one. Set here rather than relied on from whichever fixture ran last.
+            CallContext.GameScene = GameScene.Flight;
+            var config = Configuration.Instance;
+            blockingRecv = config.BlockingRecv;
+            tickHoldTimeout = config.TickHoldTimeout;
+            // Without blocking receives the server polls each client once per pass, so a client
+            // that is not ready costs it one poll rather than a wait, and the number of updates
+            // a script takes is decided by the script rather than by a clock.
+            config.BlockingRecv = false;
+        }
+
+        [TearDown]
+        public void TearDown ()
+        {
+            foreach (var client in clients)
+                core.RPCClientDisconnected (client);
+            clients.Clear ();
+            var config = Configuration.Instance;
+            config.BlockingRecv = blockingRecv;
+            config.TickHoldTimeout = tickHoldTimeout;
+        }
+
+        ScriptedClient Connect (int pollsBeforeReady, params string[] procedures)
+        {
+            return Connect (pollsBeforeReady, 0, procedures);
+        }
+
+        ScriptedClient Connect (int pollsBeforeReady, int pollsBeforeGone,
+                                params string[] procedures)
+        {
+            var client = new ScriptedClient (pollsBeforeReady, pollsBeforeGone, procedures);
+            core.RPCClientConnected (client);
+            clients.Add (client);
+            return client;
+        }
+
+        ScriptedClient Batched (params string[][] requests)
+        {
+            var client = ScriptedClient.Batched (0, 0, requests);
+            core.RPCClientConnected (client);
+            clients.Add (client);
+            return client;
+        }
+
+        static void AssertNoErrors (IEnumerable<Response> responses)
+        {
+            foreach (var response in responses) {
+                Assert.IsFalse (response.HasError, response.Error == null ? string.Empty : response.Error.Description);
+                // A call that failed is reported in its own result, so checking the response
+                // alone would pass however the calls went.
+                foreach (var result in response.Results)
+                    Assert.IsFalse (result.HasError, result.Error == null ? string.Empty : result.Error.Description);
+            }
+        }
+
+        [Test]
+        public void HoldingTheTickExecutesEveryCallInOneUpdate ()
+        {
+            var client = Connect (1, "HoldTick", "GetClientName", "GetClientName", "ReleaseTick");
+            // The first update spends its one poll finding the client not ready, and the second
+            // takes the hold and then runs the rest of the script inside itself.
+            core.Update ();
+            core.Update ();
+            Assert.AreEqual (4, client.Written.Count);
+            AssertNoErrors (client.Written);
+        }
+
+        [Test]
+        public void WithoutAHoldOneCallIsExecutedPerUpdate ()
+        {
+            var client = Connect (1, "GetClientName", "GetClientName", "GetClientName", "GetClientName");
+            core.Update ();
+            core.Update ();
+            Assert.AreEqual (1, client.Written.Count);
+            AssertNoErrors (client.Written);
+        }
+
+        [Test]
+        public void AHoldRunsOutOfTime ()
+        {
+            Configuration.Instance.TickHoldTimeout = 20000;
+            // Nothing follows the hold, so the update has nothing to wait for but the timeout.
+            var client = Connect (1, "HoldTick");
+            core.Update ();
+            var timer = Stopwatch.StartNew ();
+            core.Update ();
+            timer.Stop ();
+            Assert.AreEqual (1, client.Written.Count);
+            AssertNoErrors (client.Written);
+            Assert.GreaterOrEqual (timer.ElapsedMilliseconds, 15);
+            Assert.Less (timer.ElapsedMilliseconds, 2000);
+        }
+
+        [Test]
+        public void ADisconnectedClientDoesNotKeepHoldingTheTick ()
+        {
+            Configuration.Instance.TickHoldTimeout = 10000000;
+            // The client stops answering, and then goes away, while the tick is held.
+            var client = Connect (1, 50, "HoldTick");
+            core.Update ();
+            // Taken on this update, and the client goes away while it is held. The update has
+            // to notice, rather than waiting out a timeout that is far longer than the test.
+            var timer = Stopwatch.StartNew ();
+            core.Update ();
+            timer.Stop ();
+            Assert.AreEqual (1, client.Written.Count);
+            Assert.Less (timer.ElapsedMilliseconds, 2000);
+        }
+
+        [Test]
+        public void AHoldTakenAfterAReleaseWaitsForTheNextTick ()
+        {
+            // Sent as separate requests, so the release is the last call of its update.
+            var client = Connect (0, "HoldTick", "ReleaseTick", "HoldTick", "ReleaseTick");
+            core.Update ();
+            // The update ends when the hold does, so the second hold is not taken in it.
+            Assert.AreEqual (2, client.Written.Count);
+            core.Update ();
+            Assert.AreEqual (4, client.Written.Count);
+            AssertNoErrors (client.Written);
+        }
+
+        [Test]
+        public void AHoldSentWithTheReleaseBeforeItWaitsForTheNextTick ()
+        {
+            // Sent as one request, so both calls run in one continuation and the release cannot
+            // end the update before the hold behind it is executed. The hold has to turn itself
+            // down, or a client could defer the tick for as long as it kept asking.
+            var client = Batched (
+                new [] { "HoldTick" },
+                new [] { "ReleaseTick", "HoldTick" },
+                new [] { "ReleaseTick" });
+            core.Update ();
+            // Only the first hold has been answered: the request that released and asked again
+            // is waiting for the next update, and the one behind it has not been read.
+            Assert.AreEqual (1, client.Written.Count);
+            core.Update ();
+            Assert.AreEqual (3, client.Written.Count);
+            AssertNoErrors (client.Written);
+        }
+
+        [Test]
+        public void TheTickCannotBeHeldOutsideACall ()
+        {
+            var client = Connect (1);
+            // Holding the tick from a stream or an event would leave a hold in force with no
+            // call waiting to release it, and take another before that one had ended.
+            Assert.Throws<InvalidOperationException> (() => core.HoldTick (client));
+        }
+
+        [Test]
+        public void ReleasingATickThatIsNotHeldDoesNothing ()
+        {
+            var client = Connect (1);
+            Assert.DoesNotThrow (() => core.ReleaseTick (client));
+        }
+    }
+}

--- a/core/test/TickHoldTest.cs
+++ b/core/test/TickHoldTest.cs
@@ -163,6 +163,57 @@ namespace KRPC.Test
         }
 
         [Test]
+        public void AReleaseAndAHoldInSeparateRequestsCanMissATick ()
+        {
+            // The hold is a call the server has to be waiting for when it looks, and a client
+            // that is not ready costs it a poll. Nothing holds the tick after the release, so
+            // the update it would have held ends without it.
+            var client = Connect (1, "HoldTick", "ReleaseTick", "HoldTick", "ReleaseTick");
+            core.Update ();
+            core.Update ();
+            Assert.AreEqual (2, client.Written.Count);
+            core.Update ();
+            // The tick this update ran is the one that was missed: the second hold is still
+            // waiting to be read.
+            Assert.AreEqual (2, client.Written.Count);
+            core.Update ();
+            Assert.AreEqual (4, client.Written.Count);
+            AssertNoErrors (client.Written);
+        }
+
+        [Test]
+        public void NextTickTakesTheFollowingTickWithoutBeingPolledFor ()
+        {
+            // The same script as above with one call in place of the two, and the same client
+            // that is never ready on the first poll.
+            var client = Connect (1, "HoldTick", "NextTick", "ReleaseTick");
+            core.Update ();
+            core.Update ();
+            // The hold has been answered and the tick released again, but the call that asked
+            // for the next tick is waiting in the server rather than on the wire.
+            Assert.AreEqual (1, client.Written.Count);
+            core.Update ();
+            // Carried on at the start of this update, ahead of any polling, so the tick after
+            // the one that was released is held rather than missed.
+            Assert.AreEqual (3, client.Written.Count);
+            AssertNoErrors (client.Written);
+        }
+
+        [Test]
+        public void ALoopOfNextTicksTakesOneTickPerIteration ()
+        {
+            var client = Connect (1, "HoldTick", "NextTick", "NextTick", "NextTick",
+                                  "ReleaseTick");
+            core.Update ();
+            // One call answered per update from here on, each in the tick after the last.
+            for (int answered = 1; answered <= 4; answered++) {
+                core.Update ();
+                Assert.AreEqual (answered == 4 ? 5 : answered, client.Written.Count);
+            }
+            AssertNoErrors (client.Written);
+        }
+
+        [Test]
         public void TheTickCannotBeHeldOutsideACall ()
         {
             var client = Connect (1);

--- a/core/test/UpdateEventsTest.cs
+++ b/core/test/UpdateEventsTest.cs
@@ -1,0 +1,121 @@
+using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+
+namespace KRPC.Test
+{
+    [TestFixture]
+    public class UpdateEventsTest
+    {
+        Core core;
+        bool blockingRecv;
+        uint tickHoldTimeout;
+        readonly List<ScriptedClient> clients = new List<ScriptedClient> ();
+        int beforeCalls;
+        int afterCalls;
+
+        [SetUp]
+        public void SetUp ()
+        {
+            core = Core.Instance;
+            var config = Configuration.Instance;
+            blockingRecv = config.BlockingRecv;
+            tickHoldTimeout = config.TickHoldTimeout;
+            config.BlockingRecv = false;
+            beforeCalls = 0;
+            afterCalls = 0;
+            core.OnBeforeCalls += OnBeforeCalls;
+            core.OnAfterCalls += OnAfterCalls;
+        }
+
+        [TearDown]
+        public void TearDown ()
+        {
+            core.OnBeforeCalls -= OnBeforeCalls;
+            core.OnAfterCalls -= OnAfterCalls;
+            foreach (var client in clients)
+                core.RPCClientDisconnected (client);
+            clients.Clear ();
+            var config = Configuration.Instance;
+            config.BlockingRecv = blockingRecv;
+            config.TickHoldTimeout = tickHoldTimeout;
+        }
+
+        void OnBeforeCalls (object sender, EventArgs args)
+        {
+            beforeCalls++;
+        }
+
+        void OnAfterCalls (object sender, EventArgs args)
+        {
+            afterCalls++;
+        }
+
+        ScriptedClient Connect (int pollsBeforeReady, params string[] procedures)
+        {
+            var client = new ScriptedClient (pollsBeforeReady, 0, procedures);
+            core.RPCClientConnected (client);
+            clients.Add (client);
+            return client;
+        }
+
+        [Test]
+        public void AnIdleUpdateRaisesBothEvents ()
+        {
+            core.Update ();
+            Assert.AreEqual (1, beforeCalls);
+            Assert.AreEqual (1, afterCalls);
+        }
+
+        [Test]
+        public void EachUpdateRaisesBothEventsOnce ()
+        {
+            Connect (1, "GetClientName", "GetClientName");
+            core.Update ();
+            core.Update ();
+            core.Update ();
+            Assert.AreEqual (3, beforeCalls);
+            Assert.AreEqual (3, afterCalls);
+        }
+
+        [Test]
+        public void AnUpdateThatHeldTheTickRaisesBothEventsOnce ()
+        {
+            // A held update runs its poll loop many times over and executes the whole script
+            // inside itself, so it is the case in which a hook raised from the wrong place
+            // would fire repeatedly.
+            var client = Connect (1, "HoldTick", "GetClientName", "GetClientName", "ReleaseTick");
+            core.Update ();
+            core.Update ();
+            Assert.AreEqual (4, client.Written.Count);
+            Assert.AreEqual (2, beforeCalls);
+            Assert.AreEqual (2, afterCalls);
+        }
+
+        [Test]
+        public void TheEventsBracketTheCallsThatTheUpdateExecutes ()
+        {
+            // How many of the script's calls had been answered each time an event was raised.
+            // The update that runs the script must raise the first before any of them and the
+            // second after all of them.
+            var answeredAtBefore = new List<int> ();
+            var answeredAtAfter = new List<int> ();
+            ScriptedClient client = null;
+            EventHandler before = (s, e) => answeredAtBefore.Add (client.Written.Count);
+            EventHandler after = (s, e) => answeredAtAfter.Add (client.Written.Count);
+            core.OnBeforeCalls += before;
+            core.OnAfterCalls += after;
+            try {
+                client = Connect (1, "HoldTick", "GetClientName", "ReleaseTick");
+                core.Update ();
+                core.Update ();
+                Assert.AreEqual (3, client.Written.Count);
+                Assert.AreEqual (new [] { 0, 0 }, answeredAtBefore);
+                Assert.AreEqual (new [] { 0, 3 }, answeredAtAfter);
+            } finally {
+                core.OnBeforeCalls -= before;
+                core.OnAfterCalls -= after;
+            }
+        }
+    }
+}

--- a/doc/api/space-center/auto-pilot.tmpl
+++ b/doc/api/space-center/auto-pilot.tmpl
@@ -8,6 +8,8 @@ AutoPilot
 
 {{ macros.class(services['SpaceCenter'].classes['AutoPilot']) }}
 
+{{ macros.enumeration(services['SpaceCenter'].enumerations['AutoPilotUpdateMode']) }}
+
 {{ macros.enumeration(services['SpaceCenter'].enumerations['RateFilterMode']) }}
 
 {{ macros.enumeration(services['SpaceCenter'].enumerations['MitigationMode']) }}

--- a/doc/order.txt
+++ b/doc/order.txt
@@ -1339,6 +1339,8 @@ SpaceCenter.AutoPilot
 SpaceCenter.AutoPilot.SAS
 SpaceCenter.AutoPilot.SASMode
 SpaceCenter.AutoPilot.Engaged
+SpaceCenter.AutoPilot.UpdateMode
+SpaceCenter.AutoPilot.Update
 SpaceCenter.AutoPilot.ShowInfoUI
 SpaceCenter.AutoPilot.Reset
 SpaceCenter.AutoPilot.ReferenceFrame
@@ -1399,6 +1401,10 @@ SpaceCenter.AutoPilot.PitchYawOscillationDetectedFrequency
 SpaceCenter.AutoPilot.RollOscillationDetectedFrequency
 SpaceCenter.AutoPilot.DiagnosticLogging
 SpaceCenter.AutoPilot.DiagnosticLog
+SpaceCenter.AutoPilotUpdateMode
+SpaceCenter.AutoPilotUpdateMode.AfterCalls
+SpaceCenter.AutoPilotUpdateMode.BeforeCalls
+SpaceCenter.AutoPilotUpdateMode.Manual
 SpaceCenter.RateFilterMode
 SpaceCenter.RateFilterMode.Automatic
 SpaceCenter.RateFilterMode.Off

--- a/doc/order.txt
+++ b/doc/order.txt
@@ -9,6 +9,8 @@ KRPC.RemoveStream
 KRPC.StartStream
 KRPC.SetStreamRate
 KRPC.AddEvent
+KRPC.HoldTick
+KRPC.ReleaseTick
 KRPC.GameScene
 KRPC.GameScene.SpaceCenter
 KRPC.GameScene.Flight

--- a/doc/order.txt
+++ b/doc/order.txt
@@ -11,6 +11,7 @@ KRPC.SetStreamRate
 KRPC.AddEvent
 KRPC.HoldTick
 KRPC.ReleaseTick
+KRPC.NextTick
 KRPC.GameScene
 KRPC.GameScene.SpaceCenter
 KRPC.GameScene.Flight

--- a/doc/src/internals.rst
+++ b/doc/src/internals.rst
@@ -55,3 +55,37 @@ that the maximum time per update setting (above) is still observed.
 This behavior is enabled by the **blocking receives** option. **Receive
 timeout** sets the maximum amount of time the server will wait for a new RPC
 from a client.
+
+The receive timeout decides how much work a client may do between calls before
+it stops being waited for. A client that takes longer than the timeout to send
+its next call is not waiting when the server looks, so the server returns from
+the FixedUpdate and that call is executed in the next one: the client is served
+one RPC per update, however many it makes. The default timeout is one
+millisecond, which is easy for a program written in Python or Lua to exceed.
+
+Holding a tick
+--------------
+
+A client can hold the game on its current physics tick, so that every call it makes is
+executed before the game advances. That is what lets a control loop read the game
+state, compute with it and write the result back within one tick, rather than being
+served one RPC per update whenever it spends longer than the receive timeout between
+calls. See :ref:`the control loops tutorial <tutorial-control-loops>` for how a program
+uses it.
+
+What a hold means for the server:
+
+* **Tick hold timeout** sets how long a client may hold a tick before the server takes
+  it back, one second by default. It bounds how long the game can be made to appear
+  frozen, which is why the server owns it rather than the client. A hold also ends when
+  the client disconnects.
+* The maximum time per update and one RPC per update settings do not apply while a tick
+  is held, and an update that held one is not counted by adaptive rate control, which
+  would otherwise read the client's own work as the server spending too long on RPCs and
+  wind the limit down for every other client.
+* The game renders no frame, takes no input and runs no physics while a tick is held.
+  What it does not cost is the simulation: physics runs on a fixed time step, so a game
+  whose ticks are held runs slower than real time rather than differently.
+* Streams do not update inside a hold, since stream updates are sent once the update has
+  finished executing calls, and new connections are not accepted, since the servers are
+  polled between updates.

--- a/doc/src/tutorials.rst
+++ b/doc/src/tutorials.rst
@@ -15,4 +15,5 @@ of kRPC.
    tutorials/docking-guidance
    tutorials/user-interface
    tutorials/object-lifetime
+   tutorials/control-loops
    tutorials/autopilot

--- a/doc/src/tutorials/autopilot.rst
+++ b/doc/src/tutorials/autopilot.rst
@@ -156,6 +156,51 @@ Reading the state back
      angles and are ill-defined near the vertical. Use **rotation** / **direction** or the
      error readouts above instead.
 
+.. _autopilot-update-mode:
+
+When the control loop runs
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The control loop runs once per physics tick, and **update mode** chooses where in the tick
+it runs relative to the calls a program makes in that tick:
+
+* **after calls** (the default) runs it once the server has executed the tick's calls, so a
+  target set during a tick is flown on that tick.
+
+* **before calls** runs it before the server executes any of them, so the attitude error and
+  control output read during a tick are the ones computed for that tick, one tick behind the
+  target.
+
+* **manual** does not run it at all. Calling **update** runs it, so a program places it
+  among its own calls.
+
+For a control loop this matters most together with :ref:`holding a tick <holding-a-tick>`,
+which puts a whole read, compute and write inside one tick. Manual mode then gives complete
+control of the order: everything before **update** is what the loop will fly the tick with,
+and everything after it can read what the loop just did.
+
+.. code-block:: python
+
+   ap.update_mode = conn.space_center.AutoPilotUpdateMode.manual
+   while True:
+       conn.krpc.hold_tick()
+       try:
+           ap.target_pitch_and_heading(control_law(vessel.flight().pitch), 90)
+           ap.update()
+           record(ap.error, vessel.control.pitch)
+       finally:
+           conn.krpc.release_tick()
+
+In manual mode the vessel is only flown on the ticks the loop is run on. On a tick it is not
+run on the vessel keeps the control output of the last tick it did run on, and after a tenth
+of a second of that the autopilot stops contributing any control input at all, so a program
+that stops calling **update** leaves the vessel coasting rather than holding a deflection.
+**wait** cannot be used in manual mode: it takes several ticks and blocks the program for
+all of them, so the loop would never run.
+
+Calling **update** more than once in a tick runs the loop once. The control law assumes one
+run per tick, so running it twice would advance its filters and gains at twice the rate.
+
 Tuning the AutoPilot
 ^^^^^^^^^^^^^^^^^^^^
 
@@ -608,7 +653,8 @@ extend it.
 The control cascade
 ^^^^^^^^^^^^^^^^^^^
 
-Each physics tick the autopilot does the following:
+Each physics tick, at the point chosen by the update mode described above, the autopilot
+does the following:
 
 #. It compares the current rotation with the target rotation to compute the
    :ref:`target angular velocity <target-angular-velocity>` needed to rotate

--- a/doc/src/tutorials/control-loops.rst
+++ b/doc/src/tutorials/control-loops.rst
@@ -108,6 +108,17 @@ This is a demonstration, not a recommendation: to actually fly a vessel, use the
 :ref:`autopilot <using-the-autopilot>`, which implements a far better control law than the
 one above.
 
+Where the autopilot fits
+------------------------
+
+The autopilot's own control loop also runs once per physics tick. By default it runs after
+the calls of that tick, so a target set inside a held tick is flown on that tick.
+
+For finer control, ``AutoPilot.update_mode`` chooses where in the tick the loop runs, and its
+manual mode hands the decision to the program: everything before ``update`` is what the loop
+flies the tick with, and everything after it can read what the loop just did. See
+:ref:`when the control loop runs <autopilot-update-mode>`.
+
 What it costs
 -------------
 

--- a/doc/src/tutorials/control-loops.rst
+++ b/doc/src/tutorials/control-loops.rst
@@ -1,0 +1,81 @@
+.. _tutorial-control-loops:
+
+Control Loops
+=============
+
+A control loop reads the game state, computes something from it and writes the result back,
+over and over. The game runs its physics on a fixed step, 50 times a second, and a loop that
+flies a vessel wants to do its reading and writing once per step, with the values it writes
+acting on the state it read them from.
+
+That is not what a plain loop gets. This tutorial explains why, and what to do about it.
+
+Why a plain loop falls behind
+-----------------------------
+
+The server executes calls inside the game's physics update, and waits only a short while for
+a client's next call before giving up on it and letting the game move on. That wait is the
+**receive timeout**, one millisecond by default.
+
+A control loop spends its time between the calls, not during them: it reads, then computes,
+then writes. If the computing takes longer than a millisecond, which is easy in Python or
+Lua, the client is not waiting when the server looks for it, so each call lands in a
+different physics tick. An iteration of five calls costs five ticks, and by the time the last
+write lands the state it was computed from is five ticks old.
+
+Raising the receive timeout is not the answer. It is a global setting, and it costs the
+server that much time on every idle update for every client.
+
+.. _holding-a-tick:
+
+Holding a tick
+--------------
+
+``hold_tick`` holds the game on its current physics tick, and ``release_tick`` lets it move
+on. Every call made in between is executed before the game advances, so a whole read, compute
+and write happens in the state of one tick:
+
+.. code-block:: python
+
+   while True:
+       conn.krpc.hold_tick()
+       try:
+           pitch = vessel.flight().pitch
+           vessel.control.pitch = control_law(pitch)
+       finally:
+           conn.krpc.release_tick()
+
+Release the tick even when the code in between fails, as the ``finally`` above does. Until
+the hold is released the game is waiting, so a program that leaves one behind stops the game
+until the hold times out.
+
+What it costs
+-------------
+
+Real time. The game renders no frame, takes no input and runs no physics while a tick is
+held, so a hold of five milliseconds costs five milliseconds of every update it happens in,
+and a hold of a hundred leaves the game running at about ten frames a second.
+
+What it does not cost is the simulation. Physics runs on a fixed time step, so a game whose
+ticks are held runs slower than real time rather than differently. Nothing is skipped and
+nothing is caught up afterwards.
+
+For a control loop that is usually the right trade. Keep the held section short, and keep
+anything that does not need the tick, such as logging or plotting, outside it.
+
+Rules worth knowing
+-------------------
+
+* A hold ends by itself after the **tick hold timeout**, one second by default, and when the
+  client disconnects. The timeout is a server setting, in the advanced section of the server
+  window, because it bounds how long the server's owner has their game frozen.
+* Only one client can hold the tick at a time, and only a client making a call can hold it. A
+  second client's attempt is refused, as is a hold attempted from a stream or an event.
+* Streams do not update while a tick is held, because the server sends stream updates after
+  it has finished executing calls. Read with calls inside a hold, and never wait for a stream
+  or an event there: it cannot arrive until the hold has ended, so the wait runs out the
+  timeout.
+* Calling a procedure that takes more than one tick to finish, such as staging or warping,
+  ends the hold. Such a call can only finish in the tick the hold is holding back.
+* A hold gains nothing while the game is paused, since physics is not advancing anyway, and
+  it blocks the pause menu for as long as it lasts.

--- a/doc/src/tutorials/control-loops.rst
+++ b/doc/src/tutorials/control-loops.rst
@@ -49,12 +49,73 @@ Release the tick even when the code in between fails, as the ``finally`` above d
 the hold is released the game is waiting, so a program that leaves one behind stops the game
 until the hold times out.
 
+Taking every tick
+-----------------
+
+That loop gets whole ticks, but not consecutive ones. The ``hold_tick`` that opens an
+iteration is itself a call the server has to be waiting for, so a program that spends longer
+than the receive timeout between releasing one tick and asking for the next is not there when
+the server looks, and the game runs on without it. The loop still works, but it skips ticks,
+and it cannot tell which ones.
+
+``next_tick`` closes that gap. It releases the tick being held and holds the one immediately
+after it, in a single call, so the game runs no tick the loop has not held:
+
+.. code-block:: python
+
+   try:
+       while True:
+           conn.krpc.next_tick()
+           pitch = vessel.flight().pitch
+           vessel.control.pitch = control_law(pitch)
+   finally:
+       conn.krpc.release_tick()
+
+The call returns when the next tick has been held, so the loop runs at exactly one iteration
+per physics tick and the game advances one tick per call and no faster. When no tick is being
+held ``next_tick`` holds the soonest one it can, so it is the only call the loop needs to
+open with, and ``release_tick`` at the end is what lets the game go.
+
+A worked example
+----------------
+
+Holding a vessel's pitch with a proportional controller, one iteration per tick:
+
+.. code-block:: python
+
+   import krpc
+
+   conn = krpc.connect(name='pitch hold')
+   vessel = conn.space_center.active_vessel
+   target_pitch = 45
+
+   try:
+       for _ in range(500):
+           conn.krpc.next_tick()
+           flight = vessel.flight()
+           error = target_pitch - flight.pitch
+           vessel.control.pitch = max(-1, min(1, 0.05 * error))
+   finally:
+       conn.krpc.release_tick()
+       vessel.control.pitch = 0
+
+Every iteration reads the pitch of one tick and writes a command that acts on that same tick,
+and the 500 iterations cover 500 consecutive ticks, ten seconds of game time. Written without
+the hold, the same loop would take two calls per iteration in two different ticks, and would
+skip an unknown number of ticks between one iteration and the next.
+
+This is a demonstration, not a recommendation: to actually fly a vessel, use the
+:ref:`autopilot <using-the-autopilot>`, which implements a far better control law than the
+one above.
+
 What it costs
 -------------
 
 Real time. The game renders no frame, takes no input and runs no physics while a tick is
 held, so a hold of five milliseconds costs five milliseconds of every update it happens in,
-and a hold of a hundred leaves the game running at about ten frames a second.
+and a hold of a hundred leaves the game running at about ten frames a second. A loop using
+``next_tick`` holds every tick, so the game runs at the rate of the loop for as long as the
+loop runs.
 
 What it does not cost is the simulation. Physics runs on a fixed time step, so a game whose
 ticks are held runs slower than real time rather than differently. Nothing is skipped and
@@ -77,5 +138,8 @@ Rules worth knowing
   timeout.
 * Calling a procedure that takes more than one tick to finish, such as staging or warping,
   ends the hold. Such a call can only finish in the tick the hold is holding back.
+* A tick lost to the timeout is not reported. The next ``next_tick`` takes whatever tick it
+  lands on, so a loop that has to know whether it kept up must check the game's own clock,
+  through ``SpaceCenter.ut``.
 * A hold gains nothing while the game is paused, since physics is not advancing anyway, and
   it blocks the pause menu for as long as it lasts.

--- a/server/CHANGELOG.md
+++ b/server/CHANGELOG.md
@@ -1,4 +1,8 @@
 ## [v0.7.0] - unreleased
+- Add the `TickHoldTimeout` setting, which bounds how long a client may hold the game on one
+  physics tick using `KRPC.HoldTick` (#1070)
+- The server now updates before the game collects control inputs, so a control input written by
+  a call takes effect on the tick the call is made in rather than on the tick after (#1070)
 - **Breaking:** KSP 1.12.5 is the minimum supported version, matching the maximum. Compatibility
   code for older versions of the game has been removed (#1048)
 - Servers can now use the local socket protocol, chosen in the server window like any other. The

--- a/server/src/Addon.cs
+++ b/server/src/Addon.cs
@@ -9,6 +9,11 @@ namespace KRPC
     /// <summary>
     /// Main KRPC addon. Contains the kRPC core, config and UI.
     /// </summary>
+    // Ordered ahead of the game's own scripts so that the server executes a tick's calls before
+    // the game collects control inputs for it. Without that the order is Unity's default, which
+    // puts the control input first, and a value written by a call in one tick is not acted on
+    // until the next.
+    [DefaultExecutionOrder (-100)]
     [KSPAddon (KSPAddon.Startup.AllGameScenes, false)]
     public sealed class Addon : MonoBehaviour
     {

--- a/server/src/ConfigurationFile.cs
+++ b/server/src/ConfigurationFile.cs
@@ -78,6 +78,10 @@ namespace KRPC
         [Persistent] bool adaptiveRateControl;
         [Persistent] bool blockingRecv;
         [Persistent] uint recvTimeout;
+        // Defaulted here as well as in Configuration, since a settings file written before this
+        // setting existed has nothing to load into it, and a zero timeout would end every hold
+        // the moment it was taken.
+        [Persistent] uint tickHoldTimeout = 1000000;
 
         public ConfigurationFile (string filePath, Configuration configuration) : base (filePath, "KRPCConfiguration")
         {
@@ -109,6 +113,7 @@ namespace KRPC
             adaptiveRateControl = Configuration.AdaptiveRateControl;
             blockingRecv = Configuration.BlockingRecv;
             recvTimeout = Configuration.RecvTimeout;
+            tickHoldTimeout = Configuration.TickHoldTimeout;
 
         }
 
@@ -142,6 +147,7 @@ namespace KRPC
             Configuration.AdaptiveRateControl = adaptiveRateControl;
             Configuration.BlockingRecv = blockingRecv;
             Configuration.RecvTimeout = recvTimeout;
+            Configuration.TickHoldTimeout = tickHoldTimeout;
             Logger.WriteLine ("Loaded configuration", Logger.Severity.Debug);
         }
     }

--- a/server/src/UI/MainWindow.cs
+++ b/server/src/UI/MainWindow.cs
@@ -33,6 +33,7 @@ namespace KRPC.UI
         bool showAdvancedServerOptions;
         string maxTimePerUpdate;
         string recvTimeout;
+        string tickHoldTimeout;
         // Style settings
         internal readonly Color errorColor = Color.yellow;
         internal GUIStyle labelStyle, stretchyLabelStyle, fixedLabelStyle, textFieldStyle, longTextFieldStyle, stretchyTextFieldStyle,
@@ -46,6 +47,7 @@ namespace KRPC.UI
         float scaledIndentWidth;
         const int maxTimePerUpdateMaxLength = 20;
         const int recvTimeoutMaxLength = 20;
+        const int tickHoldTimeoutMaxLength = 20;
         // Text strings
         const string advancedModeText = "Show advanced settings";
         const string startAllServersText = "Start server";
@@ -76,6 +78,7 @@ namespace KRPC.UI
         const string adaptiveRateControlText = "Adaptive rate control";
         const string blockingRecvText = "Blocking receives";
         const string recvTimeoutText = "Receive timeout";
+        const string tickHoldTimeoutText = "Tick hold timeout";
         const string microsecondsUnitText = "us";
         const string debugLoggingText = "Debug logging";
         const string showInfoWindowText = "Show info";
@@ -145,6 +148,7 @@ namespace KRPC.UI
             Errors = new List<string> ();
             maxTimePerUpdate = config.Configuration.MaxTimePerUpdate.ToString ();
             recvTimeout = config.Configuration.RecvTimeout.ToString ();
+            tickHoldTimeout = config.Configuration.TickHoldTimeout.ToString ();
 
             if (core.Servers.Count == 1)
                 expandServers.Add (core.Servers [0].Id);
@@ -458,6 +462,11 @@ namespace KRPC.UI
 
                 GUILayout.BeginHorizontal ();
                 GUILayout.Space (scaledIndentWidth);
+                DrawTickHoldTimeout ();
+                GUILayout.EndHorizontal ();
+
+                GUILayout.BeginHorizontal ();
+                GUILayout.Space (scaledIndentWidth);
                 DrawDebugLogging ();
                 GUILayout.EndHorizontal ();
             }
@@ -549,6 +558,23 @@ namespace KRPC.UI
             if (blockingRecv != config.Configuration.BlockingRecv) {
                 config.Configuration.BlockingRecv = blockingRecv;
                 config.Save ();
+            }
+        }
+
+        void DrawTickHoldTimeout ()
+        {
+            GUILayout.Label (tickHoldTimeoutText, fixedLabelStyle);
+            uint value;
+            bool valid = uint.TryParse (tickHoldTimeout, out value);
+            var newTickHoldTimeout = GUILayoutExtensions.FilterDigits (
+                GUILayoutExtensions.ValidatedTextField (tickHoldTimeout, tickHoldTimeoutMaxLength, longTextFieldStyle, valid, errorColor));
+            GUILayout.Label (microsecondsUnitText, labelStyle);
+            if (newTickHoldTimeout != tickHoldTimeout) {
+                tickHoldTimeout = newTickHoldTimeout;
+                if (uint.TryParse (tickHoldTimeout, out value)) {
+                    config.Configuration.TickHoldTimeout = value;
+                    config.Save ();
+                }
             }
         }
 

--- a/service/SpaceCenter/CHANGELOG.md
+++ b/service/SpaceCenter/CHANGELOG.md
@@ -125,6 +125,15 @@
     `AutoPilot.UpReference` as the scalar `TargetPitch` and `TargetHeading` setters do, so
     tracking a moving direction such as prograde no longer drops the roll on every
     update (#1054)
+  - The auto-pilot's control loop runs at a defined point in the server's update rather than
+    wherever the game happened to collect control inputs, so a target set during a tick is
+    flown on that tick instead of the next one. `AutoPilot.UpdateMode` chooses that point,
+    and in its manual mode `AutoPilot.Update` runs the loop, letting a program place it
+    among its own calls inside a held tick (#1070)
+  - Fix an engaged auto-pilot failing on every physics tick once the vessel or part its
+    `AutoPilot.ReferenceFrame` is defined against is gone. The loop now waits for a frame
+    it can measure in, and releases the controls in the meantime, so pointing it at
+    another frame picks it back up (#1070)
 
 - Orbits, nodes and bodies
   - An `Orbit` reads the orbit of the vessel, celestial body or maneuver node it belongs to as

--- a/service/SpaceCenter/src/AutoPilot/AttitudeController.cs
+++ b/service/SpaceCenter/src/AutoPilot/AttitudeController.cs
@@ -2,6 +2,7 @@ using System;
 using KRPC.Server;
 using KRPC.SpaceCenter.ExtensionMethods;
 using KRPC.SpaceCenter.Services;
+using KRPC.Utils;
 using UnityEngine;
 
 namespace KRPC.SpaceCenter.AutoPilot
@@ -38,11 +39,15 @@ namespace KRPC.SpaceCenter.AutoPilot
         // game), used to auto-disengage when that client disconnects.
         bool engaged;
         IClient engagedClient;
-        // The fixed time the control loop last ran at, NaN until it has run. Ticks are
+        // The fixed time the control loop last completed at, NaN until it has run. Ticks are
         // identified by Time.fixedTime rather than counted, because it is the same value for
         // every script in a physics tick however they are ordered, and does not advance while
         // the game is paused.
         float lastStepFixedTime = float.NaN;
+        // The fixed time the loop was last tried at, whether or not it got to the end. Held
+        // apart from lastStepFixedTime so that a step which fails part way through neither runs
+        // again in the same tick nor leaves the output it did not produce looking recent.
+        float lastAttemptFixedTime = float.NaN;
         // How long the last output stays usable. The loop runs once per tick, but the tick it is
         // applied in is not always the tick it ran in, and a program driving it by hand may miss
         // one; holding the last command over a short gap is smoother than dropping to zero.
@@ -699,6 +704,7 @@ namespace KRPC.SpaceCenter.AutoPilot
             engaged = false;
             engagedClient = null;
             lastStepFixedTime = float.NaN;
+            lastAttemptFixedTime = float.NaN;
         }
 
         /// <summary>
@@ -801,8 +807,9 @@ namespace KRPC.SpaceCenter.AutoPilot
 
         /// <summary>
         /// Run one tick of the control loop, writing its result to <see cref="Output"/>. Does
-        /// nothing while not engaged, or when it has already run on this physics tick. If the
-        /// client that engaged the auto-pilot has disconnected, disengages instead.
+        /// nothing while not engaged, when it has already been tried on this physics tick, or
+        /// while the reference frame cannot be measured in. If the client that engaged the
+        /// auto-pilot has disconnected, disengages instead.
         /// </summary>
         public void Step ()
         {
@@ -814,12 +821,21 @@ namespace KRPC.SpaceCenter.AutoPilot
             }
             // The loop's numerics assume one step per physics tick: the integrators, the rate
             // filters and the oscillation detectors all advance by a fixed dt.
-            if (lastStepFixedTime == Time.fixedTime)
+            if (lastAttemptFixedTime == Time.fixedTime)
                 return;
-            lastStepFixedTime = Time.fixedTime;
+            lastAttemptFixedTime = Time.fixedTime;
+            // Everything the loop measures is expressed in the reference frame, and there is no
+            // client call here to raise at, so a frame that cannot be measured in makes the loop
+            // wait rather than fail. The frame is a settable property, so the client can point
+            // the auto-pilot at another one, and the output hold time releases the controls in
+            // the meantime.
+            if (ReferenceFrame.GameObjectState != GameObjectState.Live)
+                return;
             // The auto-pilot fights stock SAS, so hold it off while engaged.
             vessel.InternalVessel.ActionGroups.SetGroup (KSPActionGroup.SAS, false);
             Update (Output);
+            // Only a step that got this far produced an output to fly the vessel with.
+            lastStepFixedTime = Time.fixedTime;
         }
 
         void Update (PilotAddon.ControlInputs state)

--- a/service/SpaceCenter/src/AutoPilot/AttitudeController.cs
+++ b/service/SpaceCenter/src/AutoPilot/AttitudeController.cs
@@ -8,8 +8,8 @@ namespace KRPC.SpaceCenter.AutoPilot
 {
     /// <summary>
     /// Controller to hold a vessels attitude in a chosen orientation.
-    /// One per vessel, owned by <see cref="PilotAddon"/> and driven by it every physics tick via
-    /// <see cref="Fly"/>; the <see cref="Services.AutoPilot"/> API objects are transient views
+    /// One per vessel, owned by <see cref="PilotAddon"/> and driven by it once per physics tick
+    /// via <see cref="Step"/>; the <see cref="Services.AutoPilot"/> API objects are transient views
     /// onto it. Engagement is controller state: which client (if any) currently has the
     /// auto-pilot flying the vessel.
     ///
@@ -38,6 +38,17 @@ namespace KRPC.SpaceCenter.AutoPilot
         // game), used to auto-disengage when that client disconnects.
         bool engaged;
         IClient engagedClient;
+        // The fixed time the control loop last ran at, NaN until it has run. Ticks are
+        // identified by Time.fixedTime rather than counted, because it is the same value for
+        // every script in a physics tick however they are ordered, and does not advance while
+        // the game is paused.
+        float lastStepFixedTime = float.NaN;
+        // How long the last output stays usable. The loop runs once per tick, but the tick it is
+        // applied in is not always the tick it ran in, and a program driving it by hand may miss
+        // one; holding the last command over a short gap is smoother than dropping to zero.
+        // Past this the command is stale and the auto-pilot contributes nothing, so a program
+        // that stops driving it cannot leave a deflection latched on the vessel.
+        const float OutputHoldTime = 0.1f;
         public readonly PIDController PitchPID = new PIDController ();
         public readonly PIDController RollPID = new PIDController ();
         public readonly PIDController YawPID = new PIDController ();
@@ -254,6 +265,7 @@ namespace KRPC.SpaceCenter.AutoPilot
         public AttitudeController (Vessel vessel)
         {
             this.vessel = new Services.Vessel (vessel);
+            Output = new PilotAddon.ControlInputs (vessel);
             Reset ();
         }
 
@@ -460,6 +472,8 @@ namespace KRPC.SpaceCenter.AutoPilot
         public double RollEngageAngle { get; set; }
 
         public bool AutoTune { get; set; }
+
+        public Services.AutoPilotUpdateMode UpdateMode { get; set; }
 
         public Services.RateFilterMode PitchYawRateFilterMode {
             get { return pitchYawRateFilterMode; }
@@ -684,6 +698,7 @@ namespace KRPC.SpaceCenter.AutoPilot
         {
             engaged = false;
             engagedClient = null;
+            lastStepFixedTime = float.NaN;
         }
 
         /// <summary>
@@ -706,6 +721,7 @@ namespace KRPC.SpaceCenter.AutoPilot
             RollStartAngle = 20.0;
             RollEngageAngle = 15.0;
             AutoTune = true;
+            UpdateMode = Services.AutoPilotUpdateMode.AfterCalls;
             pitchYawRateFilterMode = Services.RateFilterMode.Automatic;
             rollRateFilterMode = Services.RateFilterMode.Automatic;
             pitchYawOscillationFrequency = DefaultOscillationFrequency;
@@ -769,23 +785,41 @@ namespace KRPC.SpaceCenter.AutoPilot
 
 
         /// <summary>
-        /// Run one tick of the auto-pilot, writing the control outputs to
-        /// <paramref name="state"/>. Called by <see cref="PilotAddon"/> for every vessel every
-        /// physics tick; does nothing and returns false while not engaged. If the client that
-        /// engaged the auto-pilot has disconnected, disengages instead.
+        /// The control outputs the last <see cref="Step"/> produced. Held here rather than
+        /// written into the vessel's flight control state directly, because the tick the loop
+        /// runs in is chosen by <see cref="UpdateMode"/> while the point the game takes control
+        /// inputs at is fixed, so the two are separate steps.
         /// </summary>
-        public bool Fly (PilotAddon.ControlInputs state)
+        public PilotAddon.ControlInputs Output { get; private set; }
+
+        /// <summary>
+        /// Whether <see cref="Output"/> is recent enough to fly the vessel with.
+        /// </summary>
+        public bool OutputValid {
+            get { return engaged && Time.fixedTime - lastStepFixedTime <= OutputHoldTime; }
+        }
+
+        /// <summary>
+        /// Run one tick of the control loop, writing its result to <see cref="Output"/>. Does
+        /// nothing while not engaged, or when it has already run on this physics tick. If the
+        /// client that engaged the auto-pilot has disconnected, disengages instead.
+        /// </summary>
+        public void Step ()
         {
             if (!engaged)
-                return false;
+                return;
             if (engagedClient != null && !engagedClient.Connected) {
                 Disengage ();
-                return false;
+                return;
             }
+            // The loop's numerics assume one step per physics tick: the integrators, the rate
+            // filters and the oscillation detectors all advance by a fixed dt.
+            if (lastStepFixedTime == Time.fixedTime)
+                return;
+            lastStepFixedTime = Time.fixedTime;
             // The auto-pilot fights stock SAS, so hold it off while engaged.
             vessel.InternalVessel.ActionGroups.SetGroup (KSPActionGroup.SAS, false);
-            Update (state);
-            return true;
+            Update (Output);
         }
 
         void Update (PilotAddon.ControlInputs state)

--- a/service/SpaceCenter/src/KRPC.SpaceCenter.csproj
+++ b/service/SpaceCenter/src/KRPC.SpaceCenter.csproj
@@ -114,6 +114,7 @@
     <Compile Include="Services\AlarmType.cs" />
     <Compile Include="Services\AlarmWarpAction.cs" />
     <Compile Include="Services\AutoPilot.cs" />
+    <Compile Include="Services\AutoPilotUpdateMode.cs" />
     <Compile Include="Services\Camera.cs" />
     <Compile Include="Services\AltimeterMode.cs" />
     <Compile Include="Services\CameraMode.cs" />

--- a/service/SpaceCenter/src/PilotAddon.cs
+++ b/service/SpaceCenter/src/PilotAddon.cs
@@ -303,8 +303,16 @@ namespace KRPC.SpaceCenter
             Clear ();
         }
 
+        // The physics tick the server last ran an update on, and whether the order of that
+        // update and the game's control input has been reported yet. Which of the two comes
+        // first decides whether a value written by a call in a tick is acted on in that tick.
+        // The server addon fixes that order, so the log says once what the game actually did.
+        static float lastUpdateFixedTime = float.NaN;
+        static bool reportedUpdateOrder;
+
         static void RunBeforeCalls (object sender, EventArgs args)
         {
+            lastUpdateFixedTime = Time.fixedTime;
             StepControllers (Services.AutoPilotUpdateMode.BeforeCalls);
         }
 
@@ -334,6 +342,8 @@ namespace KRPC.SpaceCenter
 
         static void Clear ()
         {
+            lastUpdateFixedTime = float.NaN;
+            reportedUpdateOrder = false;
             currentInputs.Clear ();
             manualInputs.Clear ();
             manualInputClients.Clear ();
@@ -459,6 +469,8 @@ namespace KRPC.SpaceCenter
 
         static void OnFlyByWire (Vessel vessel, FlightCtrlState state)
         {
+            ReportUpdateOrder ();
+
             var inputs = new ControlInputs (vessel, state);
 
             // Manual inputs
@@ -485,6 +497,22 @@ namespace KRPC.SpaceCenter
             if (!currentInputs.ContainsKey (vessel))
                 currentInputs [vessel] = new ControlInputs (vessel);
             currentInputs [vessel].CopyFrom (inputs);
+        }
+
+        static void ReportUpdateOrder ()
+        {
+            // Nothing to compare against until the server has run at least one update.
+            if (reportedUpdateOrder || float.IsNaN (lastUpdateFixedTime))
+                return;
+            reportedUpdateOrder = true;
+            var updateFirst = lastUpdateFixedTime == Time.fixedTime;
+            KRPC.Utils.Logger.WriteLine (
+                updateFirst
+                    ? "The server updates before the game collects control inputs, so a call's "
+                      + "effect is seen in the tick it is made in"
+                    : "The game collects control inputs before the server updates, so a call's "
+                      + "effect is not seen until the tick after it is made",
+                KRPC.Utils.Logger.Severity.Debug);
         }
 
         /// <summary>

--- a/service/SpaceCenter/src/PilotAddon.cs
+++ b/service/SpaceCenter/src/PilotAddon.cs
@@ -260,10 +260,6 @@ namespace KRPC.SpaceCenter
         /// </summary>
         static bool clearedManualInputs;
         /// <summary>
-        /// Control inputs that have been set by the auto-pilot.
-        /// </summary>
-        static IDictionary<Vessel, ControlInputs> autoPilotInputs = new Dictionary<Vessel, ControlInputs> ();
-        /// <summary>
         /// FlyByWire callbacks for vessels.
         /// </summary>
         static IDictionary<Vessel, Action<FlightCtrlState>> controlDelegates = new Dictionary<Vessel, Action<FlightCtrlState>> ();
@@ -279,6 +275,11 @@ namespace KRPC.SpaceCenter
         /// however many AutoPilot objects come and go.
         /// </summary>
         static IDictionary<Guid, AttitudeController> attitudeControllers = new Dictionary<Guid, AttitudeController> ();
+        /// <summary>
+        /// The same controllers as a list, so that the per-tick loop can walk them without
+        /// allocating an enumerator over the dictionary every tick.
+        /// </summary>
+        static List<AttitudeController> controllers = new List<AttitudeController> ();
 
         /// <summary>
         /// Wake the addon
@@ -287,6 +288,8 @@ namespace KRPC.SpaceCenter
         {
             Clear ();
             GameEvents.onVesselDestroy.Add (OnVesselDestroy);
+            Core.Instance.OnBeforeCalls += RunBeforeCalls;
+            Core.Instance.OnAfterCalls += RunAfterCalls;
         }
 
         /// <summary>
@@ -294,8 +297,39 @@ namespace KRPC.SpaceCenter
         /// </summary>
         public void OnDestroy ()
         {
+            Core.Instance.OnBeforeCalls -= RunBeforeCalls;
+            Core.Instance.OnAfterCalls -= RunAfterCalls;
             GameEvents.onVesselDestroy.Remove (OnVesselDestroy);
             Clear ();
+        }
+
+        static void RunBeforeCalls (object sender, EventArgs args)
+        {
+            StepControllers (Services.AutoPilotUpdateMode.BeforeCalls);
+        }
+
+        static void RunAfterCalls (object sender, EventArgs args)
+        {
+            StepControllers (Services.AutoPilotUpdateMode.AfterCalls);
+        }
+
+        /// <summary>
+        /// Run the control loop of every auto-pilot set to run at this point in the update.
+        /// One failing vessel must not stop the others, nor the server: these run from a Core
+        /// event, so an exception here would escape into the server's update.
+        /// </summary>
+        static void StepControllers (Services.AutoPilotUpdateMode mode)
+        {
+            for (int i = 0; i < controllers.Count; i++) {
+                if (controllers [i].UpdateMode != mode)
+                    continue;
+                try {
+                    controllers [i].Step ();
+                } catch (Exception exn) {
+                    KRPC.Utils.Logger.WriteLine (
+                        "Auto-pilot failed: " + exn, KRPC.Utils.Logger.Severity.Error);
+                }
+            }
         }
 
         static void Clear ()
@@ -303,10 +337,10 @@ namespace KRPC.SpaceCenter
             currentInputs.Clear ();
             manualInputs.Clear ();
             manualInputClients.Clear ();
-            autoPilotInputs.Clear ();
             controlDelegates.Clear ();
             remoteTechSanctionedDelegates.Clear ();
             attitudeControllers.Clear ();
+            controllers.Clear ();
         }
 
         /// <summary>
@@ -331,8 +365,11 @@ namespace KRPC.SpaceCenter
             remoteTechSanctionedDelegates.Remove (vessel);
             currentInputs.Remove (vessel);
             manualInputs.Remove (vessel);
-            autoPilotInputs.Remove (vessel);
-            attitudeControllers.Remove (vessel.id);
+            AttitudeController controller;
+            if (attitudeControllers.TryGetValue (vessel.id, out controller)) {
+                controllers.Remove (controller);
+                attitudeControllers.Remove (vessel.id);
+            }
         }
 
         /// <summary>
@@ -344,6 +381,7 @@ namespace KRPC.SpaceCenter
             if (!attitudeControllers.TryGetValue (vessel.id, out controller)) {
                 controller = new AttitudeController (vessel);
                 attitudeControllers [vessel.id] = controller;
+                controllers.Add (controller);
             }
             return controller;
         }
@@ -429,12 +467,16 @@ namespace KRPC.SpaceCenter
             HandleThrottle (vessel, manualInputs [vessel]);
             inputs.Add (manualInputs [vessel]);
 
-            // Auto-pilot inputs
-            if (!autoPilotInputs.ContainsKey (vessel))
-                autoPilotInputs [vessel] = new ControlInputs (vessel);
+            // Auto-pilot inputs. The control loop itself runs at the point in the server's
+            // update that the vessel's update mode selects; this applies whatever it last
+            // produced. With no server running nothing else drives it, so it runs here.
             var attitudeController = FindAttitudeController (vessel.id);
-            if (attitudeController != null && attitudeController.Fly (autoPilotInputs [vessel]))
-                inputs.Add (autoPilotInputs [vessel]);
+            if (attitudeController != null) {
+                if (!Core.Instance.AnyRunning)
+                    attitudeController.Step ();
+                if (attitudeController.OutputValid)
+                    inputs.Add (attitudeController.Output);
+            }
 
             // Apply the merged custom axes to the vessel's axis groups
             inputs.ApplyCustomAxes ();

--- a/service/SpaceCenter/src/Services/AutoPilot.cs
+++ b/service/SpaceCenter/src/Services/AutoPilot.cs
@@ -162,6 +162,43 @@ namespace KRPC.SpaceCenter.Services
         }
 
         /// <summary>
+        /// When the auto-pilot's control loop runs within a server update, relative to the
+        /// calls the update executes. Defaults to
+        /// <see cref="AutoPilotUpdateMode.AfterCalls"/>.
+        /// </summary>
+        /// <remarks>
+        /// The loop runs once per physics tick; this chooses where in the tick that is.
+        /// Together with <c>KRPC.HoldTick</c> it lets a program place the loop exactly within
+        /// its own read, compute and write. When no server is running the loop runs at the
+        /// point the game takes control inputs at, whatever the mode, so a vessel is never left
+        /// without control input.
+        /// </remarks>
+        [KRPCProperty]
+        public AutoPilotUpdateMode UpdateMode {
+            get { return Controller.UpdateMode; }
+            set { Controller.UpdateMode = value; }
+        }
+
+        /// <summary>
+        /// Run one tick of the auto-pilot's control loop now. Does nothing if it has already run
+        /// on this physics tick. Throws an exception if the auto-pilot is not engaged.
+        /// </summary>
+        /// <remarks>
+        /// For <see cref="AutoPilotUpdateMode.Manual"/>, where the loop runs only when this is
+        /// called. In the other modes this runs it early; either way it runs once per tick. On a
+        /// tick it is not called for, the vessel keeps the control output of the last tick it did
+        /// run on, and after a tenth of a second of that the auto-pilot stops contributing any
+        /// control input at all.
+        /// </remarks>
+        [KRPCMethod]
+        public void Update ()
+        {
+            if (!Engaged)
+                throw new InvalidOperationException ("The auto-pilot is not engaged");
+            Controller.Step ();
+        }
+
+        /// <summary>
         /// Whether an in-game window showing the auto-pilot's state (engagement, attitude error,
         /// target, angular rate, inner-loop PID gains and oscillation suppression) is displayed for
         /// this vessel. Defaults to <c>false</c>. This is a debugging aid; the window is reset to
@@ -470,6 +507,12 @@ namespace KRPC.SpaceCenter.Services
         [KRPCMethod]
         public void Wait (double timeout = -1)
         {
+            // Waiting takes more than one tick and the caller is blocked in this call for all of
+            // them, so it cannot run the loop itself and the vessel would never converge.
+            if (Controller.UpdateMode == AutoPilotUpdateMode.Manual)
+                throw new InvalidOperationException (
+                    "The auto-pilot only flies the vessel on the ticks it is updated on, " +
+                    "so it cannot be waited on");
             var deadline = timeout >= 0 ? DateTime.UtcNow + TimeSpan.FromSeconds (timeout) : DateTime.MaxValue;
             WaitWithDeadline (deadline);
         }

--- a/service/SpaceCenter/src/Services/AutoPilotUpdateMode.cs
+++ b/service/SpaceCenter/src/Services/AutoPilotUpdateMode.cs
@@ -1,0 +1,30 @@
+using System;
+using KRPC.Service.Attributes;
+
+namespace KRPC.SpaceCenter.Services
+{
+    /// <summary>
+    /// When the auto-pilot's control loop runs within a server update, relative to the calls
+    /// the update executes. See <see cref="AutoPilot.UpdateMode"/>.
+    /// </summary>
+    [Serializable]
+    [KRPCEnum (Service = "SpaceCenter")]
+    public enum AutoPilotUpdateMode
+    {
+        /// <summary>
+        /// The default. The control loop runs once the update has executed the calls it
+        /// received, so a target set during a tick is flown on that tick.
+        /// </summary>
+        AfterCalls,
+        /// <summary>
+        /// The control loop runs before the update executes any calls, so calls made during a
+        /// tick see the attitude error and control output it computed for that tick.
+        /// </summary>
+        BeforeCalls,
+        /// <summary>
+        /// The control loop runs only when <see cref="AutoPilot.Update"/> is called, so a
+        /// program chooses where among its own calls it runs.
+        /// </summary>
+        Manual
+    }
+}

--- a/service/SpaceCenter/test/test_autopilot.py
+++ b/service/SpaceCenter/test/test_autopilot.py
@@ -2311,5 +2311,98 @@ class TestAutoPilotRevertToLaunch(krpctest.TestCase):
         auto_pilot.engaged = False
 
 
+class TestAutoPilotRemovedReferenceFrame(krpctest.TestCase):
+    """What the control loop does when the frame it measures in is removed.
+
+    The loop runs from the game's update rather than from a call, so there is nothing
+    there to raise at. A frame is a settable property, so it waits for a usable one.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.new_save()
+        cls.remove_other_vessels()
+        cls.launch_vessel_from_vab("AutoPilot")
+        cls.set_orbit("Eve", 1070000, 0.15, 16.2, 70.5, 180.8, 1.83, 251.1)
+        cls.conn = cls.connect()
+        cls.space_center = cls.conn.space_center
+        cls.vessel = cls.space_center.active_vessel
+        cls.ap = cls.vessel.auto_pilot
+
+    def setUp(self):
+        self.ap.reset()
+        self.ap.sas = False
+
+    def tearDown(self):
+        self.ap.diagnostic_logging = False
+        self.ap.engaged = False
+
+    def steps(self):
+        """How many ticks the control loop has run to the end of, the log gaining a row
+        per tick that reached it."""
+        lines = [line for line in self.ap.diagnostic_log.splitlines() if line.strip()]
+        return max(0, len(lines) - 1)
+
+    def deflection(self):
+        """The largest control deflection the vessel is being flown with."""
+        control = self.vessel.control
+        return max(abs(control.pitch), abs(control.yaw), abs(control.roll))
+
+    def engage_across(self, frame):
+        """Engage on a target about 90 degrees from where the vessel points, in the given
+        frame, so the loop has an error it is nowhere near finished with."""
+        direction = self.vessel.direction(frame)
+        axis = (1, 0, 0) if abs(direction[0]) < 0.9 else (0, 1, 0)
+        across = (
+            direction[1] * axis[2] - direction[2] * axis[1],
+            direction[2] * axis[0] - direction[0] * axis[2],
+            direction[0] * axis[1] - direction[1] * axis[0],
+        )
+        length = math.sqrt(sum(x * x for x in across))
+        self.ap.reference_frame = frame
+        self.ap.target_direction = tuple(x / length for x in across)
+        self.ap.engaged = True
+
+    def test_removing_the_frame_holds_the_loop(self):
+        frame = self.space_center.ReferenceFrame.create_hybrid(
+            self.vessel.orbital_reference_frame
+        )
+        self.ap.diagnostic_logging = True
+        self.engage_across(frame)
+        self.wait(0.5)
+        self.assertGreater(self.steps(), 0)
+
+        # Removing the frame is a supported thing for a client to do and must not take
+        # the auto-pilot with it
+        frame.remove()
+        self.wait(0.5)
+        held = self.steps()
+        self.assertTrue(self.ap.engaged)
+
+        # Every quantity the loop reads is expressed in the frame, so it waits
+        self.wait(0.5)
+        self.assertEqual(held, self.steps())
+
+        # Pointing the auto-pilot at a frame that can be measured in picks it back up
+        self.ap.reference_frame = self.vessel.orbital_reference_frame
+        self.wait(0.5)
+        self.assertGreater(self.steps(), held)
+
+    def test_removing_the_frame_releases_the_controls(self):
+        frame = self.space_center.ReferenceFrame.create_hybrid(
+            self.vessel.orbital_reference_frame
+        )
+        self.engage_across(frame)
+        self.wait(0.5)
+        self.assertGreater(self.deflection(), 0.1)
+
+        # The loop stops producing an output, so the output hold time expires and the
+        # controls are released rather than the last command staying latched on the vessel
+        frame.remove()
+        self.wait(0.5)
+        self.assertTrue(self.ap.engaged)
+        self.assertEqual(0, self.deflection())
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/service/SpaceCenter/test/test_autopilot_update_mode.py
+++ b/service/SpaceCenter/test/test_autopilot_update_mode.py
@@ -1,0 +1,172 @@
+"""Where in a physics tick the auto-pilot's control loop runs, relative to the calls a
+program makes in that tick.
+
+The diagnostic log commits one row per tick the loop ran on, stamped with that tick. Reading
+it from inside a held tick says whether the loop has already run for the tick the program is
+holding, which is the whole question. The stamp is the game's fixed clock rather than
+universal time, so the two are tied together first in manual mode, where one update inside a
+held tick commits exactly one row and that row is that tick's.
+"""
+
+import unittest
+
+import krpctest
+
+# The game's physics time step.
+TICK = 0.02
+
+
+def parse(text):
+    """The diagnostic log as (tick, target pitch) pairs, oldest first."""
+    lines = [line for line in text.splitlines() if line.strip()]
+    header = lines[0].split(",")
+    tick = header.index("t")
+    pitch = header.index("tgt.pitch")
+    return [
+        (float(row.split(",")[tick]), float(row.split(",")[pitch])) for row in lines[1:]
+    ]
+
+
+class TestAutoPilotUpdateMode(krpctest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.new_save()
+        cls.remove_other_vessels()
+        cls.launch_vessel_from_vab("AutoPilot")
+        # In orbit: the loop writes no rows while the vessel is held on the launch clamps.
+        cls.set_orbit("Eve", 1070000, 0.15, 16.2, 70.5, 180.8, 1.83, 251.1)
+        cls.conn = cls.connect()
+        cls.space_center = cls.conn.space_center
+        cls.vessel = cls.space_center.active_vessel
+        cls.ap = cls.vessel.auto_pilot
+        cls.mode = cls.space_center.AutoPilotUpdateMode
+
+    def setUp(self):
+        self.ap.reset()
+        self.ap.sas = False
+        self.ap.reference_frame = self.vessel.surface_reference_frame
+        self.ap.target_pitch_and_heading(0, 90)
+        self.ap.engaged = True
+        self.wait(0.5)
+
+    def tearDown(self):
+        self.ap.diagnostic_logging = False
+        self.ap.engaged = False
+        # A test that left the auto-pilot in manual mode must not leave it there for the next.
+        self.ap.update_mode = self.mode.after_calls
+        self.conn.krpc.release_tick()
+
+    def tick_offset(self):
+        """Universal time minus the log's tick stamp, for one and the same tick.
+
+        Calibrated in manual mode, where the single row an update commits inside a held tick
+        is that tick's by construction, whatever the modes under test do.
+        """
+        self.ap.update_mode = self.mode.manual
+        self.ap.diagnostic_logging = True
+        self.conn.krpc.hold_tick()
+        try:
+            ut = self.space_center.ut
+            self.ap.update()
+        finally:
+            self.conn.krpc.release_tick()
+        rows = parse(self.ap.diagnostic_log)
+        self.ap.diagnostic_logging = False
+        self.assertEqual(1, len(rows))
+        return ut - rows[0][0]
+
+    def hold_a_tick_and_write(self, offset, pitch):
+        """Set a target inside one held tick. Returns whether the loop had already run for
+        that tick, and the log as it stood once several more ticks had passed."""
+        self.ap.diagnostic_logging = True
+        self.wait(0.25)
+        self.conn.krpc.hold_tick()
+        try:
+            ut = self.space_center.ut
+            during = parse(self.ap.diagnostic_log)
+            self.ap.target_pitch_and_heading(pitch, 90)
+        finally:
+            self.conn.krpc.release_tick()
+        self.wait(0.25)
+        after = parse(self.ap.diagnostic_log)
+        self.ap.diagnostic_logging = False
+        already_run = abs(during[-1][0] - (ut - offset)) < TICK / 2
+        return already_run, during, after
+
+    def test_after_calls_runs_the_loop_once_the_tick_s_calls_are_done(self):
+        offset = self.tick_offset()
+        self.ap.update_mode = self.mode.after_calls
+        already_run, during, after = self.hold_a_tick_and_write(offset, 20)
+        # The loop has not run for the held tick, so its row is the next one committed, and it
+        # carries the target the hold wrote: a target set in a tick is flown on that tick.
+        self.assertFalse(already_run)
+        self.assertAlmostEqual(20, after[len(during)][1], places=1)
+
+    def test_before_calls_runs_the_loop_before_the_tick_s_calls(self):
+        offset = self.tick_offset()
+        self.ap.update_mode = self.mode.before_calls
+        already_run, during, after = self.hold_a_tick_and_write(offset, 25)
+        # The held tick's row is already committed, and carries the previous target: what is
+        # written in a tick is not flown until the next one.
+        self.assertTrue(already_run)
+        self.assertNotAlmostEqual(25, during[-1][1], places=1)
+        self.assertAlmostEqual(25, after[len(during)][1], places=1)
+
+    def test_manual_runs_the_loop_only_when_it_is_updated(self):
+        self.ap.update_mode = self.mode.manual
+        self.ap.diagnostic_logging = True
+        # Several ticks in which the loop is never run.
+        self.wait(0.5)
+        self.assertEqual("", self.ap.diagnostic_log.strip())
+
+        targets = [30, 35, 40]
+        for pitch in targets:
+            self.conn.krpc.hold_tick()
+            try:
+                self.ap.target_pitch_and_heading(pitch, 90)
+                self.ap.update()
+            finally:
+                self.conn.krpc.release_tick()
+            self.wait(0.1)
+        rows = parse(self.ap.diagnostic_log)
+        self.assertEqual(len(targets), len(rows))
+        for target, row in zip(targets, rows):
+            self.assertAlmostEqual(target, row[1], places=1)
+
+    def test_updating_twice_in_a_tick_runs_the_loop_once(self):
+        self.ap.update_mode = self.mode.manual
+        self.ap.diagnostic_logging = True
+        self.conn.krpc.hold_tick()
+        try:
+            self.ap.update()
+            self.ap.update()
+            self.ap.update()
+        finally:
+            self.conn.krpc.release_tick()
+        self.assertEqual(1, len(parse(self.ap.diagnostic_log)))
+
+    def test_an_auto_pilot_that_stops_being_updated_stops_flying(self):
+        self.ap.update_mode = self.mode.manual
+        self.ap.target_pitch_and_heading(80, 90)
+        self.ap.update()
+        self.wait(0.05)
+        self.assertNotEqual(0, self.vessel.control.pitch)
+        # Well past the tenth of a second the last output is held for.
+        self.wait(0.5)
+        self.assertEqual(0, self.vessel.control.pitch)
+        # Not flying it is not the same as giving it up.
+        self.assertTrue(self.ap.engaged)
+
+    def test_the_auto_pilot_cannot_be_waited_on_in_manual_mode(self):
+        self.ap.update_mode = self.mode.manual
+        with self.assertRaises(RuntimeError):
+            self.ap.wait()
+
+    def test_updating_an_auto_pilot_that_is_not_engaged_raises(self):
+        self.ap.engaged = False
+        with self.assertRaises(RuntimeError):
+            self.ap.update()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/service/SpaceCenter/test/test_tick_hold.py
+++ b/service/SpaceCenter/test/test_tick_hold.py
@@ -2,6 +2,9 @@ import unittest
 
 import krpctest
 
+# The game's physics time step.
+TICK = 0.02
+
 
 class TestTickHold(krpctest.TestCase):
     """Holding a physics tick, which is what lets a control loop read the game state,
@@ -52,6 +55,21 @@ class TestTickHold(krpctest.TestCase):
     def test_releasing_a_tick_that_is_not_held_does_nothing(self):
         self.krpc.release_tick()
         self.krpc.release_tick()
+
+    def test_next_tick_takes_every_tick(self):
+        # Universal time counts the ticks the game ran, so a loop that misses none of them
+        # advances it by exactly one tick per iteration. Both readings are taken inside a
+        # hold, where the game is not moving.
+        iterations = 20
+        try:
+            self.krpc.next_tick()
+            start = self.space_center.ut
+            for _ in range(iterations):
+                self.krpc.next_tick()
+            elapsed = self.space_center.ut - start
+        finally:
+            self.krpc.release_tick()
+        self.assertAlmostEqual(iterations * TICK, elapsed, delta=TICK / 2)
 
 
 if __name__ == "__main__":

--- a/service/SpaceCenter/test/test_tick_hold.py
+++ b/service/SpaceCenter/test/test_tick_hold.py
@@ -1,0 +1,58 @@
+import unittest
+
+import krpctest
+
+
+class TestTickHold(krpctest.TestCase):
+    """Holding a physics tick, which is what lets a control loop read the game state,
+    compute with it and write the result back without the game moving on in between.
+
+    Universal time is advanced by the game's own update, so it is the thing to watch: it
+    does not change at all while a tick is held, and changes again once it is released.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.new_save()
+        cls.krpc = cls.connect().krpc
+        cls.space_center = cls.connect().space_center
+
+    def tearDown(self):
+        # Whatever a test did, the game must not be left held.
+        self.krpc.release_tick()
+
+    def test_the_game_does_not_advance_while_a_tick_is_held(self):
+        self.krpc.hold_tick()
+        try:
+            ut = self.space_center.ut
+            # Several ticks' worth of time, spent entirely inside the hold.
+            self.wait(0.3)
+            self.assertEqual(ut, self.space_center.ut)
+        finally:
+            self.krpc.release_tick()
+        self.wait(0.3)
+        self.assertGreater(self.space_center.ut, ut)
+
+    def test_a_hold_that_is_not_released_runs_out_of_time(self):
+        # The server's default tick hold timeout, which a test install has not changed.
+        timeout = 1.0
+        self.krpc.hold_tick()
+        ut = self.space_center.ut
+        self.wait(timeout + 0.3)
+        self.assertGreater(self.space_center.ut, ut)
+
+    def test_the_tick_cannot_be_held_twice(self):
+        self.krpc.hold_tick()
+        try:
+            with self.assertRaises(RuntimeError):
+                self.krpc.hold_tick()
+        finally:
+            self.krpc.release_tick()
+
+    def test_releasing_a_tick_that_is_not_held_does_nothing(self):
+        self.krpc.release_tick()
+        self.krpc.release_tick()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**Problem.** RPCs are executed inside `FixedUpdate`, and the server waits for a client's next call for at most the receive timeout before leaving the update. A client that spends longer than that between calls is therefore served one RPC per tick, however many it makes. A control loop does its computing between its reads and its writes, so an iteration of five calls costs five ticks, and the values it writes were computed from a state five ticks old.

**Holding a tick.** `KRPC.HoldTick` and `KRPC.ReleaseTick` hold the game on its current physics tick, so every call made in between is executed before the game advances and the whole iteration happens in the state of one tick. Measured against a 60 Hz `TestServer`, five calls with 2 ms of work between them take one tick rather than five. What it costs is real time: no physics runs and no frame is drawn while a tick is held. A hold ends by itself after the new `TickHoldTimeout` server setting, when the client disconnects, or on a call that cannot finish inside the held tick.

**Taking every tick.** A hold and a release made as two calls leave a gap the game can advance through, so a loop built from them skips ticks and cannot tell which. `KRPC.NextTick` releases the tick being held and takes the one after it in a single call, so the game runs no tick the loop has not held and advances one tick per call.

**Auto-pilot.** Its control loop ran wherever the game happened to collect control inputs, which is not ordered against the calls an update executes, so whether a target set during a tick was flown on that tick was incidental. It now runs at a chosen point in the server's update: `AutoPilot.UpdateMode` selects after the update's calls (the default), before them, or only when `AutoPilot.Update` is called, which lets a program place the loop among its own calls inside a held tick.

**Auto-pilot on a lost frame.** The loop runs from the game's update, where there is no call to raise at, so an engaged auto-pilot whose reference frame is defined against a vessel or part that is gone threw on every physics tick. It now waits for a frame it can measure in and releases the controls in the meantime, so pointing it at another one picks it back up. Failing part way through a step also left the last command looking recent, latching a deflection on the vessel rather than letting the output hold time expire it.

**Update order.** The server's update and the game's control input were both plain fixed updates, ordered by Unity's default, which put the control input first: a control value written by a call was not acted on until the next tick. The server now declares an execution order that puts it in front.

**Testing.** Unit tests cover a hold, `NextTick` and every way a hold ends, driving the server with a scripted client so that what is measured is how many updates the calls are spread over. In-game tests watch universal time, which the game's own update advances and which therefore says whether the game really stopped, and check each update mode against the auto-pilot's diagnostic log.

A stopgap until tick synchronization is part of the protocol itself. May change in future releases.

Related to #251

