### PR TITLE
Improve hash codes

### DIFF
--- a/core/src/KRPC.Core.csproj
+++ b/core/src/KRPC.Core.csproj
@@ -186,6 +186,7 @@
     <Compile Include="Utils\EventHandlerExtensions.cs" />
     <Compile Include="Utils\ExponentialMovingAverage.cs" />
     <Compile Include="Utils\GameObjectState.cs" />
+    <Compile Include="Utils\Hash.cs" />
     <Compile Include="Utils\IGameObjectState.cs" />
     <Compile Include="Utils\IScheduler.cs" />
     <Compile Include="Utils\Logger.cs" />

--- a/core/src/Utils/Hash.cs
+++ b/core/src/Utils/Hash.cs
@@ -1,0 +1,109 @@
+using System;
+using System.Collections.Generic;
+
+namespace KRPC.Utils
+{
+    /// <summary>
+    /// A hash code built from the fields that identify an object, written as
+    /// <c>Hash.Of (first).And (second).And (third)</c>.
+    /// </summary>
+    /// <remarks>
+    /// Each field is folded in at a place of its own, so which field a value came from is
+    /// part of the result and two objects holding the same values in different fields
+    /// hash differently. Any number of fields can be folded in.
+    ///
+    /// A field of null counts as zero. A field is only ever asked for its own hash code,
+    /// so nothing it points at is dereferenced, which is what an object standing for
+    /// something the game can destroy needs.
+    /// </remarks>
+    public struct Hash : IEquatable<Hash>
+    {
+        // An arbitrary starting value, and an odd multiplier that moves what has been
+        // folded in so far clear of the field being added.
+        const int seed = 17;
+        const int multiplier = 31;
+
+        readonly int value;
+
+        Hash (int value)
+        {
+            this.value = value;
+        }
+
+        /// <summary>
+        /// Start a hash code with an object's first identifying field.
+        /// </summary>
+        public static Hash Of<T> (T field)
+        {
+            return new Hash (seed).And (field);
+        }
+
+        /// <summary>
+        /// Fold in the next field.
+        /// </summary>
+        public Hash And<T> (T field)
+        {
+            unchecked {
+                return new Hash (
+                    (value * multiplier) + EqualityComparer<T>.Default.GetHashCode (field));
+            }
+        }
+
+        /// <summary>
+        /// The hash code built so far.
+        /// </summary>
+        public int Value {
+            get { return value; }
+        }
+
+        /// <summary>
+        /// The hash code built so far, so that it can be returned directly from
+        /// <c>GetHashCode</c>.
+        /// </summary>
+        public static implicit operator int (Hash hash)
+        {
+            return hash.Value;
+        }
+
+        /// <summary>
+        /// Whether two hash codes are the same.
+        /// </summary>
+        public bool Equals (Hash other)
+        {
+            return value == other.value;
+        }
+
+        /// <summary>
+        /// Whether two hash codes are the same.
+        /// </summary>
+        public override bool Equals (object obj)
+        {
+            return obj is Hash && Equals ((Hash)obj);
+        }
+
+        /// <summary>
+        /// The hash code built so far, so that hashing a hash gives the same answer as
+        /// reading it.
+        /// </summary>
+        public override int GetHashCode ()
+        {
+            return value;
+        }
+
+        /// <summary>
+        /// Whether two hash codes are the same.
+        /// </summary>
+        public static bool operator == (Hash lhs, Hash rhs)
+        {
+            return lhs.Equals (rhs);
+        }
+
+        /// <summary>
+        /// Whether two hash codes differ.
+        /// </summary>
+        public static bool operator != (Hash lhs, Hash rhs)
+        {
+            return !lhs.Equals (rhs);
+        }
+    }
+}

--- a/core/test/KRPC.Core.Test.csproj
+++ b/core/test/KRPC.Core.Test.csproj
@@ -98,6 +98,7 @@
     <Compile Include="Utils\DocumentationExtensionsTest.cs" />
     <Compile Include="Utils\DynamicBufferTest.cs" />
     <Compile Include="Utils\EquatableTest.cs" />
+    <Compile Include="Utils\HashTest.cs" />
     <Compile Include="Utils\ReflectionTest.cs" />
     <Compile Include="Utils\RoundRobinSchedulerTest.cs" />
   </ItemGroup>

--- a/core/test/Utils/HashTest.cs
+++ b/core/test/Utils/HashTest.cs
@@ -1,0 +1,69 @@
+using KRPC.Utils;
+using NUnit.Framework;
+
+namespace KRPC.Test.Utils
+{
+    [TestFixture]
+    public class HashTest
+    {
+        [Test]
+        public void SameFieldsHashTheSame ()
+        {
+            Assert.AreEqual (
+                Hash.Of ("a").And (2).And (true).Value,
+                Hash.Of ("a").And (2).And (true).Value);
+        }
+
+        [Test]
+        public void EqualFieldsDoNotCancel ()
+        {
+            // What an exclusive-or gets wrong: a pair of fields holding the same value
+            // must not leave the hash where it would have been without them.
+            Assert.AreNotEqual (Hash.Of ("a").And ("a").Value, Hash.Of ("b").And ("b").Value);
+            Assert.AreNotEqual (Hash.Of ("a").And ("a").Value, Hash.Of (0).And (0).Value);
+        }
+
+        [Test]
+        public void TheFieldAValueIsInMatters ()
+        {
+            Assert.AreNotEqual (Hash.Of ("a").And ("b").Value, Hash.Of ("b").And ("a").Value);
+        }
+
+        [Test]
+        public void NullCountsAsZero ()
+        {
+            Assert.AreEqual (Hash.Of ((string)null).Value, Hash.Of (0).Value);
+            Assert.AreNotEqual (Hash.Of ((string)null).And ("a").Value, Hash.Of ("a").Value);
+        }
+
+        [Test]
+        public void EveryFieldCounts ()
+        {
+            // Past eight fields as well, where a value tuple stops looking.
+            for (int i = 0; i < 12; i++) {
+                var fields = new int [12];
+                fields [i] = 1;
+                Assert.AreNotEqual (HashOf (new int [12]), HashOf (fields));
+            }
+        }
+
+        [Test]
+        public void AHashIsItsOwnHashCode ()
+        {
+            // Every use of Hash is inside a GetHashCode, where asking a hash for its own
+            // one instead of reading it is an easy slip to make.
+            var hash = Hash.Of ("a").And (2);
+            Assert.AreEqual (hash.Value, hash.GetHashCode ());
+            Assert.AreEqual (hash, Hash.Of ("a").And (2));
+            Assert.AreNotEqual (hash, Hash.Of ("a").And (3));
+        }
+
+        static int HashOf (int [] fields)
+        {
+            var hash = Hash.Of (fields [0]);
+            for (int i = 1; i < fields.Length; i++)
+                hash = hash.And (fields [i]);
+            return hash;
+        }
+    }
+}

--- a/service/InfernalRobotics/src/ServoGroup.cs
+++ b/service/InfernalRobotics/src/ServoGroup.cs
@@ -47,8 +47,8 @@ namespace KRPC.InfernalRobotics
         public override int GetHashCode ()
         {
             // A group the mod names with nothing at all still has to hash, as the object
-            // store hashes every object it holds.
-            return vessel.GetHashCode () ^ (name == null ? 0 : name.GetHashCode ());
+            // store hashes every object it holds; a name of null counts as zero.
+            return Hash.Of (vessel).And (name);
         }
 
         /// <summary>

--- a/service/SpaceCenter/CHANGELOG.md
+++ b/service/SpaceCenter/CHANGELOG.md
@@ -30,6 +30,9 @@
     omni-decoupler such as a stack separator. Such a decoupler detaches at every node at
     once, leaving itself on a vessel of its own as well as the vessel it separated, and the
     two vessels this produced raised an exception (#1043)
+  - Working with many stages, vessel resources, communication links or resource converters
+    no longer slows the server down. Two such objects could share a hash code, and the
+    server then searched them one by one (#1071)
 
 - Editor
   - Add `SpaceCenter.Editor`, available in the vehicle assembly building and the space
@@ -163,6 +166,11 @@
   - Fix removing a maneuver node leaking the object for the rest of the session (#771)
 
 - Reference frames
+  - Creating many hybrid reference frames no longer slows the server down. A frame given
+    the same frame for two of its components, which the defaults of
+    `ReferenceFrame.CreateHybrid` do on their own, hashed the same as every other such
+    frame, and the server searched them one by one whenever a frame was passed to it or
+    returned (#1071)
   - A reference frame taken from a docking port keeps working across a quickload, and says the
     port is gone rather than failing with a null reference once its part is destroyed (#885,
     #764)

--- a/service/SpaceCenter/src/Lifetime/ModuleRef.cs
+++ b/service/SpaceCenter/src/Lifetime/ModuleRef.cs
@@ -225,7 +225,7 @@ namespace KRPC.SpaceCenter
         /// </summary>
         public override int GetHashCode ()
         {
-            return (name == null ? 0 : name.GetHashCode ()) ^ occurrence;
+            return Hash.Of (name).And (occurrence);
         }
 
         /// <summary>

--- a/service/SpaceCenter/src/PartId.cs
+++ b/service/SpaceCenter/src/PartId.cs
@@ -170,7 +170,7 @@ namespace KRPC.SpaceCenter
         /// </summary>
         public override int GetHashCode ()
         {
-            return id.GetHashCode () ^ inEditor.GetHashCode () ^ generation.GetHashCode ();
+            return Hash.Of (id).And (inEditor).And (generation);
         }
 
         /// <summary>

--- a/service/SpaceCenter/src/Services/CelestialBody.cs
+++ b/service/SpaceCenter/src/Services/CelestialBody.cs
@@ -19,13 +19,18 @@ namespace KRPC.SpaceCenter.Services
     {
         Orbit orbit;
 
+        // The body's name. A body keeps its name for as long as it exists, and the game
+        // builds a new string every time it is asked for one, so it is taken once.
+        readonly string bodyName;
+
         /// <summary>
         /// Construct from a KSP celestial body object.
         /// </summary>
         public CelestialBody (global::CelestialBody body)
         {
             InternalBody = body;
-            if (body.name != Planetarium.fetch.Sun.name)
+            bodyName = body.name;
+            if (bodyName != Planetarium.fetch.Sun.name)
                 orbit = new Orbit (this);
         }
 
@@ -55,7 +60,7 @@ namespace KRPC.SpaceCenter.Services
         /// </summary>
         [KRPCProperty]
         public string Name {
-            get { return InternalBody.name; }
+            get { return bodyName; }
         }
 
         /// <summary>

--- a/service/SpaceCenter/src/Services/ClosestApproach.cs
+++ b/service/SpaceCenter/src/Services/ClosestApproach.cs
@@ -51,7 +51,7 @@ namespace KRPC.SpaceCenter.Services
         /// </summary>
         public override int GetHashCode ()
         {
-            return orbit.GetHashCode () ^ target.GetHashCode () ^ ut.GetHashCode ();
+            return Hash.Of (orbit).And (target).And (ut);
         }
 
         /// <summary>

--- a/service/SpaceCenter/src/Services/CommLink.cs
+++ b/service/SpaceCenter/src/Services/CommLink.cs
@@ -115,7 +115,7 @@ namespace KRPC.SpaceCenter.Services
         /// </summary>
         public override int GetHashCode ()
         {
-            return vesselId.GetHashCode () ^ start.GetHashCode () ^ end.GetHashCode ();
+            return Hash.Of (vesselId).And (start).And (end);
         }
 
         /// <summary>

--- a/service/SpaceCenter/src/Services/ContractParameter.cs
+++ b/service/SpaceCenter/src/Services/ContractParameter.cs
@@ -161,9 +161,9 @@ namespace KRPC.SpaceCenter.Services
         /// </summary>
         public override int GetHashCode()
         {
-            var hash = contract.GetHashCode();
+            var hash = Hash.Of(contract);
             foreach (var index in path)
-                hash = hash * 31 + index;
+                hash = hash.And(index);
             return hash;
         }
 

--- a/service/SpaceCenter/src/Services/Node.cs
+++ b/service/SpaceCenter/src/Services/Node.cs
@@ -76,7 +76,7 @@ namespace KRPC.SpaceCenter.Services
         {
             // The node's identity hash rather than its own: it is what the game holds, and
             // nothing about it may change while a client has this object.
-            return vesselId.GetHashCode () ^ RuntimeHelpers.GetHashCode (node);
+            return Hash.Of (vesselId).And (RuntimeHelpers.GetHashCode (node));
         }
 
         /// <summary>

--- a/service/SpaceCenter/src/Services/Orbit.cs
+++ b/service/SpaceCenter/src/Services/Orbit.cs
@@ -129,14 +129,7 @@ namespace KRPC.SpaceCenter.Services
         {
             if (!ReferenceEquals (patch, null))
                 return RuntimeHelpers.GetHashCode (patch);
-            int hash = 0;
-            if (ownerVessel != null)
-                hash ^= ownerVessel.GetHashCode ();
-            if (ownerBody != null)
-                hash ^= ownerBody.GetHashCode ();
-            if (ownerNode != null)
-                hash ^= ownerNode.GetHashCode ();
-            return hash;
+            return Hash.Of (ownerVessel).And (ownerBody).And (ownerNode);
         }
 
         /// <summary>

--- a/service/SpaceCenter/src/Services/Parts/ActionGroupAction.cs
+++ b/service/SpaceCenter/src/Services/Parts/ActionGroupAction.cs
@@ -48,12 +48,9 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         public override int GetHashCode ()
         {
-            // module can be null for a part-level action (Part.Actions) that the Extended
-            // Action Groups mod has assigned to a group, so it is not included in the hash.
-            int hash = part.GetHashCode () ^ name.GetHashCode () ^ id.GetHashCode ();
-            if (module != null)
-                hash ^= module.GetHashCode ();
-            return hash;
+            // module is null for a part-level action (Part.Actions) that the Extended
+            // Action Groups mod has assigned to a group, and counts as zero.
+            return Hash.Of (part).And (name).And (id).And (module);
         }
 
         /// <summary>

--- a/service/SpaceCenter/src/Services/Parts/Antenna.cs
+++ b/service/SpaceCenter/src/Services/Parts/Antenna.cs
@@ -59,7 +59,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         public override int GetHashCode ()
         {
-            return Part.GetHashCode () ^ transmitterRef.GetHashCode ();
+            return Hash.Of (Part).And (transmitterRef);
         }
 
         /// <summary>

--- a/service/SpaceCenter/src/Services/Parts/CargoBay.cs
+++ b/service/SpaceCenter/src/Services/Parts/CargoBay.cs
@@ -63,7 +63,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         public override int GetHashCode ()
         {
-            return Part.GetHashCode () ^ bayRef.GetHashCode ();
+            return Hash.Of (Part).And (bayRef);
         }
 
         /// <summary>

--- a/service/SpaceCenter/src/Services/Parts/ControlSurface.cs
+++ b/service/SpaceCenter/src/Services/Parts/ControlSurface.cs
@@ -60,7 +60,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         public override int GetHashCode ()
         {
-            return Part.GetHashCode () ^ controlSurfaceRef.GetHashCode ();
+            return Hash.Of (Part).And (controlSurfaceRef);
         }
 
         /// <summary>

--- a/service/SpaceCenter/src/Services/Parts/Decoupler.cs
+++ b/service/SpaceCenter/src/Services/Parts/Decoupler.cs
@@ -61,7 +61,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         public override int GetHashCode ()
         {
-            return Part.GetHashCode () ^ decouplerRef.GetHashCode ();
+            return Hash.Of (Part).And (decouplerRef);
         }
 
         /// <summary>

--- a/service/SpaceCenter/src/Services/Parts/DockingPort.cs
+++ b/service/SpaceCenter/src/Services/Parts/DockingPort.cs
@@ -63,7 +63,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         public override int GetHashCode ()
         {
-            return Part.GetHashCode () ^ portRef.GetHashCode () ^ shieldRef.GetHashCode ();
+            return Hash.Of (Part).And (portRef).And (shieldRef);
         }
 
         /// <summary>

--- a/service/SpaceCenter/src/Services/Parts/Engine.cs
+++ b/service/SpaceCenter/src/Services/Parts/Engine.cs
@@ -105,12 +105,11 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         public override int GetHashCode ()
         {
-            return
-            Part.GetHashCode () ^
-            primaryRef.GetHashCode () ^
-            secondaryRef.GetHashCode () ^
-            multiModeRef.GetHashCode () ^
-            gimbalRef.GetHashCode ();
+            return Hash.Of (Part)
+                .And (primaryRef)
+                .And (secondaryRef)
+                .And (multiModeRef)
+                .And (gimbalRef);
         }
 
         /// <summary>

--- a/service/SpaceCenter/src/Services/Parts/Experiment.cs
+++ b/service/SpaceCenter/src/Services/Parts/Experiment.cs
@@ -58,7 +58,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         public override int GetHashCode ()
         {
-            return Part.GetHashCode () ^ experimentRef.GetHashCode ();
+            return Hash.Of (Part).And (experimentRef);
         }
 
         /// <summary>

--- a/service/SpaceCenter/src/Services/Parts/Fairing.cs
+++ b/service/SpaceCenter/src/Services/Parts/Fairing.cs
@@ -57,12 +57,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         public override int GetHashCode ()
         {
-            int h = Part.GetHashCode ();
-            if (fairing != null)
-                h ^= fairing.GetHashCode();
-            if (proceduralFairing != null)
-                h ^= proceduralFairing.GetHashCode();
-            return h;
+            return Hash.Of (Part).And (fairing).And (proceduralFairing);
         }
 
         /// <summary>

--- a/service/SpaceCenter/src/Services/Parts/Intake.cs
+++ b/service/SpaceCenter/src/Services/Parts/Intake.cs
@@ -52,7 +52,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         public override int GetHashCode ()
         {
-            return Part.GetHashCode () ^ intakeRef.GetHashCode ();
+            return Hash.Of (Part).And (intakeRef);
         }
 
         /// <summary>

--- a/service/SpaceCenter/src/Services/Parts/LaunchClamp.cs
+++ b/service/SpaceCenter/src/Services/Parts/LaunchClamp.cs
@@ -52,7 +52,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         public override int GetHashCode ()
         {
-            return Part.GetHashCode () ^ launchClampRef.GetHashCode ();
+            return Hash.Of (Part).And (launchClampRef);
         }
 
         /// <summary>

--- a/service/SpaceCenter/src/Services/Parts/Leg.cs
+++ b/service/SpaceCenter/src/Services/Parts/Leg.cs
@@ -68,7 +68,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         public override int GetHashCode ()
         {
-            return Part.GetHashCode () ^ wheelRef.GetHashCode ();
+            return Hash.Of (Part).And (wheelRef);
         }
 
         /// <summary>

--- a/service/SpaceCenter/src/Services/Parts/Light.cs
+++ b/service/SpaceCenter/src/Services/Parts/Light.cs
@@ -54,7 +54,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         public override int GetHashCode ()
         {
-            return Part.GetHashCode () ^ lightRef.GetHashCode ();
+            return Hash.Of (Part).And (lightRef);
         }
 
         /// <summary>

--- a/service/SpaceCenter/src/Services/Parts/Module.cs
+++ b/service/SpaceCenter/src/Services/Parts/Module.cs
@@ -57,7 +57,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         public override int GetHashCode ()
         {
-            return Part.GetHashCode () ^ reference.GetHashCode ();
+            return Hash.Of (Part).And (reference);
         }
 
         /// <summary>

--- a/service/SpaceCenter/src/Services/Parts/PartAction.cs
+++ b/service/SpaceCenter/src/Services/Parts/PartAction.cs
@@ -53,7 +53,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         public override int GetHashCode ()
         {
-            return Module.GetHashCode () ^ name.GetHashCode ();
+            return Hash.Of (Module).And (name);
         }
 
         /// <summary>

--- a/service/SpaceCenter/src/Services/Parts/PartEvent.cs
+++ b/service/SpaceCenter/src/Services/Parts/PartEvent.cs
@@ -53,7 +53,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         public override int GetHashCode ()
         {
-            return Module.GetHashCode () ^ name.GetHashCode ();
+            return Hash.Of (Module).And (name);
         }
 
         /// <summary>

--- a/service/SpaceCenter/src/Services/Parts/PartField.cs
+++ b/service/SpaceCenter/src/Services/Parts/PartField.cs
@@ -53,7 +53,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         public override int GetHashCode ()
         {
-            return Module.GetHashCode () ^ name.GetHashCode ();
+            return Hash.Of (Module).And (name);
         }
 
         /// <summary>

--- a/service/SpaceCenter/src/Services/Parts/Parts.cs
+++ b/service/SpaceCenter/src/Services/Parts/Parts.cs
@@ -62,7 +62,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         public override int GetHashCode ()
         {
-            return vesselId.GetHashCode () ^ editorVessel.GetHashCode ();
+            return Hash.Of (vesselId).And (editorVessel);
         }
 
         /// <summary>

--- a/service/SpaceCenter/src/Services/Parts/Propellant.cs
+++ b/service/SpaceCenter/src/Services/Parts/Propellant.cs
@@ -41,7 +41,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         public override int GetHashCode ()
         {
-            return partId.GetHashCode () ^ resourceId.GetHashCode ();
+            return Hash.Of (partId).And (resourceId);
         }
 
         /// <summary>

--- a/service/SpaceCenter/src/Services/Parts/RCS.cs
+++ b/service/SpaceCenter/src/Services/Parts/RCS.cs
@@ -62,7 +62,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         public override int GetHashCode ()
         {
-            return Part.GetHashCode () ^ rcsRef.GetHashCode ();
+            return Hash.Of (Part).And (rcsRef);
         }
 
         /// <summary>

--- a/service/SpaceCenter/src/Services/Parts/Radiator.cs
+++ b/service/SpaceCenter/src/Services/Parts/Radiator.cs
@@ -68,10 +68,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         public override int GetHashCode ()
         {
-            return
-            Part.GetHashCode () ^
-            activeRadiatorRef.GetHashCode () ^
-            deployableRadiatorRef.GetHashCode ();
+            return Hash.Of (Part).And (activeRadiatorRef).And (deployableRadiatorRef);
         }
 
         /// <summary>

--- a/service/SpaceCenter/src/Services/Parts/ReactionWheel.cs
+++ b/service/SpaceCenter/src/Services/Parts/ReactionWheel.cs
@@ -60,7 +60,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         public override int GetHashCode ()
         {
-            return Part.GetHashCode () ^ reactionWheelRef.GetHashCode ();
+            return Hash.Of (Part).And (reactionWheelRef);
         }
 
         /// <summary>

--- a/service/SpaceCenter/src/Services/Parts/ResourceConverter.cs
+++ b/service/SpaceCenter/src/Services/Parts/ResourceConverter.cs
@@ -63,9 +63,9 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         public override int GetHashCode ()
         {
-            int hash = Part.GetHashCode ();
+            var hash = Hash.Of (Part);
             foreach (var converter in converterRefs)
-                hash ^= converter.GetHashCode ();
+                hash = hash.And (converter);
             return hash;
         }
 

--- a/service/SpaceCenter/src/Services/Parts/ResourceDrain.cs
+++ b/service/SpaceCenter/src/Services/Parts/ResourceDrain.cs
@@ -59,7 +59,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         public override int GetHashCode()
         {
-            return Part.GetHashCode() ^ drainRef.GetHashCode();
+            return Hash.Of (Part).And (drainRef);
         }
 
         /// <summary>

--- a/service/SpaceCenter/src/Services/Parts/ResourceHarvester.cs
+++ b/service/SpaceCenter/src/Services/Parts/ResourceHarvester.cs
@@ -66,7 +66,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         public override int GetHashCode ()
         {
-            return Part.GetHashCode () ^ harvesterRef.GetHashCode ();
+            return Hash.Of (Part).And (harvesterRef);
         }
 
         /// <summary>

--- a/service/SpaceCenter/src/Services/Parts/RoboticController.cs
+++ b/service/SpaceCenter/src/Services/Parts/RoboticController.cs
@@ -55,7 +55,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         public override int GetHashCode()
         {
-            return Part.GetHashCode() ^ controllerRef.GetHashCode();
+            return Hash.Of (Part).And (controllerRef);
         }
 
         /// <summary>

--- a/service/SpaceCenter/src/Services/Parts/RoboticHinge.cs
+++ b/service/SpaceCenter/src/Services/Parts/RoboticHinge.cs
@@ -56,7 +56,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         public override int GetHashCode()
         {
-            return Part.GetHashCode() ^ servoRef.GetHashCode();
+            return Hash.Of (Part).And (servoRef);
         }
 
         /// <summary>

--- a/service/SpaceCenter/src/Services/Parts/RoboticPiston.cs
+++ b/service/SpaceCenter/src/Services/Parts/RoboticPiston.cs
@@ -56,7 +56,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         public override int GetHashCode()
         {
-            return Part.GetHashCode() ^ servoRef.GetHashCode();
+            return Hash.Of (Part).And (servoRef);
         }
 
         /// <summary>

--- a/service/SpaceCenter/src/Services/Parts/RoboticRotation.cs
+++ b/service/SpaceCenter/src/Services/Parts/RoboticRotation.cs
@@ -56,7 +56,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         public override int GetHashCode()
         {
-            return Part.GetHashCode() ^ servoRef.GetHashCode();
+            return Hash.Of (Part).And (servoRef);
         }
 
         /// <summary>

--- a/service/SpaceCenter/src/Services/Parts/RoboticRotor.cs
+++ b/service/SpaceCenter/src/Services/Parts/RoboticRotor.cs
@@ -56,7 +56,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         public override int GetHashCode()
         {
-            return Part.GetHashCode() ^ servoRef.GetHashCode();
+            return Hash.Of (Part).And (servoRef);
         }
 
         /// <summary>

--- a/service/SpaceCenter/src/Services/Parts/ScienceData.cs
+++ b/service/SpaceCenter/src/Services/Parts/ScienceData.cs
@@ -60,7 +60,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         public override int GetHashCode ()
         {
-            return part.GetHashCode () ^ experimentRef.GetHashCode () ^ data.GetHashCode ();
+            return Hash.Of (part).And (experimentRef).And (data);
         }
 
         /// <summary>

--- a/service/SpaceCenter/src/Services/Parts/ScienceSubject.cs
+++ b/service/SpaceCenter/src/Services/Parts/ScienceSubject.cs
@@ -48,7 +48,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         public override int GetHashCode ()
         {
-            return subjectId.GetHashCode () ^ (int)generation;
+            return Hash.Of (subjectId).And (generation);
         }
 
         /// <summary>

--- a/service/SpaceCenter/src/Services/Parts/Sensor.cs
+++ b/service/SpaceCenter/src/Services/Parts/Sensor.cs
@@ -53,7 +53,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         public override int GetHashCode ()
         {
-            return Part.GetHashCode () ^ sensorRef.GetHashCode ();
+            return Hash.Of (Part).And (sensorRef);
         }
 
         /// <summary>

--- a/service/SpaceCenter/src/Services/Parts/SolarPanel.cs
+++ b/service/SpaceCenter/src/Services/Parts/SolarPanel.cs
@@ -52,7 +52,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         public override int GetHashCode ()
         {
-            return Part.GetHashCode () ^ panelRef.GetHashCode ();
+            return Hash.Of (Part).And (panelRef);
         }
 
         /// <summary>

--- a/service/SpaceCenter/src/Services/Parts/Thruster.cs
+++ b/service/SpaceCenter/src/Services/Parts/Thruster.cs
@@ -83,7 +83,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         public override int GetHashCode ()
         {
-            return part.GetHashCode () ^ transformIndex.GetHashCode ();
+            return Hash.Of (part).And (transformIndex);
         }
 
         /// <summary>

--- a/service/SpaceCenter/src/Services/Parts/Wheel.cs
+++ b/service/SpaceCenter/src/Services/Parts/Wheel.cs
@@ -94,7 +94,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         public override int GetHashCode()
         {
-            return Part.GetHashCode() ^ wheelRef.GetHashCode();
+            return Hash.Of (Part).And (wheelRef);
         }
 
         void CheckBrakes()

--- a/service/SpaceCenter/src/Services/ReferenceFrame.cs
+++ b/service/SpaceCenter/src/Services/ReferenceFrame.cs
@@ -29,6 +29,10 @@ namespace KRPC.SpaceCenter.Services
     {
         readonly ReferenceFrameType type;
         readonly global::CelestialBody body;
+        // The body's name, which is what the frame is hashed by. A body keeps its name for
+        // as long as it exists, and the game builds a new string every time it is asked for
+        // one, so it is taken once rather than on every hash.
+        readonly string bodyName;
         readonly Guid vesselId;
         readonly ManeuverNode node;
         // The part object finds the KSP part again, says whether it is still
@@ -57,6 +61,8 @@ namespace KRPC.SpaceCenter.Services
         {
             this.type = type;
             this.body = body;
+            if (body != null)
+                bodyName = body.name;
             vesselId = vessel != null ? vessel.id : Guid.Empty;
             this.node = node;
             if (part != null)
@@ -118,7 +124,7 @@ namespace KRPC.SpaceCenter.Services
         public override int GetHashCode ()
         {
             var hash = Hash.Of (type)
-                .And (body == null ? null : body.name)
+                .And (bodyName)
                 .And (vesselId)
                 .And (node == null ? 0 : RuntimeHelpers.GetHashCode (node))
                 .And (servicePart)

--- a/service/SpaceCenter/src/Services/ReferenceFrame.cs
+++ b/service/SpaceCenter/src/Services/ReferenceFrame.cs
@@ -117,33 +117,27 @@ namespace KRPC.SpaceCenter.Services
         /// </summary>
         public override int GetHashCode ()
         {
-            var hash = type.GetHashCode ();
-            if (body != null)
-                hash ^= body.name.GetHashCode ();
-            hash ^= vesselId.GetHashCode ();
-            if (node != null)
-                hash ^= RuntimeHelpers.GetHashCode (node);
-            if (servicePart != null)
-                hash ^= servicePart.GetHashCode ();
-            hash ^= dockingPortRef.GetHashCode ();
-            if (thruster != null)
-                hash ^= thruster.GetHashCode ();
-            if (orbit != null)
-                hash ^= orbit.GetHashCode ();
-            if (parent != null)
-                hash ^= parent.GetHashCode ();
-            if (type == ReferenceFrameType.Relative) {
-                hash ^= relativePosition.GetHashCode ();
-                hash ^= relativeRotation.GetHashCode ();
-                hash ^= relativeVelocity.GetHashCode ();
-                hash ^= relativeAngularVelocity.GetHashCode ();
-            }
-            if (type == ReferenceFrameType.Hybrid) {
-                hash ^= hybridPosition.GetHashCode ();
-                hash ^= hybridRotation.GetHashCode ();
-                hash ^= hybridVelocity.GetHashCode ();
-                hash ^= hybridAngularVelocity.GetHashCode ();
-            }
+            var hash = Hash.Of (type)
+                .And (body == null ? null : body.name)
+                .And (vesselId)
+                .And (node == null ? 0 : RuntimeHelpers.GetHashCode (node))
+                .And (servicePart)
+                .And (dockingPortRef)
+                .And (thruster)
+                .And (orbit)
+                .And (parent);
+            if (type == ReferenceFrameType.Relative)
+                hash = hash
+                    .And (relativePosition)
+                    .And (relativeRotation)
+                    .And (relativeVelocity)
+                    .And (relativeAngularVelocity);
+            if (type == ReferenceFrameType.Hybrid)
+                hash = hash
+                    .And (hybridPosition)
+                    .And (hybridRotation)
+                    .And (hybridVelocity)
+                    .And (hybridAngularVelocity);
             return hash;
         }
 

--- a/service/SpaceCenter/src/Services/Resource.cs
+++ b/service/SpaceCenter/src/Services/Resource.cs
@@ -40,7 +40,7 @@ namespace KRPC.SpaceCenter.Services
         /// </summary>
         public override int GetHashCode ()
         {
-            return partId.GetHashCode () ^ resourceId.GetHashCode ();
+            return Hash.Of (partId).And (resourceId);
         }
 
         /// <summary>

--- a/service/SpaceCenter/src/Services/Resources.cs
+++ b/service/SpaceCenter/src/Services/Resources.cs
@@ -98,8 +98,13 @@ namespace KRPC.SpaceCenter.Services
         /// </summary>
         public override int GetHashCode ()
         {
-            return vesselId.GetHashCode () ^ editorVessel.GetHashCode () ^ stage.GetHashCode () ^
-            cumulative.GetHashCode () ^ decoupleStage.GetHashCode () ^ partId.GetHashCode ();
+            return Hash.Of (vesselId)
+                .And (editorVessel)
+                .And (stage)
+                .And (cumulative)
+                .And (decoupleStage)
+                .And (hasPart)
+                .And (partId);
         }
 
         /// <summary>

--- a/service/SpaceCenter/src/Services/Stage.cs
+++ b/service/SpaceCenter/src/Services/Stage.cs
@@ -97,8 +97,7 @@ namespace KRPC.SpaceCenter.Services
         /// </summary>
         public override int GetHashCode ()
         {
-            return vesselId.GetHashCode () ^ editorVessel.GetHashCode () ^
-                   stageNumber.GetHashCode () ^ decoupleStage.GetHashCode ();
+            return Hash.Of (vesselId).And (editorVessel).And (stageNumber).And (decoupleStage);
         }
 
         /// <summary>


### PR DESCRIPTION
**Root cause.** Hash codes combined their fields with an exclusive-or, which is blind to the field a value came from, so two fields holding the same value cancel each other out. For example, a hybrid reference frame is routinely given the same frame for two of its components, which the defaults of `ReferenceFrame.CreateHybrid` do on their own, and every frame built that way hashed alike. The object store is keyed on the hash, so it answered a lookup by walking all of them, and the time the server spent on a call grew with the number of frames a script had created. `CommLink`, `ResourceConverter`, `Stage` and `Resources` all had the same flaw.

**Fix.** `KRPC.Utils.Hash` provides a common way to compute hash codes, without the issues of using exclusive-or.

**Additional fix.** A celestial body's name, which a reference frame hashes by, is taken once when the body is constructed: the Unity object hands its name over as a new string every time it is called, so computing a frame's hash would allocate a new string on every object store lookup.
