### PR TITLE
Object removal

### DIFF
--- a/doc/order.txt
+++ b/doc/order.txt
@@ -1329,6 +1329,7 @@ SpaceCenter.Node.Direction
 SpaceCenter.ReferenceFrame
 SpaceCenter.ReferenceFrame.CreateRelative
 SpaceCenter.ReferenceFrame.CreateHybrid
+SpaceCenter.ReferenceFrame.Remove
 SpaceCenter.AutoPilot
 SpaceCenter.AutoPilot.SAS
 SpaceCenter.AutoPilot.SASMode

--- a/doc/order.txt
+++ b/doc/order.txt
@@ -1308,6 +1308,7 @@ SpaceCenter.ResourceFlowMode.None
 SpaceCenter.ResourceTransfer
 SpaceCenter.ResourceTransfer.Start
 SpaceCenter.ResourceTransfer.Cancel
+SpaceCenter.ResourceTransfer.Remove
 SpaceCenter.ResourceTransfer.Amount
 SpaceCenter.ResourceTransfer.Complete
 SpaceCenter.Node

--- a/doc/order.txt
+++ b/doc/order.txt
@@ -390,6 +390,7 @@ SpaceCenter.Flight.ThrustSpecificFuelConsumption
 SpaceCenter.Orbit
 SpaceCenter.Orbit.CreateFromPositionAndVelocity
 SpaceCenter.Orbit.CreateFromOrbitalElements
+SpaceCenter.Orbit.Remove
 SpaceCenter.Orbit.Body
 SpaceCenter.Orbit.ReferenceFrame
 SpaceCenter.Orbit.OrbitalReferenceFrame

--- a/doc/src/tutorials/object-lifetime.rst
+++ b/doc/src/tutorials/object-lifetime.rst
@@ -42,12 +42,17 @@ roster no longer has, including the one the rename was made through. They all ra
 exception from then on, and an object for the renamed kerbal has to be obtained again under
 the new name.
 
-A reference frame built with ``ReferenceFrame.CreateRelative`` or
-``ReferenceFrame.CreateHybrid`` is the other case. It names nothing in the game, so nothing
-the game does ever finishes with it and the server holds it until the game is unloaded.
-Calling ``ReferenceFrame.Remove`` is what says a script is done with one; the frame is then
-gone, and so is any frame built on it. The server hands the same object to every client that
-builds the same frame, so a frame one of them removes is gone for the others too.
+The other case is an object a client asks the server to build, which names nothing in the
+game. Nothing the game does ever finishes with such an object, so the server holds it until
+the client says it is done with it: ``ReferenceFrame.Remove`` for a frame built with
+``ReferenceFrame.CreateRelative`` or ``ReferenceFrame.CreateHybrid``, and ``Orbit.Remove``
+for an orbit built with ``Orbit.CreateFromPositionAndVelocity`` or
+``Orbit.CreateFromOrbitalElements``. A frame defined against a removed frame or orbit goes
+with it, having nothing left to be evaluated against.
+
+The server hands the same reference frame to every client that builds the same one, so a
+frame one of them removes is gone for the others too. A created orbit belongs to the client
+that asked for it, and goes when that client disconnects.
 
 A few members read nothing and so raise nothing: those that hand back what the object was
 built from, such as the part a part module belongs to, or the name of a field. They answer as

--- a/doc/src/tutorials/object-lifetime.rst
+++ b/doc/src/tutorials/object-lifetime.rst
@@ -42,6 +42,13 @@ roster no longer has, including the one the rename was made through. They all ra
 exception from then on, and an object for the renamed kerbal has to be obtained again under
 the new name.
 
+A reference frame built with ``ReferenceFrame.CreateRelative`` or
+``ReferenceFrame.CreateHybrid`` is the other case. It names nothing in the game, so nothing
+the game does ever finishes with it and the server holds it until the game is unloaded.
+Calling ``ReferenceFrame.Remove`` is what says a script is done with one; the frame is then
+gone, and so is any frame built on it. The server hands the same object to every client that
+builds the same frame, so a frame one of them removes is gone for the others too.
+
 A few members read nothing and so raise nothing: those that hand back what the object was
 built from, such as the part a part module belongs to, or the name of a field. They answer as
 they always did, and what they hand back raises the exception itself as soon as it is used.

--- a/doc/src/tutorials/object-lifetime.rst
+++ b/doc/src/tutorials/object-lifetime.rst
@@ -48,8 +48,9 @@ the client says it is done with it: ``ReferenceFrame.Remove`` for a frame built 
 ``ReferenceFrame.CreateRelative`` or ``ReferenceFrame.CreateHybrid``, ``Orbit.Remove`` for an
 orbit built with ``Orbit.CreateFromPositionAndVelocity`` or
 ``Orbit.CreateFromOrbitalElements``, and ``ResourceTransfer.Remove`` for a transfer between
-parts. A frame defined against a removed frame or orbit goes with it, having nothing left to
-be evaluated against.
+parts. Whatever was built on what is removed goes with it, having nothing left to be
+evaluated against: a frame defined against a removed frame or orbit, and the flight
+information measured in a removed frame.
 
 Each of these belongs to the client that asked for it: two clients that build the same
 reference frame are given one each, so a frame one of them removes leaves the other's alone,

--- a/doc/src/tutorials/object-lifetime.rst
+++ b/doc/src/tutorials/object-lifetime.rst
@@ -45,14 +45,15 @@ the new name.
 The other case is an object a client asks the server to build, which names nothing in the
 game. Nothing the game does ever finishes with such an object, so the server holds it until
 the client says it is done with it: ``ReferenceFrame.Remove`` for a frame built with
-``ReferenceFrame.CreateRelative`` or ``ReferenceFrame.CreateHybrid``, and ``Orbit.Remove``
-for an orbit built with ``Orbit.CreateFromPositionAndVelocity`` or
-``Orbit.CreateFromOrbitalElements``. A frame defined against a removed frame or orbit goes
-with it, having nothing left to be evaluated against.
+``ReferenceFrame.CreateRelative`` or ``ReferenceFrame.CreateHybrid``, ``Orbit.Remove`` for an
+orbit built with ``Orbit.CreateFromPositionAndVelocity`` or
+``Orbit.CreateFromOrbitalElements``, and ``ResourceTransfer.Remove`` for a transfer between
+parts. A frame defined against a removed frame or orbit goes with it, having nothing left to
+be evaluated against.
 
-The server hands the same reference frame to every client that builds the same one, so a
-frame one of them removes is gone for the others too. A created orbit belongs to the client
-that asked for it, and goes when that client disconnects.
+Each of these belongs to the client that asked for it: two clients that build the same
+reference frame are given one each, so a frame one of them removes leaves the other's alone,
+and anything a client has not removed goes when it disconnects.
 
 A few members read nothing and so raise nothing: those that hand back what the object was
 built from, such as the part a part module belongs to, or the name of a field. They answer as

--- a/doc/src/tutorials/reference-frames.rst
+++ b/doc/src/tutorials/reference-frames.rst
@@ -324,6 +324,13 @@ orbited (inherited from :attr:`CelestialBody.reference_frame`). Hybrid
 reference frames can be constructed by calling
 :meth:`ReferenceFrame.create_hybrid`.
 
+Each call returns a new frame, which the server holds until it is removed or the
+client that created it disconnects: such a frame names nothing in the game, so
+nothing the game does ever says it is finished with. Call
+:meth:`ReferenceFrame.remove` on one that is no longer needed. A frame that has
+to follow something that moves should inherit that component from the frame of
+the thing itself, rather than be constructed again on every update.
+
 The parent reference frame(s) of a custom reference frame can also be other
 custom reference frames. For example, you could combine the two example frames
 from above: construct a hybrid reference frame, centered on the vessel and

--- a/server/src/Addon.cs
+++ b/server/src/Addon.cs
@@ -463,8 +463,14 @@ namespace KRPC
             }
             var settled = count > 0 && count == lastCount;
             lastCount = count;
-            if (settled)
+            if (settled) {
                 Service.GameState.Sweep ();
+                // After the store, so that the objects are classified with the game state
+                // settled, which is what the sweep itself records. A collection that drops
+                // something asks for a sweep, as letting go of an object always does, so
+                // this costs one further pass that finds nothing and asks for no more.
+                ClientOwnedState.RemoveDestroyed ();
+            }
         }
 
         // The number of vessels the game lists, or -1 if it is not listing them yet.

--- a/server/src/Utils/ClientOwnedObjects.cs
+++ b/server/src/Utils/ClientOwnedObjects.cs
@@ -115,9 +115,13 @@ namespace KRPC.Utils
         /// it is kept, as is one that is merely not loaded, which the game can bring back.
         /// </summary>
         /// <remarks>
-        /// An addon that acts on its objects every frame calls this first, so that a
-        /// destroyed object is dropped rather than reached into from the frame loop, where
-        /// there is no client call to report the failure to.
+        /// Called on every collection by the object store's sweep, so that a collection
+        /// never holds more than the store does; an addon that acts on its objects every
+        /// frame also calls it first, so that a destroyed object is dropped rather than
+        /// reached into from the frame loop, where there is no client call to report the
+        /// failure to. An addon with nothing to do to its objects per frame needs only the
+        /// sweep: classifying is allowed to search as widely as it needs to, so it is not
+        /// something to do to a whole collection on every frame.
         /// </remarks>
         public void RemoveDestroyed ()
         {

--- a/server/src/Utils/ClientOwnedObjects.cs
+++ b/server/src/Utils/ClientOwnedObjects.cs
@@ -78,8 +78,9 @@ namespace KRPC.Utils
 
         /// <summary>
         /// Remove an object that the client making the current RPC owns, naming it as
-        /// given if it does not. The release action is not invoked: the caller is the
-        /// object's own removal, which does its own teardown.
+        /// given if it does not. The collection's release action is not invoked: the
+        /// caller is the object's own removal, so any teardown it needs is passed in and
+        /// runs only once the object is known to be the caller's.
         /// </summary>
         /// <remarks>
         /// What a client may take out is what it put in, and everything else is one
@@ -88,11 +89,13 @@ namespace KRPC.Utils
         /// from here. So the message says only that this client did not create it,
         /// rather than blaming another client for a collection that has been detached.
         /// </remarks>
-        public void RemoveOwnedByCaller (T obj, string name)
+        public void RemoveOwnedByCaller (T obj, string name, Action<T> teardown = null)
         {
             if (!OwnedByCaller (obj))
                 throw new InvalidOperationException (
                     name + " not found among those created by this client");
+            if (teardown != null)
+                teardown (obj);
             Remove (obj);
         }
 

--- a/server/src/Utils/ClientOwnedObjects.cs
+++ b/server/src/Utils/ClientOwnedObjects.cs
@@ -77,6 +77,26 @@ namespace KRPC.Utils
         }
 
         /// <summary>
+        /// Remove an object that the client making the current RPC owns, naming it as
+        /// given if it does not. The release action is not invoked: the caller is the
+        /// object's own removal, which does its own teardown.
+        /// </summary>
+        /// <remarks>
+        /// What a client may take out is what it put in, and everything else is one
+        /// error however it came about: an object another client owns, one that was
+        /// never here, and one the collection let go of on leaving a scene are alike
+        /// from here. So the message says only that this client did not create it,
+        /// rather than blaming another client for a collection that has been detached.
+        /// </remarks>
+        public void RemoveOwnedByCaller (T obj, string name)
+        {
+            if (!OwnedByCaller (obj))
+                throw new InvalidOperationException (
+                    name + " not found among those created by this client");
+            Remove (obj);
+        }
+
+        /// <summary>
         /// Remove all objects matching the predicate, without invoking the release
         /// action.
         /// </summary>

--- a/server/src/Utils/ClientOwnedOverrides.cs
+++ b/server/src/Utils/ClientOwnedOverrides.cs
@@ -109,12 +109,26 @@ namespace KRPC.Utils
         /// </summary>
         public void Sweep ()
         {
+            Drop (key => Destroyed (key) || ClientConnections.Disconnected (entries [key].Owner));
+        }
+
+        /// <summary>
+        /// Release the overrides whose key object has been destroyed, keeping those whose
+        /// client has merely gone: an override on an object that is still there is still
+        /// installed on it, and releasing it is what puts the object back.
+        /// </summary>
+        public void RemoveDestroyed ()
+        {
+            Drop (Destroyed);
+        }
+
+        void Drop (Func<TKey, bool> finished)
+        {
             foreach (var key in entries.Keys.ToList ()) {
-                var entry = entries [key];
-                if (Destroyed (key) || ClientConnections.Disconnected (entry.Owner)) {
-                    release (key, entry);
-                    entries.Remove (key);
-                }
+                if (!finished (key))
+                    continue;
+                release (key, entries [key]);
+                entries.Remove (key);
             }
         }
 

--- a/server/src/Utils/ClientOwnedState.cs
+++ b/server/src/Utils/ClientOwnedState.cs
@@ -42,20 +42,41 @@ namespace KRPC.Utils
         public static void ReleaseAll ()
         {
             foreach (var collection in collections) {
-                Release (collection.Clear);
-                Release (collection.ReleaseDetached);
+                Guarded (collection.Clear, "Failed to release client-owned state");
+                Guarded (collection.ReleaseDetached, "Failed to release client-owned state");
             }
         }
 
-        static void Release (Action release)
+        /// <summary>
+        /// Drop from every collection the entries whose object stands for something the
+        /// game has destroyed, so that a collection holds no more than the object store
+        /// does.
+        /// </summary>
+        /// <remarks>
+        /// Called from the object store's sweep, which is the one point where classifying
+        /// an object is both meaningful and already being paid for: the game has finished
+        /// building the state it moved to, and the store is asking everything it holds the
+        /// same question. A collection cannot ask it every frame on its own account,
+        /// because classifying is allowed to search as widely as it needs to, and a
+        /// collection whose objects are not acted on every frame has nothing else to do
+        /// there.
+        /// </remarks>
+        public static void RemoveDestroyed ()
+        {
+            foreach (var collection in collections)
+                Guarded (
+                    collection.RemoveDestroyed,
+                    "Failed to drop destroyed client-owned state");
+        }
+
+        static void Guarded (Action action, string failure)
         {
             try {
-                release ();
+                action ();
             } catch (Exception exn) {
-                // Anything at all, as the release actions are supplied by the services and
-                // run here against state whose subject the game may already have destroyed.
-                Logger.WriteLine (
-                    "Failed to release client-owned state; " + exn, Logger.Severity.Error);
+                // Anything at all, as what runs here is supplied by the services and acts
+                // on state whose subject the game may already have destroyed.
+                Logger.WriteLine (failure + "; " + exn, Logger.Severity.Error);
             }
         }
     }

--- a/server/src/Utils/IClientOwnedCollection.cs
+++ b/server/src/Utils/IClientOwnedCollection.cs
@@ -12,6 +12,11 @@ namespace KRPC.Utils
         void Sweep ();
 
         /// <summary>
+        /// Drop the entries whose object stands for something the game has destroyed.
+        /// </summary>
+        void RemoveDestroyed ();
+
+        /// <summary>
         /// Release all entries, whoever owns them.
         /// </summary>
         void Clear ();

--- a/service/Drawing/CHANGELOG.md
+++ b/service/Drawing/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [v0.7.0] - unreleased
 
+- **Breaking:** Removing a drawing object another client created, or one the server no
+  longer holds, reports that it is not among those this client created, rather than a bad
+  argument. Every other object a client asks the server to build already refused it that
+  way (#1072)
 - Line, polygon, text and navball marker objects raise `KRPC.ObjectDestroyedException` once
   the object they draw is gone, which removing it, `Drawing.Clear`, the client that made it
   disconnecting and leaving the flight scene all do. They previously failed on a destroyed

--- a/service/Drawing/src/Addon.cs
+++ b/service/Drawing/src/Addon.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using KRPC.Service;
 using KRPC.Utils;
@@ -30,10 +29,7 @@ namespace KRPC.Drawing
 
         internal static void RemoveObject (IDrawable obj)
         {
-            if (!objects.OwnedByCaller (obj))
-                throw new ArgumentException ("Drawing object not found");
-            obj.Destroy ();
-            objects.Remove (obj);
+            objects.RemoveOwnedByCaller (obj, "Drawing object", x => x.Destroy ());
         }
 
         internal static void Clear (bool clientOnly)

--- a/service/Drawing/src/Drawing.cs
+++ b/service/Drawing/src/Drawing.cs
@@ -56,7 +56,7 @@ namespace KRPC.Drawing
         public static Line AddDirectionFromCom(Tuple3 direction, ReferenceFrame referenceFrame, float length = 10f, bool visible = true)
         {
             var activeVesselRefFrame = SpaceCenter.Services.SpaceCenter.ActiveVessel.ReferenceFrame;
-            referenceFrame = ReferenceFrame.CreateHybrid(
+            referenceFrame = ReferenceFrame.Hybrid(
                 activeVesselRefFrame,
                 referenceFrame,
                 referenceFrame,

--- a/service/SpaceCenter/CHANGELOG.md
+++ b/service/SpaceCenter/CHANGELOG.md
@@ -154,6 +154,16 @@
     the second with the orbital prograde/normal/radial directions. Together with a
     constructed orbit these give a reference frame that follows a coasting object that
     need not exist (#1046)
+  - Add `Orbit.Remove`, which releases the memory the server holds for an orbit created
+    by `Orbit.CreateFromPositionAndVelocity` or `Orbit.CreateFromOrbitalElements`. Such an
+    orbit stands for nothing in the game, so nothing else says when it is finished with;
+    one that is not removed is held until the client that created it disconnects. A
+    reference frame defined against a removed orbit goes with it (#1072)
+  - **Breaking:** A `ClosestApproach` reads the two orbits as they are now rather than
+    describing the moment it was created, so its estimate follows them as the game runs.
+    Asking for the same approach again gives back the same object; the server previously
+    kept a separate one per call, so a script polling the approach to a target filled its
+    memory (#1072)
   - Add `Orbit.VelocityAt`, giving the velocity at a given time in a given reference
     frame, alongside the existing `Orbit.PositionAt` (#1046)
   - `Orbit.Epoch` is documented as the universal time at which the mean anomaly at epoch
@@ -166,6 +176,18 @@
   - Fix removing a maneuver node leaking the object for the rest of the session (#771)
 
 - Reference frames
+  - Add `ReferenceFrame.Remove`, which releases the memory the server holds for a frame
+    created by `ReferenceFrame.CreateRelative` or `ReferenceFrame.CreateHybrid`. Such a
+    frame stands for nothing in the game, so nothing else says when it is finished with,
+    and a script creating one repeatedly needed a reload of the game to get the memory
+    back. One that is not removed is held until the client that created it disconnects
+    (#1072)
+  - `ReferenceFrame.CreateRelative` and `ReferenceFrame.CreateHybrid` return a new frame
+    on each call, rather than one object shared by every client that asks for the same
+    frame. A frame is now each client's own to remove (#1072)
+  - `ReferenceFrame.CreateRelative` and `ReferenceFrame.CreateHybrid` raise an error when
+    given no frame to be defined against, rather than returning one that fails with a
+    `NullReferenceException` on first use (#1072)
   - Creating many hybrid reference frames no longer slows the server down. A frame given
     the same frame for two of its components, which the defaults of
     `ReferenceFrame.CreateHybrid` do on their own, hashed the same as every other such
@@ -275,6 +297,9 @@
   - Fix a resource transfer failing on every update, and never completing, once one of the
     parts it runs between is destroyed; the transfer is now canceled. A transfer whose vessel
     the game unloads waits for it rather than failing (#1051)
+  - Add `ResourceTransfer.Remove`, which stops a transfer and releases the memory the
+    server holds for it. A transfer that is left is held for as long as the game holds
+    the two parts it runs between, which may be the rest of the flight (#1072)
 
 - Camera
   - `Camera.NextCamera` and `Camera.PreviousCamera` now move the IVA view between the crew of
@@ -439,6 +464,8 @@
     in vacuum, or in atmospheric flight) (#914)
   - Fix `Part.Lift`, `Flight.Lift` and `Flight.AerodynamicForce` including stale body lift for
     parts whose body lift the game suppresses, e.g. a pod with a heatshield attached (#971)
+  - A `Flight` is freed once the reference frame it is measured in is gone, rather than
+    being kept for as long as its vessel exists (#1072)
 
 - Control
   - **Breaking:** `Control.SAS` now throws an exception when set to true while the autopilot is

--- a/service/SpaceCenter/src/ConstructedOrbitsAddon.cs
+++ b/service/SpaceCenter/src/ConstructedOrbitsAddon.cs
@@ -1,3 +1,4 @@
+using System;
 using KRPC.Utils;
 using UnityEngine;
 
@@ -32,6 +33,18 @@ namespace KRPC.SpaceCenter
         static internal void Add (Services.Orbit orbit)
         {
             orbits.Add (orbit);
+        }
+
+        /// <summary>
+        /// Stop holding an orbit that its client has removed. Raises if the orbit is not one
+        /// this client constructed.
+        /// </summary>
+        static internal void Remove (Services.Orbit orbit)
+        {
+            if (!orbits.OwnedByCaller (orbit))
+                throw new InvalidOperationException (
+                    "Orbit not found among those created by this client");
+            orbits.Remove (orbit);
         }
 
         /// <summary>

--- a/service/SpaceCenter/src/ConstructedOrbitsAddon.cs
+++ b/service/SpaceCenter/src/ConstructedOrbitsAddon.cs
@@ -1,4 +1,3 @@
-using System;
 using KRPC.Utils;
 using UnityEngine;
 
@@ -41,10 +40,7 @@ namespace KRPC.SpaceCenter
         /// </summary>
         static internal void Remove (Services.Orbit orbit)
         {
-            if (!orbits.OwnedByCaller (orbit))
-                throw new InvalidOperationException (
-                    "Orbit not found among those created by this client");
-            orbits.Remove (orbit);
+            orbits.RemoveOwnedByCaller (orbit, "Orbit");
         }
 
         /// <summary>

--- a/service/SpaceCenter/src/CreatedReferenceFramesAddon.cs
+++ b/service/SpaceCenter/src/CreatedReferenceFramesAddon.cs
@@ -1,4 +1,3 @@
-using System;
 using KRPC.Utils;
 using UnityEngine;
 
@@ -41,10 +40,7 @@ namespace KRPC.SpaceCenter
         /// </summary>
         static internal void Remove (Services.ReferenceFrame frame)
         {
-            if (!frames.OwnedByCaller (frame))
-                throw new InvalidOperationException (
-                    "Reference frame not found among those created by this client");
-            frames.Remove (frame);
+            frames.RemoveOwnedByCaller (frame, "Reference frame");
         }
 
         /// <summary>

--- a/service/SpaceCenter/src/CreatedReferenceFramesAddon.cs
+++ b/service/SpaceCenter/src/CreatedReferenceFramesAddon.cs
@@ -1,0 +1,60 @@
+using System;
+using KRPC.Utils;
+using UnityEngine;
+
+namespace KRPC.SpaceCenter
+{
+    /// <summary>
+    /// Addon that holds the reference frames clients create, so that a frame is let go of
+    /// when the client that asked for it disconnects.
+    /// </summary>
+    /// <remarks>
+    /// A created frame stands for nothing in the game, so nothing the game destroys ever
+    /// retires one and the object would otherwise stay in the object store for the rest of
+    /// the session. Its client removing it or going is the only thing that can say it is
+    /// finished with.
+    ///
+    /// It is not a <see cref="ClientCleanupAddon" />, which gives up its collections on
+    /// entering a scene: a frame is arithmetic the server holds on a client's behalf and is
+    /// as valid in one scene as in another, so a scene change leaves it alone. It runs in
+    /// every game scene because a frame can be created in any of them,
+    /// <see cref="Services.ReferenceFrame" /> carrying no scene restriction of its own.
+    /// </remarks>
+    [KSPAddon (KSPAddon.Startup.AllGameScenes, false)]
+    public sealed class CreatedReferenceFramesAddon : MonoBehaviour
+    {
+        static readonly ClientOwnedObjects<Services.ReferenceFrame> frames =
+            new ClientOwnedObjects<Services.ReferenceFrame> (x => x.Release ());
+
+        /// <summary>
+        /// Record a frame a client has created.
+        /// </summary>
+        static internal void Add (Services.ReferenceFrame frame)
+        {
+            frames.Add (frame);
+        }
+
+        /// <summary>
+        /// Stop holding a frame that its client has removed. Raises if the frame is not one
+        /// this client created, which is also what a frame let go of on leaving a scene
+        /// looks like.
+        /// </summary>
+        static internal void Remove (Services.ReferenceFrame frame)
+        {
+            if (!frames.OwnedByCaller (frame))
+                throw new InvalidOperationException (
+                    "Reference frame not found among those created by this client");
+            frames.Remove (frame);
+        }
+
+        /// <summary>
+        /// Let go of the frames of clients that have disconnected. This runs in Update
+        /// rather than FixedUpdate, which stops while the game is paused, as nothing about
+        /// a frame a client created is tied to the physics step.
+        /// </summary>
+        public void Update ()
+        {
+            frames.Sweep ();
+        }
+    }
+}

--- a/service/SpaceCenter/src/KRPC.SpaceCenter.csproj
+++ b/service/SpaceCenter/src/KRPC.SpaceCenter.csproj
@@ -85,6 +85,7 @@
     <Compile Include="ActuatorControlAddon.cs" />
     <Compile Include="CameraAddon.cs" />
     <Compile Include="ConstructedOrbitsAddon.cs" />
+    <Compile Include="CreatedReferenceFramesAddon.cs" />
     <Compile Include="EditorShipAddon.cs" />
     <Compile Include="EVAAddon.cs" />
     <Compile Include="ExternalAPIAddon.cs" />

--- a/service/SpaceCenter/src/ResourceTransferAddon.cs
+++ b/service/SpaceCenter/src/ResourceTransferAddon.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using KRPC.SpaceCenter.Services;
 using KRPC.Utils;
@@ -12,7 +13,7 @@ namespace KRPC.SpaceCenter
     public sealed class ResourceTransferAddon : ClientCleanupAddon
     {
         static readonly ClientOwnedObjects<ResourceTransfer> transfers =
-            new ClientOwnedObjects<ResourceTransfer> (transfer => transfer.Cancel ());
+            new ClientOwnedObjects<ResourceTransfer> (transfer => transfer.Release ());
 
         static readonly IClientOwnedCollection[] collections = { transfers };
 
@@ -32,15 +33,32 @@ namespace KRPC.SpaceCenter
         }
 
         /// <summary>
-        /// Update the transfers, first canceling those whose client has disconnected
+        /// Stop holding a transfer that its client has removed. Raises if the transfer is
+        /// not one this client started, which is also what a transfer let go of on leaving
+        /// the flight scene looks like.
+        /// </summary>
+        static internal void Remove (ResourceTransfer transfer)
+        {
+            if (!transfers.OwnedByCaller (transfer))
+                throw new InvalidOperationException (
+                    "Resource transfer not found among those started by this client");
+            transfers.Remove (transfer);
+        }
+
+        /// <summary>
+        /// Update the transfers, first stopping those whose client has disconnected
         /// so they move no more resource.
         /// </summary>
+        /// <remarks>
+        /// A transfer that has finished is kept, rather than dropped here: it goes on
+        /// answering for how much it moved, and it is the client's object until that
+        /// client removes it or disconnects. Updating it does nothing.
+        /// </remarks>
         public void FixedUpdate ()
         {
             Sweep ();
             foreach (var transfer in transfers.Items)
                 transfer.Update (Time.fixedDeltaTime);
-            transfers.RemoveAll (transfer => transfer.Complete);
         }
     }
 }

--- a/service/SpaceCenter/src/ResourceTransferAddon.cs
+++ b/service/SpaceCenter/src/ResourceTransferAddon.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using KRPC.SpaceCenter.Services;
 using KRPC.Utils;
@@ -39,10 +38,7 @@ namespace KRPC.SpaceCenter
         /// </summary>
         static internal void Remove (ResourceTransfer transfer)
         {
-            if (!transfers.OwnedByCaller (transfer))
-                throw new InvalidOperationException (
-                    "Resource transfer not found among those started by this client");
-            transfers.Remove (transfer);
+            transfers.RemoveOwnedByCaller (transfer, "Resource transfer");
         }
 
         /// <summary>

--- a/service/SpaceCenter/src/Services/ClosestApproach.cs
+++ b/service/SpaceCenter/src/Services/ClosestApproach.cs
@@ -1,7 +1,9 @@
 using System;
+using KRPC.Service;
 using KRPC.Service.Attributes;
 using KRPC.SpaceCenter.ExtensionMethods;
 using KRPC.Utils;
+using UnityEngine;
 using Tuple3 = System.Tuple<double, double, double>;
 
 namespace KRPC.SpaceCenter.Services
@@ -13,9 +15,10 @@ namespace KRPC.SpaceCenter.Services
     /// <remarks>
     /// The object names the approach rather than describing it once: each member
     /// estimates the time of closest approach from where the two orbits are now, and
-    /// describes the state at that time. The estimate moves as the game runs, and
-    /// members read one after another can differ a little as a result. Relative
-    /// quantities are the target relative to the orbiting object (target minus self).
+    /// describes the state at that time. The estimate moves as the game runs, so
+    /// members read at different moments can differ a little; members read in one
+    /// physics tick all describe the same estimate. Relative quantities are the target
+    /// relative to the orbiting object (target minus self).
     /// </remarks>
     [KRPCClass (Service = "SpaceCenter")]
     public class ClosestApproach : Equatable<ClosestApproach>, IGameObjectState
@@ -25,6 +28,12 @@ namespace KRPC.SpaceCenter.Services
         // Which of the successive approaches this is: the search covers one orbital
         // period, starting this many periods from now.
         readonly int orbitsAhead;
+        // The approach as it was last solved, with the physics tick and the game state it
+        // was solved in.
+        float solvedFixedTime = float.NaN;
+        uint solvedGeneration;
+        double solvedUT;
+        double solvedDistance;
 
         internal ClosestApproach (Orbit orbit, Orbit target, int orbitsAhead)
         {
@@ -84,11 +93,20 @@ namespace KRPC.SpaceCenter.Services
         }
 
         // The universal time of the closest approach, and the distance there, estimated
-        // from where the two orbits are now. Members that need both take them from one
-        // call, so that they describe the same moment.
+        // from where the two orbits are now. The estimate is a search over an orbital
+        // period, sampling both orbits at some seventy points, so it costs far more than
+        // any member that reads it. Nothing it reads moves within a physics tick, so it
+        // is solved once per tick: the members read in a tick share that one search, and
+        // all describe the same moment.
         double Solve (out double approachDistance)
         {
-            return Orbit.CalcClosestAproach (orbit, target, BeginTime, out approachDistance);
+            if (solvedFixedTime != Time.fixedTime || solvedGeneration != GameState.Generation) {
+                solvedUT = Orbit.CalcClosestAproach (orbit, target, BeginTime, out solvedDistance);
+                solvedFixedTime = Time.fixedTime;
+                solvedGeneration = GameState.Generation;
+            }
+            approachDistance = solvedDistance;
+            return solvedUT;
         }
 
         double Solve ()

--- a/service/SpaceCenter/src/Services/ClosestApproach.cs
+++ b/service/SpaceCenter/src/Services/ClosestApproach.cs
@@ -11,20 +11,22 @@ namespace KRPC.SpaceCenter.Services
     /// <see cref="Orbit.NextClosestApproach"/> or <see cref="Orbit.ClosestApproaches"/>.
     /// </summary>
     /// <remarks>
-    /// A close approach is a snapshot: the time of closest approach is estimated once
-    /// when the object is created, and every member describes the state at that time.
-    /// Relative quantities are the target relative to the orbiting object (target minus
-    /// self).
+    /// The object names the approach rather than describing it once: each member
+    /// estimates the time of closest approach from where the two orbits are now, and
+    /// describes the state at that time. The estimate moves as the game runs, and
+    /// members read one after another can differ a little as a result. Relative
+    /// quantities are the target relative to the orbiting object (target minus self).
     /// </remarks>
     [KRPCClass (Service = "SpaceCenter")]
     public class ClosestApproach : Equatable<ClosestApproach>, IGameObjectState
     {
         readonly Orbit orbit;
         readonly Orbit target;
-        readonly double ut;
-        readonly double distance;
+        // Which of the successive approaches this is: the search covers one orbital
+        // period, starting this many periods from now.
+        readonly int orbitsAhead;
 
-        internal ClosestApproach (Orbit orbit, Orbit target, double beginTime)
+        internal ClosestApproach (Orbit orbit, Orbit target, int orbitsAhead)
         {
             if (ReferenceEquals (orbit, null))
                 throw new ArgumentNullException (nameof (orbit));
@@ -32,18 +34,24 @@ namespace KRPC.SpaceCenter.Services
                 throw new ArgumentNullException (nameof (target));
             this.orbit = orbit;
             this.target = target;
-            ut = Orbit.CalcClosestAproach (orbit, target, beginTime, out distance);
+            this.orbitsAhead = orbitsAhead;
         }
 
         /// <summary>
         /// Returns true if the objects are equal.
         /// </summary>
+        /// <remarks>
+        /// What the object stands for is which approach between the two orbits it is,
+        /// so asking for the same one again gives back the same object. The estimated
+        /// time of the approach is not part of that: it is read from the orbits and
+        /// moves as they do.
+        /// </remarks>
         public override bool Equals (ClosestApproach other)
         {
             return !ReferenceEquals (other, null) &&
                    orbit.Equals (other.orbit) &&
                    target.Equals (other.target) &&
-                   ut == other.ut;
+                   orbitsAhead == other.orbitsAhead;
         }
 
         /// <summary>
@@ -51,20 +59,46 @@ namespace KRPC.SpaceCenter.Services
         /// </summary>
         public override int GetHashCode ()
         {
-            return Hash.Of (orbit).And (target).And (ut);
+            return Hash.Of (orbit).And (target).And (orbitsAhead);
         }
 
         /// <summary>
-        /// What the game holds for the approach. It describes the two orbits at a moment,
-        /// and every member reads both of them, so it needs both: it is as live, dormant or
-        /// destroyed as the less alive of the two.
+        /// What the game holds for the approach. Every member reads both of the orbits,
+        /// so it needs both: it is as live, dormant or destroyed as the less alive of
+        /// the two.
         /// </summary>
         public GameObjectState GameObjectState {
             get { return orbit.GameObjectState.LeastAlive (target.GameObjectState); }
         }
 
+        // The time the search for this approach starts from, which it covers one
+        // orbital period of the approaching object from. The next approach is searched
+        // for from now, and needs no period to step by; a hyperbolic orbit, which has
+        // none, therefore still has a next approach.
+        double BeginTime {
+            get {
+                if (orbitsAhead == 0)
+                    return SpaceCenter.UT;
+                return SpaceCenter.UT + orbitsAhead * orbit.InternalOrbit.period;
+            }
+        }
+
+        // The universal time of the closest approach, and the distance there, estimated
+        // from where the two orbits are now. Members that need both take them from one
+        // call, so that they describe the same moment.
+        double Solve (out double approachDistance)
+        {
+            return Orbit.CalcClosestAproach (orbit, target, BeginTime, out approachDistance);
+        }
+
+        double Solve ()
+        {
+            double approachDistance;
+            return Solve (out approachDistance);
+        }
+
         // The world-space position of the given orbit at the closest approach.
-        Vector3d WorldPosition (Orbit o)
+        Vector3d WorldPosition (Orbit o, double ut)
         {
             return o.InternalOrbit.getPositionAtUT (ut);
         }
@@ -76,7 +110,7 @@ namespace KRPC.SpaceCenter.Services
         // reference frame moves at, which is also the body's current one. Both objects
         // are treated the same way, so the relative quantities remain the difference of
         // the absolute ones.
-        Vector3d WorldVelocity (Orbit o)
+        Vector3d WorldVelocity (Orbit o, double ut)
         {
             var internalOrbit = o.InternalOrbit;
             return internalOrbit.getOrbitalVelocityAtUT (ut).SwapYZ () +
@@ -93,7 +127,7 @@ namespace KRPC.SpaceCenter.Services
         /// </summary>
         [KRPCProperty]
         public double UT {
-            get { return ut; }
+            get { return Solve (); }
         }
 
         /// <summary>
@@ -101,7 +135,7 @@ namespace KRPC.SpaceCenter.Services
         /// </summary>
         [KRPCProperty]
         public double TimeTo {
-            get { return ut - SpaceCenter.UT; }
+            get { return Solve () - SpaceCenter.UT; }
         }
 
         /// <summary>
@@ -109,7 +143,11 @@ namespace KRPC.SpaceCenter.Services
         /// </summary>
         [KRPCProperty]
         public double Distance {
-            get { return distance; }
+            get {
+                double approachDistance;
+                Solve (out approachDistance);
+                return approachDistance;
+            }
         }
 
         /// <summary>
@@ -119,7 +157,10 @@ namespace KRPC.SpaceCenter.Services
         /// </summary>
         [KRPCProperty]
         public double RelativeSpeed {
-            get { return (WorldVelocity (target) - WorldVelocity (orbit)).magnitude; }
+            get {
+                var ut = Solve ();
+                return (WorldVelocity (target, ut) - WorldVelocity (orbit, ut)).magnitude;
+            }
         }
 
         /// <summary>
@@ -167,7 +208,7 @@ namespace KRPC.SpaceCenter.Services
         public Tuple3 Position (ReferenceFrame referenceFrame = null)
         {
             referenceFrame = DefaultedFrame (referenceFrame);
-            return referenceFrame.PositionFromWorldSpace (WorldPosition (orbit)).ToTuple ();
+            return referenceFrame.PositionFromWorldSpace (WorldPosition (orbit, Solve ())).ToTuple ();
         }
 
         /// <summary>
@@ -181,7 +222,7 @@ namespace KRPC.SpaceCenter.Services
         public Tuple3 TargetPosition (ReferenceFrame referenceFrame = null)
         {
             referenceFrame = DefaultedFrame (referenceFrame);
-            return referenceFrame.PositionFromWorldSpace (WorldPosition (target)).ToTuple ();
+            return referenceFrame.PositionFromWorldSpace (WorldPosition (target, Solve ())).ToTuple ();
         }
 
         /// <summary>
@@ -195,7 +236,9 @@ namespace KRPC.SpaceCenter.Services
         public Tuple3 Velocity (ReferenceFrame referenceFrame = null)
         {
             referenceFrame = DefaultedFrame (referenceFrame);
-            return referenceFrame.VelocityFromWorldSpace (WorldPosition (orbit), WorldVelocity (orbit)).ToTuple ();
+            var ut = Solve ();
+            return referenceFrame.VelocityFromWorldSpace (
+                WorldPosition (orbit, ut), WorldVelocity (orbit, ut)).ToTuple ();
         }
 
         /// <summary>
@@ -209,7 +252,9 @@ namespace KRPC.SpaceCenter.Services
         public Tuple3 TargetVelocity (ReferenceFrame referenceFrame = null)
         {
             referenceFrame = DefaultedFrame (referenceFrame);
-            return referenceFrame.VelocityFromWorldSpace (WorldPosition (target), WorldVelocity (target)).ToTuple ();
+            var ut = Solve ();
+            return referenceFrame.VelocityFromWorldSpace (
+                WorldPosition (target, ut), WorldVelocity (target, ut)).ToTuple ();
         }
 
         /// <summary>
@@ -224,7 +269,9 @@ namespace KRPC.SpaceCenter.Services
         public Tuple3 RelativePosition (ReferenceFrame referenceFrame = null)
         {
             referenceFrame = DefaultedFrame (referenceFrame);
-            return referenceFrame.DirectionFromWorldSpace (WorldPosition (target) - WorldPosition (orbit)).ToTuple ();
+            var ut = Solve ();
+            return referenceFrame.DirectionFromWorldSpace (
+                WorldPosition (target, ut) - WorldPosition (orbit, ut)).ToTuple ();
         }
 
         /// <summary>
@@ -239,7 +286,9 @@ namespace KRPC.SpaceCenter.Services
         public Tuple3 RelativeVelocity (ReferenceFrame referenceFrame = null)
         {
             referenceFrame = DefaultedFrame (referenceFrame);
-            return referenceFrame.DirectionFromWorldSpace (WorldVelocity (target) - WorldVelocity (orbit)).ToTuple ();
+            var ut = Solve ();
+            return referenceFrame.DirectionFromWorldSpace (
+                WorldVelocity (target, ut) - WorldVelocity (orbit, ut)).ToTuple ();
         }
     }
 }

--- a/service/SpaceCenter/src/Services/ClosestApproach.cs
+++ b/service/SpaceCenter/src/Services/ClosestApproach.cs
@@ -19,6 +19,11 @@ namespace KRPC.SpaceCenter.Services
     /// members read at different moments can differ a little; members read in one
     /// physics tick all describe the same estimate. Relative quantities are the target
     /// relative to the orbiting object (target minus self).
+    ///
+    /// The search runs forward over one orbital period from the current time. Once an
+    /// approach has passed and the two orbits are moving apart, the closest point in
+    /// that period is the current one, so the object reports the approach as now, at
+    /// the present separation, until the orbits bring another one within range.
     /// </remarks>
     [KRPCClass (Service = "SpaceCenter")]
     public class ClosestApproach : Equatable<ClosestApproach>, IGameObjectState

--- a/service/SpaceCenter/src/Services/Flight.cs
+++ b/service/SpaceCenter/src/Services/Flight.cs
@@ -34,10 +34,16 @@ namespace KRPC.SpaceCenter.Services
         }
 
         /// <summary>
-        /// What the game holds for the vessel this belongs to.
+        /// What the game holds for the vessel this belongs to and the frame it is
+        /// measured in. Every member reads both, so it is as alive as the less alive of
+        /// them: a flight measured in a frame the client has removed has nothing left to
+        /// be expressed against.
         /// </summary>
         public GameObjectState GameObjectState {
-            get { return FlightGlobalsExtensions.VesselState (vesselId); }
+            get {
+                return FlightGlobalsExtensions.VesselState (vesselId)
+                    .LeastAlive (referenceFrame.GameObjectState);
+            }
         }
 
         /// <summary>

--- a/service/SpaceCenter/src/Services/Orbit.cs
+++ b/service/SpaceCenter/src/Services/Orbit.cs
@@ -4,6 +4,7 @@ using System.Runtime.CompilerServices;
 using KRPC.Service.Attributes;
 using KRPC.SpaceCenter.ExtensionMethods;
 using KRPC.Utils;
+using ObjectDestroyedException = KRPC.Service.KRPC.ObjectDestroyedException;
 using Tuple3 = System.Tuple<double, double, double>;
 
 namespace KRPC.SpaceCenter.Services
@@ -25,9 +26,12 @@ namespace KRPC.SpaceCenter.Services
         // game builds a new one whenever it builds the owner, and the object has to read
         // the loaded game rather than the state it was made in.
         readonly global::Orbit patch;
-        // Whether the client that constructed the orbit has gone. A constructed orbit is
-        // as valid on the last frame of the session as on the first, so it stands for
-        // nothing the game can destroy, and its client going is the only thing that can
+        // Whether a client asked for the orbit to be built, rather than it being the
+        // orbit of something in the game or a patch of one.
+        bool constructed;
+        // Whether the orbit has been let go of. A constructed orbit is as valid on the
+        // last frame of the session as on the first, so it stands for nothing the game
+        // can destroy, and the client removing it or going is the only thing that can
         // say the object is finished with.
         bool released;
 
@@ -78,7 +82,7 @@ namespace KRPC.SpaceCenter.Services
         /// <summary>
         /// What the game holds for the thing the orbit belongs to. An orbit built from a KSP
         /// orbit alone has no owner to ask, so it is kept, and an orbit constructed for a
-        /// client is kept until that client goes.
+        /// client is kept until it is removed or that client goes.
         /// </summary>
         public GameObjectState GameObjectState {
             get {
@@ -99,6 +103,45 @@ namespace KRPC.SpaceCenter.Services
         internal void Release ()
         {
             released = true;
+        }
+
+        /// <summary>
+        /// Remove the orbit, releasing the memory the server holds for it.
+        /// </summary>
+        /// <remarks>
+        /// Only an orbit created by <see cref="CreateFromPositionAndVelocity"/> or
+        /// <see cref="CreateFromOrbitalElements"/> can be removed. Every other orbit is
+        /// the orbit of something in the game, which is what says when it is finished
+        /// with, and the server holds one of each however often it is asked for.
+        ///
+        /// Any further use of this object throws an exception, as does use of a
+        /// reference frame defined against it. An orbit is removed for the client that
+        /// created it and is not shared with any other, and one whose client disconnects
+        /// is removed with it.
+        /// </remarks>
+        [KRPCMethod]
+        public void Remove ()
+        {
+            CheckExists ();
+            if (!constructed)
+                throw new InvalidOperationException (
+                    "Only an orbit created by CreateFromPositionAndVelocity or " +
+                    "CreateFromOrbitalElements can be removed");
+            // The addon holds the orbit on its client's behalf and has nothing left to
+            // do for one the client has finished with. Taking it out is also what asks
+            // for the sweep that drops it from the object store.
+            ConstructedOrbitsAddon.Remove (this);
+            released = true;
+        }
+
+        /// <summary>
+        /// Raise if the orbit has been removed.
+        /// </summary>
+        void CheckExists ()
+        {
+            if (released)
+                throw new ObjectDestroyedException (
+                    "The orbit no longer exists, as it has been removed.");
         }
 
         /// <summary>
@@ -140,6 +183,7 @@ namespace KRPC.SpaceCenter.Services
         /// </summary>
         public global::Orbit InternalOrbit {
             get {
+                CheckExists ();
                 if (!ReferenceEquals (patch, null))
                     return patch;
                 if (ownerVessel != null)
@@ -178,7 +222,7 @@ namespace KRPC.SpaceCenter.Services
         /// </remarks>
         [KRPCProperty]
         public ReferenceFrame ReferenceFrame {
-            get { return ReferenceFrame.NonRotating (this); }
+            get { CheckExists (); return ReferenceFrame.NonRotating (this); }
         }
 
         /// <summary>
@@ -204,7 +248,7 @@ namespace KRPC.SpaceCenter.Services
         /// </remarks>
         [KRPCProperty]
         public ReferenceFrame OrbitalReferenceFrame {
-            get { return ReferenceFrame.Orbital (this); }
+            get { CheckExists (); return ReferenceFrame.Orbital (this); }
         }
 
         // The reference frame used by the closest-approach members when the caller
@@ -470,9 +514,10 @@ namespace KRPC.SpaceCenter.Services
         /// <see cref="ReferenceFrame"/> and <see cref="OrbitalReferenceFrame"/> follow
         /// the orbit as time passes.
         ///
-        /// The orbit that is returned is kept for as long as the server is running,
-        /// so creating one repeatedly, for example once per update, uses more and more
-        /// memory.
+        /// The orbit that is returned is kept until <see cref="Remove"/> is called on
+        /// it or the client that created it disconnects, so a script that creates one
+        /// repeatedly, for example once per update, should remove each one when it is
+        /// finished with it.
         /// </remarks>
         [KRPCMethod]
         public static Orbit CreateFromPositionAndVelocity (
@@ -559,9 +604,10 @@ namespace KRPC.SpaceCenter.Services
         /// <see cref="ReferenceFrame"/> and <see cref="OrbitalReferenceFrame"/> follow
         /// the orbit as time passes.
         ///
-        /// The orbit that is returned is kept for as long as the server is running,
-        /// so creating one repeatedly, for example once per update, uses more and more
-        /// memory.
+        /// The orbit that is returned is kept until <see cref="Remove"/> is called on
+        /// it or the client that created it disconnects, so a script that creates one
+        /// repeatedly, for example once per update, should remove each one when it is
+        /// finished with it.
         /// </remarks>
         [KRPCMethod]
         public static Orbit CreateFromOrbitalElements (
@@ -621,6 +667,7 @@ namespace KRPC.SpaceCenter.Services
         static Orbit Constructed (global::Orbit orbit)
         {
             var result = new Orbit (orbit);
+            result.constructed = true;
             ConstructedOrbitsAddon.Add (result);
             return result;
         }

--- a/service/SpaceCenter/src/Services/Orbit.cs
+++ b/service/SpaceCenter/src/Services/Orbit.cs
@@ -865,7 +865,8 @@ namespace KRPC.SpaceCenter.Services
         [KRPCMethod]
         public ClosestApproach NextClosestApproach (Orbit target)
         {
-            return new ClosestApproach (this, target, Planetarium.GetUniversalTime ());
+            CheckExists ();
+            return new ClosestApproach (this, target, 0);
         }
 
         /// <summary>
@@ -877,13 +878,10 @@ namespace KRPC.SpaceCenter.Services
         [KRPCMethod]
         public IList<ClosestApproach> ClosestApproaches (Orbit target, int orbits)
         {
+            CheckExists ();
             var approaches = new List<ClosestApproach> ();
-            double orbitstart = Planetarium.GetUniversalTime ();
-            double period = InternalOrbit.period;
-            for (int i = 0; i < orbits; i++) {
-                approaches.Add (new ClosestApproach (this, target, orbitstart));
-                orbitstart += period;
-            }
+            for (int i = 0; i < orbits; i++)
+                approaches.Add (new ClosestApproach (this, target, i));
             return approaches;
         }
 

--- a/service/SpaceCenter/src/Services/ReferenceFrame.cs
+++ b/service/SpaceCenter/src/Services/ReferenceFrame.cs
@@ -5,6 +5,7 @@ using KRPC.SpaceCenter.ExtensionMethods;
 using KRPC.SpaceCenter.Services.Parts;
 using KRPC.Utils;
 using UnityEngine;
+using ObjectDestroyedException = KRPC.Service.KRPC.ObjectDestroyedException;
 using Tuple3 = System.Tuple<double, double, double>;
 using Tuple4 = System.Tuple<double, double, double, double>;
 
@@ -21,8 +22,8 @@ namespace KRPC.SpaceCenter.Services
     /// </list>
     /// </summary>
     /// <remarks>
-    /// This class does not contain any properties or methods. It is only
-    /// used as a parameter to other functions.
+    /// Apart from being created and removed, a reference frame is only used as a
+    /// parameter to other functions.
     /// </remarks>
     [KRPCClass (Service = "SpaceCenter")]
     public class ReferenceFrame : Equatable<ReferenceFrame>, IGameObjectState
@@ -51,6 +52,10 @@ namespace KRPC.SpaceCenter.Services
         readonly ReferenceFrame hybridRotation;
         readonly ReferenceFrame hybridVelocity;
         readonly ReferenceFrame hybridAngularVelocity;
+        // Whether the client has let go of the frame. A frame a client creates stands
+        // for nothing in the game, so nothing the game destroys ever retires one and the
+        // client removing it or disconnecting is the only thing that can.
+        bool removed;
 
         ReferenceFrame (
             ReferenceFrameType type, global::CelestialBody body = null, global::Vessel vessel = null,
@@ -82,6 +87,10 @@ namespace KRPC.SpaceCenter.Services
 
         ReferenceFrame (ReferenceFrame parent, Vector3d relativePosition, QuaternionD relativeRotation, Vector3d relativeVelocity, Vector3d relativeAngularVelocity)
         {
+            // The frame is defined against its parent and has no meaning without one,
+            // so this is caught here rather than left to the first member that reads it.
+            if (ReferenceEquals (parent, null))
+                throw new ArgumentNullException (nameof (parent));
             type = ReferenceFrameType.Relative;
             this.parent = parent;
             this.relativePosition = relativePosition;
@@ -95,8 +104,11 @@ namespace KRPC.SpaceCenter.Services
         /// </summary>
         public override bool Equals (ReferenceFrame other)
         {
+            if (ReferenceEquals (other, null))
+                return false;
+            if (Created || other.Created)
+                return ReferenceEquals (this, other);
             return
-            !ReferenceEquals (other, null) &&
             type == other.type &&
             body == other.body &&
             vesselId == other.vesselId &&
@@ -105,17 +117,7 @@ namespace KRPC.SpaceCenter.Services
             dockingPortRef == other.dockingPortRef &&
             thruster == other.thruster &&
             orbit == other.orbit &&
-            parent == other.parent &&
-            (type != ReferenceFrameType.Relative ||
-            (relativePosition == other.relativePosition &&
-            relativeRotation == other.relativeRotation &&
-            relativeVelocity == other.relativeVelocity &&
-            relativeAngularVelocity == other.relativeAngularVelocity)) &&
-            (type != ReferenceFrameType.Hybrid ||
-            (hybridPosition == other.hybridPosition &&
-            hybridRotation == other.hybridRotation &&
-            hybridVelocity == other.hybridVelocity &&
-            hybridAngularVelocity == other.hybridAngularVelocity));
+            parent == other.parent;
         }
 
         /// <summary>
@@ -123,7 +125,9 @@ namespace KRPC.SpaceCenter.Services
         /// </summary>
         public override int GetHashCode ()
         {
-            var hash = Hash.Of (type)
+            if (Created)
+                return RuntimeHelpers.GetHashCode (this);
+            return Hash.Of (type)
                 .And (bodyName)
                 .And (vesselId)
                 .And (node == null ? 0 : RuntimeHelpers.GetHashCode (node))
@@ -132,19 +136,18 @@ namespace KRPC.SpaceCenter.Services
                 .And (thruster)
                 .And (orbit)
                 .And (parent);
-            if (type == ReferenceFrameType.Relative)
-                hash = hash
-                    .And (relativePosition)
-                    .And (relativeRotation)
-                    .And (relativeVelocity)
-                    .And (relativeAngularVelocity);
-            if (type == ReferenceFrameType.Hybrid)
-                hash = hash
-                    .And (hybridPosition)
-                    .And (hybridRotation)
-                    .And (hybridVelocity)
-                    .And (hybridAngularVelocity);
-            return hash;
+        }
+
+        // Whether a client asked for the frame to be built, rather than it being named by
+        // something in the game. Such a frame is a distinct thing each time it is created,
+        // so it keeps the identity of the object itself: it is the client's to remove, and
+        // removing it must neither take away a frame another client built from the same
+        // values nor leave the next creation from those values handing back the one that
+        // has gone.
+        bool Created {
+            get {
+                return type == ReferenceFrameType.Relative || type == ReferenceFrameType.Hybrid;
+            }
         }
 
         /// <summary>
@@ -279,10 +282,13 @@ namespace KRPC.SpaceCenter.Services
         /// What the game holds for everything the frame is built from. A frame needs each
         /// of the vessel, part, maneuver node, thruster, orbit and other frames it is
         /// defined against, so it is as alive as the least alive of them; one defined
-        /// against a celestial body alone never dies.
+        /// against a celestial body alone never dies. A frame the client has removed is
+        /// gone whatever it was built from, and so is anything built on it.
         /// </summary>
         public GameObjectState GameObjectState {
             get {
+                if (removed)
+                    return GameObjectState.Destroyed;
                 var state = GameObjectState.Live;
                 if (vesselId != Guid.Empty)
                     state = node == null
@@ -462,6 +468,12 @@ namespace KRPC.SpaceCenter.Services
         /// as a vector. This vector points in the direction of the axis of rotation,
         /// and its magnitude is the speed of the rotation in radians per second.
         /// Defaults to <math>(0, 0, 0)</math>.</param>
+        /// <remarks>
+        /// Each call returns a new frame, which is kept until <see cref="Remove"/> is
+        /// called on it or the client that created it disconnects, so a script that
+        /// creates one repeatedly, for example once per update, should remove each one
+        /// when it is finished with it.
+        /// </remarks>
         [KRPCMethod]
         public static ReferenceFrame CreateRelative (
             ReferenceFrame referenceFrame,
@@ -470,7 +482,11 @@ namespace KRPC.SpaceCenter.Services
             [KRPCDefaultValue(typeof(VectorZero))] Tuple3 velocity,
             [KRPCDefaultValue(typeof(VectorZero))] Tuple3 angularVelocity)
         {
-            return new ReferenceFrame (referenceFrame, position.ToVector (), rotation.ToQuaternion (), velocity.ToVector (), angularVelocity.ToVector ());
+            var frame = new ReferenceFrame (
+                referenceFrame, position.ToVector (), rotation.ToQuaternion (),
+                velocity.ToVector (), angularVelocity.ToVector ());
+            CreatedReferenceFramesAddon.Add (frame);
+            return frame;
         }
 
         /// <summary>
@@ -487,17 +503,91 @@ namespace KRPC.SpaceCenter.Services
         /// The <paramref name="position"/> reference frame is required but all other
         /// reference frames are optional. If omitted, they are set to the
         /// <paramref name="position"/> reference frame.
+        ///
+        /// Each call returns a new frame, which is kept until <see cref="Remove"/> is
+        /// called on it or the client that created it disconnects, so a script that
+        /// creates one repeatedly, for example once per update, should remove each one
+        /// when it is finished with it.
         /// </remarks>
         [KRPCMethod]
         public static ReferenceFrame CreateHybrid (ReferenceFrame position, ReferenceFrame rotation = null, ReferenceFrame velocity = null, ReferenceFrame angularVelocity = null)
         {
-            if (rotation == null)
-                rotation = position;
-            if (velocity == null)
-                velocity = position;
-            if (angularVelocity == null)
-                angularVelocity = position;
-            return new ReferenceFrame (ReferenceFrameType.Hybrid, hybridPosition: position, hybridRotation: rotation, hybridVelocity: velocity, hybridAngularVelocity: angularVelocity);
+            var frame = Hybrid (position, rotation, velocity, angularVelocity);
+            CreatedReferenceFramesAddon.Add (frame);
+            return frame;
+        }
+
+        /// <summary>
+        /// Build a hybrid reference frame for the server's own use, rather than for a
+        /// client that will remove it. The frame is as alive as the frames it is built
+        /// from, and is held by whatever is built on it rather than by any client.
+        /// </summary>
+        /// <remarks>
+        /// A component that is not given is taken from the position frame. Every one of
+        /// the four has to be a frame: the object is defined against all of them and
+        /// answers for the state of all of them, so a missing one would leave it unable
+        /// to say what it is worth without dereferencing nothing.
+        /// </remarks>
+        public static ReferenceFrame Hybrid (
+            ReferenceFrame position, ReferenceFrame rotation = null,
+            ReferenceFrame velocity = null, ReferenceFrame angularVelocity = null)
+        {
+            if (ReferenceEquals (position, null))
+                throw new ArgumentNullException (nameof (position));
+            return new ReferenceFrame (
+                ReferenceFrameType.Hybrid,
+                hybridPosition: position,
+                hybridRotation: rotation ?? position,
+                hybridVelocity: velocity ?? position,
+                hybridAngularVelocity: angularVelocity ?? position);
+        }
+
+        /// <summary>
+        /// Remove the reference frame, releasing the memory the server holds for it.
+        /// </summary>
+        /// <remarks>
+        /// Only a frame created by <see cref="CreateRelative"/> or
+        /// <see cref="CreateHybrid"/> can be removed. Every other frame is named by
+        /// something in the game, which is what says when it is finished with, and the
+        /// server holds one of each however often it is asked for.
+        ///
+        /// Any further use of this object throws an exception, as does use of a frame
+        /// built on it, which cannot be evaluated without it. A frame is removed for the
+        /// client that created it and is not shared with any other, and one whose client
+        /// disconnects is removed with it.
+        /// </remarks>
+        [KRPCMethod]
+        public void Remove ()
+        {
+            CheckExists ();
+            if (!Created)
+                throw new InvalidOperationException (
+                    "Only a reference frame created by CreateRelative or CreateHybrid " +
+                    "can be removed");
+            // The addon holds the frame on its client's behalf and has nothing left to do
+            // for one the client has finished with. Taking it out is also what asks for
+            // the sweep that drops it from the object store.
+            CreatedReferenceFramesAddon.Remove (this);
+            removed = true;
+        }
+
+        /// <summary>
+        /// Let go of a frame created for a client that has gone, so that it and anything
+        /// built on it leave the object store at the next sweep.
+        /// </summary>
+        internal void Release ()
+        {
+            removed = true;
+        }
+
+        /// <summary>
+        /// Raise if the frame has been removed.
+        /// </summary>
+        void CheckExists ()
+        {
+            if (removed)
+                throw new ObjectDestroyedException (
+                    "The reference frame no longer exists, as it has been removed.");
         }
 
         /// <summary>
@@ -505,6 +595,7 @@ namespace KRPC.SpaceCenter.Services
         /// </summary>
         public Vector3d Position {
             get {
+                CheckExists ();
                 switch (type) {
                 case ReferenceFrameType.CelestialBody:
                 case ReferenceFrameType.CelestialBodyNonRotating:
@@ -561,6 +652,7 @@ namespace KRPC.SpaceCenter.Services
         /// </summary>
         public QuaternionD Rotation {
             get {
+                CheckExists ();
                 // For transform-backed frames use the Unity quaternion directly.
                 // Unity derives transform.up/forward from the quaternion, so
                 // q.Inverse * up == (0,1,0) to near double precision, avoiding
@@ -783,6 +875,7 @@ namespace KRPC.SpaceCenter.Services
         /// </summary>
         public Vector3d Velocity {
             get {
+                CheckExists ();
                 switch (type) {
                 case ReferenceFrameType.CelestialBody:
                 case ReferenceFrameType.CelestialBodyNonRotating:
@@ -840,6 +933,7 @@ namespace KRPC.SpaceCenter.Services
         /// </summary>
         public Vector3d AngularVelocity {
             get {
+                CheckExists ();
                 switch (type) {
                 case ReferenceFrameType.CelestialBody:
                     return body.angularVelocity;

--- a/service/SpaceCenter/src/Services/ResourceTransfer.cs
+++ b/service/SpaceCenter/src/Services/ResourceTransfer.cs
@@ -1,6 +1,8 @@
 using System;
+using KRPC.Service;
 using KRPC.Service.Attributes;
 using KRPC.Utils;
+using ObjectDestroyedException = KRPC.Service.KRPC.ObjectDestroyedException;
 
 namespace KRPC.SpaceCenter.Services
 {
@@ -14,14 +16,25 @@ namespace KRPC.SpaceCenter.Services
         // craft, so unlike the parts it is not something the game tears down.
         readonly PartResourceDefinition internalResource;
         readonly float transferRate;
+        // The game state the transfer was started in. A transfer is let go of when the
+        // flight it runs in is left as much as when its client removes it, and the two
+        // look the same to the object, so the state having moved on is what tells them
+        // apart when there is a client left to say it to.
+        readonly uint generation = GameState.Generation;
+        // Whether the client has removed the transfer. A finished transfer moves nothing
+        // and goes on standing for a pair of parts the game may keep for hours, so the
+        // client saying it is done with it is the only thing that can retire the object.
+        bool removed;
+        bool complete;
+        float amount;
 
-        ResourceTransfer (Part fromPart, Part toPart, PartResourceDefinition resource, float amount)
+        ResourceTransfer (Part fromPart, Part toPart, PartResourceDefinition resource, float maxAmount)
         {
             internalResource = resource;
             FromPart = new Parts.Part (fromPart);
             ToPart = new Parts.Part (toPart);
             Resource = resource.name;
-            TotalAmount = amount;
+            TotalAmount = maxAmount;
             // Compute the transfer rate (in units/sec) as one tenth the size of the destination tank (determined experimentally from the KSP transfer UI)
             var totalStorage = (float)toPart.Resources.Get (resource.id).maxAmount;
             transferRate = 0.1f * totalStorage;
@@ -30,10 +43,28 @@ namespace KRPC.SpaceCenter.Services
 
         /// <summary>
         /// What the game holds for the transfer, which needs both of the parts it runs
-        /// between and so is as alive as the less alive of them.
+        /// between and so is as alive as the less alive of them. A transfer the client
+        /// has removed is gone whatever the parts are doing.
         /// </summary>
         public GameObjectState GameObjectState {
-            get { return FromPart.GameObjectState.LeastAlive (ToPart.GameObjectState); }
+            get {
+                if (removed)
+                    return GameObjectState.Destroyed;
+                return FromPart.GameObjectState.LeastAlive (ToPart.GameObjectState);
+            }
+        }
+
+        /// <summary>
+        /// Raise if the transfer has been let go of.
+        /// </summary>
+        void CheckExists ()
+        {
+            if (!removed)
+                return;
+            throw new ObjectDestroyedException (
+                generation == GameState.Generation
+                ? "The resource transfer no longer exists, as it has been removed."
+                : "The resource transfer no longer exists, as the flight it ran in was left.");
         }
 
         /// <summary>
@@ -49,9 +80,11 @@ namespace KRPC.SpaceCenter.Services
         /// <param name="resource">The name of the resource to transfer.</param>
         /// <param name="maxAmount">The maximum amount of resource to transfer.</param>
         /// <remarks>
-        /// Use <see cref="Cancel"/> to stop the transfer before it finishes. The transfer is
-        /// also canceled if the client that started it disconnects. A canceled transfer is
-        /// marked as complete.
+        /// Use <see cref="Cancel"/> to stop the transfer before it finishes; a canceled
+        /// transfer is marked as complete. Use <see cref="Remove"/> to release the memory
+        /// the server holds for a transfer that is done with. A transfer is stopped and
+        /// removed if the client that started it disconnects, or if the flight it runs in
+        /// is left.
         /// </remarks>
         [KRPCMethod]
         public static ResourceTransfer Start (Parts.Part fromPart, Parts.Part toPart, string resource, float maxAmount)
@@ -99,12 +132,13 @@ namespace KRPC.SpaceCenter.Services
         public float TotalAmount { get; private set; }
 
         /// <summary>
-        /// Whether the transfer has completed. Also becomes true if the transfer is canceled,
-        /// either by calling <see cref="Cancel"/> or because the client that started it
-        /// disconnected.
+        /// Whether the transfer has completed. Also becomes true if the transfer is
+        /// canceled by calling <see cref="Cancel"/>.
         /// </summary>
         [KRPCProperty]
-        public bool Complete { get; private set; }
+        public bool Complete {
+            get { CheckExists (); return complete; }
+        }
 
         /// <summary>
         /// Cancel the transfer. No more of the resource is moved and
@@ -113,14 +147,49 @@ namespace KRPC.SpaceCenter.Services
         [KRPCMethod]
         public void Cancel ()
         {
-            Complete = true;
+            CheckExists ();
+            complete = true;
+        }
+
+        /// <summary>
+        /// Remove the transfer, releasing the memory the server holds for it. The
+        /// transfer is canceled if it has not finished.
+        /// </summary>
+        /// <remarks>
+        /// Any further use of this object throws an exception. A transfer that is left is
+        /// held until the parts it runs between are gone, the flight it runs in is left,
+        /// or the client that started it disconnects, whichever comes first; the first of
+        /// those may be the rest of the flight away.
+        /// </remarks>
+        [KRPCMethod]
+        public void Remove ()
+        {
+            CheckExists ();
+            // The addon runs the transfer and has nothing left to do for one the client
+            // is finished with. Taking it out is also what asks for the sweep that drops
+            // it from the object store.
+            ResourceTransferAddon.Remove (this);
+            Release ();
+        }
+
+        /// <summary>
+        /// Stop the transfer and let go of it, so that it leaves the object store at the
+        /// next sweep. Called for a transfer the client that started it has finished
+        /// with, and for one whose client has disconnected.
+        /// </summary>
+        internal void Release ()
+        {
+            complete = true;
+            removed = true;
         }
 
         /// <summary>
         /// The amount of the resource that has been transferred.
         /// </summary>
         [KRPCProperty]
-        public float Amount { get; private set; }
+        public float Amount {
+            get { CheckExists (); return amount; }
+        }
 
         /// <summary>
         /// Update the transfer. Called once per fixed update.
@@ -131,7 +200,7 @@ namespace KRPC.SpaceCenter.Services
         /// </summary>
         internal void Update (float deltaTime)
         {
-            if (Complete)
+            if (complete)
                 return;
             // A transfer runs from the game's fixed update, so it has to decide for itself
             // what to do about a part it can no longer reach rather than raise the error a
@@ -141,7 +210,7 @@ namespace KRPC.SpaceCenter.Services
             var fromState = FromPart.GameObjectState;
             var toState = ToPart.GameObjectState;
             if (fromState == GameObjectState.Destroyed || toState == GameObjectState.Destroyed) {
-                Cancel ();
+                complete = true;
                 return;
             }
             if (fromState != GameObjectState.Live || toState != GameObjectState.Live)
@@ -152,11 +221,11 @@ namespace KRPC.SpaceCenter.Services
             var storage = toPart.Resources.Get (internalResource.id);
             var storageAvailable = (float)(storage.maxAmount - storage.amount);
             var available = Math.Min (resourceAvailable, storageAvailable);
-            var amountToTransfer = Math.Min (available, Math.Min (TotalAmount - Amount, transferRate * deltaTime));
+            var amountToTransfer = Math.Min (available, Math.Min (TotalAmount - amount, transferRate * deltaTime));
             fromPart.TransferResource (internalResource.id, -amountToTransfer);
             toPart.TransferResource (internalResource.id, amountToTransfer);
-            Amount += amountToTransfer;
-            Complete |= amountToTransfer < 0.0001f;
+            amount += amountToTransfer;
+            complete |= amountToTransfer < 0.0001f;
         }
     }
 }

--- a/service/SpaceCenter/test/test_object_lifetime.py
+++ b/service/SpaceCenter/test/test_object_lifetime.py
@@ -290,6 +290,23 @@ class TestObjectLifetime(krpctest.TestCase):
         self.assertRaises(RuntimeError, vessel.orbit.remove)
         self.assertGreater(vessel.orbit.apoapsis, 0)
 
+    def test_a_flight_goes_with_the_frame_it_is_measured_in(self):
+        # A flight reads every quantity in its frame, so a frame the client removes
+        # leaves it with nothing to express anything against.
+        vessel = self.space_center.active_vessel
+        frame = self.space_center.ReferenceFrame.create_relative(
+            vessel.orbital_reference_frame, position=(7, 8, 9)
+        )
+        flight = vessel.flight(frame)
+        self.assertIsNotNone(flight.velocity)
+        before = self.conn.testing_tools.object_store_size
+        frame.remove()
+        self.assertRaises(self.destroyed, getattr, flight, "velocity")
+        self.wait_until(
+            lambda: self.conn.testing_tools.object_store_size <= before - 2,
+            message="the removed frame and the flight were not dropped from the store",
+        )
+
     def test_removing_a_force(self):
         # The command pod, which nothing here destroys: the tests run in name order and
         # the thermometer and the strut have both been destroyed by this point.

--- a/service/SpaceCenter/test/test_object_lifetime.py
+++ b/service/SpaceCenter/test/test_object_lifetime.py
@@ -240,6 +240,33 @@ class TestObjectLifetime(krpctest.TestCase):
         )
         self.assertIsNotNone(self.space_center.active_vessel.position(vessel_frame))
 
+    def test_removing_an_object_another_client_created(self):
+        # A created object belongs to the client that asked for it. Ids come from one
+        # sequence and one store, so a client passed one out of band can reach the
+        # object, but it is not that client's to remove.
+        other = self.connect(use_cached=False)
+        theirs = other.space_center.ReferenceFrame.create_relative(
+            other.space_center.active_vessel.reference_frame, position=(9, 9, 9)
+        )
+        # The same object reached through this connection. Reading the id is what a
+        # client passing one to another out of band amounts to, which is the only way
+        # this comes up; taking the class from this connection is what makes the calls
+        # go out on it rather than on the other.
+        # pylint: disable=protected-access
+        ours = self.space_center.ReferenceFrame(self.conn, theirs._object_id)
+        vessel = self.space_center.active_vessel
+        self.assertIsNotNone(vessel.position(ours))
+
+        # Named as not this client's rather than as gone: the frame is still there, and
+        # every kind of object a client asks the server to build refuses it that way
+        self.assertRaisesRegex(
+            RuntimeError, "not found among those created by this client", ours.remove
+        )
+        # Refusing it leaves the frame working for the client it does belong to
+        self.assertIsNotNone(vessel.position(ours))
+        theirs.remove()
+        other.close()
+
     def test_removing_a_reference_frame_the_client_did_not_create(self):
         # A frame named by something in the game is shared and bounded: the server holds
         # one of each however often it is asked for, so there is nothing to release.

--- a/service/SpaceCenter/test/test_object_lifetime.py
+++ b/service/SpaceCenter/test/test_object_lifetime.py
@@ -144,6 +144,109 @@ class TestObjectLifetime(krpctest.TestCase):
         )
         self.assertRaises(self.destroyed, getattr, force, "force_vector")
 
+    def test_removing_a_created_reference_frame(self):
+        # A frame a client creates stands for nothing in the game, so nothing the game
+        # destroys ever says it is finished with; removing it is the only thing that can.
+        vessel = self.space_center.active_vessel
+        frame = self.space_center.ReferenceFrame.create_relative(
+            vessel.reference_frame, position=(1, 2, 3)
+        )
+        self.assertIsNotNone(vessel.position(frame))
+        before = self.conn.testing_tools.object_store_size
+        frame.remove()
+        self.assertRaises(self.destroyed, vessel.position, frame)
+        self.assertRaises(self.destroyed, frame.remove)
+        self.wait_until(
+            lambda: self.conn.testing_tools.object_store_size < before,
+            message="the removed reference frame was not dropped from the object store",
+        )
+
+    def test_removing_a_reference_frame_another_is_built_on(self):
+        vessel = self.space_center.active_vessel
+        relative = self.space_center.ReferenceFrame.create_relative(
+            vessel.reference_frame, position=(4, 5, 6)
+        )
+        hybrid = self.space_center.ReferenceFrame.create_hybrid(
+            relative, vessel.orbit.body.non_rotating_reference_frame
+        )
+        self.assertIsNotNone(vessel.position(hybrid))
+        before = self.conn.testing_tools.object_store_size
+        relative.remove()
+        # The hybrid frame takes its position from the frame that has gone, so there is
+        # nothing left to evaluate it against and it goes too.
+        self.assertRaises(self.destroyed, vessel.position, hybrid)
+        self.wait_until(
+            lambda: self.conn.testing_tools.object_store_size <= before - 2,
+            message="the removed frames were not dropped from the object store",
+        )
+
+    def test_creating_a_relative_frame_twice_gives_two_objects(self):
+        # A frame a client creates is its own to remove, so each call builds a new one
+        # rather than the store handing back one object for a set of values.
+        vessel = self.space_center.active_vessel
+        first = self.space_center.ReferenceFrame.create_relative(
+            vessel.reference_frame, position=(1, 1, 1)
+        )
+        second = self.space_center.ReferenceFrame.create_relative(
+            vessel.reference_frame, position=(1, 1, 1)
+        )
+        self.assertNotEqual(first, second)
+        first.remove()
+        # Removing one leaves the other alone, and a frame created afterwards from the
+        # same values is a working frame rather than the one that has gone
+        self.assertRaises(self.destroyed, vessel.position, first)
+        self.assertIsNotNone(vessel.position(second))
+        third = self.space_center.ReferenceFrame.create_relative(
+            vessel.reference_frame, position=(1, 1, 1)
+        )
+        self.assertNotEqual(first, third)
+        self.assertIsNotNone(vessel.position(third))
+        second.remove()
+        third.remove()
+
+    def test_creating_a_hybrid_frame_twice_gives_two_objects(self):
+        vessel = self.space_center.active_vessel
+        body_frame = vessel.orbit.body.non_rotating_reference_frame
+        first = self.space_center.ReferenceFrame.create_hybrid(
+            vessel.reference_frame, body_frame
+        )
+        second = self.space_center.ReferenceFrame.create_hybrid(
+            vessel.reference_frame, body_frame
+        )
+        self.assertNotEqual(first, second)
+        first.remove()
+        self.assertRaises(self.destroyed, vessel.position, first)
+        self.assertIsNotNone(vessel.position(second))
+        second.remove()
+
+    def test_the_store_drops_a_created_frame_when_its_client_goes(self):
+        # A frame a client creates stands for nothing in the game, so nothing the game
+        # destroys ever says it is finished with. The client that asked for it going is
+        # the only thing that can, short of removing it.
+        conn = self.connect(use_cached=False)
+        vessel = conn.space_center.active_vessel
+        created = conn.space_center.ReferenceFrame.create_relative(
+            vessel.reference_frame, position=(2, 2, 2)
+        )
+        self.assertIsNotNone(vessel.position(created))
+        # A frame named by something in the game is shared by both connections, and must
+        # not go anywhere when one of them does
+        vessel_frame = self.space_center.active_vessel.reference_frame
+        before = self.conn.testing_tools.object_store_size
+        conn.close()
+        self.wait_until(
+            lambda: self.conn.testing_tools.object_store_size < before,
+            message="the created reference frame was not dropped from the object store",
+        )
+        self.assertIsNotNone(self.space_center.active_vessel.position(vessel_frame))
+
+    def test_removing_a_reference_frame_the_client_did_not_create(self):
+        # A frame named by something in the game is shared and bounded: the server holds
+        # one of each however often it is asked for, so there is nothing to release.
+        vessel = self.space_center.active_vessel
+        self.assertRaises(RuntimeError, vessel.reference_frame.remove)
+        self.assertIsNotNone(vessel.position(vessel.reference_frame))
+
     def test_removing_a_force(self):
         # The command pod, which nothing here destroys: the tests run in name order and
         # the thermometer and the strut have both been destroyed by this point.

--- a/service/SpaceCenter/test/test_object_lifetime.py
+++ b/service/SpaceCenter/test/test_object_lifetime.py
@@ -247,6 +247,49 @@ class TestObjectLifetime(krpctest.TestCase):
         self.assertRaises(RuntimeError, vessel.reference_frame.remove)
         self.assertIsNotNone(vessel.position(vessel.reference_frame))
 
+    def test_removing_a_created_orbit(self):
+        # An orbit a client creates is arithmetic the server holds on its behalf. It
+        # stands for nothing in the game, so removing it is the only thing that says it
+        # is finished with.
+        kerbin = self.space_center.bodies["Kerbin"]
+        orbit = self.space_center.Orbit.create_from_orbital_elements(
+            kerbin, 900000, 0.1, 0, 0, 0, 0, self.space_center.ut
+        )
+        self.assertAlmostEqual(900000, orbit.semi_major_axis, delta=1)
+        before = self.conn.testing_tools.object_store_size
+        orbit.remove()
+        self.assertRaises(self.destroyed, getattr, orbit, "semi_major_axis")
+        self.assertRaises(self.destroyed, orbit.remove)
+        self.wait_until(
+            lambda: self.conn.testing_tools.object_store_size < before,
+            message="the removed orbit was not dropped from the object store",
+        )
+
+    def test_removing_an_orbit_a_reference_frame_is_defined_against(self):
+        kerbin = self.space_center.bodies["Kerbin"]
+        orbit = self.space_center.Orbit.create_from_orbital_elements(
+            kerbin, 1000000, 0, 0, 0, 0, 0, self.space_center.ut
+        )
+        frame = orbit.reference_frame
+        vessel = self.space_center.active_vessel
+        self.assertIsNotNone(vessel.position(frame))
+        before = self.conn.testing_tools.object_store_size
+        orbit.remove()
+        # The frame is centered on the point the orbit has reached, so it has nothing
+        # left to be evaluated against and goes with it.
+        self.assertRaises(self.destroyed, vessel.position, frame)
+        self.wait_until(
+            lambda: self.conn.testing_tools.object_store_size <= before - 2,
+            message="the removed orbit and its frame were not dropped from the store",
+        )
+
+    def test_removing_an_orbit_the_client_did_not_create(self):
+        # The orbit of something in the game is shared and bounded: the server holds one
+        # of each however often it is asked for, so there is nothing to release.
+        vessel = self.space_center.active_vessel
+        self.assertRaises(RuntimeError, vessel.orbit.remove)
+        self.assertGreater(vessel.orbit.apoapsis, 0)
+
     def test_removing_a_force(self):
         # The command pod, which nothing here destroys: the tests run in name order and
         # the thermometer and the strut have both been destroyed by this point.

--- a/service/SpaceCenter/test/test_orbit.py
+++ b/service/SpaceCenter/test/test_orbit.py
@@ -384,6 +384,19 @@ class TestClosestApproach(krpctest.TestCase):
         self.assertAlmostEqual(approaches[0].ut, first.ut, delta=1)
         self.assertAlmostEqual(approaches[0].distance, first.distance, delta=1)
 
+    def test_the_approach_is_solved_again_once_it_has_passed(self):
+        # The object names which approach it is, not when that approach was estimated to
+        # be, so the estimate has to be made again as the orbits move. Warping past the
+        # one it named is what says it was: a solve held from before the warp would still
+        # be naming a moment that is now in the past.
+        approach = self.orbit.next_closest_approach(self.target)
+        passed = approach.ut
+        self.assertGreater(passed, self.sc.ut)
+        self.sc.warp_to(passed + 60)
+        self.assertGreater(approach.ut, passed)
+        # The search runs forward from now, so whatever it lands on is not behind us
+        self.assertGreaterEqual(approach.time_to, 0)
+
 
 class TestCreateFromPositionAndVelocity(krpctest.TestCase):
     """Orbits built from state vectors rather than read off a game object.

--- a/service/SpaceCenter/test/test_orbit.py
+++ b/service/SpaceCenter/test/test_orbit.py
@@ -271,7 +271,8 @@ class TestClosestApproach(krpctest.TestCase):
         cls.set_orbit("Kerbin", 1600000, 0, 0, 0, 0, 0, 0)
         cls.launch_vessel_from_vab("Basic")
         cls.set_orbit("Kerbin", 1650000, 0, 0, 0, 0, 0.15, 0)
-        cls.sc = cls.connect().space_center
+        cls.conn = cls.connect()
+        cls.sc = cls.conn.space_center
         cls.vessel = cls.sc.active_vessel
         cls.other = next(v for v in cls.sc.vessels if v != cls.vessel)
         cls.orbit = cls.vessel.orbit
@@ -355,6 +356,20 @@ class TestClosestApproach(krpctest.TestCase):
                 mu * ((2 / orbit.radius_at(approach.ut)) - (1 / orbit.semi_major_axis))
             )
             self.assertAlmostEqual(expected, speed, delta=1)
+
+    def test_asking_for_the_same_approach_twice(self):
+        # The object names which of the approaches between the two orbits it is, and
+        # reads the time and distance from the orbits as they are now. Asking for the
+        # same one again gives back the same object, rather than filling the object
+        # store with a snapshot per call.
+        first = self.orbit.next_closest_approach(self.target)
+        before = self.conn.testing_tools.object_store_size
+        for _ in range(5):
+            self.wait(0.1)
+            self.assertEqual(first, self.orbit.next_closest_approach(self.target))
+        self.assertEqual(before, self.conn.testing_tools.object_store_size)
+        # The first of the approaches per orbital period is the same one
+        self.assertEqual(first, self.orbit.closest_approaches(self.target, 3)[0])
 
     def test_closest_approaches(self):
         approaches = self.orbit.closest_approaches(self.target, 3)

--- a/service/SpaceCenter/test/test_referenceframe.py
+++ b/service/SpaceCenter/test/test_referenceframe.py
@@ -1316,6 +1316,21 @@ class TestReferenceFrame(krpctest.TestCase):
             (0, 0, 0, 1), self.vessel.rotation(ref), places=6
         )
 
+    def test_hybrid_missing_components_come_from_position(self):
+        # Passing a component explicitly as null is how a client asks for the default,
+        # and it has to give the same frame as leaving the argument out.
+        frames = self.space_center.ReferenceFrame
+        given = frames.create_hybrid(self.vessel.reference_frame, None, None, None)
+        left_out = frames.create_hybrid(self.vessel.reference_frame)
+        self.assertAlmostEqual(
+            self.vessel.direction(left_out), self.vessel.direction(given), places=6
+        )
+        self.assertAlmostEqual(
+            self.vessel.position(left_out), self.vessel.position(given), places=6
+        )
+        given.remove()
+        left_out.remove()
+
     def test_hybrid_position(self):
         ref = self.space_center.ReferenceFrame.create_hybrid(
             position=self.vessel.reference_frame

--- a/service/SpaceCenter/test/test_resource_transfer.py
+++ b/service/SpaceCenter/test/test_resource_transfer.py
@@ -170,6 +170,71 @@ class TestResourceTransferCancel(krpctest.TestCase):
         self.assertAlmostEqual(amount, transfer.amount)
 
 
+class TestResourceTransferRemove(krpctest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.new_save()
+        cls.launch_vessel_from_vab("ResourceTransfer")
+        cls.remove_other_vessels()
+        cls.conn = cls.connect()
+        cls.sc = cls.conn.space_center
+        cls.parts = cls.sc.active_vessel.parts
+        cls.destroyed = cls.conn.krpc.ObjectDestroyedException
+
+    def test_remove(self):
+        from_part = self.parts.with_name("fuelTank")[0]
+        to_part = self.parts.with_name("fuelTankSmallFlat")[0]
+        # Obtained up front, so that the store holds them before its size is read
+        from_resources = from_part.resources
+        to_resources = to_part.resources
+
+        # A transfer that would take several seconds to complete
+        transfer = self.sc.ResourceTransfer.start(
+            from_part, to_part, "Oxidizer", float("inf")
+        )
+        self.wait(0.5)
+        self.assertFalse(transfer.complete)
+        before = self.conn.testing_tools.object_store_size
+
+        transfer.remove()
+        # Removing a transfer stops it and the object is gone, so there is nothing left
+        # to read the amount moved from
+        self.assertRaises(self.destroyed, getattr, transfer, "complete")
+        self.assertRaises(self.destroyed, getattr, transfer, "amount")
+        self.assertRaises(self.destroyed, transfer.cancel)
+        self.assertRaises(self.destroyed, transfer.remove)
+
+        # No more of the resource is moved
+        from_amount = from_resources.amount("Oxidizer")
+        to_amount = to_resources.amount("Oxidizer")
+        self.wait(1)
+        self.assertAlmostEqual(from_amount, from_resources.amount("Oxidizer"), places=2)
+        self.assertAlmostEqual(to_amount, to_resources.amount("Oxidizer"), places=2)
+
+        # A transfer names nothing the game destroys, so the removal is what has to get
+        # the object out of the store
+        self.wait_until(
+            lambda: self.conn.testing_tools.object_store_size < before,
+            message="the removed transfer was not dropped from the object store",
+        )
+
+    def test_remove_when_complete(self):
+        from_part = self.parts.with_name("rcsTankRadialLong")[0]
+        to_part = self.parts.with_name("radialRCSTank")[0]
+        transfer = self.sc.ResourceTransfer.start(
+            from_part, to_part, "MonoPropellant", 5
+        )
+        while not transfer.complete:
+            self.wait()
+        before = self.conn.testing_tools.object_store_size
+        transfer.remove()
+        self.assertRaises(self.destroyed, getattr, transfer, "amount")
+        self.wait_until(
+            lambda: self.conn.testing_tools.object_store_size < before,
+            message="the removed transfer was not dropped from the object store",
+        )
+
+
 class TestResourceTransferDisconnect(krpctest.TestCase):
     @classmethod
     def setUpClass(cls):

--- a/service/UI/CHANGELOG.md
+++ b/service/UI/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [v0.7.0] - unreleased
 
+- **Breaking:** Removing a user interface element another client created, or one the
+  server no longer holds, reports that it is not among those this client created, rather
+  than a bad argument. Every other object a client asks the server to build already
+  refused it that way (#1072)
 - **Breaking:** Colors are given as `(red, green, blue, alpha)` rather than
   `(red, green, blue)`, so that an element can be drawn translucent. Affects `Text.Color`
   and the color of a `UI.Message` (#1040)

--- a/service/UI/src/Addon.cs
+++ b/service/UI/src/Addon.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using KRPC.Service;
 using KRPC.Utils;
@@ -31,10 +30,7 @@ namespace KRPC.UI
 
         internal static void Remove (Object obj)
         {
-            if (!objects.OwnedByCaller (obj))
-                throw new ArgumentException ("UI object not found");
-            obj.Destroy ();
-            objects.Remove (obj);
+            objects.RemoveOwnedByCaller (obj, "UI object", x => x.Destroy ());
         }
 
         internal static void Clear (bool clientOnly)


### PR DESCRIPTION
**Problem.** Five kinds of object exist only because a client asked the server to build one: a reference frame from `ReferenceFrame.CreateRelative` or `CreateHybrid`, an orbit from `Orbit.CreateFromPositionAndVelocity` or `CreateFromOrbitalElements`, a resource transfer, a drawing and a user interface element. Nothing in the game destroys any of them, so nothing ever said when the server was finished with one and it was held until the client disconnected. A `ClosestApproach` was worse: it stood in part for the time it was solved at, so every call built a distinct object and a script polling the approach to a target filled the object store.

**Change.** `ReferenceFrame.Remove`, `Orbit.Remove` and `ResourceTransfer.Remove` say a script is done with one. A created frame is now each client's own rather than one object shared by everyone that asks for the same frame, so one client removing it leaves the other's alone. A close approach is identified by its pair of orbits and which of the successive approaches it is, and reads its time and distance from those orbits as they are now, so asking for the same approach again gives back the same object. A `Flight` retires with the reference frame it is measured in. Removing an object a client did not create is refused in one place for all five, so drawing and interface removal report that rather than a bad argument. Finally, the object store's sweep drops destroyed objects from the collections holding them, so a collection never holds more than the store does.

**Testing.** In-game coverage in `service/SpaceCenter/test/test_object_lifetime.py`, with additions to the orbit, reference frame and resource transfer tests.
