### PR TITLE
Documentation and comment style

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,11 +126,81 @@ General guidance:
    Legitimate unknown words → `doc/src/dictionary.txt`.
  * No "Authored by" / `Co-Authored-By` lines.
 
-## Comments and docs
+### Sentences
 
- * Explain what the code does now and why; must make sense to someone who never saw the old version.
- * **Never reference what a change replaced** — no "replaces X", "instead of the old Y", "previously",
-   "no longer needed", no migration/phase references. That belongs in the commit message and changelog.
+Average 14 words per sentence and under half a comma. Long comma-chained sentences are the main
+way writing here goes wrong.
+
+ * **One idea per sentence, two clauses at most.** A fact and its consequence make a sentence.
+   Never chain with `, so ..., and ...` or `, which ..., so ...`.
+ * **Say what a thing is, not what it is not.** Negate only to correct a misreading the reader is
+   likely to arrive with, and only attached to a positive statement. "rather than", "no longer",
+   "nothing" and "not a" are the tells.
+ * **Name the thing.** No "the thing", "nothing", "whatever", "anything". The subject of a
+   sentence is a definite noun.
+ * **No anthropomorphism.** The game and the server do not say, ask, see, hear or refuse, and are
+   never finished with anything. State the mechanism.
+ * **No setup and payoff, and no editorializing.** A sentence that only frames the next one is cut.
+ * **Paragraphs run one to three sentences**, about 30 words. Past four it is two paragraphs, or a
+   list.
+
+### Documentation
+
+ * **Lead with the example.** The unit of explanation is one or two sentences of setup ending in a
+   colon, then the code, then any explanation of it. A section that explains a feature without
+   showing it is the wrong shape.
+ * Examples live in `doc/src/scripts/` and are pulled in with `.. literalinclude::` inside a
+   `.. tabs::` block, one tab per client language. An inline `.. code-block::` is for a fragment.
+ * **Address the reader**: "you" in the client guides, "we" when walking through a script. Do not
+   write about an abstract "a client" or "a program".
+ * Reuse the stock forms already in the docs.
+ * Headings are short Title Case noun phrases, not clauses with verbs.
+ * `.. note::` in block form with a one or two sentence body for a caveat, `.. seealso::` for a
+   cross-reference. Never hang a paragraph off an inline `.. note::`.
+ * Say what something does. Why it is implemented that way belongs in the code.
+
+### XML documentation comments
+
+These generate the API reference, so they are user-facing prose. Keep them terse. A
+`[KRPCProperty]` or `[KRPCMethod]` gets a sentence. Internal comments are covered under *Code
+comments* below.
+
+ * `<summary>` is one sentence, usually a noun phrase under ten words, with the unit inline.
+ * Openers are "The ...", "Whether ..." and, for a combined getter and setter, "Returns X, and
+   sets Y." Never "What" or "How".
+ * One exception formula, appended last: "Throws an exception if ...".
+ * `<remarks>` is rare, and is a sentence or two carrying a cross-reference or a caveat, never a
+   design rationale.
+ * Keep `<returns>` on methods that return a value, and keep `<param>` to a short noun phrase.
+   `e.g.` and `i.e.` are used in this codebase.
+
+### Code comments
+
+Comments in the source that are not `///` documentation. They carry the constraint the code itself
+cannot.
+
+ * **Size the comment to the code it describes.** A line or two of code gets a fragment naming the
+   step, a method a sentence, a file or a mechanism not recoverable from the code a paragraph. A
+   paragraph over a one-line statement is the usual failure.
+ * **The default form is a label**: a fragment above the lines it covers, sentence case, no
+   trailing period. A long method is often a run of these.
+ * **Comment the surprise**: a game quirk, a workaround, an ordering constraint, a unit, a sign
+   convention. Code that reads plainly gets no comment, and never one that restates the line below.
+ * **State the constraint, do not argue the alternative.** A comment that proves a case, or names
+   what would break, is arguing.
+ * **Never reference what a change replaced.** A comment explains the code as it stands, to someone
+   who never saw the old version. How a value was arrived at belongs in the commit message and the
+   PR, though a measurement that sizes a constant is part of what it means.
+ * **Name the thing, and use "we".** Openers are "The ...", "Whether ..." and a verb, as in the XML
+   comments. Do not nominalize to avoid the first person.
+ * **Write what the code names.** ASCII only, and no symbol that appears nowhere in the source.
+   `--` is an emdash by another spelling. American English, as everywhere else.
+ * **One comment per place.** Do not clone a comment across sibling files with the noun swapped.
+ * `// Note:` prefixes a one-sentence caveat attached to the line below. It is the only marker in
+   use, and an open question is a GitHub issue.
+ * Trailing comments are rare and short, and are not padded into aligned columns. Do not split a
+   comment into paragraphs, or mark up `*emphasis*`.
+ * The **Sentences** rules apply in full. Anthropomorphism is the one comments break most.
 
 ## Commits
 
@@ -168,6 +238,8 @@ Add entries under that header, creating it if needed, only for components actual
 
  * Be concise and high level. Size the entry to the diff. Keep your audience in mind: these are read by
    the end user, not a developer. The PR/issue link provides the detail, not the changelog text.
+ * Verb-first and one clause. An entry over 30 words is nearly always two entries, or one entry
+   plus detail that belongs in the PR. No rationale, and no analogy to what the game does.
  * **Before a branch is pushed, consolidate into a dedicated final commit** (single-commit PRs
    excepted) — every PR touches these files. On an unpushed local branch this is relaxed: you may
    commit changelog entries freely, e.g. alongside the change they describe. Squash them into that

--- a/client/cnano/CHANGELOG.md
+++ b/client/cnano/CHANGELOG.md
@@ -1,34 +1,18 @@
 ## [v0.7.0] - unreleased
-- Support structure types, which a service defines as a compound value with named fields. One
-  is generated as a C struct with a member per field, named for the field it carries (#1066)
-- **Breaking:** Support null for any nullable type; a nullable non-class return adds a `bool*
-  returnValueIsNull` out-parameter and a nullable argument is a pointer (#1017)
-- Add `KRPC_COMMUNICATION_TCP`, which builds the library to communicate with a server over
-  TCP/IP rather than over a serial port, leaving the server on its default protocol. A
-  connection is opened with the address and port the server is listening on, held in a
-  `krpc_connection_config_t`, in place of the name of a port. CMake builds of the library ask
-  for it with `-DKRPC_COMMUNICATION_TCP=ON`, which also links the winsock library it needs on
-  Windows (#1055)
-- Add a `tcp` feature to the vcpkg port, which installs the library built to communicate over
-  TCP/IP; `vcpkg install "krpc-cnano[tcp]"` (#1055)
-- Add `KRPC_COMMUNICATION_LOCALSOCKET`, which builds the library to communicate over a unix
-  domain socket with a server on the same machine, opened with the path of the server's RPC
-  socket in place of a serial port name. CMake builds of the library ask for it with
-  `-DKRPC_COMMUNICATION_LOCALSOCKET=ON`, which also links the winsock library it needs on
-  Windows, and the vcpkg port with the `localsocket` feature;
-  `vcpkg install "krpc-cnano[localsocket]"` (#1065)
-- Add `KRPC_SINGLE_CONNECTION`, for a `KRPC_COMMUNICATION_CUSTOM` communication mechanism that
-  opens a connection of its own to each server. Messages are then sent as they are, rather than
-  wrapped in the multiplexed message a serial port needs to say which of the connections it
-  carries a message belongs to (#1055)
-- Reduce the cost of a remote procedure call. A message is sent and received through a buffer
-  rather than a piece at a time, taking a call from tens of reads and writes down to one write
-  and two reads, and a message is measured as it is encoded rather than by a pass over it
-  first (#1056)
-- Add `KRPC_BUFFER_SIZE`, how much of a message to hold in memory while it is written to or
-  read from the connection. It bounds the memory a call costs and never the size of a message,
-  but a message that fits is cheaper to send, so it is worth setting above the largest call a
-  program makes. Defaults to 1024 bytes, and to 128 on Arduino (#1056)
+- Support structure types, generated as a C struct with a member per field (#1066)
+- **Breaking:** Support null for any nullable type; a nullable non-class return adds a
+  `bool* returnValueIsNull` out-parameter and a nullable argument is a pointer (#1017)
+- Add `KRPC_COMMUNICATION_TCP`, building the library to communicate over TCP/IP. A connection
+  is opened with a `krpc_connection_config_t` in place of a port name (#1055)
+- Add a `tcp` feature to the vcpkg port; `vcpkg install "krpc-cnano[tcp]"` (#1055)
+- Add `KRPC_COMMUNICATION_LOCALSOCKET` and a `localsocket` vcpkg feature, building the library
+  to communicate over a unix domain socket (#1065)
+- Add `KRPC_SINGLE_CONNECTION`, for a `KRPC_COMMUNICATION_CUSTOM` mechanism that opens its own
+  connection to each server (#1055)
+- Reduce the cost of a remote procedure call, from tens of reads and writes to one write and
+  two reads (#1056)
+- Add `KRPC_BUFFER_SIZE`, how much of a message to hold in memory while it is sent or
+  received. Defaults to 1024 bytes, and to 128 on Arduino (#1056)
 
 ## [v0.6.0]
 - Distribute via vcpkg (#874)

--- a/client/cnano/src/encoder.c
+++ b/client/cnano/src/encoder.c
@@ -52,7 +52,7 @@ krpc_error_t krpc_add_argument(krpc_call_t* call, uint32_t position,
   krpc_argument_t* argument = call->arguments + position;
   argument->message.position = position;
   // The arguments array is caller-allocated and may be uninitialized, so is_null is set
-  // explicitly rather than relying on it being zeroed.
+  // explicitly.
   argument->message.is_null = false;
   argument->message.value.funcs.encode = encode;
   argument->message.value.arg = (void*)arg;

--- a/client/cnano/test/arduino/test_communication_arduino.cpp
+++ b/client/cnano/test/arduino/test_communication_arduino.cpp
@@ -14,7 +14,7 @@ TEST(test_communication_arduino, test_read) {
 }
 
 // A read that returns fewer bytes than requested must resume at the point the previous one
-// finished, rather than restarting at the beginning of the buffer.
+// finished, and not restart at the beginning of the buffer.
 TEST(test_communication_arduino, test_read_partial) {
   const size_t chunks[] = {3, 5};
   HardwareSerial serial(data, sizeof(data), chunks, 2);
@@ -25,7 +25,7 @@ TEST(test_communication_arduino, test_read_partial) {
 }
 
 // A read that returns nothing means the serial timeout elapsed without a single byte
-// arriving, which is as close to a disconnect as a serial link gets. It must fail rather than
+// arriving, which is as close to a disconnect as a serial link gets. It must fail, and not
 // retry forever.
 TEST(test_communication_arduino, test_read_timeout) {
   const size_t chunks[] = {2, 0};

--- a/client/cnano/test/server_test.hpp
+++ b/client/cnano/test/server_test.hpp
@@ -32,8 +32,8 @@ inline server_test::~server_test() {
   if (KRPC_OK != krpc_close(conn)) exit(1);
 }
 
-// Where the server the test harness started is listening, in whatever form the transport this
-// build uses opens a connection from.
+// The address the server the test harness started is listening on, in whatever form the
+// transport this build uses opens a connection from.
 #ifdef KRPC_COMMUNICATION_TCP
 inline krpc_connection_config_t server_address() {
   // The port the test harness passes in, or the server's default when the binary is run directly

--- a/client/cnano/test/test_client.cpp
+++ b/client/cnano/test/test_client.cpp
@@ -14,10 +14,10 @@
 
 class test_client : public server_test {};
 
-// The version is three dot separated runs of digits. It is checked by hand
-// rather than against a regular expression because gtest falls back to a syntax
-// of its own where it cannot use POSIX ones, and the two have no spelling of a
-// digit in common: [0-9] is only understood by the former, \d only by the latter.
+// The version is three dot separated runs of digits, checked by hand. gtest falls back to
+// a regular expression syntax of its own where it cannot use POSIX ones, and the two have
+// no spelling of a digit in common: [0-9] is only understood by the former, \d only by the
+// latter.
 static bool is_version(const char* value) {
   int parts = 1;
   int digits = 0;

--- a/client/cnano/test/test_communication_localsocket.cpp
+++ b/client/cnano/test/test_communication_localsocket.cpp
@@ -81,8 +81,8 @@ class EchoServer {
     address.sun_family = AF_UNIX;
     strncpy(address.sun_path, path_.c_str(), sizeof(address.sun_path) - 1);
     listener_ = socket(AF_UNIX, SOCK_STREAM, 0);
-    // Checked here so that a server that never came up says so, rather than leaving the
-    // client to report only that it could not connect to it
+    // Checked here, so that a server that never came up is reported as such and not as a
+    // client that could not connect
     EXPECT_NE(INVALID_SOCKET, listener_);
     EXPECT_EQ(0, bind(listener_, reinterpret_cast<struct sockaddr*>(&address),
                       static_cast<int>(sizeof(address))));
@@ -181,8 +181,8 @@ TEST(test_communication_localsocket, test_open_nonexistent) {
   ASSERT_EQ(KRPC_ERROR_IO, krpc_open(&connection, missing_path().c_str()));
 }
 
-// The path is copied into a fixed size field, so one that does not fit is reported
-// rather than silently truncated to name a different socket
+// The path is copied into a fixed size field, so one that does not fit is reported and not
+// truncated to name a different socket
 TEST(test_communication_localsocket, test_open_path_too_long) {
   krpc_connection_t connection;
   std::string path(512, 'x');

--- a/client/cnano/test/test_communication_posix.cpp
+++ b/client/cnano/test/test_communication_posix.cpp
@@ -12,7 +12,7 @@
 #include <thread>
 
 // A read that returns fewer bytes than requested must resume at the point the previous one
-// finished, rather than restarting at the beginning of the buffer.
+// finished, and not restart at the beginning of the buffer.
 TEST(test_communication, test_read_partial) {
   int fds[2];
   ASSERT_EQ(0, pipe(fds));

--- a/client/cnano/test/test_communication_socket.cpp
+++ b/client/cnano/test/test_communication_socket.cpp
@@ -26,9 +26,8 @@ void count_alarm(int) { alarms++; }
 }  // namespace
 
 // A read that returns fewer bytes than requested must resume at the point the previous one
-// finished, rather than restarting at the beginning of the buffer. A large response arrives in
-// as many segments as the network chose to split it into, so this is the usual case rather than
-// an unusual one.
+// finished, and not restart at the beginning of the buffer. A large response arrives in as
+// many segments as the network chose to split it into, so this is the usual case.
 TEST(test_communication, test_socket_read_partial) {
   int fds[2];
   ASSERT_EQ(0, socketpair(AF_UNIX, SOCK_STREAM, 0, fds));
@@ -65,8 +64,8 @@ TEST(test_communication, test_socket_read_eof) {
 }
 
 // Writing to a socket whose peer has gone must report the failure. Left to itself it raises
-// SIGPIPE, whose default action ends the program before the caller is told anything, so this
-// test crashes rather than fails when the signal is not suppressed.
+// SIGPIPE, whose default action ends the program before the caller is told anything, so
+// this test crashes when the signal is not suppressed.
 TEST(test_communication, test_socket_write_peer_closed) {
   int fds[2];
   ASSERT_EQ(0, socketpair(AF_UNIX, SOCK_STREAM, 0, fds));
@@ -89,8 +88,8 @@ TEST(test_communication, test_socket_read_interrupted) {
   const uint8_t data[] = {1, 2, 3, 4, 5, 6, 7, 8};
   ASSERT_EQ(3, send(fds[1], data, 3, 0));
 
-  // A handler with no SA_RESTART, which is what leaves an interrupted read to be resumed by the
-  // program rather than by the system
+  // A handler with no SA_RESTART, so an interrupted read is resumed by the program and not
+  // by the system
   struct sigaction action;
   struct sigaction previous_action;
   std::memset(&action, 0, sizeof(action));

--- a/client/cnano/test/test_communication_windows.cpp
+++ b/client/cnano/test/test_communication_windows.cpp
@@ -23,7 +23,7 @@
 #endif
 
 // A read that returns fewer bytes than requested must resume at the point the previous one
-// finished, rather than restarting at the beginning of the buffer.
+// finished, and not restart at the beginning of the buffer.
 TEST(test_communication, test_read_partial) {
   HANDLE read_end = INVALID_HANDLE_VALUE;
   HANDLE write_end = INVALID_HANDLE_VALUE;
@@ -52,7 +52,7 @@ TEST(test_communication, test_read_partial) {
   for (size_t i = 0; i < sizeof(buf); i++) ASSERT_EQ(data[i], buf[i]);
 }
 
-// A read whose data can never arrive has to fail rather than hand back whatever the buffer
+// A read whose data can never arrive has to fail, and not hand back whatever the buffer
 // already held. A pipe reports the far end closing as a failed read, where a serial port, whose
 // far end is hardware, reports no data.
 TEST(test_communication, test_read_peer_closed) {

--- a/client/cnano/test/test_encode_decode.cpp
+++ b/client/cnano/test/test_encode_decode.cpp
@@ -427,10 +427,9 @@ void test_tuple_int32_bool(const krpc_tuple_int32_bool_t& decoded, std::string e
   }
 }
 
-// Which payload std::numeric_limits gives a signalling NaN is left to the
-// implementation, so there is no one encoding to expect it to produce. What the
-// codec has to get right is that it comes back a NaN rather than an infinity or
-// a number, so check the round trip and not the bytes it goes through.
+// The payload std::numeric_limits gives a signaling NaN is implementation defined, so there
+// is no one encoding to expect. The codec has to bring it back as a NaN, so check the round
+// trip and not the bytes it goes through.
 void test_nan_double(double decoded) {
   uint8_t data[8];
   pb_ostream_t ostream = create_ostream(data, sizeof(data));

--- a/client/cpp/CHANGELOG.md
+++ b/client/cpp/CHANGELOG.md
@@ -1,34 +1,20 @@
 ## [v0.7.0] - unreleased
-- Support structure types, which a service defines as a compound value with named fields. One
-  is generated as a `struct` carrying its fields as members, with a constructor taking them in
-  the order the structure declares them, and equality, ordering and a `std::hash` over them,
-  comparing its fields in turn as a `std::tuple` of the same values does (#1066)
+- Support structure types, a compound value with named fields a service defines, generated as
+  a `struct` with a constructor, equality, ordering and a `std::hash` over its fields (#1066)
 - Add `krpc::hash_value` and the `krpc::hash` function object, which hash any type the client
-  carries. The standard library hashes neither `std::tuple` nor its containers, which is what a
-  kRPC tuple and the collection types are, so a tuple could not be the key of an unordered
-  container: `std::unordered_set<std::tuple<double, double, double>, krpc::hash>` now can be
-  (#1067)
+  carries, so a tuple or a collection can key an unordered container (#1067)
 - **Breaking:** Support null for any nullable type; nullable non-class values use
   `std::optional`, changing generated signatures (#1017)
-- Add `krpc::connect_local`, which connects to a server on the same machine over unix
-  domain sockets rather than TCP/IP. The connection behaves identically once established
+- Add `krpc::connect_local`, which connects to a server on the same machine over unix domain
+  sockets (#1065)
+- Add a `timeout` parameter to `krpc::connect`, bounding how long a connection is waited for
   (#1065)
-- Add a `timeout` parameter to `krpc::connect`, bounding how long a connection is waited for. A
-  network that drops a connection attempt rather than refusing it otherwise leaves the client
-  waiting indefinitely (#1065)
 - Fix a service with a collection of enumerations in a procedure signature failing to
   compile (#1044)
-- Fix `krpc::Connection::close` failing to link; it was declared but never defined (#1065)
-- Reduce the cost of a remote procedure call. A response is read a block at a time and
-  parsed straight out of the read buffer, the request a call is built into and the response
-  it is answered by are kept from one call to the next, the arguments of a call are sized up
-  front, and the client connections disable Nagle's algorithm. `Client::invoke`,
-  `Client::build_request` and `Client::build_call` name a service and a procedure with
-  `std::string_view`, so a call no longer builds a string for either (#1056)
-- Reduce the cost of a call that carries a collection. A value is read without setting up a
-  protobuf stream for it, the message a collection is carried in is kept from one call to the
-  next rather than allocated and freed for each, and a list is given room for its values up
-  front (#1056)
+- Fix `krpc::Connection::close` failing to link (#1065)
+- Reduce the cost of a remote procedure call, reusing the request and response messages and
+  parsing a response straight out of the read buffer (#1056)
+- Reduce the cost of a call that carries a collection (#1056)
 
 ## [v0.6.0]
 - Update to protobuf v35.1 (#850)

--- a/client/cpp/benchmark/benchmark.cpp
+++ b/client/cpp/benchmark/benchmark.cpp
@@ -1,10 +1,9 @@
 // Benchmarks for the C++ client, run by //tools/benchmarks:cpp.
 //
-// Measures what this client costs from inside it: the round trip for a procedure call, and what
-// a call carrying a collection of values costs. The runner starts a TestServer, says in the
-// environment where it is listening and which transport that is, and reads the JSON printed
-// here; see tools/benchmarks/run_client.py for the contract and for what happens to these
-// numbers afterwards.
+// Measures this client from inside it: the round trip for a procedure call, and the cost of a
+// call carrying a collection of values. The runner starts a TestServer, names in the
+// environment where it is listening and over which transport, and reads the JSON printed here.
+// See tools/benchmarks/run_client.py for the contract.
 
 #include <krpc.hpp>
 
@@ -24,28 +23,28 @@ namespace {
 
 using clock_type = std::chrono::steady_clock;
 
-// How long one timed loop should run for. Long enough that the clock and a stray scheduling
-// delay do not decide the answer, short enough that a whole run stays in seconds.
+// Duration of one timed loop. Long enough that the clock and a stray scheduling delay do not
+// decide the answer, and short enough that a whole run stays in seconds.
 const double kTargetSeconds = 0.2;
 
-// How many timed loops to take. A round trip crosses a socket and a scheduler as well as the
-// server, and every one of those can only make a sample slower.
+// The number of timed loops to take. A round trip crosses a socket and a scheduler as well as
+// the server, and every one of those can only make a sample slower.
 const int kSamples = 9;
 
-// How long one discarded chunk of calls runs for while a case is being settled, how many of
-// them at a time are asked whether it has stopped getting faster, and how much better the
-// last few have to be than everything before them for it to count as still improving.
+// The duration of one discarded chunk of calls while a case is being settled, the number of
+// them compared at a time, and the margin the last few have to beat for the case to count as
+// still improving.
 const double kSettleChunkSeconds = 0.1;
 const int kSettleChunks = 3;
 const double kSettleTolerance = 0.02;
 
-// How long to keep settling one case before measuring it anyway.
+// The time to keep settling one case before measuring it anyway.
 const double kSettleTimeoutSeconds = 10.0;
 
-// How many values the collection case sends and gets back. A call carries a value at a time,
-// so what one costs to encode and decode is lost in the round trip it arrives in; a list makes
-// that per-value cost most of what the case measures. The same count for every client, so that
-// the figures can be read against each other.
+// The number of values the collection case sends and gets back. A call carries one value at a
+// time, so the cost of encoding and decoding it is lost in the round trip. A list makes that
+// per-value cost most of what the case measures. The same count for every client, so that the
+// figures can be read against each other.
 const int kListValues = 100;
 
 struct Case {
@@ -55,7 +54,7 @@ struct Case {
   std::string rate;
   std::string note;
   // Whether the case had settled before it was measured. See tools/benchmarks/run_client.py
-  // for what the runner does with it.
+  // for how the runner uses it.
   bool settled = true;
 };
 
@@ -68,8 +67,8 @@ int port(const char* name, int fallback) {
   return value == nullptr ? fallback : std::stoi(value);
 }
 
-// Connect over whichever transport the runner started the server with, which it names by socket
-// path or by port. Both are measured, since which one carries a call is part of what it costs.
+// Connect over whichever transport the runner started the server with, named by socket path or
+// by port. Both are measured, as the transport is part of what a call costs.
 krpc::Client connect_to_server() {
   const char* rpc_path = std::getenv("RPC_PATH");
   if (rpc_path != nullptr) {
@@ -97,12 +96,11 @@ struct Settled {
   bool settled;
 };
 
-// Make discarded calls until they stop getting faster, and return what one costs along with
+// Make discarded calls until they stop getting faster, and return the cost of one along with
 // whether it got there. A fixed warmup cannot know when it is done: both ends of a round trip
-// get faster under load for a while, and a case measured before that finishes returns a curve
-// rather than a cost. Every case is settled on its own, since one already warmed by the case
-// before it says so within a few chunks. The cost of a call also falls out of the last chunk,
-// which is what sizes the timed loops.
+// get faster under load for a while, and a case measured before that finishes returns a curve.
+// Every case is settled on its own, as one already warmed by the case before it settles within
+// a few chunks. The cost of a call falls out of the last chunk, which sizes the timed loops.
 Settled settle(const std::function<void()>& call) {
   std::vector<double> chunks{chunk(call)};
   auto start = clock_type::now();
@@ -116,8 +114,8 @@ Settled settle(const std::function<void()>& call) {
         return {recent, true};
     }
   }
-  // However many chunks it got through, which is fewer than a settle compares where a single
-  // one of them ran longer than the whole timeout.
+  // The chunks it got through, which is fewer than a settle compares when a single chunk ran
+  // longer than the whole timeout.
   auto taken = static_cast<long>(chunks.size());
   auto recent = chunks.begin() + std::max(taken - kSettleChunks, 0L);
   return {*std::min_element(recent, chunks.end()), false};

--- a/client/cpp/include/krpc/client.hpp
+++ b/client/cpp/include/krpc/client.hpp
@@ -90,8 +90,8 @@ class Client {
   std::shared_ptr<StreamManager> stream_manager;
   std::shared_ptr<std::mutex> lock;
   // The request a call is built into, the bytes it is written as, and the response it is
-  // answered by. Kept from one call to the next and guarded by lock, so that a call reuses
-  // what the one before it allocated: clearing a protobuf message keeps the storage its fields
+  // answered by. Kept from one call to the next and guarded by lock, so that a call reuses the
+  // allocations of the one before it: clearing a protobuf message keeps the storage its fields
   // have, and the buffer keeps its capacity.
   schema::Request request_buffer;
   std::string request_data;

--- a/client/cpp/include/krpc/connection.hpp
+++ b/client/cpp/include/krpc/connection.hpp
@@ -66,12 +66,12 @@ class Connection {
 
   const std::string address;
   const unsigned int port;
-  // How long to wait for the connection to be made. Zero waits indefinitely.
+  // The time to wait for the connection to be made. Zero waits indefinitely.
   const std::chrono::milliseconds timeout;
   asio::ip::tcp::resolver resolver;
   // Data read from the socket, how much of it there is and how much has been consumed. Reads
-  // are made a block at a time rather than exactly the bytes wanted, so that a message costs
-  // one read rather than one per byte of its size prefix plus one for its body.
+  // are made a block at a time, so that a message costs one read and not one per byte of its
+  // size prefix plus one for its body.
   std::vector<char> buffer;
   size_t filled = 0;
   size_t consumed = 0;

--- a/client/cpp/include/krpc/decoder.hpp
+++ b/client/cpp/include/krpc/decoder.hpp
@@ -92,19 +92,19 @@ inline void decode(std::optional<T>& value, const std::string& data, Client* cli
 }
 
 // A collection arrives as a message holding its items, one encoded value each. That message is
-// kept between calls rather than made for one: parsing into it reuses the storage the items it
-// held last time have, where a message made for the call goes to the allocator for every item
-// and gives it all back again. It is one per thread, since the thread that reads stream updates
-// decodes them while the program is decoding what it asked for; and it is one per element type,
-// which is what makes it safe to reuse - reaching this function again while it is running takes
-// a collection of itself, which is not a type that can be written.
+// kept between calls: parsing into it reuses the storage the items it held last time have,
+// where a message made for the call goes to the allocator for every item and gives it all back
+// again. It is one per thread, as the thread that reads stream updates decodes them while the
+// program is decoding what it asked for. It is one per element type, which makes it safe to
+// reuse: reaching this function again while it is running takes a collection of itself, which
+// is not a type that can be written.
 template <typename T>
 inline void decode(std::vector<T>& list, const std::string& data, Client* client) {
   static thread_local krpc::schema::List listMessage;
   if (!listMessage.ParseFromString(data)) throw EncodingError("Failed to decode message");
   list.clear();
   // The number of items is known before any of them are decoded, so the list is given room for
-  // all of them rather than growing as they arrive.
+  // all of them up front.
   list.reserve(listMessage.items_size());
   for (int i = 0; i < listMessage.items_size(); i++) {
     T value;

--- a/client/cpp/include/krpc/encoder.hpp
+++ b/client/cpp/include/krpc/encoder.hpp
@@ -58,12 +58,12 @@ inline std::string encode(const Object<T>& object) {
 }
 
 // A collection is sent as a message holding its items, one encoded value each. That message is
-// kept between calls rather than made for one: clearing it reuses the storage the items it held
-// last time have, where a message made for the call goes to the allocator for every item and
-// gives it all back again. It is one per thread, since a stream is added from the thread that
-// reads stream updates while the program is making calls of its own; and it is one per element
-// type, which is what makes it safe to reuse - reaching this function again while it is running
-// takes a collection of itself, which is not a type that can be written.
+// kept between calls: clearing it reuses the storage the items it held last time have, where a
+// message made for the call goes to the allocator for every item and gives it all back again.
+// It is one per thread, as a stream is added from the thread that reads stream updates while
+// the program is making calls of its own. It is one per element type, which makes it safe to
+// reuse: reaching this function again while it is running takes a collection of itself, which
+// is not a type that can be written.
 template <typename T>
 inline std::string encode(const std::vector<T>& list) {
   static thread_local krpc::schema::List listMessage;
@@ -99,7 +99,7 @@ inline std::string encode(const std::tuple<Ts...>& tuple) {
   // See the note on the list above for why the message this is sent in is kept between calls.
   static thread_local krpc::schema::Tuple tupleMessage;
   tupleMessage.Clear();
-  // The message is not captured: it lives for the thread rather than for this call.
+  // The message is not captured: it lives for the thread, not for this call.
   std::apply([](const Ts&... args) { (tupleMessage.add_items(encode(args)), ...); }, tuple);
   return encode(tupleMessage);
 }

--- a/client/cpp/include/krpc/object.hpp
+++ b/client/cpp/include/krpc/object.hpp
@@ -18,8 +18,8 @@ class Object {
   friend bool operator==(const Object<U>&, const Object<U>&);
   template <typename U>
   friend bool operator<(const Object<U>&, const Object<U>&);
-  // Public because the encoder and decoder need them; they cannot be granted access with 'friend'
-  // without introducing a circular dependency between this header and theirs.
+  // Public because the encoder and decoder need them. Granting access with 'friend' would
+  // introduce a circular dependency between this header and theirs.
   Client* _client;
   uint64_t _id;
 

--- a/client/cpp/src/client.cpp
+++ b/client/cpp/src/client.cpp
@@ -80,9 +80,8 @@ schema::ProcedureResult Client::invoke(std::string_view service, std::string_vie
   return this->send_request(request_buffer);
 }
 
-// Send a request and return the result it is answered by. Called with lock held, which is what
-// makes the response and the bytes the request is written as safe to keep from one call to the
-// next.
+// Send a request and return the result it is answered by. Called with lock held, which makes
+// the response and the bytes the request is written as safe to keep from one call to the next.
 schema::ProcedureResult Client::send_request(const schema::Request& request) {
   encoder::encode_message_with_size(request, &request_data);
   rpc_connection->send(request_data);
@@ -90,7 +89,7 @@ schema::ProcedureResult Client::send_request(const schema::Request& request) {
 
   if (response_buffer.has_error()) throw_exception(response_buffer.error());
 
-  // Moved out of the response, which is about to be reused, rather than copied out of it.
+  // Moved out of the response, which is about to be reused.
   schema::ProcedureResult result = std::move(*response_buffer.mutable_results(0));
 
   if (result.has_error()) throw_exception(result.error());
@@ -143,8 +142,7 @@ void Client::throw_exception(const schema::Error& error) const {
     if (thrower == exception_throwers.end()) {
       // The type is unknown here if the generated header for its service was never
       // instantiated in this translation unit, so nothing registered a thrower for it.
-      // Report the error itself, named by its type on the server, rather than dereferencing
-      // the end of the map.
+      // Report the error itself, named by its type on the server.
       throw RPCError(error.service() + "." + error.name() + ": " + error.description());
     }
     // Copy the thrower and release the lock before calling it: it throws, and it must not

--- a/client/cpp/src/connection.cpp
+++ b/client/cpp/src/connection.cpp
@@ -42,7 +42,7 @@ static void connect_generic(asio::generic::stream_protocol::socket& socket,
 }
 
 // Connect, giving up once the deadline has passed. A network that drops a connection attempt
-// rather than refusing it otherwise leaves the caller waiting indefinitely.
+// instead of refusing it otherwise leaves the caller waiting indefinitely.
 static void connect_generic(asio::io_context& io_context,
                             asio::generic::stream_protocol::socket& socket,
                             const asio::generic::stream_protocol::endpoint& endpoint,
@@ -85,7 +85,7 @@ void Connection::connect() {
   // Each address the name resolved to is tried in turn, so a host that has more than one is
   // reached through whichever of them answers, and the failure reported when none of them does
   // is the one from the last address tried. The timeout is what connecting is given as a
-  // whole, so they share one deadline rather than each being given the whole of it.
+  // whole, so they share one deadline.
   auto deadline = std::chrono::steady_clock::now() + timeout;
   std::exception_ptr failure;
   for (auto& endpoint : endpoints) {
@@ -122,8 +122,8 @@ void LocalConnection::connect() {
 void Connection::close() {
   // A connection that was never opened, or has already been closed, has no socket to close
   if (socket.is_open()) socket.close();
-  // What was read but not consumed belongs to a connection that is gone, so it is dropped
-  // rather than handed out by a later read
+  // Bytes read but not consumed belong to a connection that is gone, so they are dropped
+  // and not handed out by a later read
   filled = 0;
   consumed = 0;
 }
@@ -161,8 +161,8 @@ std::pair<const char*, size_t> Connection::buffered_message() {
 }
 
 void Connection::fill() {
-  // Move what is left to the front rather than reading further along a buffer that only ever
-  // grows. In the ordinary case nothing is left and this moves nothing.
+  // Move what is left to the front, so the buffer does not grow with every read. In the
+  // ordinary case nothing is left and this moves nothing.
   if (consumed > 0) {
     std::memmove(buffer.data(), buffer.data() + consumed, available());
     filled -= consumed;

--- a/client/cpp/src/decoder.cpp
+++ b/client/cpp/src/decoder.cpp
@@ -28,7 +28,7 @@ const size_t MAX_VARINT_LENGTH = 10;
 // not hold a whole one yet. A varint carries seven bits of the value in each byte, with the
 // top bit saying whether another byte follows.
 //
-// Read here rather than through a coded stream. A value is a few bytes long, and a collection
+// Read here and not through a coded stream. A value is a few bytes long, and a collection
 // arrives a value at a time, so setting a stream up to read one costs more than reading it.
 size_t read_varint(const char* data, size_t length, uint64_t* value) {
   uint64_t result = 0;

--- a/client/cpp/test/connection_test.hpp
+++ b/client/cpp/test/connection_test.hpp
@@ -25,7 +25,7 @@ class echo_server {
  public:
   explicit echo_server(const typename Protocol::endpoint& endpoint)
       : acceptor_(io_context_), stopping_(false) {
-    // Opened, bound and listened on a step at a time rather than through the constructor
+    // Opened, bound and listened on a step at a time, and not through the constructor
     // that does all three, which also asks for the address to be reusable. That option is
     // meaningless for a unix domain socket, and asking for it on one is an error on Windows;
     // the port these tests listen on over TCP/IP is one the system picks, so nothing needs it.
@@ -101,8 +101,8 @@ TYPED_TEST_P(connection_test, long_send_receive) {
 }
 
 TYPED_TEST_P(connection_test, send_receive_in_pieces) {
-  // What is received need not line up with what was sent, as a read returns whatever has
-  // arrived rather than what a particular send put on the wire
+  // A receive need not line up with a send, as a read returns whatever has
+  // arrived, and not what a particular send put on the wire
   auto connection = this->connect();
   connection->send("foobar");
   ASSERT_EQ("foo", connection->receive(3));
@@ -118,7 +118,7 @@ TYPED_TEST_P(connection_test, partial_receive) {
 }
 
 TYPED_TEST_P(connection_test, partial_receive_with_nothing_waiting) {
-  // Nothing has been sent, so this gives up once its timeout has passed rather than
+  // Nothing has been sent, so this gives up once its timeout has passed instead of
   // blocking until something arrives
   auto connection = this->connect();
   ASSERT_EQ("", connection->partial_receive(16));
@@ -137,7 +137,7 @@ TYPED_TEST_P(connection_test, receive_message) {
 }
 
 TYPED_TEST_P(connection_test, receive_two_messages_from_one_read) {
-  // A read brings in a block rather than a message, so a block holding two of them has to
+  // A read brings in a block and not a message, so a block holding two messages has to
   // yield both without a second read
   auto connection = this->connect();
   krpc::schema::Response response;
@@ -178,7 +178,7 @@ TYPED_TEST_P(connection_test, close_twice) {
 }
 
 TYPED_TEST_P(connection_test, close_drops_what_was_read_but_not_taken) {
-  // A read brings in a block rather than the bytes asked for, so a connection can be closed
+  // A read brings in a block and not the bytes asked for, so a connection can be closed
   // with data still in hand. It belongs to a connection that is gone, so it is not handed out.
   auto connection = this->connect();
   connection->send("foobar");

--- a/client/cpp/test/test_client.cpp
+++ b/client/cpp/test/test_client.cpp
@@ -26,10 +26,10 @@
 
 class test_client : public server_test {};
 
-// The version is three dot separated runs of digits. It is checked by hand
-// rather than against a regular expression because gtest falls back to a syntax
-// of its own where it cannot use POSIX ones, and the two have no spelling of a
-// digit in common: [0-9] is only understood by the former, \d only by the latter.
+// The version is three dot separated runs of digits, checked by hand. gtest falls back to
+// a regular expression syntax of its own where it cannot use POSIX ones, and the two have
+// no spelling of a digit in common: [0-9] is only understood by the former, \d only by the
+// latter.
 static bool is_version(const char* value) {
   int parts = 1;
   int digits = 0;
@@ -447,7 +447,7 @@ TEST_F(test_client, test_test_service_enum_members) {
 }
 
 // An error naming a service whose generated header was never instantiated has no registered
-// thrower, and must be reported rather than looked up past the end of the map. This client
+// thrower, and must be reported and not looked up past the end of the map. This client
 // deliberately never constructs the TestService object, so nothing registers its exceptions.
 TEST_F(test_client, test_unknown_exception_type) {
   krpc::Client client = connect("C++ClientTestUnknownExceptionType");

--- a/client/cpp/test/test_connection_tcpip.cpp
+++ b/client/cpp/test/test_connection_tcpip.cpp
@@ -13,7 +13,7 @@ class tcpip_transport {
  public:
   void start() {
     // Port zero, so the system picks one nothing else is using. Bound to the loopback address
-    // rather than to every interface, both because nothing outside this machine has any business
+    // and not to every interface, both because nothing outside this machine has any business
     // reaching it and because the address a server is bound to is the one it is reached on when
     // it is stopped; connecting to the address that stands for every interface is an error on
     // Windows, which would leave the server waiting to be woken.

--- a/client/cpp/test/test_encode_decode.cpp
+++ b/client/cpp/test/test_encode_decode.cpp
@@ -45,10 +45,9 @@ void test_double(double decoded, std::string encoded) {
     ASSERT_TRUE(std::isnan(value));
 }
 
-// Which payload std::numeric_limits gives a signalling NaN is left to the
-// implementation, so there is no one encoding to expect it to produce. What the
-// codec has to get right is that it comes back a NaN rather than an infinity or
-// a number, so check the round trip and not the bytes it goes through.
+// The payload std::numeric_limits gives a signaling NaN is implementation defined, so
+// there is no one encoding to expect. The codec has to bring it back as a NaN, so check
+// the round trip and not the bytes it goes through.
 template <typename T>
 void test_nan(T decoded) {
   T value = 0;

--- a/client/cpp/test/test_hash.cpp
+++ b/client/cpp/test/test_hash.cpp
@@ -56,7 +56,7 @@ TEST(test_hash, nested_collections) {
 }
 
 TEST(test_hash, as_a_container_hash) {
-  // What the hash is for: a standard container keyed by a type the standard library does not
+  // The use the hash is for: a standard container keyed by a type the standard library does not
   // hash on its own
   std::unordered_set<std::tuple<double, double, double>, krpc::hash> points;
   points.insert(std::make_tuple(1.0, 2.0, 3.0));

--- a/client/csharp/CHANGELOG.md
+++ b/client/csharp/CHANGELOG.md
@@ -1,27 +1,17 @@
 ## [v0.7.0] - unreleased
-- Support structure types, which a service defines as a compound value with named fields. One
-  is generated as a `struct` carrying its fields as properties, with a constructor taking them
-  in the order the structure declares them. It implements `IEquatable` and `IComparable` and
-  carries the equality and relational operators, ordering by its fields in turn as a
-  `System.Tuple` of the same values does (#1066)
+- Support structure types, a compound value with named fields a service defines, generated as
+  a `struct` with a constructor, `IEquatable`, `IComparable` and the comparison operators over
+  its fields (#1066)
 - Stream expressions can be multiplied by a constant (#1062)
 - **Breaking:** Support `null` for any nullable type; nullable value types use the nullable
   form (`int?`) (#1017)
 - Add `Connection.ConnectLocal`, which connects to a server on the same machine over unix
-  domain sockets rather than TCP/IP. The connection behaves identically once established
-  (#1065)
+  domain sockets (#1065)
 - Add a `timeout` parameter to the `Connection` constructor, bounding how long a connection is
-  waited for. A network that drops a connection attempt rather than refusing it otherwise leaves
-  the client waiting indefinitely (#1065)
-- Reduce the cost of a remote procedure call. A value is encoded and decoded without a
-  protobuf stream of its own, its bytes are written into a buffer of their own rather than one
-  the thread keeps, a response is read a block at a time and parsed straight out of the read
-  buffer, the request a call is built into is kept from one call to the next, and the client
-  connections disable Nagle's algorithm (#1056)
-- Reduce the cost of a call that returns a collection or an object. What kind of value a type
-  carries, and how to build one, is worked out the first time the type is seen rather than for
-  every value encoded or decoded, and a collection works out how to encode and decode its
-  items once for the collection rather than once for every item (#1056)
+  waited for (#1065)
+- Reduce the cost of a remote procedure call, encoding and decoding without a protobuf stream
+  and parsing a response straight out of the read buffer (#1056)
+- Reduce the cost of a call that returns a collection or an object (#1056)
 
 ## [v0.6.0]
 - **Breaking:** Requires .NET Framework 4.7.2 or later (#948)

--- a/client/csharp/InternalsVisibleTo.cs
+++ b/client/csharp/InternalsVisibleTo.cs
@@ -1,6 +1,6 @@
 using System.Runtime.CompilerServices;
 
-// For the Visual Studio solution / dotnet build. The Bazel build injects this
-// via rules_dotnet's internals_visible_to attr instead, so this file lives
-// outside src/ (which Bazel globs) to avoid a duplicate attribute.
+// For the Visual Studio solution and the dotnet build. The Bazel build injects the
+// attribute through rules_dotnet, so this file sits outside the src/ directory that
+// Bazel globs.
 [assembly: InternalsVisibleTo("KRPC.Client.Test")]

--- a/client/csharp/benchmark/Benchmark.cs
+++ b/client/csharp/benchmark/Benchmark.cs
@@ -19,28 +19,26 @@ namespace KRPC.Client.Benchmark
     /// </summary>
     static class Benchmark
     {
-        // How long one timed loop should run for. Long enough that the clock and a stray
-        // scheduling delay do not decide the answer, short enough that a whole run stays in
-        // seconds.
+        // Duration of one timed loop. Long enough that the clock and a stray scheduling delay
+        // do not decide the answer, and short enough that a whole run stays in seconds.
         const double TargetSeconds = 0.2;
 
-        // How many timed loops to take.
+        // The number of timed loops to take.
         const int Samples = 9;
 
-        // How long one discarded chunk of calls runs for while a case is being settled, how
-        // many of them at a time are asked whether it has stopped getting faster, and how much
-        // better the last few have to be than everything before them for it to count as still
-        // improving.
+        // The duration of one discarded chunk of calls while a case is being settled, the
+        // number of them compared at a time, and the margin the last few have to beat for the
+        // case to count as still improving.
         const double SettleChunkSeconds = 0.1;
         const int SettleChunks = 3;
         const double SettleTolerance = 0.02;
 
-        // How long to keep settling one case before measuring it anyway.
+        // The time to keep settling one case before measuring it anyway.
         const double SettleTimeoutSeconds = 10.0;
 
-        // How many values the collection case sends and gets back. A call carries a value at a
-        // time, so what one costs to encode and decode is lost in the round trip it arrives in;
-        // a list makes that per-value cost most of what the case measures. The same count for
+        // The number of values the collection case sends and gets back. A call carries one
+        // value at a time, so the cost of encoding and decoding it is lost in the round trip.
+        // A list makes that per-value cost most of what the case measures. The same count for
         // every client, so that the figures can be read against each other.
         const int ListValues = 100;
 
@@ -53,7 +51,7 @@ namespace KRPC.Client.Benchmark
             public string Note { get; set; }
 
             // Whether the case had settled before it was measured. See
-            // tools/benchmarks/run_client.py for what the runner does with it.
+            // tools/benchmarks/run_client.py for how the runner uses it.
             public bool Settled { get; set; } = true;
         }
 
@@ -65,7 +63,7 @@ namespace KRPC.Client.Benchmark
             public bool Settled { get; set; }
         }
 
-        // What one call costs once a case has stopped getting faster, and whether it got there.
+        // The cost of one call once a case has stopped getting faster, and whether it got there.
         sealed class Settled
         {
             public double PerCall { get; set; }
@@ -80,9 +78,8 @@ namespace KRPC.Client.Benchmark
             return value != null && ushort.TryParse (value, out port) ? port : fallback;
         }
 
-        // Connect over whichever transport the runner started the server with, which it names
-        // by socket path or by port. Both are measured, since which one carries a call is part
-        // of what it costs.
+        // Connect over whichever transport the runner started the server with, named by socket
+        // path or by port. Both are measured, as the transport is part of what a call costs.
         static Connection Connect ()
         {
             var rpcPath = Environment.GetEnvironmentVariable ("RPC_PATH");
@@ -138,8 +135,8 @@ namespace KRPC.Client.Benchmark
                         return new Settled { PerCall = recent, Reached = true };
                 }
             }
-            // However many chunks it got through, which is fewer than a settle compares where
-            // a single one of them ran longer than the whole timeout.
+            // The chunks it got through, which is fewer than a settle compares when a single
+            // chunk ran longer than the whole timeout.
             return new Settled {
                 PerCall = chunks.Skip (Math.Max (chunks.Count - SettleChunks, 0)).Min (),
                 Reached = false

--- a/client/csharp/src/Connection.cs
+++ b/client/csharp/src/Connection.cs
@@ -77,7 +77,7 @@ namespace KRPC.Client
             if (timeout == TimeSpan.Zero) {
                 socket.Connect (address, port);
             } else {
-                // A network that drops a connection attempt rather than refusing it leaves the
+                // A network that drops a connection attempt instead of refusing it leaves the
                 // client waiting, so bound the wait where one was asked for.
                 var pending = socket.BeginConnect (address, port, null, null);
                 if (!pending.AsyncWaitHandle.WaitOne (timeout)) {
@@ -87,8 +87,7 @@ namespace KRPC.Client
                 socket.EndConnect (pending);
             }
             // A call writes a request and then waits for its response, so there is never a
-            // second small write for Nagle's algorithm to hold the first one back for. Left on,
-            // it can only delay a request the server is already waiting for.
+            // second small write for Nagle's algorithm to hold the first one back for.
             socket.NoDelay = true;
             return socket;
         }
@@ -198,11 +197,10 @@ namespace KRPC.Client
                     rpcSocket.Close ();
                     if (streamSocket != null)
                         streamSocket.Close ();
-                    // Join the update thread, so that it has ended by the time this returns
-                    // rather than at some later point of its own choosing. This has to come
-                    // after the sockets are closed: the thread spends its time blocked in a
-                    // read that does not observe the stop event, and closing the socket
-                    // underneath it is what releases it.
+                    // Join the update thread, so that it has ended by the time this returns.
+                    // This has to come after the sockets are closed: the thread spends its time
+                    // blocked in a read that does not observe the stop event, and closing the
+                    // socket underneath it releases the read.
                     if (StreamManager != null)
                         StreamManager.Dispose ();
                 }
@@ -487,9 +485,8 @@ namespace KRPC.Client
                 System.Type exnType;
                 if (!exceptionTypes.TryGetValue (key, out exnType)) {
                     // The type is unknown here if the service it belongs to was never
-                    // registered. Report the error itself, named by its type on the server,
-                    // rather than the failure to build an exception for it, which would say
-                    // nothing about what actually went wrong.
+                    // registered. Report the error itself, named by its type on the server, so
+                    // that the failure to build an exception for it does not hide it.
                     return new RPCException (key + ": " + message);
                 }
                 return (System.Exception)Activator.CreateInstance (exnType, new [] { message });

--- a/client/csharp/src/Encoder.cs
+++ b/client/csharp/src/Encoder.cs
@@ -464,9 +464,8 @@ namespace KRPC.Client
         const int VarintSize = 10;
 
         // A value's bytes are written into a buffer of their own, made where they are written.
-        // Keeping one buffer per thread instead was measured and is far worse: reaching a
-        // thread's own static costs several times what making a buffer this small costs, and it
-        // is reached once for every value written.
+        // Reaching a per-thread static costs several times what making a buffer this small
+        // costs, and it is reached once for every value written.
 
         static ByteString Varint (ulong value)
         {

--- a/client/csharp/src/MessageReader.cs
+++ b/client/csharp/src/MessageReader.cs
@@ -20,7 +20,7 @@ namespace KRPC.Client
         // Big enough that anything a server sends arrives in one read.
         const int InitialSize = 1024 * 1024;
 
-        // How much more room to make when a message does not fit in the buffer.
+        // The extra room to make when a message does not fit in the buffer.
         const int IncreaseSize = 512 * 1024;
 
         // A length prefix is a varint, and one that does not end within five bytes cannot be the
@@ -30,7 +30,7 @@ namespace KRPC.Client
         readonly Stream stream;
         byte[] buffer = new byte [InitialSize];
 
-        // What has been read but not yet handed out, as the half open range [start, end) of the
+        // The bytes read but not yet handed out, as the half open range [start, end) of the
         // buffer.
         int start;
         int end;

--- a/client/csharp/src/StreamManager.cs
+++ b/client/csharp/src/StreamManager.cs
@@ -92,10 +92,10 @@ namespace KRPC.Client
             IList<Action<object>> callbacks;
             // The update lock is held only to find the stream and decode its new value, and is
             // released before the stream's condition is taken. A thread waiting for an update
-            // holds the condition and then needs the update lock -- Event.Wait resets the
-            // stream value while holding it, as its documented use requires -- so taking the
-            // two in the opposite order here deadlocks. The callbacks are copied for the same
-            // reason: they run below without the lock held.
+            // holds the condition and then needs the update lock, as Event.Wait resets the
+            // stream value while holding it, so taking the two in the opposite order here
+            // deadlocks. The callbacks are copied for the same reason: they run below without
+            // the lock held.
             lock (updateLock) {
                 if (!streams.ContainsKey (id))
                     return;

--- a/client/csharp/src/UnixEndPoint.cs
+++ b/client/csharp/src/UnixEndPoint.cs
@@ -71,8 +71,7 @@ namespace KRPC.Client
             if (socketAddress == null)
                 throw new ArgumentNullException (nameof (socketAddress));
             // A call handed the address this endpoint serialized to writes into it and reports
-            // the size it wrote whether or not it was given that much room, so no more of it is
-            // read than was there to write into
+            // the size it wrote whether or not it was given that much room
             int written = Math.Min (
                 socketAddress.Size,
                 SerializedLength (Encoding.UTF8.GetByteCount (path)));

--- a/client/csharp/test/ConnectionTest.cs
+++ b/client/csharp/test/ConnectionTest.cs
@@ -445,10 +445,9 @@ namespace KRPC.Client.Test
         [Test]
         public void StructEqualityOfACollectionFieldIsByContents ()
         {
-            // A collection field is equal to one holding the same items, whatever object
-            // each of them is
-            // Asserted through Equals rather than through Assert.AreEqual, which compares
-            // collections structurally with a comparer of NUnit's own
+            // A collection field is equal to one holding the same items, whatever object each
+            // of them is. Asserted through Equals, as Assert.AreEqual compares collections
+            // structurally with a comparer of NUnit's own
             var x = new TestStruct (1, "jeb", TestEnum.ValueA, new List<int> { 1 });
             var y = new TestStruct (1, "jeb", TestEnum.ValueA, new List<int> { 1 });
             var z = new TestStruct (1, "jeb", TestEnum.ValueA, new List<int> { 2 });
@@ -484,7 +483,7 @@ namespace KRPC.Client.Test
         public void UnknownExceptionType ()
         {
             // An error naming a type this client has no registered types for still reports
-            // what went wrong, rather than failing while constructing the exception for it
+            // what went wrong, and does not fail while constructing the exception for it
             var error = new KRPC.Schema.KRPC.Error {
                 Service = "NotAService",
                 Name = "NotAnException",

--- a/client/csharp/test/ConnectionTestCase.cs
+++ b/client/csharp/test/ConnectionTestCase.cs
@@ -56,8 +56,8 @@ namespace KRPC.Client.Test
         [Test]
         public void CarriesACall ()
         {
-            // The stand-in answers every request, so this is the request reaching it and the
-            // response coming back rather than anything the call means
+            // The stand-in answers every request, so this measures the request reaching it and
+            // the response coming back, and not what the call means
             using (var connection = Connect ("CSharpConnectionTest")) {
                 Assert.IsNotNull (connection.Invoke ("TestService", "TestProcedure"));
             }
@@ -67,7 +67,7 @@ namespace KRPC.Client.Test
         public void CarriesManyCalls ()
         {
             // A response is taken out of a buffer that reads fill a block at a time, so a run
-            // of calls covers the buffer being refilled and reused rather than only its first use
+            // of calls covers the buffer being refilled and reused, and not only its first use
             using (var connection = Connect ("CSharpConnectionTest")) {
                 for (int i = 0; i < 100; i++)
                     Assert.IsNotNull (connection.Invoke ("TestService", "TestProcedure"));

--- a/client/csharp/test/EncoderTest.cs
+++ b/client/csharp/test/EncoderTest.cs
@@ -293,8 +293,8 @@ namespace KRPC.Client.Test
         [Test]
         public void TupleCollectionWithMissingItems ()
         {
-            // The same decoder reads a structure, where too few items is what an older
-            // server sends for one this client has more fields for
+            // The same decoder reads a structure, where an older server sends too few items
+            // for one this client has more fields for
             const string data = "0a0101";
             Assert.Throws<ArgumentException> (
                 () => Encoder.Decode (data.ToByteString (), typeof(Tuple<uint,string>), null));

--- a/client/csharp/test/EventTest.cs
+++ b/client/csharp/test/EventTest.cs
@@ -19,10 +19,9 @@ namespace KRPC.Client.Test
                 timer.Start ();
                 e.Wait ();
                 var time = timer.ElapsedMilliseconds;
-                // Lower bound is a correctness check (the event must not fire
-                // before its timer); the upper bound is a generous hang
-                // detector, kept loose so the test does not flake under
-                // parallel load.
+                // Lower bound is a correctness check: the event must not fire before its
+                // timer. The upper bound is a generous hang detector, kept loose so the test
+                // does not flake under parallel load.
                 Assert.Greater (time, 150);
                 Assert.Less (time, 2000);
                 Assert.True (e.Stream.Get ());
@@ -142,12 +141,11 @@ namespace KRPC.Client.Test
             var evnt = Connection.KRPC ().AddEvent(expr);
             lock (evnt.Condition) {
                 evnt.Wait();
-                // The event fires when the server-side counter reaches 20. The
-                // counter increments on every expression evaluation, so the
-                // value read back is >= 21 (20 at the trigger, plus this read);
-                // the exact figure depends on how many more times the server
-                // evaluated the expression first, so assert the lower bound to
-                // avoid flaking under load.
+                // The event fires when the server-side counter reaches 20. The counter
+                // increments on every expression evaluation, so the value read back is at
+                // least 21: 20 at the trigger, plus this read. The exact figure depends on how
+                // many more times the server evaluated the expression, so assert the lower
+                // bound to avoid flaking under load.
                 Assert.GreaterOrEqual(Connection.TestService ().Counter("TestEvent.TestCustomEvent", 1), 21);
             }
         }

--- a/client/csharp/test/StandInServer.cs
+++ b/client/csharp/test/StandInServer.cs
@@ -90,7 +90,7 @@ namespace KRPC.Client.Test
                     Write (stream, response);
                     if (Status != ConnectionResponse.Types.Status.Ok)
                         return;
-                    // Every request is answered with an empty result, which is what a call
+                    // Every request is answered with an empty result, the same as a call
                     // returning nothing gets back from a real server
                     while (!stopping) {
                         reader.Read ();
@@ -102,7 +102,7 @@ namespace KRPC.Client.Test
                 }
             } catch (IOException) {
                 // The client has gone, which is how a connection ends here. A malformed
-                // message reports itself as one of these too.
+                // message raises the same exception.
             } catch (SocketException) {
             } catch (ObjectDisposedException) {
             }

--- a/client/csharp/test/StreamTest.cs
+++ b/client/csharp/test/StreamTest.cs
@@ -448,10 +448,10 @@ namespace KRPC.Client.Test
         [Test]
         public void TestRemoveWhileWaitingOnCondition () {
             // The update thread must not hold the update lock while waiting for a stream's
-            // condition. A caller holding that condition -- which is how waiting for an
-            // update is documented to work -- otherwise blocks forever on anything needing
-            // the update lock, and the update thread blocks on the condition, deadlocking
-            // both. Run on a thread so a regression fails here instead of hanging the suite.
+            // condition. A caller holding that condition, which is how waiting for an update
+            // is documented to work, otherwise blocks forever on anything needing the update
+            // lock, and the update thread blocks on the condition, deadlocking both. Run on a
+            // thread so a regression fails here instead of hanging the suite.
             var done = new ManualResetEvent (false);
             var thread = new Thread (() => {
                 var s = Connection.AddStream (
@@ -519,9 +519,8 @@ namespace KRPC.Client.Test
             stop.WaitOne ();
             s.Remove();
             var elapsed = timer.ElapsedMilliseconds;
-            // Lower bound checks the rate limit was honoured; the upper bound is
-            // a generous hang detector, kept loose so the test does not flake
-            // under parallel load.
+            // Lower bound checks the rate limit was honored. The upper bound is a generous
+            // hang detector, kept loose so the test does not flake under parallel load.
             Assert.Greater(elapsed, 1000);
             Assert.Less(elapsed, 3000);
             Assert.False(error);

--- a/client/java/CHANGELOG.md
+++ b/client/java/CHANGELOG.md
@@ -1,18 +1,14 @@
 ## [v0.7.0] - unreleased
-- Support structure types, which a service defines as a compound value with named fields. One
-  is generated as a class carrying its fields, with a constructor taking them in the order the
-  structure declares them, getters, `equals`, `hashCode` and `Comparable`, comparing its fields
-  in turn as a javatuples tuple of the same values does (#1066)
-- **Breaking:** Requires Java 17 or later, up from Java 9, for the unix domain sockets the
-  local socket protocol is carried over (#1065)
+- Support structure types, a compound value with named fields a service defines, generated as
+  a class with a constructor, getters, `equals`, `hashCode` and `Comparable` over its
+  fields (#1066)
+- **Breaking:** Requires Java 17 or later, up from Java 9, for unix domain sockets (#1065)
 - **Breaking:** Support `null` for any nullable type; nullable value types use the boxed type
   (`Integer`, `Double`, …) (#1017)
 - Add `Connection.newLocalInstance`, which connects to a server on the same machine over unix
-  domain sockets rather than TCP/IP. The connection behaves identically once established
-  (#1065)
+  domain sockets (#1065)
 - Add `Connection.newInstance` overloads taking a `timeout`, bounding how long a connection is
-  waited for. A network that drops a connection attempt rather than refusing it otherwise leaves
-  the client waiting indefinitely (#1065)
+  waited for (#1065)
 
 ## [v0.6.0]
 - Update to protobuf v4.35.1, guava 33.4.8-jre, antlr4-runtime 4.13.2 (#850)

--- a/client/java/benchmark/krpc/client/Benchmark.java
+++ b/client/java/benchmark/krpc/client/Benchmark.java
@@ -163,8 +163,8 @@ public final class Benchmark {
         }
       }
     }
-    // However many chunks it got through, which is fewer than a settle compares where a single
-    // one of them ran longer than the whole timeout.
+    // The chunks it got through, which is fewer than a settle compares when a single chunk ran
+    // longer than the whole timeout.
     int taken = Math.max(chunks.size() - SETTLE_CHUNKS, 0);
     return new Settled(smallest(chunks.subList(taken, chunks.size())), false);
   }

--- a/client/java/src/krpc/client/Connection.java
+++ b/client/java/src/krpc/client/Connection.java
@@ -254,7 +254,7 @@ public class Connection implements AutoCloseable {
     if (timeout.isZero()) {
       return SocketChannel.open(new InetSocketAddress(address, port));
     }
-    // A network that drops a connection attempt rather than refusing it leaves the client
+    // A network that drops a connection attempt instead of refusing it leaves the client
     // waiting, so bound the wait where one was asked for.
     SocketChannel channel = SocketChannel.open();
     try {
@@ -472,8 +472,8 @@ public class Connection implements AutoCloseable {
       if (ctor == null) {
         // The type is unknown here if the service it belongs to has no generated stubs loaded,
         // and has no usable constructor if it was not generated as an exception type. Report
-        // the error itself, named by its type on the server, rather than the failure to build
-        // an exception for it, which would say nothing about what actually went wrong.
+        // the error itself, named by its type on the server, so that the failure to build an
+        // exception for it does not hide it.
         throw new RPCException(key + ": " + message);
       }
       try {

--- a/client/java/src/krpc/client/StreamManager.java
+++ b/client/java/src/krpc/client/StreamManager.java
@@ -74,9 +74,9 @@ class StreamManager {
     List<Consumer<Object>> callbacks;
     // The update lock is held only to find the stream and decode its new value, and is released
     // before the stream's condition is taken. A thread waiting for an update holds the condition
-    // and then needs the update lock -- Event.waitFor resets the stream value while holding it,
-    // as its documented use requires -- so taking the two in the opposite order here deadlocks.
-    // The callbacks are copied for the same reason: they run below without the lock held.
+    // and then needs the update lock, as Event.waitFor resets the stream value while holding it,
+    // so taking the two in the opposite order here deadlocks. The callbacks are copied for the
+    // same reason: they run below without the lock held.
     synchronized (updateLock) {
       if (!streams.containsKey(id)) {
         return;
@@ -96,7 +96,7 @@ class StreamManager {
       synchronized (updateLock) {
         // The stream can be removed while its new value is being decoded, in which case
         // remove() has already stored the error saying so and this value must not overwrite
-        // it - the stream is gone from the registry, so nothing would ever replace it and it
+        // it. The stream is gone from the registry, so nothing would ever replace it and it
         // would be returned as though the stream were still live.
         if (!streams.containsKey(id)) {
           return;

--- a/client/java/test/krpc/client/ConnectionTest.java
+++ b/client/java/test/krpc/client/ConnectionTest.java
@@ -365,8 +365,8 @@ public class ConnectionTest {
     assertEquals("value=bob", list.get(1).getValue());
   }
 
-  // A method name is matched by value, so one assembled at runtime resolves the same as a
-  // literal, which is interned and so happened to work when the two were compared by identity.
+  // A method name is matched by value, so one assembled at runtime resolves the same as an
+  // interned literal.
   @Test
   public void testGetCallWithNonInternedMethodName() throws RPCException {
     String name = new StringBuilder("floatToString").toString();
@@ -375,8 +375,8 @@ public class ConnectionTest {
         connection.getCall(TestService.class, name, 3.14159f));
   }
 
-  // Arguments of the wrong type do not match, rather than any method of the same name taking
-  // the same number of arguments.
+  // Arguments of the wrong type do not match, so a method of the same name taking the same
+  // number of arguments is not resolved.
   @Test
   public void testGetCallWithWrongArgumentType() {
     RPCException e = assertThrows(RPCException.class,
@@ -384,8 +384,8 @@ public class ConnectionTest {
     assertTrue(e.getMessage().contains("not found"));
   }
 
-  // An error naming a type this client has no stubs for still reports what went wrong, rather
-  // than failing while trying to construct the exception for it.
+  // An error naming a type this client has no stubs for still reports what went wrong, and
+  // does not fail while constructing the exception for it.
   @Test
   public void testUnknownExceptionType() {
     Error error = Error.newBuilder()

--- a/client/java/test/krpc/client/ConnectionTestCase.java
+++ b/client/java/test/krpc/client/ConnectionTestCase.java
@@ -70,8 +70,8 @@ public abstract class ConnectionTestCase {
   @Test
   @SuppressWarnings("checkstyle:missingjavadocmethod")
   public void testCarriesOneCall() throws IOException, RPCException {
-    // The stand-in answers every request, so this is the request reaching it and the response
-    // coming back rather than anything the call means
+    // The stand-in answers every request, so this measures the request reaching it and the
+    // response coming back, and not what the call means
     try (Connection connection = connect("JavaConnectionTest")) {
       assertNotNull(connection.invoke("TestService", "TestProcedure"));
     }
@@ -81,7 +81,7 @@ public abstract class ConnectionTestCase {
   @SuppressWarnings("checkstyle:missingjavadocmethod")
   public void testCarriesManyCalls() throws IOException, RPCException {
     // Calls are read out of a buffer the transport fills, so a run of them covers that buffer
-    // being refilled and reused rather than only its first use
+    // being refilled and reused, and not only its first use
     try (Connection connection = connect("JavaConnectionTest")) {
       for (int i = 0; i < 100; i++) {
         assertNotNull(connection.invoke("TestService", "TestProcedure"));

--- a/client/java/test/krpc/client/EventTest.java
+++ b/client/java/test/krpc/client/EventTest.java
@@ -38,9 +38,9 @@ public class EventTest {
       long startTime = System.currentTimeMillis();
       event.waitFor();
       long time = System.currentTimeMillis() - startTime;
-      // Lower bound is a correctness check (the event must not fire before its
-      // timer); the upper bound is a generous hang detector, kept loose so the
-      // test does not flake under parallel load.
+      // Lower bound is a correctness check: the event must not fire before its timer.
+      // The upper bound is a generous hang detector, kept loose so the test does not
+      // flake under parallel load.
       assertTrue(150 < time && time < 2000);
       assertTrue(event.getStream().get());
     }
@@ -172,11 +172,11 @@ public class EventTest {
     Event event = krpc.addEvent(expr);
     synchronized (event.getCondition()) {
       event.waitFor();
-      // The event fires when the server-side counter reaches 20. The counter
-      // increments on every expression evaluation, so the value read back is
-      // >= 21 (20 at the trigger, plus this read); the exact figure depends on
-      // how many more times the server evaluated the expression first, so
-      // assert the lower bound to avoid flaking under load. See issue #540.
+      // The event fires when the server-side counter reaches 20. The counter increments
+      // on every expression evaluation, so the value read back is at least 21: 20 at the
+      // trigger, plus this read. The exact figure depends on how many more times the
+      // server evaluated the expression, so assert the lower bound to avoid flaking under
+      // load. See issue #540.
       assertTrue(testService.counter("TestEvent.TestCustomEvent", 1) >= 21);
     }
   }

--- a/client/java/test/krpc/client/StandInServer.java
+++ b/client/java/test/krpc/client/StandInServer.java
@@ -72,8 +72,8 @@ class StandInServer implements AutoCloseable {
   }
 
   private void serve(SocketChannel channel) {
-    // A message is a size varint followed by the message itself, which is what protobuf's
-    // delimited form is, so the messages are read and written through that
+    // A message is a size varint followed by the message itself, the same as protobuf's
+    // delimited form, so the messages are read and written through that
     try (SocketChannel socket = channel) {
       InputStream input = Channels.newInputStream(socket);
       OutputStream output = Channels.newOutputStream(socket);
@@ -88,7 +88,7 @@ class StandInServer implements AutoCloseable {
       if (status != KRPC.ConnectionResponse.Status.OK) {
         return;
       }
-      // Every request is answered with an empty result, which is what a call returning
+      // Every request is answered with an empty result, the same as a call returning
       // nothing gets back from a real server
       while (!stopping) {
         if (KRPC.Request.parseDelimitedFrom(input) == null) {

--- a/client/java/test/krpc/client/StreamTest.java
+++ b/client/java/test/krpc/client/StreamTest.java
@@ -431,7 +431,7 @@ public class StreamTest {
   }
 
   // The update thread must not hold the update lock while waiting for a stream's condition. A
-  // caller holding that condition -- which is how waiting for an update is documented to work --
+  // caller holding that condition, which is how waiting for an update is documented to work,
   // otherwise blocks forever on anything needing the update lock, and the update thread blocks
   // on the condition, deadlocking both. The timeout catches it, as it hangs the test outright.
   @Test(timeout = 30000)

--- a/client/lua/CHANGELOG.md
+++ b/client/lua/CHANGELOG.md
@@ -1,32 +1,20 @@
 ## [v0.7.0] - unreleased
-- Support structure types, which a service defines as a compound value with named fields. A
-  value of one is built from the values of its fields in order and gives them named access; a
-  list with one element per field is accepted where one is expected. It compares for
-  equality and orders by its fields in turn (#1066)
-- A service definition that names a type this client does not know about, as one from a newer
-  server may, now skips the member that names it with a warning, rather than failing to
-  connect (#1066)
+- Support structure types, built from their field values in order and giving them named
+  access (#1066)
+- A service definition naming an unknown type skips the member that names it with a warning,
+  instead of failing to connect (#1066)
 - **Breaking:** Support `Types.none` for any nullable type (#1017)
-- Add `krpc.connect_local`, which connects to a server on the same machine over a unix
-  domain socket rather than TCP/IP. The connection behaves identically once established.
-  On Windows this needs luasocket's `socket.unix` module, which luasocket does not build
-  there, so the client now depends on the `luasocket-unix-windows` rock as well (#1065)
+- Add `krpc.connect_local`, which connects to a server on the same machine over a unix domain
+  socket. On Windows this needs the `luasocket-unix-windows` rock, now a dependency (#1065)
 - Fix a service failing to load when one of its procedures defaults to a member of an
-  enumeration defined by a service that had not been loaded yet (#1044)
-- Add `krpc.limits`, naming the extremes of the numeric types kRPC carries over the wire,
-  such as `krpc.limits.SINT32_MAX` and `krpc.limits.DOUBLE_LOWEST`. Lua names none of them
-  itself, as `math.maxinteger` and `math.mininteger` need Lua 5.3, and a parameter that
-  defaults to one is now documented as the constant rather than the decimal value (#1045)
-- Reduce the cost of a remote procedure call. The request carrying a call is written as the
-  bytes it comes to, rather than built as a protocol buffer message and serialized, and so are
-  the lists, sets, tuples and dictionaries a call carries, which are read back the same way. A
-  value is encoded and decoded by looking up its type code rather than by asking the type what
-  class it is, a float or a double is packed without building a protobuf field encoder for it,
-  the size of a message is read directly rather than by handing each byte to a decoder until it
-  stops raising an error, and the client connection disables Nagle's algorithm (#1056)
+  enumeration from a service that had not been loaded yet (#1044)
+- Add `krpc.limits`, naming the extremes of the numeric types kRPC carries over the wire, such
+  as `krpc.limits.SINT32_MAX` (#1045)
+- Reduce the cost of a remote procedure call, writing and reading messages as bytes rather
+  than as protocol buffer messages (#1056)
 - Require luasocket 3.0 or later (#1060)
-- Fix a type occasionally being built a second time rather than reused, which could leave
-  an enumeration or class type in a service unusable (#1068)
+- Fix a type occasionally being built a second time, leaving an enumeration or class type in a
+  service unusable (#1068)
 
 ## [v0.6.0]
 - Fix `attributes` module to always return boolean for `is_a_class_member` and `is_a_class_property_accessor` (#850)

--- a/client/lua/benchmark.lua
+++ b/client/lua/benchmark.lua
@@ -1,39 +1,38 @@
 -- Benchmarks for the lua client, run by //tools/benchmarks:lua.
 --
--- Measures what this client costs from inside it: the round trip for a procedure call, and
--- what a call carrying a collection of values costs. The runner starts a TestServer, says in
--- the environment where it is listening and which transport that is, and reads the JSON printed
--- here; see tools/benchmarks/run_client.py for the contract and for what happens to these
--- numbers.
+-- Measures this client from inside it: the round trip for a procedure call, and the cost of
+-- a call carrying a collection of values. The runner starts a TestServer, names in the
+-- environment where it is listening and over which transport, and reads the JSON printed
+-- here. See tools/benchmarks/run_client.py for the contract.
 
 local krpc = require 'krpc.init'
 local socket = require 'socket'
 
--- How long one timed loop should run for. Long enough that the clock and a stray scheduling
--- delay do not decide the answer, short enough that a whole run stays in seconds.
+-- Duration of one timed loop. Long enough that the clock and a stray scheduling delay do not
+-- decide the answer, and short enough that a whole run stays in seconds.
 local TARGET_SECONDS = 0.2
 
--- How many timed loops to take.
+-- The number of timed loops to take.
 local SAMPLES = 9
 
--- How long one discarded chunk of calls runs for while a case is being settled, how many of
--- them at a time are asked whether it has stopped getting faster, and how much better the last
--- few have to be than everything before them for it to count as still improving.
+-- The duration of one discarded chunk of calls while a case is being settled, the number of
+-- them compared at a time, and the margin the last few have to beat for the case to count as
+-- still improving.
 local SETTLE_CHUNK_SECONDS = 0.1
 local SETTLE_CHUNKS = 3
 local SETTLE_TOLERANCE = 0.02
 
--- How long to keep settling one case before measuring it anyway.
+-- The time to keep settling one case before measuring it anyway.
 local SETTLE_TIMEOUT_SECONDS = 10.0
 
--- How many values the collection case sends and gets back. A call carries a value at a time, so
--- what one costs to encode and decode is lost in the round trip it arrives in; a list makes that
+-- The number of values the collection case sends and gets back. A call carries one value at a
+-- time, so the cost of encoding and decoding it is lost in the round trip. A list makes that
 -- per-value cost most of what the case measures. The same count for every client, so that the
 -- figures can be read against each other.
 local LIST_VALUES = 100
 
--- Wall clock. os.clock measures processor time, which leaves out everything spent waiting for
--- the server to answer - that is most of a round trip, so it is the wrong clock entirely.
+-- Wall clock. os.clock measures processor time, which leaves out the wait for the server to
+-- answer, and that is most of a round trip.
 local function now()
   return socket.gettime()
 end
@@ -66,14 +65,12 @@ local function smallest(values, first, last)
   return best
 end
 
--- Make discarded calls until they stop getting faster, and return what one costs along with
--- whether it got there.
---
--- A fixed warmup cannot know when it is done. Both ends of a round trip get faster under load
--- for a while - the server's rate control adapts to what it is being asked for - and a case
--- measured before that finishes returns a curve rather than a cost. Every case is settled on
--- its own, since one already warmed by the case before it says so within a few chunks. The
--- cost of a call also falls out of the last chunk, which is what sizes the timed loops.
+-- Make discarded calls until they stop getting faster, and return the cost of one along with
+-- whether it got there. A fixed warmup cannot know when it is done: both ends of a round trip
+-- get faster under load for a while, as the server's rate control adapts, and a case measured
+-- before that finishes returns a curve. Every case is settled on its own, as one already
+-- warmed by the case before it settles within a few chunks. The cost of a call falls out of
+-- the last chunk, which sizes the timed loops.
 local function settle(call)
   local chunks = {chunk(call)}
   local start = now()
@@ -88,8 +85,8 @@ local function settle(call)
       end
     end
   end
-  -- However many chunks it got through, which is fewer than a settle compares where a single
-  -- one of them ran longer than the whole timeout.
+  -- The chunks it got through, which is fewer than a settle compares when a single chunk ran
+  -- longer than the whole timeout.
   return smallest(chunks, math.max(#chunks - SETTLE_CHUNKS + 1, 1), #chunks), false
 end
 
@@ -133,8 +130,8 @@ local function emit(cases)
   print(string.format('{"results": [%s]}', table.concat(parts, ', ')))
 end
 
--- Connect over whichever transport the runner started the server with, which it names by socket
--- path or by port. Both are measured, since which one carries a call is part of what it costs.
+-- Connect over whichever transport the runner started the server with, named by socket path or
+-- by port. Both are measured, as the transport is part of what a call costs.
 local function connect()
   local rpc_path = os.getenv('RPC_PATH')
   if rpc_path ~= nil then

--- a/client/lua/krpc/connection.lua
+++ b/client/lua/krpc/connection.lua
@@ -22,15 +22,14 @@ function Connection:_open()
   -- Open a socket to the server, and set whatever options it takes. Everything above this is
   -- transport agnostic, so a different transport only has to replace this.
   --
-  -- The server listens on IPv4, so the socket is opened for that family rather than for
-  -- whichever one an address resolves to first: a name commonly resolves to the IPv6
-  -- loopback ahead of the IPv4 one, and the attempt on it is slow to give up.
+  -- The server listens on IPv4, so the socket is opened for that family. A name commonly
+  -- resolves to the IPv6 loopback ahead of the IPv4 one, and the attempt on it is slow to
+  -- give up.
   self._socket = socket.tcp4()
   local result, err = self._socket:connect(self._address, self._port)
   if result ~= nil then
-    -- A call writes a request and then waits for its response, so there is never a second small
-    -- write for Nagle's algorithm to hold the first one back for. Left on, it can only delay a
-    -- request the server is already waiting for.
+    -- A call writes a request and then waits for its response, so there is never a second
+    -- small write for Nagle's algorithm to hold the first one back for.
     self._socket:setoption('tcp-nodelay', true)
   end
   return result, err
@@ -73,11 +72,10 @@ function Connection:send_message(message)
 end
 
 function Connection:receive_message(typ)
-  -- Receive a protobuf message. Its size arrives in front of it as a varint, and how long that
-  -- varint is is only known once its last byte has arrived, so it is read a byte at a time.
-  -- Reading the size itself, rather than handing what has arrived so far to a decoder that
-  -- raises an error until the whole of it has, saves a protected call for every one of those
-  -- bytes.
+  -- Receive a protobuf message. Its size arrives in front of it as a varint, whose length is
+  -- only known once its last byte has arrived, so it is read a byte at a time. Reading the
+  -- size here saves a protected call per byte, which handing the bytes so far to a decoder
+  -- that raises until the whole of it has arrived would cost.
   local size = 0
   local shift = 1
   -- A message size is a 32 bit value, so five bytes carry the whole of it. A varint that has

--- a/client/lua/krpc/decoder.lua
+++ b/client/lua/krpc/decoder.lua
@@ -25,7 +25,7 @@ local function _decode_varint(data)
   return value
 end
 
--- What pb.struct_unpack calls a single precision and a double precision number.
+-- The pb.struct_unpack format codes for a single precision and a double precision number.
 local FLOAT_FORMAT = string.byte('f')
 local DOUBLE_FORMAT = string.byte('d')
 
@@ -42,9 +42,8 @@ local function _decode_string(data)
   return data:sub(position+1, position+size+1)
 end
 
--- How to decode a value, by the code of the type it has. Which of these a type wants is the
--- first thing decoding a value asks, and a table says so in one lookup where asking a type what
--- class it is walks its ancestry once per question.
+-- The decoder for each value type, by type code. Decoding a value starts here, and a table
+-- resolves it in one lookup, where testing a type's class walks its ancestry every time.
 local _value_decoders = {
   [Types.DOUBLE] = _decode_double,
   [Types.FLOAT] = _decode_float,
@@ -83,7 +82,7 @@ local _ENTRY_VALUE = 18
 
 --- Read the values a collection carries, each a length delimited field under the given tag.
 --
--- Read here rather than by parsing a message, for the reason the encoder writes them here: the
+-- Read here and not by parsing a message, for the reason the encoder writes them here: the
 -- protocol buffer library is written in lua, and parsing a message of a hundred values into a
 -- container that type checks each one costs far more than reading the bytes does.
 local function _decode_items(data, tag)
@@ -105,11 +104,11 @@ end
 
 --- Read the key and the value out of one entry of a dictionary.
 --
--- The two are read by the tag in front of each rather than by the order they are in, as a
--- message carries its fields in whatever order the writer chose.
+-- The two are read by the tag in front of each, as a message carries its fields in whatever
+-- order the writer chose.
 local function _decode_entry(data)
-  -- A key or a value that encodes to nothing, an empty collection or an empty string among
-  -- them, is left out of the entry entirely, and reads back as the nothing it was
+  -- A key or a value that encodes to nothing, such as an empty collection or an empty
+  -- string, is left out of the entry entirely and reads back empty
   local key = ''
   local value = ''
   local position = 0

--- a/client/lua/krpc/encoder.lua
+++ b/client/lua/krpc/encoder.lua
@@ -5,15 +5,15 @@ local Types = require 'krpc.types'
 
 local encoder = {}
 
--- Where the routines below leave the bytes they produce. They are handed to a writer, and one
+-- The buffer the routines below leave their bytes in. They are handed to a writer, and one
 -- writer shared by all of them costs nothing per value, where a closure made for the value
--- would be allocated and thrown away again for every one encoded.
+-- would be allocated and thrown away for every one encoded.
 local _written
 local function _write(data)
   _written = data
 end
 
--- What pb.struct_pack calls a single precision and a double precision number.
+-- The pb.struct_pack format codes for a single precision and a double precision number.
 local FLOAT_FORMAT = string.byte('f')
 local DOUBLE_FORMAT = string.byte('d')
 
@@ -49,9 +49,8 @@ local function _encode_double(value)
   return _written
 end
 
--- How to encode a value, by the code of the type it has. Which of these a type wants is the
--- first thing encoding a value asks, and a table says so in one lookup where asking a type what
--- class it is walks its ancestry once per question.
+-- The encoder for each value type, by type code. Encoding a value starts here, and a table
+-- resolves it in one lookup, where testing a type's class walks its ancestry every time.
 local _value_encoders = {
   [Types.DOUBLE] = _encode_double,
   [Types.FLOAT] = _encode_float,
@@ -174,10 +173,10 @@ end
 --- Encode the request carrying one procedure call, prefixed by its size, ready to send.
 --
 -- The arguments are the already encoded value of each, in order, with Types.none where a call
--- passes nothing. Written here rather than built as a protocol buffer message and serialized:
--- the message layer allocates a table of fields and a pair of listeners for each of the three
--- messages a call needs, and then walks all of them twice, once to size them and once to write
--- them. That costs an order of magnitude more than the bytes it produces.
+-- passes nothing. Written here and not built as a protocol buffer message: the message layer
+-- allocates a table of fields and a pair of listeners for each of the three messages a call
+-- needs, then walks all of them twice, once to size them and once to write them. That costs an
+-- order of magnitude more than the bytes it produces.
 function encoder.encode_request(service, procedure, arguments)
   local parts = { _delimited(_CALL_SERVICE, service), _delimited(_CALL_PROCEDURE, procedure) }
   local count = 2

--- a/client/lua/krpc/init.lua
+++ b/client/lua/krpc/init.lua
@@ -15,10 +15,10 @@ krpc.limits = limits
 local DEFAULT_ADDRESS = '127.0.0.1'
 local DEFAULT_RPC_PORT = 50000
 
--- A default path for a socket of the given name, matching the one the server uses unless
--- it was configured with another. Windows has no runtime directory for this, so its
--- per-user application data directory stands in. The fallback names a fixed directory
--- rather than the temporary one, which TMPDIR moves for the client and not the server.
+-- A default path for a socket of the given name, matching the server's own default. Windows
+-- has no runtime directory for this, so its per-user application data directory stands in.
+-- The fallback names a fixed directory, as TMPDIR moves the temporary one for the client and
+-- not for the server.
 local function default_path(name)
   local windows = package.config:sub(1, 1) == '\\'
   local separator = windows and '\\' or '/'
@@ -32,8 +32,8 @@ local function default_path(name)
     temporary = os.getenv('TMP') or os.getenv('TEMP') or '.'
     user = os.getenv('USERNAME')
   end
-  -- Lua has the environment and nothing else to ask, and a path without a user name in it
-  -- would be shared between accounts rather than belonging to this one
+  -- Lua can only read the environment, and a path without a user name in it would be shared
+  -- between accounts
   if user == nil or user == '' then
     error('Could not work out which user this is, so there is no default socket path to ' ..
           'connect to; pass rpc_path instead')
@@ -67,8 +67,8 @@ function krpc.connect(name, address, rpc_port)
   return connect_using(Connection(address, rpc_port), name)
 end
 
--- Connect to a server on the same machine, over a unix domain socket named by the
--- given path rather than over TCP. The path defaults to the one the server uses.
+-- Connect to a server on the same machine, over a unix domain socket named by the given
+-- path. The path defaults to the one the server uses.
 function krpc.connect_local(name, rpc_path)
   rpc_path = rpc_path or default_path('rpc')
   return connect_using(LocalConnection(rpc_path), name)

--- a/client/lua/krpc/limits.lua
+++ b/client/lua/krpc/limits.lua
@@ -1,16 +1,16 @@
 -- The extremes of the numeric types kRPC carries over the wire.
 --
 -- Lua names none of them itself: math.maxinteger and math.mininteger arrive in Lua 5.3, and
--- this client targets 5.1 and 5.2. A service may declare one of these as a parameter's default
--- value, in which case the documentation names the constant here rather than writing out the
--- decimal value, which says far less about what was meant.
+-- this client targets 5.1 and 5.2. A service may declare one of these as a parameter's
+-- default value, and the documentation then names the constant here instead of the decimal
+-- value.
 --
 -- The minimum of an unsigned type is 0, so it has no constant.
 --
--- Every Lua 5.1 and 5.2 number is a double, which holds each value here exactly except the two
--- 64-bit integer maxima: SINT64_MAX and UINT64_MAX round up to 2^63 and 2^64. That is a
--- property of the number type, not of these constants - a literal written in their place rounds
--- identically, as does a 64-bit integer arriving from the server.
+-- Every Lua 5.1 and 5.2 number is a double, which holds each value here exactly except the
+-- two 64-bit integer maxima: SINT64_MAX and UINT64_MAX round up to 2^63 and 2^64. That is a
+-- property of the number type: a literal written in their place rounds identically, as does a
+-- 64-bit integer arriving from the server.
 
 local limits = {}
 

--- a/client/lua/krpc/localconnection.lua
+++ b/client/lua/krpc/localconnection.lua
@@ -10,9 +10,8 @@ function LocalConnection:_init(path)
 end
 
 -- luasocket carries its unix domain sockets in a module of its own, which it builds
--- everywhere but Windows, where it comes from a rock of its own. It is asked for when a
--- socket is opened rather than when this module is loaded, so that an installation
--- without it can still connect over TCP/IP.
+-- everywhere but Windows, where it comes from a rock of its own. It is loaded when a socket
+-- is opened, so that an installation without it can still connect over TCP/IP.
 local function unix_socket()
   local found, unix = pcall(require, 'socket.unix')
   if not found then

--- a/client/lua/krpc/service.lua
+++ b/client/lua/krpc/service.lua
@@ -125,7 +125,7 @@ function service.register_definitions(types, svc)
   end
   for _,struct in ipairs(svc.structs) do
     -- A structure whose fields cannot all be resolved is left without any, so that whatever
-    -- names it is skipped rather than the whole service failing to build
+    -- names it is skipped and the service still builds
     local known = true
     for _,field in ipairs(struct.fields) do
       known = known and Types.is_a_known_type(field.type)
@@ -230,9 +230,9 @@ function ServiceBase:_add_service_class_property(class_name, property_name, gett
 end
 
 --- Run one step of building a service, skipping it with a warning if it names a type this
---- client does not know about, rather than failing to create the service at all. That is what
---- a definition from a newer server looks like, where a member has been added whose type is
---- from a later version of the protocol.
+--- client does not know about, so that the service is still created. A definition from a
+--- newer server carries such a type where a member has been added from a later version of
+--- the protocol.
 local function _skipping_unknown_types(what, build)
   local ok, err = pcall(build)
   if not ok then

--- a/client/lua/krpc/test/connectiontest.lua
+++ b/client/lua/krpc/test/connectiontest.lua
@@ -6,7 +6,7 @@ local schema = require 'krpc.schema.KRPC'
 
 -- A stand-in for a kRPC server, which sends back whatever it is sent. These tests are
 -- about how a transport moves bytes, so nothing above the transport has to be understood
--- to answer them. It is driven by the test rather than by a thread of its own: the client
+-- to answer them. It is driven by the test and not by a thread of its own: the client
 -- sends, then the test tells the server how much to echo back.
 local EchoServer = class()
 
@@ -31,7 +31,7 @@ function EchoServer:close()
   self._listener:close()
 end
 
--- What a connection to a server does regardless of what carries it. Only opening the
+-- The behavior a connection to a server has whatever carries it. Only opening the
 -- connection differs between the transports, so each of them supplies a server to talk to
 -- and a connection reaching it, and shares these.
 local ConnectionTest = class()
@@ -66,8 +66,8 @@ function ConnectionTest:test_long_send_receive()
 end
 
 function ConnectionTest:test_send_receive_in_pieces()
-  -- What is received need not line up with what was sent, as the transport carries a
-  -- stream of bytes rather than the messages put into it
+  -- A receive need not line up with a send, as the transport carries a stream of bytes
+  -- and not the messages put into it
   self.conn:send('foobar')
   self.server:echo(6)
   luaunit.assertEquals(self.conn:receive(3), 'foo')
@@ -91,9 +91,9 @@ function ConnectionTest:test_receive_on_closed_connection()
 end
 
 -- A TCP listener on a port the system picks, and the address a client reaches it at.
--- The loopback address is given rather than a name, so that the listener is on the
--- address family the connection under test opens a socket for: 'localhost' resolves to
--- the IPv6 loopback first on some platforms, and a connection is IPv4.
+-- The loopback address is given, and not a name, so that the listener is on the address
+-- family the connection under test opens a socket for: 'localhost' resolves to the IPv6
+-- loopback first on some platforms, and a connection is IPv4.
 local function tcpip_listener()
   local listener = assert(socket.bind('127.0.0.1', 0))
   local address, port = listener:getsockname()

--- a/client/lua/krpc/test/unit.lua
+++ b/client/lua/krpc/test/unit.lua
@@ -1,5 +1,5 @@
--- What the client does regardless of the transport it talks over, and without a server
--- to talk to: encoding and decoding values, the types they are carried as, and reading a
+-- The behavior the client has whatever transport it talks over, and without a server to
+-- talk to: encoding and decoding values, the types they are carried as, and reading a
 -- service definition.
 local luaunit = require 'luaunit'
 

--- a/client/python/CHANGELOG.md
+++ b/client/python/CHANGELOG.md
@@ -1,34 +1,19 @@
 ## [v0.7.0] - unreleased
-- Support structure types, which a service defines as a compound value with named fields. A
-  value of one is a named tuple, so its fields can be read by name and it is also the tuple of
-  their values; a tuple or list with one element per field is accepted where one is expected.
-  It compares, orders and hashes as the tuple of its field values does (#1066)
-- A service definition that names a type this client does not know about, as one from a newer
-  server may, now skips the member that names it with a warning, rather than failing to
-  connect (#1066)
+- Support structure types. A value is a named tuple, and a tuple or list with one element per
+  field is accepted where one is expected (#1066)
+- A service definition naming an unknown type skips the member that names it with a warning,
+  instead of failing to connect (#1066)
 - **Breaking:** Support `None` for any nullable type (#1017)
 - Fix a service failing to load when one of its procedures defaults to a member of an
-  enumeration defined by a service that had not been loaded yet (#1044)
-- Add `krpc.limits`, naming the extremes of the numeric types kRPC carries over the wire,
-  such as `krpc.limits.SINT32_MAX` and `krpc.limits.DOUBLE_LOWEST`. Python names none of
-  them itself, and a generated stub whose parameter defaults to one now names the constant
-  rather than writing out the decimal value (#1045)
-- Reduce the cost of a remote procedure call. Type objects are cached by the arguments
-  naming them and their python type and type code read as plain attributes, values are
-  encoded and decoded through a lookup on their type code rather than a chain of
-  comparisons, floats and doubles are packed directly and short varints without going
-  through protobuf's varint routines, a request is built as a single message, a response
-  is read in one system call and taken out of the read buffer in one pass, a service
-  reaches its procedures by ordinary attribute lookup, and the client connections disable
-  Nagle's algorithm. A collection works out how to encode and decode its items once for
-  the collection rather than once for every item (#1056)
+  enumeration from a service that had not been loaded yet (#1044)
+- Add `krpc.limits`, naming the extremes of the numeric types kRPC carries over the wire, such
+  as `krpc.limits.SINT32_MAX` (#1045)
+- Reduce the cost of a remote procedure call, caching type objects, dispatching on the type
+  code, and reading a response in one system call (#1056)
 - Add `krpc.connect_local`, which connects to a server on the same machine over a unix domain
-  socket rather than TCP/IP. The connection behaves identically once established. Windows is
-  supported as well as Linux and macOS, even though python names no unix domain address family
-  there (#1065)
-- Add a `timeout` parameter to `krpc.connect`, bounding how long a connection is waited for. A
-  network that drops a connection attempt rather than refusing it otherwise leaves the client
-  waiting indefinitely (#1065)
+  socket (#1065)
+- Add a `timeout` parameter to `krpc.connect`, bounding how long a connection is waited for
+  (#1065)
 
 ## [v0.6.0]
 - **Breaking:** Requires Python 3.10+ (#837)

--- a/client/python/krpc/__init__.py
+++ b/client/python/krpc/__init__.py
@@ -16,8 +16,8 @@ from krpc.version import __version__
 DEFAULT_ADDRESS = "127.0.0.1"
 DEFAULT_RPC_PORT = 50000
 DEFAULT_STREAM_PORT = 50001
-# An empty path stands for the path the server uses unless it was configured with
-# another, which is worked out when the connection is made rather than on import
+# An empty path stands for the server's own default path, which is worked out when the
+# connection is made
 DEFAULT_RPC_PATH = ""
 DEFAULT_STREAM_PATH = ""
 

--- a/client/python/krpc/client.py
+++ b/client/python/krpc/client.py
@@ -52,7 +52,7 @@ def _stub_definitions(
         if len(struct.fields) < len(field_names):
             # Fields are only ever appended to a structure, so a server that declares fewer
             # of them than the stubs is an older one. Its values cannot be built as the stub
-            # type, so a plain named tuple of the fields it does declare is used instead
+            # type, so use a plain named tuple of the fields it does declare
             warnings.warn(
                 "Reading the struct %s.%s as a plain named tuple, as the server declares "
                 "fewer fields for it than this client was generated against"
@@ -84,9 +84,9 @@ def _stub_definitions(
             [],
             register_enumeration(enum_name, python_type),
         )
-    # The field types of a structure come from the service definition rather than from the
-    # stubs, so that the same code decodes a structure whether its stubs were generated
-    # ahead of time or not. Only the type a value is built as comes from the stubs
+    # The field types of a structure come from the service definition, so that the same code
+    # decodes a structure whether its stubs were generated ahead of time or not. Only the
+    # type a value is built as comes from the stubs
     structs = service._structs  # type: ignore[attr-defined]
     for struct in service_info.structs:
         python_type = structs.get(struct.name)
@@ -170,12 +170,11 @@ class Client(krpc.services.Client):
         self._rpc_connection.close()
         if self._stream_thread is not None:
             self._stream_thread_stop.set()
-            # Callbacks run on the update thread, so a client closed from one would be
-            # joining the thread it is running on, which raises
+            # Callbacks run on the update thread, so a client closed from one would join the
+            # thread it is running on, which raises
             if threading.current_thread() is not self._stream_thread:
                 self._stream_thread.join()
-        # No further updates will arrive, so wake anything waiting for one rather than
-        # leaving it blocked for good
+        # No further updates will arrive, so wake anything waiting for one
         self._stream_manager.notify_closed()
 
     def __enter__(self) -> Client:
@@ -283,8 +282,8 @@ class Client(krpc.services.Client):
     ) -> object:
         """Execute an RPC"""
 
-        # Build the request. A request carries exactly one call, so the call is
-        # filled in where it belongs rather than built on its own and copied in
+        # Build the request. A request carries exactly one call, so the call is filled in
+        # where it belongs
         request = KRPC.Request()
         self._encode_call(request.calls.add(), service, procedure, args, param_types)
 
@@ -367,8 +366,8 @@ class Client(krpc.services.Client):
             type_name = error.name
             # The service is missing here if it is not one this client knows about, and the
             # type is missing if it is not one the service declares as an exception. Report
-            # the error itself, named by its type on the server, rather than the failure to
-            # build an exception for it, which would say nothing about what went wrong.
+            # the error itself, named by its type on the server, so that the failure to build
+            # an exception for it does not hide it.
             if not hasattr(self, service_name):
                 return RPCError(
                     "%s.%s: %s" % (error.service, type_name, self._error_message(error))

--- a/client/python/krpc/connection.py
+++ b/client/python/krpc/connection.py
@@ -7,9 +7,8 @@ from krpc import winsock
 from krpc.encoder import Encoder
 from krpc.decoder import Decoder
 
-# Size of a socket read. Reads are made a block at a time and buffered, rather
-# than exactly the number of bytes wanted, so that a message costs one read
-# rather than one per byte of its size prefix plus one for its body.
+# Size of a socket read. Reads are made a block at a time and buffered, so that a message
+# costs one read and not one per byte of its size prefix plus one for its body.
 _READ_SIZE = 8192
 
 
@@ -31,7 +30,7 @@ class Connection:
         """Open a socket to the server. Everything above this is transport agnostic,
         so a different transport only has to replace this."""
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        # A network that drops a connection attempt rather than refusing it leaves the
+        # A network that drops a connection attempt instead of refusing it leaves the
         # client waiting, so bound the wait where one was asked for.
         sock.settimeout(self._timeout)
         sock.connect((self._address, self._port))

--- a/client/python/krpc/decoder.py
+++ b/client/python/krpc/decoder.py
@@ -31,9 +31,8 @@ if TYPE_CHECKING:
 
 
 # protobuf's varint reader and zigzag decoder are internal and carry no types, so they are
-# bound here with the types they do have rather than described again at every call. A call
-# carrying a collection reaches them once per value, so this also saves looking them up on
-# their module that many times
+# bound here with the types they do have. A call carrying a collection reaches them once
+# per value, so this also saves looking them up on their module that many times
 _pb_decode_varint: Callable[[bytes, int], Tuple[int, int]] = (
     protobuf_decoder._DecodeVarint  # type: ignore[attr-defined]
 )
@@ -79,8 +78,8 @@ class Decoder:
     @classmethod
     def decode(cls, client: Optional[Client], data: bytes, typ: TypeBase) -> object:
         """Given a python type, and serialized data, decode the value"""
-        # The value types come first: they are what most results are, and this is on
-        # the hot path of every remote procedure call
+        # The value types come first, as most results are one, and this is on the hot path
+        # of every remote procedure call
         if isinstance(typ, ValueType):
             return cls._decode_value(data, typ)
         if isinstance(typ, MessageType):
@@ -192,13 +191,11 @@ class _ValueDecoder:
 
     @classmethod
     def _decode_signed_varint(cls, data: bytes) -> int:
-        # The zigzag payload is an unsigned varint. Reading it as a signed one would sign
-        # extend it as two's complement first, which corrupts anything from 2**62 up once
-        # the payload sets bit 63 - long.MaxValue would decode as -1.
-        #
-        # The single byte case is read here rather than through _decode_varint, which is the
-        # general form of it: a collection reaches this once per value it carries, and a
-        # value from -64 to 63 is one byte.
+        # The zigzag payload is an unsigned varint. Reading it as a signed one sign extends
+        # it as two's complement first, which corrupts anything from 2**62 up once the
+        # payload sets bit 63, where long.MaxValue decodes as -1. The single byte case is
+        # read here and not through the general _decode_varint: a collection reaches this
+        # once per value it carries, and a value from -64 to 63 is one byte.
         first = data[0]
         if first < 128:
             return _pb_zigzag_decode(first)
@@ -281,10 +278,9 @@ class _ValueDecoder:
         return data[position : position + size]
 
 
-# The decoder for each value type, looked up by type code rather than found by
-# comparing against each code in turn, as this is on the hot path of every
-# remote procedure call. The signed and unsigned integer types share a decoder
-# apiece, named for what it reads rather than for one of the types that read it
+# The decoder for each value type, looked up by type code, as this is on the hot path of
+# every remote procedure call. The signed and unsigned integer types share a decoder
+# apiece, named for what it reads
 _VALUE_DECODERS: Mapping[KRPC.Type.TypeCode, Callable[[bytes], object]] = {
     KRPC.Type.SINT32: _ValueDecoder._decode_signed_varint,
     KRPC.Type.SINT64: _ValueDecoder._decode_signed_varint,

--- a/client/python/krpc/definitions.py
+++ b/client/python/krpc/definitions.py
@@ -41,7 +41,7 @@ _KIND_FROM_CODE = {
     KRPC.Type.STRUCT: STRUCT,
 }
 
-# What identifies a definition, and therefore what a reference to one resolves against
+# The key a definition is identified by, and that a reference to one resolves against
 Key = Tuple[str, str, str]
 
 Node = TypeVar("Node")

--- a/client/python/krpc/encoder.py
+++ b/client/python/krpc/encoder.py
@@ -32,14 +32,13 @@ _pb_VarintEncoder = protobuf_encoder._VarintEncoder()  # type: ignore[attr-defin
 _pb_SignedVarintEncoder = protobuf_encoder._SignedVarintEncoder()  # type: ignore[attr-defined]  # pylint: disable=invalid-name
 
 # protobuf's zigzag encoder carries no types, so it is bound here with the type it does
-# have rather than described again at every call. A call carrying a collection reaches it
-# once per value, so this also saves looking it up on its module that many times
+# have. A call carrying a collection reaches it once per value, so this also saves looking
+# it up on its module that many times
 _pb_zigzag_encode: Callable[[int], int] = protobuf_wire_format.ZigZagEncode
 
-# The one byte encoding of every value that fits in one. A varint below 128 is
-# the byte itself, and message sizes and the length prefixes of strings and
-# bytes almost always are, so the common case is a lookup rather than a loop
-# that builds a list and joins it
+# The one byte encoding of every value that fits in one. A varint below 128 is the byte
+# itself, and message sizes and the length prefixes of strings and bytes almost always
+# are, so the common case is a lookup
 _SINGLE_BYTE_VARINTS = tuple(bytes((value,)) for value in range(128))
 
 
@@ -52,8 +51,8 @@ class Encoder:
     @classmethod
     def encode(cls, x: object, typ: TypeBase) -> bytes:
         """Encode a message or value of the given protocol buffer type"""
-        # The value types come first: they are what most arguments are, and this is
-        # on the hot path of every remote procedure call
+        # The value types come first, as most arguments are one, and this is on the hot
+        # path of every remote procedure call
         if isinstance(typ, ValueType):
             return cls._encode_value(x, typ)
         if isinstance(typ, MessageType):
@@ -189,7 +188,7 @@ class _ValueEncoder:
         value = _pb_zigzag_encode(value)
         if value < 128:
             return _SINGLE_BYTE_VARINTS[value]
-        # Two bytes carry a value up to 16383, which is most of what is not one byte, and
+        # Two bytes carry a value up to 16383, which covers most values above one byte, and
         # writing them costs one call where protobuf's encoder builds a list and joins it.
         # A collection reaches this once per value it carries.
         if value < 16384:
@@ -225,10 +224,9 @@ class _ValueEncoder:
         return b"".join([cls._encode_varint(len(value)), value])
 
 
-# The encoder for each value type, looked up by type code rather than found by
-# comparing against each code in turn, as this is on the hot path of every
-# remote procedure call. The signed integer types share an encoder, named for
-# what it writes rather than for one of the types that write it
+# The encoder for each value type, looked up by type code, as this is on the hot path of
+# every remote procedure call. The signed integer types share an encoder, named for what
+# it writes
 _VALUE_ENCODERS: Mapping[KRPC.Type.TypeCode, Callable[[Any], bytes]] = {
     KRPC.Type.SINT32: _ValueEncoder._encode_signed_varint,
     KRPC.Type.SINT64: _ValueEncoder._encode_signed_varint,

--- a/client/python/krpc/service.py
+++ b/client/python/krpc/service.py
@@ -312,7 +312,7 @@ def service_definitions(service: KRPC.Service) -> Iterator[Definition]:
 
         def register(types: Types) -> None:
             # A structure whose fields cannot all be resolved is left without any, so that
-            # whatever names it is skipped rather than the whole service failing to build
+            # whatever names it is skipped and the service still builds
             if not all(is_a_known_type(field.type) for field in struct.fields):
                 warnings.warn(
                     "Skipping the struct %s.%s, as the type of one of its fields is not a "

--- a/client/python/krpc/streammanager.py
+++ b/client/python/krpc/streammanager.py
@@ -193,10 +193,10 @@ class StreamManager:
     def update(self, results: Iterable[KRPC.StreamResult]) -> None:
         # The update lock is held only to find the streams and decode their new values, and
         # is released before any stream condition is taken. A thread waiting for an update
-        # holds a condition and then needs the update lock - Event.wait resets the stream
-        # value while holding it, as its documented use requires - so taking the two in the
-        # opposite order here deadlocks. The callbacks are read under the lock for the same
-        # reason: they run below without it held.
+        # holds a condition and then needs the update lock, as Event.wait resets the stream
+        # value while holding it, so taking the two in the opposite order here deadlocks.
+        # The callbacks are read under the lock for the same reason: they run below without
+        # it held.
         decoded = []
         with self._update_lock:
             for result in results:
@@ -223,8 +223,8 @@ class StreamManager:
                 with self._update_lock:
                     # The stream can be removed while its new value is being decoded, in
                     # which case remove() has already stored the error saying so and this
-                    # value must not overwrite it - the stream is gone from the registry,
-                    # so nothing would ever replace it and it would be returned forever.
+                    # value must not overwrite it. The stream is gone from the registry, so
+                    # nothing would ever replace it and it would be returned forever.
                     if stream_id not in self._streams:
                         continue
                     stream.value = value

--- a/client/python/krpc/test/connectiontest.py
+++ b/client/python/krpc/test/connectiontest.py
@@ -9,9 +9,8 @@ import krpc.schema.KRPC_pb2 as KRPC
 from krpc.connection import Connection
 
 # The unix domain address family, where the socket module has it. It is absent on Windows,
-# so it is read once here rather than reached for through the module, which lets the code
-# below name the family on every platform. The tests that listen on one are skipped where
-# it is missing.
+# so it is read once here, which lets the code below name the family on every platform.
+# The tests that listen on one are skipped where it is missing.
 AF_UNIX = getattr(socket, "AF_UNIX", None)
 
 
@@ -129,9 +128,9 @@ class ConnectionTest(unittest.TestCase):
         self.assertRaises(socket.error, conn.partial_receive, 1)
 
     def test_receive_message_on_remote_closed_connection(self) -> None:
-        # The loop reading the message size must give up rather than retry a closed
-        # connection at full speed forever. Run on a thread so a regression fails here
-        # instead of hanging the suite.
+        # The loop reading the message size must give up on a closed connection instead of
+        # retrying at full speed forever. Run on a thread so a regression fails here instead
+        # of hanging the suite.
         conn = self.connect()
         self.server_close_connection(conn)
         raised: List[BaseException] = []

--- a/client/python/krpc/test/servertestcase.py
+++ b/client/python/krpc/test/servertestcase.py
@@ -8,9 +8,9 @@ from krpc.client import Client
 class ServerTestCase:
     conn: Client = None  # type: ignore[assignment]
 
-    # How long a connection to a port nothing is listening on is waited for. It is
-    # normally refused at once; where the system drops the attempt instead, this bounds
-    # the wait rather than leaving the test to hang.
+    # The wait for a connection to a port nothing is listening on. It is normally refused
+    # at once, and where the system drops the attempt instead, this bounds the wait so that
+    # the test does not hang.
     CONNECT_TIMEOUT = 10
 
     @classmethod

--- a/client/python/krpc/test/test_client.py
+++ b/client/python/krpc/test/test_client.py
@@ -524,8 +524,8 @@ class TestClient(ServerTestCase, unittest.TestCase):
 
     def test_special_default_values(self) -> None:
         # The special values of the numeric types survive the round trip from the
-        # declaration in the service, through the generated client, to the server, and
-        # the client's own constants for them are what the defaults apply
+        # declaration in the service, through the generated client, to the server, and the
+        # defaults apply the client's own constants for them
         values = self.conn.test_service.double_special_defaults()
         self.assertTrue(math.isnan(values[0]))
         self.assertEqual(
@@ -568,7 +568,7 @@ class TestClient(ServerTestCase, unittest.TestCase):
 
     def test_unknown_exception_type(self) -> None:
         # An error naming a service or type this client does not know about still reports
-        # what went wrong, rather than failing while building the exception for it
+        # what went wrong, and does not fail while building the exception for it
         for service, name in (
             ("NotAService", "NotAnException"),
             ("KRPC", "NotAnException"),

--- a/client/python/krpc/test/test_documentation.py
+++ b/client/python/krpc/test/test_documentation.py
@@ -11,8 +11,8 @@ class TestDocumentation(ServerTestCase, unittest.TestCase):
         super(TestDocumentation, cls).setUpClass()
 
     def check_doc(self, expected: str, obj: object) -> None:
-        # Normalise with cleandoc rather than strip: pre-generated stubs indent
-        # multi-line docstrings, whereas dynamically-created services do not.
+        # Normalize with cleandoc, as pre-generated stubs indent multi-line docstrings
+        # where dynamically-created services do not.
         doc = cast(str, obj.__doc__)
         self.assertEqual(expected, inspect.cleandoc(doc))
 

--- a/client/python/krpc/test/test_encodedecode.py
+++ b/client/python/krpc/test/test_encodedecode.py
@@ -167,8 +167,8 @@ class TestEncodeDecode(unittest.TestCase):
             ]
         )
         value = typ.python_type(count=1, name="jeb", flag=False)
-        # A structure carries the values of its fields in order, which is what a tuple of
-        # those values encodes to
+        # A structure carries the values of its fields in order, the same encoding as a
+        # tuple of those values
         cases: List[Tuple[object, str]] = [(value, "0a01010a04036a65620a0100")]
         self._run_test_encode_value(typ, cases)
         self._run_test_decode_value(typ, cases)

--- a/client/python/krpc/types.py
+++ b/client/python/krpc/types.py
@@ -60,8 +60,7 @@ EXCEPTION_TYPES = {
 
 
 # Every type code a type object can be built for. A definition from a newer server may name
-# a type code that is not among them, which is what makes a definition partly unusable
-# rather than malformed
+# a type code outside this set, which leaves the definition partly unusable
 _KNOWN_TYPE_CODES = (
     set(VALUE_TYPES)
     | set(MESSAGE_TYPES)
@@ -401,9 +400,8 @@ class TypeBase:
     ) -> None:
         self.protobuf_type = protobuf_type
         self.python_type = python_type
-        # The type code, which is what the encoder and decoder select on. Held
-        # here as well as in the protocol buffer type, as reading it from there
-        # is a protocol buffer field access
+        # The type code the encoder and decoder select on. Held here as well as in the
+        # protocol buffer type, as reading it from there is a protocol buffer field access
         self.code = protobuf_type.code
         self._string = string
 

--- a/client/python/krpc/winsock.py
+++ b/client/python/krpc/winsock.py
@@ -11,12 +11,12 @@ import ctypes
 import socket
 import sys
 
-# What winsock calls the address family, and the size of the path in the address structure. Both
-# are as they are on every other platform: Windows kept the layout so that the same code works.
+# The winsock address family, and the size of the path in the address structure. Both are as
+# they are on every other platform: Windows kept the layout so that the same code works.
 AF_UNIX = 1
 UNIX_PATH_MAX = 108
 
-# What winsock returns from a call that failed.
+# The value winsock returns from a call that failed.
 SOCKET_ERROR = -1
 
 

--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -1,39 +1,24 @@
 ## [v0.7.0] - unreleased
-- Add structure types: a compound value with named fields, whose value is sent to the client in
-  full rather than as a reference to an object that stays on the server. A structure is declared
-  with `KRPCStruct` on a C# `struct`, its fields are the properties annotated with
-  `KRPCProperty`, and its value is encoded as the values of those fields in the order the
-  structure declares them (#1066)
-- Add a communication protocol carrying protocol buffer messages over a unix domain socket, for
-  clients running on the same machine as the game. It carries the same messages as the TCP/IP
-  protocol over a cheaper path: a client that makes many calls in quick succession completes
-  around 20% more of them per physics update, and around 35% more when the values are large.
-  A client that makes one call and then waits is unaffected, as the wait is governed by the
-  game's update rate. Available on Linux, macOS, and Windows 10 1803 and later (#1065)
-- Add `KRPC.HoldTick` and `KRPC.ReleaseTick`, which hold the game on its current physics tick so
-  that a program can read the game state, compute with it and write the result back without the
-  game advancing in between. Intended for control loops, which are otherwise served one RPC per
-  tick whenever they spend longer than the receive timeout between calls. The game runs no
-  physics and draws no frame while a tick is held, and a hold ends by itself after
-  `TickHoldTimeout` (#1070)
-- Add `KRPC.NextTick`, which releases the tick being held and holds the one after it, so that a
-  loop acts on consecutive physics ticks. A release and a hold made as two calls leave the
-  server free to advance between them; this closes that gap (#1070)
-- Fix the game freezing for as long as a serial connection takes to carry an RPC; serial ports are
-  now read and written on their own threads rather than on the thread that runs the game. Data
-  waiting to be sent is buffered up to 1 MB, beyond which the connection is dropped (#1035)
-- Add `KRPC.ObjectDestroyedException`, raised when the game object that an object refers to
-  no longer exists (#1051)
+- Add structure types: a compound value with named fields, declared with `KRPCStruct` on a C#
+  `struct` and sent to the client in full (#1066)
+- Add a communication protocol carrying protocol buffer messages over a unix domain socket,
+  for clients running on the same machine as the game (#1065)
+- Add `KRPC.HoldTick` and `KRPC.ReleaseTick`, which hold the game on its current physics tick
+  so a control loop can read, compute and write within one tick (#1070)
+- Add `KRPC.NextTick`, which releases the tick being held and holds the one after it (#1070)
+- Fix the game freezing for as long as a serial connection takes to carry an RPC; serial ports
+  are read and written on their own threads (#1035)
+- Add `KRPC.ObjectDestroyedException`, raised when the game object that an object refers to no
+  longer exists (#1051)
 - Objects whose game objects the game no longer has are removed from the object store when a
-  game state is loaded, and using an object that has been removed raises
-  `KRPC.ObjectDestroyedException` rather than an argument error (#1051)
-- Fix one server stopping emptying the object store that every server shares, which invalidated
-  the objects held by clients of the servers still running (#1020)
+  game state is loaded (#1051)
+- Fix one server stopping emptying the object store that every server shares, which
+  invalidated the objects held by clients of the servers still running (#1020)
 - Support for nullable values across all types (#1017)
-- **Breaking:** Null values are now signaled by an `is_null` field rather than by an object id
-  of 0, and nullability is enforced uniformly for every type. Class-typed arguments are no longer implicitly nullable (#1017)
-- Fix a request that names an object the server no longer has leaving the connection stuck, with
-  every later call failing; the failure is now reported to the client as the error it is (#1019)
+- **Breaking:** Null values are signaled by an `is_null` field rather than by an object id of
+  0. Class-typed arguments are no longer implicitly nullable (#1017)
+- Fix a request that names an object the server no longer has leaving the connection
+  stuck (#1019)
 
 ## [v0.6.0]
 - Add `Version` property to `Core`, set by the server plugin on startup (#848)

--- a/core/InternalsVisibleTo.cs
+++ b/core/InternalsVisibleTo.cs
@@ -1,8 +1,8 @@
 using System.Runtime.CompilerServices;
 
-// For the Visual Studio solution / dotnet build. The Bazel build injects this
-// via rules_dotnet's internals_visible_to attr instead, so this file lives
-// outside src/ (which Bazel globs) to avoid a duplicate attribute.
+// For the Visual Studio solution and the dotnet build. The Bazel build injects the
+// attribute through rules_dotnet, so this file sits outside the src/ directory that
+// Bazel globs.
 [assembly: InternalsVisibleTo("KRPC.Core.Test")]
 [assembly: InternalsVisibleTo("TestingTools")]
 // The Benchmark service runs a call through Services, the server's own dispatch path

--- a/core/src/Core.cs
+++ b/core/src/Core.cs
@@ -217,9 +217,8 @@ namespace KRPC
             server.OnStopped += (s, e) => {
                 Logger.WriteLine ("Server '" + ((Server.Server)s).Name + "' stopped");
                 AnyRunning = Servers.Any (x => x.Running);
-                // The object store is shared by every server, and its object identifiers
-                // are handed out from a single sequence, so it is only emptied once no
-                // server is left for a client to hold an identifier through.
+                // The object store is shared by every server, so it is only emptied
+                // once they have all stopped
                 if (!AnyRunning)
                     ObjectStore.Clear ();
                 EventHandlerExtensions.Invoke (OnServerStopped, this, new ServerStoppedEventArgs ((Server.Server)s));
@@ -393,10 +392,9 @@ namespace KRPC
             ulong startBytesRead = BytesRead;
             ulong startBytesWritten = BytesWritten;
 
-            // The events bracket the call phase rather than being raised from inside it, so that
-            // they are raised exactly once per update whatever the update does: the poll loop
-            // runs many times over while a client holds the tick. Raising OnAfterCalls before
-            // the stream update also means streams observe whatever the handlers did.
+            // Bracket the call phase, so that the events are raised once per update however
+            // many times the poll loop runs. OnAfterCalls is raised before the stream update,
+            // so that streams observe what the handlers did.
             EventHandlerExtensions.Invoke (OnBeforeCalls, this);
             RPCServerUpdate ();
             EventHandlerExtensions.Invoke (OnAfterCalls, this);
@@ -419,10 +417,8 @@ namespace KRPC
             // This prevents MaxTimePerUpdate from being set to a high value when the server is idle, which would
             // cause a drop in framerate if a large burst of RPCs are received.
             var config = Configuration.Instance;
-            // An update that a client held the tick through ran for as long as that client
-            // asked it to. Adapting to it would read the client's own work as the server
-            // spending too long on RPCs, and wind the limit down to its floor for every other
-            // client as well.
+            // An update that held the tick ran for as long as the client asked. Adapting to it
+            // would wind the limit down to its floor for every other client.
             if (config.AdaptiveRateControl && !heldTick) {
                 var targetTicks = Stopwatch.Frequency / 59;
                 if (ticksElapsed > targetTicks) {
@@ -492,10 +488,8 @@ namespace KRPC
                     PollRequests (rpcYieldedContinuations);
                     if (rpcContinuations.Count > 0)
                         break;
-                    // A client holding the tick is waited for until it releases it, so that a
-                    // call it makes after seeing the result of an earlier one is executed in
-                    // this update rather than the next. The hold ending is the only thing that
-                    // ends this wait, which is why it is asked about every time around.
+                    // Wait for the client to release the tick, so that a call it makes after
+                    // seeing an earlier result is executed in this update
                     if (TickHeld) {
                         heldTick = true;
                         continue;
@@ -547,8 +541,8 @@ namespace KRPC
                     continue;
                 }
 
-                // Exit if a hold on the tick ended during this update, so that the game takes
-                // the tick it was held back from before another hold can defer it again.
+                // Exit if a hold ended during this update, so that the game takes the tick
+                // before another hold can defer it
                 if (heldTick)
                     break;
 
@@ -561,9 +555,8 @@ namespace KRPC
                     break;
             }
 
-            // Nothing leaves the loop while a client holds the tick, so a hold still in force
-            // here belongs to an update that failed part way through. Which is also the only
-            // way calls can still be marked as executing.
+            // Nothing leaves the loop while the tick is held, so a hold still in force here
+            // belongs to an update that failed part way through
             executingRPCs = false;
             if (tickHoldClient != null) {
                 Logger.WriteLine (
@@ -684,18 +677,14 @@ namespace KRPC
             if (!rpcClients.TryGetValue (rpcClient.Guid, out client))
                 throw new InvalidOperationException (
                     "No RPC client is connected with this identifier");
-            // Taking a hold that is already held would let a client renew its own before it ran
-            // out of time, and so hold the game for as long as it liked.
+            // Renewing a hold would let a client hold the game for as long as it liked
             if (TickHeld)
                 throw new InvalidOperationException (
                     tickHoldClient.Guid == rpcClient.Guid
                     ? "This client is already holding the tick"
                     : "Another client is holding the tick");
-            // One hold per tick, whoever asks for it. A tick that has already been held and let
-            // go has done its waiting, and holding it again would defer it a second time; a
-            // client looping on hold and release, or two passing it between them, could defer it
-            // for as long as they kept asking. The call waits for the next tick instead, which
-            // is where the work it is about to do belongs.
+            // One hold per tick. Holding a tick that has already been held and released would
+            // defer it a second time, so the call waits for the next tick
             if (heldTick)
                 throw new YieldException<Action> (() => HoldTick (rpcClient));
             tickHoldClient = client;
@@ -751,8 +740,8 @@ namespace KRPC
                     ReleaseTickHold ();
                     return false;
                 }
-                // Clients that have gone away are only reconciled between updates, so an update
-                // holding a tick has to notice for itself that the client it waits for has left.
+                // Clients are only reconciled between updates, so an update holding a tick
+                // checks for itself that the client is still connected
                 if (!rpcClients.ContainsKey (tickHoldClient.Guid) || !tickHoldClient.Connected) {
                     Logger.WriteLine (
                         "Client " + tickHoldClient.Address + " disconnected while holding the tick",
@@ -944,10 +933,9 @@ namespace KRPC
                     client.Stream.Close ();
                     continue;
                 } catch (KRPC.Server.Message.RequestDecodeException e) {
-                    // The request arrived intact but names something the server cannot
-                    // give, such as an object it has reclaimed. That is a failed call
-                    // rather than a broken connection, so it is reported as the error it
-                    // is and the client carries on.
+                    // The request arrived intact but names something the server cannot give,
+                    // such as an object it has reclaimed. Report a failed call, and leave the
+                    // connection open
                     SendErrorResponse (client, KRPC.Service.Services.Instance.HandleException (e.InnerException ?? e));
                 } catch (System.Exception e) {
                     if (Logger.ShouldLog (Logger.Severity.Debug))

--- a/core/src/Server/LocalSocket/LocalSocketClient.cs
+++ b/core/src/Server/LocalSocket/LocalSocketClient.cs
@@ -17,8 +17,8 @@ namespace KRPC.Server.LocalSocket
                 throw new ArgumentNullException (nameof (innerSocket));
             guid = Guid.NewGuid ();
             socket = innerSocket;
-            // A unix socket has no remote address of its own; the path the client
-            // connected to is the only thing there is to identify it by
+            // A unix socket has no remote address, so the path the client connected to is
+            // what identifies it
             address = socketPath ?? string.Empty;
         }
 
@@ -49,8 +49,8 @@ namespace KRPC.Server.LocalSocket
                 try {
                     if (!socket.Connected)
                         return false;
-                    // A closed peer polls readable and then reads nothing, which is
-                    // what tells a disconnect apart from an idle connection
+                    // A closed peer polls readable and then reads nothing, which tells a
+                    // disconnect apart from an idle connection
                     if (socket.Poll (0, SelectMode.SelectRead))
                         return socket.Receive (connectedTestBuffer, SocketFlags.Peek) != 0;
                     return true;

--- a/core/src/Server/LocalSocket/LocalSocketServer.cs
+++ b/core/src/Server/LocalSocket/LocalSocketServer.cs
@@ -142,9 +142,8 @@ namespace KRPC.Server.LocalSocket
             Logger.WriteLine ("LocalSocketServer: starting", Logger.Severity.Debug);
             if (string.IsNullOrEmpty (ListenPath))
                 throw new ServerException ("Socket path is empty");
-            // Bind reports a path that does not fit in the kernel's address structure as
-            // nothing more specific than an invalid argument, so check it here and say
-            // what is actually wrong
+            // Bind reports a path too long for the kernel's address structure as an invalid
+            // argument, so check the length here and report what is wrong
             var pathLength = PathLength (ListenPath);
             if (pathLength > MaximumPathLength)
                 throw new ServerException (
@@ -198,15 +197,15 @@ namespace KRPC.Server.LocalSocket
             if (!error.HasValue)
                 throw new ServerException (
                     "Another server is already listening on " + ListenPath);
-            // Only a refusal means nothing is there to answer. Anything else leaves the
-            // question open, and a path that cannot be asked is not one to delete.
+            // Only a refusal means nothing is listening. Any other error leaves that
+            // unknown, so the path is left alone
             if (error.Value != SocketError.ConnectionRefused)
                 throw new ServerException (
                     "Could not find out whether a server is listening on " + ListenPath +
                     "; connecting to it reported '" + error.Value + "'");
-            // A socket carries no content, so a path holding some is not one and belongs to
-            // whoever put it there. A symbolic link counts as holding the path it names, so
-            // one is reported rather than followed to whatever is on the end of it.
+            // A socket carries no content, so a path with content belongs to something
+            // else. A symbolic link holds the path it names, and is reported without
+            // being followed
             if (new FileInfo (ListenPath).Length > 0)
                 throw new ServerException (
                     ListenPath + " already exists and is not a socket");

--- a/core/src/Server/LocalSocket/UnixEndPoint.cs
+++ b/core/src/Server/LocalSocket/UnixEndPoint.cs
@@ -83,9 +83,9 @@ namespace KRPC.Server.LocalSocket
         {
             if (socketAddress == null)
                 throw new ArgumentNullException (nameof (socketAddress));
-            // Accepting a connection writes the address of the peer into the address this
-            // endpoint serialized to, and reports the size the system wrote whether or not it
-            // was given that much room, so no more of it is read than was there to write into
+            // Accepting a connection writes the peer address into the address this endpoint
+            // serialized to, and reports the size it wrote whether or not it was given that
+            // much room
             int written = Math.Min (
                 socketAddress.Size,
                 SerializedLength (Encoding.UTF8.GetByteCount (path)));

--- a/core/src/Server/Message/RPCStream.cs
+++ b/core/src/Server/Message/RPCStream.cs
@@ -141,8 +141,8 @@ namespace KRPC.Server.Message
                 throw;
             } catch (RequestDecodeException e) {
                 // The request arrived in full and only what it names is wrong, so drop the
-                // bytes it occupied before letting the error be reported. The connection is
-                // then still in step with the client, which can carry on making calls.
+                // bytes it occupied before reporting the error. The connection stays in step
+                // with the client
                 ConsumeReceiveBuffer (e.BytesRead);
                 throw;
             }

--- a/core/src/Server/ProtocolBuffers/Utils.cs
+++ b/core/src/Server/ProtocolBuffers/Utils.cs
@@ -78,8 +78,8 @@ namespace KRPC.Server.ProtocolBuffers
                 return null; // The length prefix has not been fully received yet.
             if (data.Length < prefixLength + size)
                 return null; // The message body has not been fully received yet.
-            // Parse the message body straight out of the buffer, with no copy or intermediate stream,
-            // reading exactly the message's own bytes.
+            // Parse the message body straight out of the buffer, with no copy or intermediate
+            // stream
             var message = new T ();
             message.MergeFrom (data.GetBuffer (), prefixLength, size);
             return message;
@@ -100,9 +100,8 @@ namespace KRPC.Server.ProtocolBuffers
             var totalSize = prefixLength + size;
             if (length < totalSize)
                 return 0; // The message body has not been fully received yet.
-            // Parse the message body straight out of the buffer. This copies no payload bytes and
-            // allocates no intermediate stream, and reads exactly the message's own bytes, so a
-            // following message in the same buffer is left untouched.
+            // Parse the message body straight out of the buffer, reading exactly the message's
+            // own bytes so that a following message in the buffer is left untouched
             message = parser.ParseFrom (data, offset + prefixLength, size);
             return totalSize;
         }

--- a/core/src/Server/SerialIO/BufferedPort.cs
+++ b/core/src/Server/SerialIO/BufferedPort.cs
@@ -17,29 +17,24 @@ namespace KRPC.Server.SerialIO
     /// </summary>
     sealed class BufferedPort
     {
-        // How often the read thread checks the port for received data. Reads are only issued for
-        // data the port already holds, so that they return promptly without engaging the port's
-        // timeout handling: a read left waiting for data that arrives just as the read gives up
-        // can lose that data, depending on the port implementation.
+        // Interval at which the read thread checks the port for received data. Reads are
+        // only issued for data the port already holds, so that they return without engaging
+        // the port's timeout handling, which can lose data that arrives as a read gives up
         const int pollInterval = 10;
-        // How long a read is allowed to take before it fails with TimeoutException. Reads are only
-        // issued for data the port already holds, so this is a guard against a port that
-        // misreports how much it has, which would otherwise leave the read thread stuck in a read
-        // that never returns.
+        // Time a read is allowed to take before it fails with TimeoutException. This guards
+        // against a port that misreports how much data it holds, which would leave the read
+        // thread stuck in a read that never returns
         const int readTimeout = 100;
-        // How long Close waits for each background thread to finish before abandoning it.
+        // Time Close waits for each background thread to finish before abandoning it.
         const int shutdownTimeout = 500;
         // Number of bytes transferred to or from the port at a time.
         const int chunkSize = 4096;
-        // Amount of unread received data at which reading from the port pauses, so that a client
-        // sending faster than the game reads cannot grow the buffer without limit. The data stays
-        // in the port's own buffer until the game catches up.
+        // Amount of unread received data at which reading from the port pauses, so that a
+        // client sending faster than the game reads cannot grow the buffer without limit
         const int receiveLimit = 1024 * 1024;
-        // Amount of unsent written data at which the port is failed. A caller that writes faster
-        // than the configured baud rate for long enough would otherwise grow the buffer without
-        // limit, while the data waiting in it grows ever staler. Unlike reading, which can pause
-        // and leave data with the port, written data has nowhere else to live, so the connection
-        // is dropped instead.
+        // Amount of unsent written data at which the port is failed. A caller writing faster
+        // than the configured baud rate would otherwise grow the buffer without limit, and
+        // written data has nowhere else to wait
         const int sendLimit = 1024 * 1024;
 
         readonly IPort port;
@@ -113,9 +108,9 @@ namespace KRPC.Server.SerialIO
                 Monitor.PulseAll (receivedLock);
             lock (sendingLock)
                 Monitor.PulseAll (sendingLock);
-            // Wait for the write thread first, so that it gets the chance to send what is left in
-            // the send buffer. A thread that does not finish in time is left to the port being
-            // closed under it, which fails its transfer and ends it.
+            // Wait for the write thread first, so that it can send what is left in the send
+            // buffer. A thread that does not finish in time fails its transfer when the port
+            // is closed under it
             JoinThread (writeThread);
             JoinThread (readThread);
             writeThread = null;
@@ -136,8 +131,8 @@ namespace KRPC.Server.SerialIO
             CheckFailed ();
             lock (receivedLock) {
                 var read = received.Take (buffer, offset, size);
-                // Reading may have taken the buffer back below the limit at which the read thread
-                // pauses, so let it know there is room again.
+                // Reading may have taken the buffer back below the limit at which the read
+                // thread pauses, so signal that there is room again
                 if (read > 0)
                     Monitor.PulseAll (receivedLock);
                 return read;
@@ -169,8 +164,8 @@ namespace KRPC.Server.SerialIO
         {
             var thread = new Thread (body);
             thread.Name = "kRPC SerialIO " + role + " " + port.PortName;
-            // The threads only move data for a server that the game owns, so they must never be
-            // what keeps the process alive.
+            // The threads only move data for a server that the game owns, so they must not
+            // keep the process alive
             thread.IsBackground = true;
             thread.Start ();
             return thread;
@@ -207,8 +202,8 @@ namespace KRPC.Server.SerialIO
                     return;
                 }
                 if (size <= 0) {
-                    // The port reports itself readable but has nothing to give, which means the
-                    // other end has gone. Wait rather than ask again immediately.
+                    // The port reports itself readable but has nothing to give, so the other
+                    // end has gone. Wait before polling again
                     Thread.Sleep (readTimeout);
                     continue;
                 }

--- a/core/src/Service/KRPC/Expression.cs
+++ b/core/src/Service/KRPC/Expression.cs
@@ -133,8 +133,8 @@ namespace KRPC.Service.KRPC
                 servicesExpr, executeCallMethod,
                 new[] { procedureExpr, instanceExpr, argumentsExpr });
             var returnType = procedure.ReturnType;
-            // A nullable value-type return may be null, so evaluate it as Nullable<T> so the
-            // null is representable rather than faulting the conversion.
+            // A nullable value-type return may be null, so evaluate it as Nullable<T> to keep
+            // the null representable
             if (procedure.ReturnIsNullable && returnType.IsValueType)
                 returnType = typeof(System.Nullable<>).MakeGenericType(returnType);
             var value = LinqExpression.Convert(

--- a/core/src/Service/KRPC/KRPC.cs
+++ b/core/src/Service/KRPC/KRPC.cs
@@ -282,24 +282,22 @@ namespace KRPC.Service.KRPC
 
         /// <summary>
         /// Hold the game on its current physics tick until <see cref="ReleaseTick" /> is called
-        /// or the hold times out. Every call made in between is executed before the game moves
-        /// on, so that a program which reads the game state, computes with it and writes the
-        /// result back does all three in the state of a single tick.
-        ///
-        /// A tick is held once and no more, so this waits for the next tick when the current
-        /// one has already been held and let go.
+        /// or the hold times out. Every call made in between is executed before the game
+        /// advances, so a read, compute and write all happen in the state of one tick.
         /// </summary>
         /// <remarks>
         /// The game renders no frame, takes no input and runs no physics while the tick is
-        /// held, so a hold should be as short as the program can make it, and should be
-        /// released even when the code between the two calls fails. Only one client can hold
-        /// the tick at a time, and only a client making a call can hold it: the tick cannot be
-        /// held by a stream or an event. A hold ends by itself when it times out, when the
-        /// client disconnects, or when the client calls a procedure that takes more than one
-        /// tick to finish, such as staging or warping, since such a call can only finish in the
-        /// tick the hold is holding back. Waiting for a stream or an event while holding the
-        /// tick therefore waits out the timeout, as stream updates are only sent once the tick
-        /// has been let go.
+        /// held. Keep a hold as short as possible, and release it even when the code between
+        /// the two calls fails.
+        ///
+        /// A tick is held once, so this waits for the next tick when the current one has
+        /// already been released. One client holds the tick at a time, and only a client
+        /// making a call can hold it: a stream or an event cannot.
+        ///
+        /// A hold ends by itself when it times out, when the client disconnects, and when the
+        /// client calls a procedure that takes more than one tick to finish, such as staging
+        /// or warping. Stream updates are sent once the tick is released, so waiting for a
+        /// stream or an event inside a hold waits out the timeout.
         /// </remarks>
         [KRPCProcedure]
         public static void HoldTick ()
@@ -309,8 +307,7 @@ namespace KRPC.Service.KRPC
 
         /// <summary>
         /// Let the game move on from the tick that <see cref="HoldTick" /> held it on. Does
-        /// nothing if the tick is not being held, which is what a client whose hold has already
-        /// ended sees.
+        /// nothing when no tick is held, which is the case once a hold has timed out.
         /// </summary>
         [KRPCProcedure]
         public static void ReleaseTick ()
@@ -324,17 +321,15 @@ namespace KRPC.Service.KRPC
         /// is currently being held.
         /// </summary>
         /// <remarks>
-        /// A release and a hold made as two separate calls leave the server free to advance
-        /// between them, since the hold is a call it has to be waiting for when it looks. This
-        /// takes the next tick without that gap, so it is the call a loop that has to act on
-        /// every tick is built around: call it at the top of the loop, work, and come back to
-        /// it. The game advances one tick per call and no faster, so it runs at the rate of the
-        /// loop for as long as the loop runs, and the loop ends by calling
-        /// <see cref="ReleaseTick" />.
+        /// A release and a hold made as two separate calls let the game advance between them.
+        /// This takes the next tick without that gap. Call it at the top of a loop that has to
+        /// act on every tick, work, and come back to it.
         ///
-        /// Every other limit of <see cref="HoldTick" /> applies unchanged, the timeout
-        /// included. A hold lost to the timeout is not reported: the next call simply takes
-        /// whatever tick it lands on.
+        /// The game advances one tick per call, so it runs at the rate of the loop for as long
+        /// as the loop runs. End the loop with <see cref="ReleaseTick" />.
+        ///
+        /// Every limit of <see cref="HoldTick" /> applies, the timeout included. A hold lost to
+        /// the timeout is not reported, and the next call takes whatever tick it lands on.
         /// </remarks>
         [KRPCProcedure]
         public static void NextTick ()

--- a/core/src/Service/ObjectStore.cs
+++ b/core/src/Service/ObjectStore.cs
@@ -86,11 +86,9 @@ namespace KRPC.Service
                 try {
                     state = instance.GameObjectState;
                 } catch (Exception e) {
-                    // One pass covers the whole store, so an instance that breaks the
-                    // interface's promise not to throw must not stop the rest from being
-                    // checked. Keeping it is the safe answer, on the same grounds as
-                    // reporting anything uncertain as dormant: an instance wrongly kept
-                    // costs memory until the next sweep, where one wrongly removed is gone.
+                    // One pass covers the whole store, so an instance that throws must not
+                    // stop the rest being checked. Keep it: an instance wrongly kept costs
+                    // memory until the next sweep, where one wrongly removed is gone
                     Logger.WriteLine (
                         "Failed to determine whether an instance in the object store still " +
                         "exists, so it was kept: " + e.Message, Logger.Severity.Error);
@@ -119,10 +117,9 @@ namespace KRPC.Service
             object result;
             if (objectIds.TryGetValue (id, out result))
                 return result;
-            // Identifiers are allocated in sequence and never reused, so an identifier
-            // below the next one to be allocated was issued and has since been removed.
-            // That means the object it referred to is gone, rather than the client
-            // having made the identifier up.
+            // Identifiers are allocated in sequence and never reused, so an identifier below
+            // the next one to be allocated was issued and has since been removed. The object
+            // it referred to is gone
             if (id < nextObjectId)
                 throw new global::KRPC.Service.KRPC.ObjectDestroyedException (
                     "The object with id " + id + " no longer exists, " +

--- a/core/src/Service/Scanner/ServiceSignature.cs
+++ b/core/src/Service/Scanner/ServiceSignature.cs
@@ -154,9 +154,9 @@ namespace KRPC.Service.Scanner
 
         void AddPropertyProcedure (PropertyInfo property, MethodInfo method, bool nullable, bool isSetter)
         {
-            // For a getter the nullable flag makes the return value nullable; for a setter it makes
-            // the synthesized value parameter nullable, since that parameter cannot itself carry
-            // the [KRPCNullable] attribute.
+            // For a getter the nullable flag makes the return value nullable. For a setter it
+            // makes the synthesized value parameter nullable, which cannot carry the attribute
+            // itself
             var handler = new ProcedureHandler (method, isSetter ? false : nullable);
             if (isSetter && nullable)
                 handler.SetValueParameterNullable ();
@@ -295,9 +295,9 @@ namespace KRPC.Service.Scanner
 
         void AddClassPropertyMethod (string cls, Type classType, PropertyInfo property, MethodInfo method, bool nullable, bool isSetter)
         {
-            // For a getter the nullable flag makes the return value nullable; for a setter it makes
-            // the synthesized value parameter nullable, since that parameter cannot itself carry
-            // the [KRPCNullable] attribute.
+            // For a getter the nullable flag makes the return value nullable. For a setter it
+            // makes the synthesized value parameter nullable, which cannot carry the attribute
+            // itself
             var handler = new ClassMethodHandler (classType, method, isSetter ? false : nullable);
             if (isSetter && nullable)
                 handler.SetValueParameterNullable ();

--- a/core/src/Utils/GameObjectState.cs
+++ b/core/src/Utils/GameObjectState.cs
@@ -1,7 +1,7 @@
 namespace KRPC.Utils
 {
     /// <summary>
-    /// What the game holds for the thing that a service object stands for.
+    /// The state of the game object that a service object identifies.
     /// </summary>
     /// <remarks>
     /// The values are ordered from most to least alive, so that an object built on
@@ -14,23 +14,23 @@ namespace KRPC.Utils
         /// </summary>
         Live,
         /// <summary>
-        /// The game object does not exist, but the game still holds what it needs to
-        /// build it again, so the thing the service object stands for is intact.
+        /// The game object does not exist, and the game holds what it needs to build it
+        /// again. What the service object identifies is intact.
         /// </summary>
         Dormant,
         /// <summary>
-        /// The game holds nothing for it. It can never be used again.
+        /// The game object is gone. It can never be used again.
         /// </summary>
         Destroyed
     }
 
     /// <summary>
-    /// Combines the states of the things a service object is built on.
+    /// Combines the states of the objects a service object is built on.
     /// </summary>
     public static class GameObjectStates
     {
         /// <summary>
-        /// The state of an object that needs both of the things it is built on, which is
+        /// The state of an object that needs both of the objects it is built on, which is
         /// the less alive of their two states.
         /// </summary>
         public static GameObjectState LeastAlive (this GameObjectState state, GameObjectState other)
@@ -39,7 +39,7 @@ namespace KRPC.Utils
         }
 
         /// <summary>
-        /// The state of an object that either of the things it is built on is enough for,
+        /// The state of an object that either of the objects it is built on is enough for,
         /// which is the more alive of their two states.
         /// </summary>
         public static GameObjectState MostAlive (this GameObjectState state, GameObjectState other)

--- a/core/src/Utils/Hash.cs
+++ b/core/src/Utils/Hash.cs
@@ -18,8 +18,8 @@ namespace KRPC.Utils
     /// </remarks>
     public struct Hash : IEquatable<Hash>
     {
-        // An arbitrary starting value, and an odd multiplier that moves what has been
-        // folded in so far clear of the field being added.
+        // An arbitrary starting value, and an odd multiplier that spreads the bits folded
+        // in so far clear of the field being added
         const int seed = 17;
         const int multiplier = 31;
 

--- a/core/src/Utils/IGameObjectState.cs
+++ b/core/src/Utils/IGameObjectState.cs
@@ -1,22 +1,22 @@
 namespace KRPC.Utils
 {
     /// <summary>
-    /// Implemented by an object that stands for something in the game, which the game
+    /// Implemented by an object that identifies something in the game, which the game
     /// can destroy. The object store drops objects that report themselves destroyed; an
     /// object that does not implement this interface is kept until the server stops.
     /// </summary>
     public interface IGameObjectState
     {
         /// <summary>
-        /// What the game holds for the thing this object stands for.
+        /// The state of the game object this identifies.
         /// </summary>
         /// <remarks>
-        /// <see cref="GameObjectState.Destroyed" /> means the thing is definitively gone
-        /// and the object can never work again. Anything less certain, including a thing
-        /// the game has unloaded but can build again, is dormant: an object wrongly
-        /// dropped cannot be recovered, whereas one wrongly kept only costs memory until
-        /// it is checked again. Implementations must not throw, as this is called while
-        /// sweeping the whole object store.
+        /// <see cref="GameObjectState.Destroyed" /> means the game object is definitively
+        /// gone and the object can never work again. Every less certain case is dormant,
+        /// including a game object the game has unloaded and can build again: an object
+        /// wrongly dropped cannot be recovered, whereas one wrongly kept only costs memory
+        /// until it is checked again. Implementations must not throw, as this is called
+        /// while sweeping the whole object store.
         /// </remarks>
         GameObjectState GameObjectState { get; }
     }

--- a/core/test/ScriptedClient.cs
+++ b/core/test/ScriptedClient.cs
@@ -7,8 +7,7 @@ namespace KRPC.Test
 {
     // A client whose requests are handed over one at a time, and only once the server has
     // polled for them often enough. Polling stands in for the time a real client spends
-    // deciding what to call next, so that what is measured is how many updates the calls
-    // are spread over rather than how long anything took.
+    // between calls, so the measurement is how many updates the calls are spread over
     sealed class ScriptedClient : IClient<Request,Response>
     {
         sealed class ScriptedStream : IStream<Request,Response>
@@ -32,8 +31,8 @@ namespace KRPC.Test
 
             public bool DataAvailable {
                 get {
-                    // Counted here, since polling for a request is what the server does
-                    // while it waits for one.
+                    // Counted here, since the server polls for a request while it waits
+                    // for one
                     polls++;
                     if (pollsBeforeGone > 0 && polls > pollsBeforeGone)
                         onPollsBeforeGone ();

--- a/core/test/Server/LocalSocket/LocalSocketServerTest.cs
+++ b/core/test/Server/LocalSocket/LocalSocketServerTest.cs
@@ -219,8 +219,7 @@ namespace KRPC.Test.Server.LocalSocket
         public void StartFailsWhenAnotherServerIsListening ()
         {
             // The socket file alone does not say whether the server that made it is still
-            // there, and taking the path from one that is would leave it unreachable with
-            // nothing to say where its clients had gone
+            // there, and taking the path from a running server would leave it unreachable
             var running = new LocalSocketServer (path);
             running.OnClientRequestingConnection += (s, e) => {
                 return;
@@ -242,8 +241,8 @@ namespace KRPC.Test.Server.LocalSocket
         [Test]
         public void StartDoesNotDeleteAFileThatIsNotASocket ()
         {
-            // A mistyped path points at a file that is nothing to do with the server, and
-            // whatever is in it is not the server's to remove
+            // A mistyped path points at a file that has nothing to do with the server, and
+            // the server does not remove it
             File.WriteAllText (path, "not a socket");
             var server = new LocalSocketServer (path);
             server.OnClientRequestingConnection += (s, e) => {
@@ -271,8 +270,8 @@ namespace KRPC.Test.Server.LocalSocket
         [Platform (Exclude = "Win", Reason = "made with the link command POSIX has")]
         public void StartReportsAPathItCannotAsk ()
         {
-            // A link with nothing on the end of it answers a connection with neither a server
-            // nor a refusal, which says only that the question went unanswered
+            // A link with nothing on the end of it gives neither a connection nor a refusal,
+            // so whether a server is there stays unknown
             Link ("/nowhere-at-all", path);
             var server = new LocalSocketServer (path);
             server.OnClientRequestingConnection += (s, e) => {
@@ -333,8 +332,8 @@ namespace KRPC.Test.Server.LocalSocket
         public void StartWithATooLongPathFails ()
         {
             // The limit is on the bytes a path takes, not the characters it is written with,
-            // so one written in characters that take more than a byte each reaches it while
-            // it still has fewer characters than the limit names
+            // so a path in multi-byte characters reaches it with fewer characters than the
+            // limit names
             var longPath = new string ('\u00e9', LocalSocketServer.MaximumPathLength / 2 + 1);
             Assert.IsTrue (longPath.Length <= LocalSocketServer.MaximumPathLength);
             Assert.IsTrue (LocalSocketServer.PathLength (longPath) > LocalSocketServer.MaximumPathLength);

--- a/core/test/Server/LocalSocket/UnixEndPointTest.cs
+++ b/core/test/Server/LocalSocket/UnixEndPointTest.cs
@@ -89,9 +89,8 @@ namespace KRPC.Test.Server.LocalSocket
         [Platform (Exclude = "Win", Reason = "the directory it falls back to is one only POSIX has")]
         public void DefaultPathFallsBackToAFixedDirectory ()
         {
-            // A client works the same path out in a process of its own, where TMPDIR may
-            // well say something else, so the fallback cannot be whichever temporary
-            // directory this process was pointed at
+            // A client works the same path out in a process of its own, where TMPDIR may say
+            // something else, so the fallback is a fixed directory
             var runtimeDirectory = Environment.GetEnvironmentVariable ("XDG_RUNTIME_DIR");
             var temporaryDirectory = Environment.GetEnvironmentVariable ("TMPDIR");
             try {

--- a/core/test/Server/LocalSocket/UnixSocketTest.cs
+++ b/core/test/Server/LocalSocket/UnixSocketTest.cs
@@ -43,9 +43,8 @@ namespace KRPC.Test.Server.LocalSocket
         {
             using (var listener = NewSocket ()) {
                 UnixSocket.BindAndListenThroughWinsock (listener, path, 1);
-                // Reaching it is what shows the socket is bound to that path and listening on
-                // it, and takes nothing from the runtime this test is running on, which cannot
-                // accept on a socket it did not bind itself
+                // Connecting shows the socket is bound to that path and listening on it,
+                // without relying on the runtime to accept on a socket it did not bind
                 using (var client = NewSocket ()) {
                     client.Connect (new UnixEndPoint (path));
                     Assert.IsTrue (client.Connected);

--- a/core/test/Service/ObjectStoreTest.cs
+++ b/core/test/Service/ObjectStoreTest.cs
@@ -113,8 +113,7 @@ namespace KRPC.Test.Service
             var deadId = store.AddInstance (dead);
             dead.GameObjectState = GameObjectState.Destroyed;
 
-            // The rest of the store is still swept, and the instance that could not be
-            // asked is kept rather than dropped on the strength of an error.
+            // The rest of the store is still swept, and the instance that threw is kept
             Assert.AreEqual (1, store.Sweep ());
             Assert.AreSame (broken, store.GetInstance (brokenId));
             Assert.Throws<ObjectDestroyedException> (() => store.GetInstance (deadId));

--- a/core/test/Service/TypeUtilsTest.cs
+++ b/core/test/Service/TypeUtilsTest.cs
@@ -402,8 +402,8 @@ namespace KRPC.Test.Service
         }
 
         // Structures whose fields break one of the rules. They do not carry the KRPCStruct
-        // attribute, as the scanner finds every type that does and would report them for every
-        // test in this assembly rather than only here.
+        // attribute, as the scanner finds every type that does and would report them for
+        // every test in this assembly
 
         public struct StructWithoutFields
         {

--- a/core/test/TickHoldTest.cs
+++ b/core/test/TickHoldTest.cs
@@ -20,15 +20,15 @@ namespace KRPC.Test
         public void SetUp ()
         {
             core = Core.Instance;
-            // Procedures are gated on the game scene, so the calls these tests script only run
-            // in one. Set here rather than relied on from whichever fixture ran last.
+            // Procedures are gated on the game scene, so the calls these tests script only
+            // run in one. Set here, as another fixture may have left a different scene
             CallContext.GameScene = GameScene.Flight;
             var config = Configuration.Instance;
             blockingRecv = config.BlockingRecv;
             tickHoldTimeout = config.TickHoldTimeout;
-            // Without blocking receives the server polls each client once per pass, so a client
-            // that is not ready costs it one poll rather than a wait, and the number of updates
-            // a script takes is decided by the script rather than by a clock.
+            // Without blocking receives the server polls each client once per pass, so a
+            // client that is not ready costs it one poll. The number of updates a script
+            // takes is then decided by the script and not by a clock
             config.BlockingRecv = false;
         }
 
@@ -69,8 +69,8 @@ namespace KRPC.Test
         {
             foreach (var response in responses) {
                 Assert.IsFalse (response.HasError, response.Error == null ? string.Empty : response.Error.Description);
-                // A call that failed is reported in its own result, so checking the response
-                // alone would pass however the calls went.
+                // A call that failed is reported in its own result, so the response alone
+                // would pass however the calls went
                 foreach (var result in response.Results)
                     Assert.IsFalse (result.HasError, result.Error == null ? string.Empty : result.Error.Description);
             }
@@ -122,7 +122,7 @@ namespace KRPC.Test
             var client = Connect (1, 50, "HoldTick");
             core.Update ();
             // Taken on this update, and the client goes away while it is held. The update has
-            // to notice, rather than waiting out a timeout that is far longer than the test.
+            // to notice before the timeout, which is far longer than the test
             var timer = Stopwatch.StartNew ();
             core.Update ();
             timer.Stop ();
@@ -146,9 +146,9 @@ namespace KRPC.Test
         [Test]
         public void AHoldSentWithTheReleaseBeforeItWaitsForTheNextTick ()
         {
-            // Sent as one request, so both calls run in one continuation and the release cannot
-            // end the update before the hold behind it is executed. The hold has to turn itself
-            // down, or a client could defer the tick for as long as it kept asking.
+            // Sent as one request, so both calls run in one continuation and the release
+            // cannot end the update before the hold behind it is executed. The second hold
+            // is refused
             var client = Batched (
                 new [] { "HoldTick" },
                 new [] { "ReleaseTick", "HoldTick" },
@@ -165,9 +165,9 @@ namespace KRPC.Test
         [Test]
         public void AReleaseAndAHoldInSeparateRequestsCanMissATick ()
         {
-            // The hold is a call the server has to be waiting for when it looks, and a client
-            // that is not ready costs it a poll. Nothing holds the tick after the release, so
-            // the update it would have held ends without it.
+            // The server has to be polling when the hold arrives, and a client that is not
+            // ready costs it a poll. Nothing holds the tick after the release, so the update
+            // it would have held ends without it
             var client = Connect (1, "HoldTick", "ReleaseTick", "HoldTick", "ReleaseTick");
             core.Update ();
             core.Update ();

--- a/core/test/UpdateEventsTest.cs
+++ b/core/test/UpdateEventsTest.cs
@@ -95,9 +95,9 @@ namespace KRPC.Test
         [Test]
         public void TheEventsBracketTheCallsThatTheUpdateExecutes ()
         {
-            // How many of the script's calls had been answered each time an event was raised.
-            // The update that runs the script must raise the first before any of them and the
-            // second after all of them.
+            // The number of the script's calls answered each time an event was raised. The
+            // update that runs the script must raise the first before any of them and the
+            // second after all of them
             var answeredAtBefore = new List<int> ();
             var answeredAtAfter = new List<int> ();
             ScriptedClient client = null;

--- a/core/test/Utils/HashTest.cs
+++ b/core/test/Utils/HashTest.cs
@@ -17,8 +17,8 @@ namespace KRPC.Test.Utils
         [Test]
         public void EqualFieldsDoNotCancel ()
         {
-            // What an exclusive-or gets wrong: a pair of fields holding the same value
-            // must not leave the hash where it would have been without them.
+            // An exclusive-or gets this wrong: a pair of fields holding the same value must
+            // not leave the hash where it would have been without them
             Assert.AreNotEqual (Hash.Of ("a").And ("a").Value, Hash.Of ("b").And ("b").Value);
             Assert.AreNotEqual (Hash.Of ("a").And ("a").Value, Hash.Of (0).And (0).Value);
         }
@@ -50,8 +50,8 @@ namespace KRPC.Test.Utils
         [Test]
         public void AHashIsItsOwnHashCode ()
         {
-            // Every use of Hash is inside a GetHashCode, where asking a hash for its own
-            // one instead of reading it is an easy slip to make.
+            // Every use of Hash is inside a GetHashCode, where calling GetHashCode on the
+            // hash instead of reading its value is an easy slip
             var hash = Hash.Of ("a").And (2);
             Assert.AreEqual (hash.Value, hash.GetHashCode ());
             Assert.AreEqual (hash, Hash.Of ("a").And (2));

--- a/doc/src/cnano/client.rst
+++ b/doc/src/cnano/client.rst
@@ -48,7 +48,7 @@ The C-nano client is available from `vcpkg <https://vcpkg.io>`_. It can be insta
 
          vcpkg install krpc-cnano:x64-windows
 
-The library communicates over a serial port unless a transport feature is asked for. The ``tcp``
+The library communicates over a serial port unless a transport feature is given. The ``tcp``
 feature builds it to communicate over TCP/IP instead:
 
 .. tabs::
@@ -137,38 +137,35 @@ argument to the compiler.
     serial communication mechanisms. The Arduino platform will be auto-detected so you do not need
     to specify this manually.
   * ``KRPC_COMMUNICATION_TCP`` -- Specifies that the library should be built to communicate over
-    TCP/IP with a server reachable over the network. A serial port remains the usual choice for the
-    devices this client is written for, so this is never auto-detected and has to be specified.
-    CMake builds of the library should ask for it with ``-DKRPC_COMMUNICATION_TCP=ON``, and vcpkg
-    installs with the ``tcp`` feature, rather than by defining it directly, so that programs
-    linking the library are built for the same transport and, on Windows, are linked against
-    winsock along with it.
+    TCP/IP with a server reachable over the network. A serial port is the usual choice for the
+    devices this client is written for, so this is specified rather than auto-detected. Use
+    ``-DKRPC_COMMUNICATION_TCP=ON`` for a CMake build and the ``tcp`` feature for a vcpkg install.
+    These build a program linking the library for the same transport, and on Windows link it
+    against winsock.
   * ``KRPC_COMMUNICATION_LOCALSOCKET`` -- Specifies that the library should be built to
-    communicate over a unix domain socket, for a server running on the same machine. The
+    communicate over a unix domain socket, with a server running on the same machine. The
     connection is opened with the path of the server's RPC socket in place of a serial port
-    name. Not auto-detected, as a serial port is the usual choice on the platforms that
-    provide both. CMake builds of the library should ask for it with
-    ``-DKRPC_COMMUNICATION_LOCALSOCKET=ON``, and vcpkg installs with the ``localsocket``
-    feature, rather than by defining it directly, so that programs linking the library are
-    built for the same transport.
+    name. A serial port is the usual choice on the platforms providing both, so this is
+    specified rather than auto-detected. Use ``-DKRPC_COMMUNICATION_LOCALSOCKET=ON`` for a
+    CMake build and the ``localsocket`` feature for a vcpkg install, so that a program linking
+    the library is built for the same transport.
   * ``KRPC_COMMUNICATION_CUSTOM`` -- Allows you to provide your own implementation for the
     communication mechanism.
   * ``KRPC_SINGLE_CONNECTION`` -- Only meaningful alongside ``KRPC_COMMUNICATION_CUSTOM``. A serial
-    port carries the RPC and stream connections over the one link, so every message sent over it is
-    wrapped in a multiplexed message saying which connection it belongs to. A custom communication
-    mechanism is assumed to work the same way; define this if yours instead opens a connection of
-    its own to each server, as a socket does, and the messages are sent unwrapped.
+    port carries the RPC and stream connections over one link, so each message is wrapped in a
+    multiplexed message naming the connection it belongs to. Define this when a custom
+    communication mechanism opens a connection to each server, as a socket does, and sends
+    messages unwrapped.
 
 * Memory allocation
 
   * ``KRPC_BUFFER_SIZE`` -- How much of a message to hold in memory while it is written to or read
-    from the connection, defaulting to 1024 bytes, and to 128 bytes when building for Arduino where
-    a kilobyte is a large share of the memory there is. A message larger than this is carried in as
-    many passes as it takes, so this bounds the memory a call costs and never the size of a message
-    it can carry. A message that fits is also cheaper to send, as its size can be written in front
-    of it rather than found by a pass over it first, so it is worth setting this above the largest
-    call a program makes. Two buffers of this size are used, one for a message being sent and one
-    for a message being received, and neither outlives the call it is made for.
+    from the connection. The default is 1024 bytes, and 128 bytes when building for Arduino, where
+    a kilobyte is a large share of the memory available. A larger message is carried in as many
+    passes as it takes, so this bounds the memory a call costs rather than the size of a message.
+    A message that fits is cheaper to send, as its size is written in front of it instead of found
+    by a first pass over it. Two buffers of this size are used, one for sending and one for
+    receiving, and neither outlives the call it is made for.
   * ``KRPC_ALLOC_BLOCK_SIZE`` -- The size of collections (lists, sets, etc.) are not know ahead of
     time, so when they are received from the server they are decoded into dynamically allocated
     memory on the heap. This option controls how many items to increase the capacity of the
@@ -201,11 +198,12 @@ server left on its default protocol. A connection is then opened with the addres
 server is listening on rather than the name of a port.
 
 .. note:: A serial port carries data far more slowly than the game produces it, and the server
-          drops a connection that produces more data than the port can carry for a sustained
-          period. See :ref:`communication-protocol-serialio-buffering` for the limits and how to
-          stay within them. This does not apply over TCP/IP. The client blocks while waiting for
-          data from the server, with no timeout, so a call that is never answered, for example
-          because the connection was dropped, never returns.
+          drops a connection that sustains more data than the port can carry. See
+          :ref:`communication-protocol-serialio-buffering` for the limits and how to stay within
+          them.
+
+.. note:: The client blocks while waiting for data from the server, with no timeout. A call left
+          unanswered, after a dropped connection for example, never returns.
 
 Linking
 ^^^^^^^
@@ -260,9 +258,9 @@ The following example demonstrates how to invoke remote procedures using the Cna
 
 .. literalinclude:: /scripts/client/cnano/RemoteProcedures.c
 
-Many procedures return an object standing for something in the game, such as a vessel or
-a part. See :doc:`Object Lifetime </tutorials/object-lifetime>` for what those objects do
-when a game is loaded or the thing they stand for is destroyed.
+Many procedures return an object identifying something in the game, such as a vessel or
+a part. See :doc:`Object Lifetime </tutorials/object-lifetime>` for how such an object
+behaves when a game is loaded or what it identifies is destroyed.
 
 .. _cnano-client-streams:
 .. _cnano-client-events:
@@ -294,10 +292,9 @@ Client API Reference
    ``krpc_open(&conn, "COM1")``.
 
    When the library is built using ``KRPC_COMMUNICATION_TCP`` calling this function connects to the
-   server over TCP/IP. *arg* is a pointer to a structure of type ``krpc_connection_config_t``
-   holding the address of the machine the server is running on and the port its RPC server is
-   listening on. The address may be a host name or an address literal, and every endpoint it
-   resolves to is tried until one accepts the connection. For example:
+   server over TCP/IP. *arg* is a pointer to a ``krpc_connection_config_t`` holding the address of
+   the machine running the server and the port its RPC server listens on. The address may be a host
+   name or an address literal, and each endpoint it resolves to is tried in turn. For example:
 
    .. code-block:: c
 

--- a/doc/src/communication-protocols/localsocket.rst
+++ b/doc/src/communication-protocols/localsocket.rst
@@ -4,10 +4,10 @@ Protocol Buffers over a Local Socket
 This communication protocol allows a client running on the same machine as the game to interact
 with a kRPC server over a unix domain socket, rather than a TCP/IP connection.
 
-Compared to :doc:`tcpip`, a local socket carries the same messages over a cheaper path: it does not
-go through the network stack, so a client that makes many calls in quick succession gets more of
-them done per physics update. A client that makes one call and then waits sees no difference, as
-the wait is governed by the game's update rate rather than by the connection.
+A local socket carries the same messages as :doc:`tcpip` over a cheaper path, bypassing the
+network stack. A client that makes many calls in quick succession completes more of them per
+physics update. A client that makes one call and then waits runs at the game's update rate
+either way.
 
 .. note:: If a client library is available for your language, you do not need to implement this
           protocol.
@@ -50,47 +50,41 @@ there is no need to connect.
 Default Socket Paths
 --------------------
 
-The server and its clients each work the default paths out for themselves, without either telling
-the other, so they only meet if they agree at every step. A client that computes a path by hand
-follows the same rule, for a socket named ``rpc`` or ``stream``:
+The server and its clients each compute the default paths for themselves. They meet only by
+following the same rule. For a socket named ``rpc`` or ``stream``:
 
 1. If ``XDG_RUNTIME_DIR`` is set and not empty, the path is ``krpc/<name>`` inside it. On Windows
    ``LOCALAPPDATA`` is read instead, as there is no runtime directory there.
 
 2. Otherwise the path is ``krpc-<user>/<name>`` inside ``/tmp``, where ``<user>`` is the name of
-   the account running the process. The directory is fixed rather than the one ``TMPDIR`` asks
-   for, because the server and the client are separate processes and that variable moves the
-   directory for one of them and not the other. Windows always names a directory in
-   ``LOCALAPPDATA`` and so never reaches this step, which is why it is the one place the system
-   temporary directory is used.
+   the account running the process. ``/tmp`` is fixed, as ``TMPDIR`` is set per process and would
+   move the directory for the server or the client alone. Windows always names a directory in
+   ``LOCALAPPDATA``, and so never reaches this step.
 
-The user name is that of the account running the process, taken from the account database rather
-than from ``USER`` alone, which is unset in a process started without a login shell. A client whose
-language leaves it nothing but the environment to ask, and finds nothing there, reports that rather
-than building a path with the name left out, which would be shared between accounts instead of
-belonging to one.
+The user name comes from the account database, as ``USER`` is unset in a process started without a
+login shell. A client whose language offers only the environment, and finds nothing there, reports
+an error. A path built without the user name would be shared between accounts.
 
 Socket Paths
 ------------
 
-A socket path is limited to 100 bytes, as the address is copied into a fixed size structure by the
-operating system. The limit is on the bytes a path takes rather than the characters it is written
-with, so a path using characters that take more than one byte reaches it sooner. The server
-reports a path that is too long rather than failing to start with an unhelpful error.
+A socket path is limited to 100 bytes, as the operating system copies the address into a fixed size
+structure. The limit counts the bytes a path takes rather than its characters, so a path using
+multi-byte characters reaches it sooner. The server reports a path that is too long.
 
-The socket file is created when the server starts and removed when it stops. A server whose process
-is killed rather than stopped leaves the file behind; the next server to use that path removes it
-before binding, so a stale file does not prevent a restart. The file alone does not say whether the
-server that made it is still there, so that server connects to the path first and refuses to start
-if anything answers, rather than taking a path another server is listening on and leaving it
-unreachable. A path holding content is not a socket at all and is left alone.
+The socket file is created when the server starts and removed when it stops. A killed server leaves
+the file behind, and the next server to use that path removes it before binding.
 
-Access to the server is controlled by the permissions on the socket and on the directory holding it.
+A stale file is indistinguishable from a live one, so the server connects to the path first and
+refuses to start if the connection succeeds. A path holding a file with content is left alone.
+
+The permissions on the socket and on the directory holding it control access to the server.
 ``XDG_RUNTIME_DIR`` and ``LOCALAPPDATA`` are private to the account they belong to, so sockets
-placed there are reachable only by that user. The ``/tmp`` fallback is named after the user rather
-than restricted to them: it is created with whatever the process ``umask`` allows, which can leave
-the socket open to the user's group. Where that matters, set ``XDG_RUNTIME_DIR`` or configure the
-paths.
+placed there are reachable only by that user.
+
+The ``/tmp`` fallback is created with whatever the process ``umask`` allows, which can leave the
+socket open to the user's group. Set ``XDG_RUNTIME_DIR`` or configure the paths where that
+matters.
 
 Invoking Remote Procedures
 --------------------------
@@ -104,9 +98,9 @@ The following Python code connects to the RPC server over a local socket using t
 invokes the ``KRPC.GetStatus`` RPC and prints the server version number from the response. The
 message encoding is identical to the TCP/IP protocol; only the socket differs.
 
-It is written for the socket API as POSIX has it, so it runs on Linux and macOS. The protocol is
-the same on Windows, where the address family has to be reached through winsock, as Python's
-socket module does not expose it.
+It is written for the POSIX socket API, so it runs on Linux and macOS. The protocol is the same on
+Windows, where the address family is reached through winsock, as Python's socket module does not
+expose it.
 
 .. literalinclude:: /scripts/communication-protocol-localsocket.py
    :language: python

--- a/doc/src/communication-protocols/messages.rst
+++ b/doc/src/communication-protocols/messages.rst
@@ -176,12 +176,11 @@ Protocol Buffer version 3 serialization format:
 * Protocol Buffer libraries in many languages are available here:
   https://github.com/google/protobuf/releases
 
-A null value is not encoded in the ``value`` field. Instead it is signaled out-of-band by the
-``is_null`` field on the ``Argument`` or ``ProcedureResult`` message. When ``is_null`` is set, the
-``value`` field is unset and carries no encoded value. Null is signaled out-of-band because the
-encoding of every type already assigns a meaning to all byte sequences, leaving no spare value to
-reserve for null. This applies to values of any type. Note that a zero-length ``value`` is a valid
-encoding -- for example an empty collection -- and is distinct from a null value.
+The ``is_null`` field on the ``Argument`` or ``ProcedureResult`` message signals a null value of
+any type. When it is set, the ``value`` field is unset and carries no encoded value. Null is
+signaled this way because the encoding of every type assigns a meaning to all byte sequences,
+leaving no spare value for null. A zero-length ``value``, an empty collection for example, is a
+valid encoding and is distinct from null.
 
 .. _communication-protocol-streams:
 
@@ -570,10 +569,9 @@ The fields are:
 Structures
 ^^^^^^^^^^
 
-A structure is a compound value with named fields. Unlike a class, whose value on the wire is an
-identifier for an object that stays on the server, a structure's value is the values of its fields,
-sent inline. Details about each :csharp:attr:`KRPCStruct` are specified in a ``Struct`` message,
-with the format:
+A structure is a compound value with named fields, whose value on the wire is the values of those
+fields sent inline. A class sends an identifier for an object held on the server instead. Details
+about each :csharp:attr:`KRPCStruct` are specified in a ``Struct`` message, with the format:
 
 .. code-block:: protobuf
 
@@ -623,20 +621,18 @@ The fields are:
   empty.
 
 A value of a structure type is encoded as a ``Tuple`` message whose items are the encoded values of
-the structure's fields, in the order the ``fields`` list gives them. This is the same encoding as a
-tuple of the field types, so a client can encode and decode a structure with the codec it already
-has for tuples, and the field names exist only in the definition above.
+the structure's fields, in the order the ``fields`` list gives them. This is the encoding of a tuple
+of the field types, so a client can use the codec it already has for tuples. The field names appear
+only in the definition above.
 
-Two rules follow from that encoding, and a client author should rely on them:
+Two rules follow from that encoding:
 
-* Fields are only ever appended to a structure. A value may therefore carry more items than the
-  fields a client knows about, when it was generated against an older definition of the structure,
-  and those extra items are to be ignored. Fewer items than the known fields means the definitions
-  do not match, and is an error.
+* Fields are only ever appended to a structure. A client generated against an older definition may
+  receive more items than it has fields for, and ignores the extra items. Fewer items than its
+  fields means the definitions do not match, and is an error.
 
-* A field is never null. Null is signaled out-of-band by the ``is_null`` field of the enclosing
-  ``Argument`` or ``ProcedureResult`` message, which can say that a whole structure value is null
-  but says nothing about its fields.
+* A field is never null. The ``is_null`` field of the enclosing ``Argument`` or ``ProcedureResult``
+  message applies to the structure value as a whole, and carries nothing about its fields.
 
 Exceptions
 ^^^^^^^^^^
@@ -739,9 +735,8 @@ not return a value.
 
 For ``CLASS``, ``ENUMERATION`` and ``STRUCT`` types the ``service`` and ``name`` fields specify the
 service that defines the class, enumeration or structure and its name. For all other types these
-fields are empty. A ``STRUCT`` type carries no more than that, so the fields of a structure have to
-be read from the :ref:`Struct message <communication-protocol-structures>` in the definition of the
-service that names it.
+fields are empty. The fields of a structure are read from the :ref:`Struct message
+<communication-protocol-structures>` in the definition of the service that names it.
 
 For collection types the ``types`` repeated field will contain the sub-types:
 
@@ -792,8 +787,8 @@ properties make remote procedure calls to the server. Object identifiers have ty
 When a procedure returns a proxy object or takes one as a parameter, the type code will be set to
 ``CLASS``.
 
-A null object reference is signaled by the ``is_null`` field of the ``ProcedureResult`` or
-``Argument`` message, in the same way as a null value of any other type. The object identifier is
-not used to represent null on the wire.
+The ``is_null`` field of the ``ProcedureResult`` or ``Argument`` message signals a null object
+reference, as it does a null value of any other type. The object identifier is never used to
+represent null on the wire.
 
 .. _C# XML documentation: https://msdn.microsoft.com/en-us/library/aa288481%28v=vs.71%29.aspx

--- a/doc/src/communication-protocols/serialio.rst
+++ b/doc/src/communication-protocols/serialio.rst
@@ -130,8 +130,8 @@ carries roughly a thousand bytes per second. The server therefore buffers up to 
 in each direction, and the two directions behave differently when their buffer fills:
 
 * Data received from the port is buffered until the game reads it. When the buffer fills, the
-  server stops reading from the port until the game catches up. Nothing is lost, but the client
-  sees the port carry its data more slowly.
+  server stops reading from the port until the game catches up. The data is kept, and the port
+  carries it more slowly.
 
 * Data written by the game is buffered until the port has sent it. When this buffer fills, which
   means the game has been producing data faster than the port can send for a sustained period,

--- a/doc/src/cpp/client.rst
+++ b/doc/src/cpp/client.rst
@@ -116,9 +116,9 @@ its altitude:
 
 .. literalinclude:: /scripts/client/cpp/RemoteProcedures.cpp
 
-Many procedures return an object standing for something in the game, such as a vessel or
-a part. See :doc:`Object Lifetime </tutorials/object-lifetime>` for what those objects do
-when a game is loaded or the thing they stand for is destroyed.
+Many procedures return an object identifying something in the game, such as a vessel or
+a part. See :doc:`Object Lifetime </tutorials/object-lifetime>` for how such an object
+behaves when a game is loaded or what it identifies is destroyed.
 
 .. _cpp-client-streams:
 
@@ -511,7 +511,7 @@ Client API Reference
    Returns a hash of a value of any type the client carries: the arithmetic types, strings,
    enumerations, class objects, tuples, and the list, set and dictionary collection types,
    nested however deeply. A structure is also hashed by this function, and is given a
-   ``std::hash`` of its own, so an unordered container keyed by one needs nothing further.
+   ``std::hash`` of its own, so an unordered container can be keyed by one directly.
 
 .. class:: hash
 

--- a/doc/src/csharp/client.rst
+++ b/doc/src/csharp/client.rst
@@ -53,9 +53,9 @@ vessel and then prints out its altitude:
 
 .. literalinclude:: /scripts/client/csharp/RemoteProcedures.cs
 
-Many procedures return an object standing for something in the game, such as a vessel or
-a part. See :doc:`Object Lifetime </tutorials/object-lifetime>` for what those objects do
-when a game is loaded or the thing they stand for is destroyed.
+Many procedures return an object identifying something in the game, such as a vessel or
+a part. See :doc:`Object Lifetime </tutorials/object-lifetime>` for how such an object
+behaves when a game is loaded or what it identifies is destroyed.
 
 .. _csharp-client-streams:
 

--- a/doc/src/dictionary.txt
+++ b/doc/src/dictionary.txt
@@ -185,6 +185,7 @@ tuple
 turbofan
 uint
 ullage
+unannotated
 unchecks
 undocked
 undocking

--- a/doc/src/extending.rst
+++ b/doc/src/extending.rst
@@ -411,12 +411,12 @@ to add functionality to the kRPC server.
 
    This `attribute <https://msdn.microsoft.com/en-us/library/aa287992.aspx>`_ is applied to a
    ``struct``. It adds the structure and its fields to the server. A structure is a compound value
-   with named fields, whose value is sent to the client in full rather than as a reference to an
-   object that stays on the server.
+   with named fields. Its value is sent to the client in full, where a class sends a reference to
+   an object held on the server.
 
    The fields of the structure are its ``public`` instance properties that are annotated with
    :csharp:attr:`KRPCProperty` and have both a getter and a setter, in the order they are declared.
-   A property that is not annotated is not a field, and is not visible to a client.
+   An unannotated property is invisible to a client.
 
    A :csharp:attr:`KRPCStruct` must be part of a service, just like a
    :csharp:attr:`KRPCClass`. Similarly, a :csharp:attr:`KRPCStruct` can be declared outside of a
@@ -441,15 +441,14 @@ to add functionality to the kRPC server.
    * The structure must not contain itself, whether directly or through the fields of another
      structure that it contains.
 
-   Fields may only be **appended** to a structure. Reordering them, removing one or changing the
-   type of one is a breaking change for clients generated against the previous definition, as the
-   value of a structure is sent as the values of its fields in order.
+   Fields may only be **appended** to a structure. A structure's value is sent as the values of its
+   fields in order, so reordering them, removing one, or changing the type of one breaks clients
+   generated against the previous definition.
 
    **Choosing between a structure and a class.** A structure sends the values of all of its fields
-   whenever it is sent, in a single procedure call. Use one for compound data whose fields are
-   almost always wanted together, such as a position and a velocity. Use a
-   :csharp:attr:`KRPCClass` for something with mutable state, or whose members are expensive enough
-   that a client should be able to ask for them one at a time.
+   in a single procedure call. Use one for compound data whose fields are almost always wanted
+   together, such as a position and a velocity. Use a :csharp:attr:`KRPCClass` for something with
+   mutable state, or whose members are expensive enough to read one at a time.
 
    **Examples**
 
@@ -647,8 +646,7 @@ A **return value** is nullable if the ``Nullable`` parameter of its :csharp:attr
 is ``Nullable<T>``. For a property, ``Nullable = true`` makes the getter's return value *and* the
 setter's argument nullable.
 
-Whether a procedure returns ``null`` cannot necessarily be statically determined from its code, so
-return nullability must always be declared -- kRPC never infers it from the method body.
+Return nullability is always declared, as kRPC reads the attribute rather than the method body.
 
 .. _service-api-nullable-value-types:
 
@@ -659,13 +657,13 @@ A parameter or return value of type ``Nullable<T>`` -- ``int?``, ``float?``, ``b
 ``enum?`` and so on -- is automatically nullable; it needs neither :csharp:attr:`KRPCNullable` nor
 ``Nullable = true``. To clients it appears as an ordinary value of type ``T`` that may be null.
 
-Only value types can be ``Nullable<T>``. Reference types -- ``string``, :csharp:attr:`KRPCClass`
-types and collections such as ``IList<T>`` -- cannot be, so a `nullable reference type
-<https://learn.microsoft.com/en-us/dotnet/csharp/nullable-references>`_ annotation like ``string?``
-or ``IList<int>?`` is **not** recognized: it is a compile-time annotation only and does not change
-the runtime type, so the ``?`` is erased before kRPC sees the type and the parameter or return value
-is treated as non-nullable. Use :csharp:attr:`KRPCNullable` or ``Nullable = true`` to make a
-reference-typed parameter or return value nullable.
+Only value types can be ``Nullable<T>``. A `nullable reference type
+<https://learn.microsoft.com/en-us/dotnet/csharp/nullable-references>`_ annotation such as
+``string?`` or ``IList<int>?`` is a compile-time annotation, and the ``?`` is erased before kRPC
+reads the type. Such a parameter or return value is treated as non-nullable.
+
+Use :csharp:attr:`KRPCNullable` or ``Nullable = true`` to make a reference-typed parameter or
+return value nullable.
 
 Events
 ^^^^^^

--- a/doc/src/internals.rst
+++ b/doc/src/internals.rst
@@ -56,36 +56,33 @@ This behavior is enabled by the **blocking receives** option. **Receive
 timeout** sets the maximum amount of time the server will wait for a new RPC
 from a client.
 
-The receive timeout decides how much work a client may do between calls before
-it stops being waited for. A client that takes longer than the timeout to send
-its next call is not waiting when the server looks, so the server returns from
-the FixedUpdate and that call is executed in the next one: the client is served
-one RPC per update, however many it makes. The default timeout is one
-millisecond, which is easy for a program written in Python or Lua to exceed.
+The receive timeout bounds the work a client may do between calls. A client
+that takes longer than the timeout to send its next call has that call executed
+in the following FixedUpdate. It is then served one RPC per update, however many
+it makes. The default timeout is one millisecond, which a program written in
+Python or Lua exceeds easily.
 
-Holding a tick
+Holding a Tick
 --------------
 
-A client can hold the game on its current physics tick, so that every call it makes is
-executed before the game advances. That is what lets a control loop read the game
-state, compute with it and write the result back within one tick, rather than being
-served one RPC per update whenever it spends longer than the receive timeout between
-calls. See :ref:`the control loops tutorial <tutorial-control-loops>` for how a program
-uses it.
+A client can hold the game on its current physics tick, so every call it makes is
+executed before the game advances. A control loop can then read the game state,
+compute with it and write the result back within one tick. See :ref:`the control
+loops tutorial <tutorial-control-loops>` for how a program uses it.
 
 What a hold means for the server:
 
-* **Tick hold timeout** sets how long a client may hold a tick before the server takes
-  it back, one second by default. It bounds how long the game can be made to appear
-  frozen, which is why the server owns it rather than the client. A hold also ends when
-  the client disconnects.
-* The maximum time per update and one RPC per update settings do not apply while a tick
-  is held, and an update that held one is not counted by adaptive rate control, which
-  would otherwise read the client's own work as the server spending too long on RPCs and
-  wind the limit down for every other client.
-* The game renders no frame, takes no input and runs no physics while a tick is held.
-  What it does not cost is the simulation: physics runs on a fixed time step, so a game
-  whose ticks are held runs slower than real time rather than differently.
-* Streams do not update inside a hold, since stream updates are sent once the update has
-  finished executing calls, and new connections are not accepted, since the servers are
-  polled between updates.
+* **Tick hold timeout** sets how long a client may hold a tick, one second by
+  default. It bounds how long the game can be made to appear frozen, and the
+  server owns it rather than the client. A hold also ends when the client
+  disconnects.
+* The maximum time per update and one RPC per update settings do not apply while
+  a tick is held. Adaptive rate control skips an update that held one, which
+  would otherwise count the client's own work as time the server spent on RPCs
+  and wind the limit down for every client.
+* The game renders no frame, takes no input and runs no physics while a tick is
+  held. Physics runs on a fixed time step, so a game whose ticks are held runs
+  slower than real time and simulates every tick in turn.
+* Streams do not update inside a hold, as stream updates are sent once the update
+  has finished executing calls. New connections are not accepted either, as the
+  servers are polled between updates.

--- a/doc/src/java/client.rst
+++ b/doc/src/java/client.rst
@@ -56,9 +56,9 @@ vessel and then prints out its altitude:
 
 .. literalinclude:: /scripts/client/java/RemoteProcedures.java
 
-Many procedures return an object standing for something in the game, such as a vessel or
-a part. See :doc:`Object Lifetime </tutorials/object-lifetime>` for what those objects do
-when a game is loaded or the thing they stand for is destroyed.
+Many procedures return an object identifying something in the game, such as a vessel or
+a part. See :doc:`Object Lifetime </tutorials/object-lifetime>` for how such an object
+behaves when a game is loaded or what it identifies is destroyed.
 
 .. _java-client-streams:
 

--- a/doc/src/lua/client.rst
+++ b/doc/src/lua/client.rst
@@ -56,9 +56,9 @@ InfernalRobotics service is accessible via ``conn.infernal_robotics``.
 Calling methods, getting or setting properties, etc. are mapped to remote
 procedure calls and passed to the server by the lua client.
 
-Many procedures return an object standing for something in the game, such as a vessel or
-a part. See :doc:`Object Lifetime </tutorials/object-lifetime>` for what those objects do
-when a game is loaded or the thing they stand for is destroyed.
+Many procedures return an object identifying something in the game, such as a vessel or
+a part. See :doc:`Object Lifetime </tutorials/object-lifetime>` for how such an object
+behaves when a game is loaded or what it identifies is destroyed.
 
 Streams and Events
 ------------------
@@ -148,10 +148,10 @@ Reference
 Numeric Limits
 --------------
 
-The ``krpc.limits`` module names the extremes of the numeric types that kRPC carries over the
-wire. Lua names none of them itself, as ``math.maxinteger`` and ``math.mininteger`` arrive in
-Lua 5.3 and this client targets 5.1 and 5.2. A service can declare one of these as a
-parameter's default value, in which case it is documented as the constant here.
+The ``krpc.limits`` module names the extremes of the numeric types kRPC carries over the wire.
+Lua gained ``math.maxinteger`` and ``math.mininteger`` in 5.3, and this client targets 5.1 and
+5.2. A service can declare one of these limits as a parameter's default value, and it is then
+documented as the constant here.
 
 The minimum of an unsigned type is ``0``, so it has no constant.
 

--- a/doc/src/python/client.rst
+++ b/doc/src/python/client.rst
@@ -48,9 +48,9 @@ The following example demonstrates how to invoke remote procedures using the Pyt
 
 .. literalinclude:: /scripts/client/python/RemoteProcedures.py
 
-Many procedures return an object standing for something in the game, such as a vessel or
-a part. See :doc:`Object Lifetime </tutorials/object-lifetime>` for what those objects do
-when a game is loaded or the thing they stand for is destroyed.
+Many procedures return an object identifying something in the game, such as a vessel or
+a part. See :doc:`Object Lifetime </tutorials/object-lifetime>` for how such an object
+behaves when a game is loaded or what it identifies is destroyed.
 
 All of the functionality provided by the ``SpaceCenter`` service is accessible via
 ``conn.space_center``. To explore the functionality provided by a service, you can use the
@@ -225,8 +225,8 @@ Client API Reference
 
    Use this when the script runs on the same machine as the game and the server is configured to
    use the local socket protocol. A script that makes many calls in quick succession completes
-   more of them per physics update this way; one that makes a call and then waits sees no
-   difference, as the wait is governed by the game's update rate.
+   more of them per physics update. A script that makes a call and then waits runs at the game's
+   update rate either way.
 
    Unix domain sockets are available on Linux, macOS, and Windows 10 1803 and Windows Server
    2019 or later. Python's socket module does not expose the address family on Windows, so the
@@ -426,11 +426,10 @@ Client API Reference
 Numeric Limits
 --------------
 
-The ``krpc.limits`` module names the extremes of the numeric types that kRPC carries over the
-wire. Python names none of them itself: its integers are unbounded, so there is no largest
-``int``, and its floats are C doubles, so the standard library describes ``DOUBLE`` but says
-nothing about the 32-bit ``FLOAT``. A service can declare one of these as a parameter's default
-value, in which case the generated stub names the constant here.
+The ``krpc.limits`` module names the extremes of the numeric types kRPC carries over the wire.
+Python integers are unbounded, and Python floats are C doubles, so the standard library covers
+``DOUBLE`` alone. A service can declare one of these limits as a parameter's default value, and
+the generated stub then names the constant from this module.
 
 The minimum of an unsigned type is ``0``, so it has no constant.
 

--- a/doc/src/tutorials/autopilot.rst
+++ b/doc/src/tutorials/autopilot.rst
@@ -158,8 +158,8 @@ Reading the state back
 
 .. _autopilot-update-mode:
 
-When the control loop runs
-^^^^^^^^^^^^^^^^^^^^^^^^^^
+Update modes
+^^^^^^^^^^^^
 
 The control loop runs once per physics tick, and **update mode** chooses where in the tick
 it runs relative to the calls a program makes in that tick:
@@ -171,13 +171,12 @@ it runs relative to the calls a program makes in that tick:
   control output read during a tick are the ones computed for that tick, one tick behind the
   target.
 
-* **manual** does not run it at all. Calling **update** runs it, so a program places it
-  among its own calls.
+* **manual** runs it only when **update** is called, so a program places it among its own
+  calls.
 
-For a control loop this matters most together with :ref:`holding a tick <holding-a-tick>`,
-which puts a whole read, compute and write inside one tick. Manual mode then gives complete
-control of the order: everything before **update** is what the loop will fly the tick with,
-and everything after it can read what the loop just did.
+This matters most for a control loop that :ref:`holds a tick <holding-a-tick>`, putting a
+whole read, compute and write inside one tick. Manual mode then fixes the order: calls before
+**update** set what the loop flies the tick with, and calls after it read what the loop did.
 
 .. code-block:: python
 
@@ -191,12 +190,13 @@ and everything after it can read what the loop just did.
        finally:
            conn.krpc.release_tick()
 
-In manual mode the vessel is only flown on the ticks the loop is run on. On a tick it is not
-run on the vessel keeps the control output of the last tick it did run on, and after a tenth
-of a second of that the autopilot stops contributing any control input at all, so a program
-that stops calling **update** leaves the vessel coasting rather than holding a deflection.
-**wait** cannot be used in manual mode: it takes several ticks and blocks the program for
-all of them, so the loop would never run.
+In manual mode the vessel is flown only on the ticks the loop runs on. On any other tick the
+vessel keeps the control output of the last run, and after a tenth of a second the autopilot
+stops contributing control input. A program that stops calling **update** therefore leaves the
+vessel coasting.
+
+**wait** cannot be used in manual mode. It takes several ticks and blocks the program for all
+of them, so the loop would never run.
 
 Calling **update** more than once in a tick runs the loop once. The control law assumes one
 run per tick, so running it twice would advance its filters and gains at twice the rate.

--- a/doc/src/tutorials/control-loops.rst
+++ b/doc/src/tutorials/control-loops.rst
@@ -4,36 +4,34 @@ Control Loops
 =============
 
 A control loop reads the game state, computes something from it and writes the result back,
-over and over. The game runs its physics on a fixed step, 50 times a second, and a loop that
-flies a vessel wants to do its reading and writing once per step, with the values it writes
-acting on the state it read them from.
+over and over. The game runs its physics on a fixed step, 50 times a second. A loop that flies
+a vessel needs to read and write once per step, acting on the state it read.
 
-That is not what a plain loop gets. This tutorial explains why, and what to do about it.
+The Receive Timeout
+-------------------
 
-Why a plain loop falls behind
------------------------------
+The server executes calls inside the game's physics update, and waits a short while between
+them for a client's next call. That wait is the **receive timeout**, one millisecond by
+default.
 
-The server executes calls inside the game's physics update, and waits only a short while for
-a client's next call before giving up on it and letting the game move on. That wait is the
-**receive timeout**, one millisecond by default.
+A control loop spends its time between the calls: it reads, then computes, then writes.
+Computing for longer than a millisecond is easy in Python or Lua, and each call then lands in
+a different physics tick.
 
-A control loop spends its time between the calls, not during them: it reads, then computes,
-then writes. If the computing takes longer than a millisecond, which is easy in Python or
-Lua, the client is not waiting when the server looks for it, so each call lands in a
-different physics tick. An iteration of five calls costs five ticks, and by the time the last
-write lands the state it was computed from is five ticks old.
+An iteration of five calls therefore costs five ticks, and the state the last write was
+computed from is five ticks old.
 
-Raising the receive timeout is not the answer. It is a global setting, and it costs the
-server that much time on every idle update for every client.
+The receive timeout is a server-wide setting, and the server spends it on every idle update
+for every client.
 
 .. _holding-a-tick:
 
-Holding a tick
+Holding a Tick
 --------------
 
 ``hold_tick`` holds the game on its current physics tick, and ``release_tick`` lets it move
-on. Every call made in between is executed before the game advances, so a whole read, compute
-and write happens in the state of one tick:
+on. Every call made in between is executed before the game advances. A whole read, compute and
+write then happens in the state of one tick:
 
 .. code-block:: python
 
@@ -45,21 +43,19 @@ and write happens in the state of one tick:
        finally:
            conn.krpc.release_tick()
 
-Release the tick even when the code in between fails, as the ``finally`` above does. Until
-the hold is released the game is waiting, so a program that leaves one behind stops the game
-until the hold times out.
+Release the tick even when the code in between fails, as the ``finally`` above does. The game
+stays on the held tick until the hold is released or times out.
 
-Taking every tick
+Consecutive Ticks
 -----------------
 
-That loop gets whole ticks, but not consecutive ones. The ``hold_tick`` that opens an
-iteration is itself a call the server has to be waiting for, so a program that spends longer
-than the receive timeout between releasing one tick and asking for the next is not there when
-the server looks, and the game runs on without it. The loop still works, but it skips ticks,
-and it cannot tell which ones.
+That loop gets whole ticks, but not consecutive ones. The ``hold_tick`` opening an iteration
+is itself a call the server has to be waiting for. A program that spends longer than the
+receive timeout between releasing one tick and holding the next skips ticks, and cannot tell
+which ones.
 
 ``next_tick`` closes that gap. It releases the tick being held and holds the one immediately
-after it, in a single call, so the game runs no tick the loop has not held:
+after it, in a single call. The game then runs no tick the loop has not held:
 
 .. code-block:: python
 
@@ -71,12 +67,11 @@ after it, in a single call, so the game runs no tick the loop has not held:
    finally:
        conn.krpc.release_tick()
 
-The call returns when the next tick has been held, so the loop runs at exactly one iteration
-per physics tick and the game advances one tick per call and no faster. When no tick is being
-held ``next_tick`` holds the soonest one it can, so it is the only call the loop needs to
-open with, and ``release_tick`` at the end is what lets the game go.
+The call returns once the next tick is held. The loop therefore runs at one iteration per
+physics tick, and the game advances one tick per call. With no tick held, ``next_tick`` holds
+the soonest one it can, and is the only call the loop needs to open with.
 
-A worked example
+A Worked Example
 ----------------
 
 Holding a vessel's pitch with a proportional controller, one iteration per tick:
@@ -99,58 +94,51 @@ Holding a vessel's pitch with a proportional controller, one iteration per tick:
        conn.krpc.release_tick()
        vessel.control.pitch = 0
 
-Every iteration reads the pitch of one tick and writes a command that acts on that same tick,
-and the 500 iterations cover 500 consecutive ticks, ten seconds of game time. Written without
-the hold, the same loop would take two calls per iteration in two different ticks, and would
-skip an unknown number of ticks between one iteration and the next.
+Every iteration reads the pitch of one tick and writes a command that acts on that same tick.
+The 500 iterations cover 500 consecutive ticks, ten seconds of game time.
 
-This is a demonstration, not a recommendation: to actually fly a vessel, use the
-:ref:`autopilot <using-the-autopilot>`, which implements a far better control law than the
-one above.
+To actually fly a vessel, use the :ref:`autopilot <using-the-autopilot>`, which implements a
+far better control law than the one above.
 
-Where the autopilot fits
-------------------------
-
-The autopilot's own control loop also runs once per physics tick. By default it runs after
-the calls of that tick, so a target set inside a held tick is flown on that tick.
-
-For finer control, ``AutoPilot.update_mode`` chooses where in the tick the loop runs, and its
-manual mode hands the decision to the program: everything before ``update`` is what the loop
-flies the tick with, and everything after it can read what the loop just did. See
-:ref:`when the control loop runs <autopilot-update-mode>`.
-
-What it costs
+The AutoPilot
 -------------
 
-Real time. The game renders no frame, takes no input and runs no physics while a tick is
-held, so a hold of five milliseconds costs five milliseconds of every update it happens in,
-and a hold of a hundred leaves the game running at about ten frames a second. A loop using
-``next_tick`` holds every tick, so the game runs at the rate of the loop for as long as the
-loop runs.
+The autopilot's own control loop also runs once per physics tick. By default it runs after the
+calls of that tick, so a target set inside a held tick is flown on that tick.
 
-What it does not cost is the simulation. Physics runs on a fixed time step, so a game whose
-ticks are held runs slower than real time rather than differently. Nothing is skipped and
-nothing is caught up afterwards.
+``AutoPilot.update_mode`` chooses where in the tick the loop runs. Its manual mode splits the
+tick at ``update``: calls before it set what the loop flies the tick with, and calls after it
+read what the loop did. See :ref:`when the control loop runs <autopilot-update-mode>`.
 
-For a control loop that is usually the right trade. Keep the held section short, and keep
-anything that does not need the tick, such as logging or plotting, outside it.
+The Cost of a Hold
+------------------
 
-Rules worth knowing
--------------------
+A hold costs real time. The game renders no frame, takes no input and runs no physics while a
+tick is held. A hold of five milliseconds costs five milliseconds of the update it happens in,
+and a hold of a hundred leaves the game running at about ten frames a second.
+
+A loop using ``next_tick`` holds every tick, and the game runs at the rate of the loop for as
+long as the loop runs. Physics runs on a fixed time step. A game whose ticks are held runs
+slower than real time and simulates every tick in turn.
+
+Keep the held section short, and keep anything that does not need the tick, such as logging or
+plotting, outside it.
+
+Limits of a Hold
+----------------
 
 * A hold ends by itself after the **tick hold timeout**, one second by default, and when the
   client disconnects. The timeout is a server setting, in the advanced section of the server
-  window, because it bounds how long the server's owner has their game frozen.
-* Only one client can hold the tick at a time, and only a client making a call can hold it. A
-  second client's attempt is refused, as is a hold attempted from a stream or an event.
-* Streams do not update while a tick is held, because the server sends stream updates after
-  it has finished executing calls. Read with calls inside a hold, and never wait for a stream
-  or an event there: it cannot arrive until the hold has ended, so the wait runs out the
-  timeout.
+  window, as it bounds how long the server's owner has their game frozen.
+* One client holds the tick at a time, and only a client making a call can hold it. A second
+  client's attempt is refused, as is a hold attempted from a stream or an event.
+* Streams do not update while a tick is held, as the server sends stream updates once it has
+  finished executing calls. Read with calls inside a hold. A wait for a stream or an event
+  there runs the hold out to its timeout.
 * Calling a procedure that takes more than one tick to finish, such as staging or warping,
   ends the hold. Such a call can only finish in the tick the hold is holding back.
 * A tick lost to the timeout is not reported. The next ``next_tick`` takes whatever tick it
-  lands on, so a loop that has to know whether it kept up must check the game's own clock,
-  through ``SpaceCenter.ut``.
-* A hold gains nothing while the game is paused, since physics is not advancing anyway, and
-  it blocks the pause menu for as long as it lasts.
+  lands on, so a loop that has to know whether it kept up reads the game's own clock through
+  ``SpaceCenter.ut``.
+* A hold gains nothing while the game is paused, since physics is not advancing, and it blocks
+  the pause menu for as long as it lasts.

--- a/doc/src/tutorials/object-lifetime.rst
+++ b/doc/src/tutorials/object-lifetime.rst
@@ -7,62 +7,29 @@ it looks up that game state. An object therefore keeps working when the game des
 rebuilds what it identifies, and raises ``KRPC.ObjectDestroyedException`` once it has been
 destroyed for good.
 
-Objects follow the game
------------------------
+Objects Across a Load
+---------------------
 
-Loading a save, quickloading and reverting all replace the game's own objects, and the game
-also rebuilds a vessel's parts whenever it comes back into range. An object obtained before
-any of that keeps working afterwards, provided the thing it names still exists, and reads the
-state of the loaded game rather than the state it was obtained in.
+Loading a save, quickloading and reverting all replace the game's own objects. A vessel's
+parts are rebuilt the same way whenever it comes back into range.
 
-So a script can hold onto a vessel or a part across a quickload. In Python, for example:
+An object obtained beforehand goes on working, and reads the state of the loaded game. So you
+can hold onto a vessel or a part across a quickload:
 
 .. code-block:: python
 
    vessel = conn.space_center.active_vessel
    parachute = vessel.parts.with_name('parachuteSingle')[0].parachute
    conn.space_center.quickload()
-   # after the load, this reads the parachute of the game that was loaded
+   # reads the parachute of the loaded game
    print(parachute.state)
 
-Objects that are gone
----------------------
+Destroyed Objects
+-----------------
 
-When the thing an object names no longer exists, every member of that object that reads the
-game raises ``KRPC.ObjectDestroyedException`` instead of returning a value. A part raises it
-once it has been destroyed, or its vessel destroyed or recovered; a vessel raises it once it
-has been recovered or destroyed; a maneuver node raises it once it has been removed from the
-vessel's flight plan, which includes every node the vessel had before a game was loaded; a
-science subject raises it once the game state it was read from has been replaced.
-
-An object can also become gone because of what a client itself does. A crew member is named
-by the kerbal's name, which is what the game keeps its roster under, so renaming a kerbal by
-setting ``CrewMember.Name`` leaves every object for that kerbal standing for a kerbal the
-roster no longer has, including the one the rename was made through. They all raise the
-exception from then on, and an object for the renamed kerbal has to be obtained again under
-the new name.
-
-The other case is an object a client asks the server to build, which names nothing in the
-game. Nothing the game does ever finishes with such an object, so the server holds it until
-the client says it is done with it: ``ReferenceFrame.Remove`` for a frame built with
-``ReferenceFrame.CreateRelative`` or ``ReferenceFrame.CreateHybrid``, ``Orbit.Remove`` for an
-orbit built with ``Orbit.CreateFromPositionAndVelocity`` or
-``Orbit.CreateFromOrbitalElements``, and ``ResourceTransfer.Remove`` for a transfer between
-parts. Whatever was built on what is removed goes with it, having nothing left to be
-evaluated against: a frame defined against a removed frame or orbit, and the flight
-information measured in a removed frame.
-
-Each of these belongs to the client that asked for it: two clients that build the same
-reference frame are given one each, so a frame one of them removes leaves the other's alone,
-and anything a client has not removed goes when it disconnects.
-
-A few members read nothing and so raise nothing: those that hand back what the object was
-built from, such as the part a part module belongs to, or the name of a field. They answer as
-they always did, and what they hand back raises the exception itself as soon as it is used.
-
-The exception is documented in the ``KRPC`` API reference for each client language, alongside
-the other exceptions the server can raise, and is caught like any other exception the client
-library defines. In Python:
+Once what an object identifies is destroyed, every member of it that reads the game raises
+``KRPC.ObjectDestroyedException``. Catch it as you would any other exception the client
+library defines:
 
 .. code-block:: python
 
@@ -71,86 +38,109 @@ library defines. In Python:
    except conn.krpc.ObjectDestroyedException:
        print('that part is gone')
 
-The server also stops holding an object once the thing it names is gone, which it does when a
-game is loaded. Using such an object afterwards raises the same exception, so a client cannot
-tell whether the server still had the object or had already let go of it. That is deliberate:
-either way, the answer is that the thing is gone and a fresh object has to be obtained from
-the vessel, its parts, or wherever the first one came from.
+The ``KRPC`` API reference for each client language documents it alongside the other
+exceptions the server raises.
 
-Objects that are not loaded
----------------------------
+What destroys an object depends on what it identifies:
 
-A vessel far enough from the active vessel is *unloaded*: the game keeps it as orbital data
-and a description of its parts, and instantiates the parts again when it comes back into
-range. The vessel itself is unaffected and can be read normally, but its parts do not exist to
-be read, so using one raises an error saying that the part is not loaded.
+* a part, once it is destroyed, or its vessel is destroyed or recovered
+* a vessel, once it is destroyed or recovered
+* a maneuver node, once it leaves the vessel's flight plan, which includes every node the
+  vessel had before a game was loaded
+* a science subject, once the game state it was read from is replaced
 
-That is not the same as the part being destroyed, and it is temporary. The part works again
-once the game loads the vessel, and the object stays valid throughout. ``Vessel.Loaded``
-reports whether a vessel's parts are there to be used.
+A client can also destroy an object itself. A crew member is identified by the kerbal's name,
+which is the key the game's roster holds it under. Setting ``CrewMember.Name`` therefore
+destroys every object for that kerbal, including the one the name was set through, and the
+crew member has to be obtained again under the new name.
 
-Anything the game cannot currently answer for reports itself the same way, rather than
-claiming to be gone. A maneuver node of a vessel the game is not computing a flight plan for
-is one case, and a call that arrives while the game is between states, part way through
-loading one, is another.
+An object the server builds on request identifies nothing in the game, and lasts until the
+client removes it:
 
-Objects in the editor
+* ``ReferenceFrame.Remove``, for a frame from ``ReferenceFrame.CreateRelative`` or
+  ``ReferenceFrame.CreateHybrid``
+* ``Orbit.Remove``, for an orbit from ``Orbit.CreateFromPositionAndVelocity`` or
+  ``Orbit.CreateFromOrbitalElements``
+* ``ResourceTransfer.Remove``, for a transfer between two parts
+
+Removing one destroys whatever was built on it: a reference frame defined against a removed
+frame or orbit, and the flight information measured in a removed frame.
+
+Each of these belongs to the client that created it. Two clients that create the same
+reference frame get one each, and removing one leaves the other intact. The server removes a
+client's remaining objects when it disconnects.
+
+A few members read no game state and so raise nothing, such as the part a part module belongs
+to or the name of a field. These return a value as they always did, and the object one of them
+returns raises the exception when it is used.
+
+Loading a game also drops the server's own record of a destroyed object. Using such an object
+raises the same exception, and a fresh one has to be obtained from the vessel, its parts, or
+wherever the first came from.
+
+Unloaded Objects
+----------------
+
+A vessel far enough from the active vessel is *unloaded*. The game keeps it as orbital data
+and a description of its parts, and instantiates those parts again when it comes back into
+range.
+
+The vessel itself reads normally. Its parts are not instantiated, and using one raises an
+error saying that the part is not loaded. ``Vessel.Loaded`` reports whether a vessel's parts
+are available.
+
+The object stays valid throughout, and the part works again once the game loads the vessel.
+Two other cases raise the same error. A maneuver node raises it while the game computes no
+flight plan for its vessel, and a vessel raises it while the game is between states, part way
+through a load.
+
+Objects in the Editor
 ---------------------
 
-The vessel under construction in the VAB or the SPH follows the same rules, with one
-difference: nothing there has an unloaded form. The editor holds exactly one vessel, so a part
-that is no longer in it is gone for good rather than waiting to be loaded, and using it raises
-``KRPC.ObjectDestroyedException``.
+The vessel under construction in the VAB or the SPH follows the same rules, and everything the
+editor holds is loaded. The editor holds one vessel, so a part removed from it is destroyed
+and raises ``KRPC.ObjectDestroyedException``.
 
-Loading a craft into the editor starts a new vessel, and the parts of the vessel it replaced
-are gone. That is so whether or not the craft loaded is the one the editor already had: a
-part in the editor is named by an identifier that is only unique within one vessel, and a
-craft file saved from another carries those identifiers over, so a part of the old vessel
-cannot be told apart from the part of the new one that answers to the same identifier. Rather
-than hand back a part of a vessel that was never asked for, both raise
-``KRPC.ObjectDestroyedException``.
+Loading a craft into the editor starts a new vessel and destroys the parts of the vessel it
+replaces, whether or not it is the craft the editor already had. A part is identified by a
+number that is unique within one vessel, and a craft file carries those numbers with it, so a
+part of the old vessel is indistinguishable from the new part with the same number.
 
-Undo and redo are not a new vessel. They rebuild the one the editor already has, and the
-parts they rebuild keep the identifiers they had, so objects for the parts an undo leaves
-alone go on working. An object for a part that an undo takes away raises
-``KRPC.ObjectDestroyedException``, as one for any part no longer in the vessel does. An
-object is not expected to survive an undo followed by a redo.
+Undo and redo rebuild the vessel the editor already has, and the rebuilt parts keep their
+numbers. Objects for the parts an undo leaves in place go on working, and an object for a part
+an undo removes raises ``KRPC.ObjectDestroyedException``. Obtain a part again after an undo
+followed by a redo.
 
-Leaving the editor destroys the vessel it had open, and with it every object reached through
-``SpaceCenter.Editor``: its parts, their part modules, its stages and its resources. A script
-that returns to the editor has to obtain them again.
+Leaving the editor destroys the vessel it had open, along with every object reached through
+``SpaceCenter.Editor``: its parts, their part modules, its stages and its resources. Obtain
+these again on returning to the editor.
 
-Objects in other services
+Objects in Other Services
 -------------------------
 
-The same rules hold for every service, not only ``SpaceCenter``.
+The same rules hold for every service.
 
-An object a client makes itself follows what the game does with it. A line or a marker from
-the ``Drawing`` service, a panel or a button from ``UI``, and a force from ``Part.AddForce``
-are all gone once they are removed, once the service's ``Clear`` is called, or once the scene
-changes, and using one then raises ``KRPC.ObjectDestroyedException``. The server also removes
-what a client made when that client disconnects. A force is applied to a part, so it also
-stops, and is gone, once that part is destroyed.
+A line or a marker from the ``Drawing`` service, a panel or a button from ``UI``, and a force
+from ``Part.AddForce`` are destroyed by their own removal, by the service's ``Clear``, or by a
+scene change. The server also removes what a client created when that client disconnects. A
+force is destroyed with the part it is applied to, and stops acting on it.
 
-An object that stands for something on a part or a vessel is exactly as alive as the part or
-the vessel. A RemoteTech antenna, an Infernal Robotics servo, a LaserDist laser and a docking
-camera all raise the exception once their part is destroyed, or once the part no longer
-carries the module that made it one of those things. An Infernal Robotics servo group is named
-by its vessel and the group's name, so renaming a group leaves every object for it standing
-for a group the vessel no longer has, exactly as renaming a kerbal does, and an object for the
-group has to be obtained again under the new name.
+An object for something carried by a part lives as long as that part. A RemoteTech antenna, an
+Infernal Robotics servo, a LaserDist laser and a docking camera are destroyed once their part
+is destroyed, or once the part loses the module that provides them.
 
-An object that stands for a record the game keeps finds that record again on every call, so it
-goes on working when the game rebuilds it and raises the exception once the game no longer has
-it. An alarm, a contract and its parameters, and a Kerbal Alarm Clock alarm all keep working
-across a load; removing an alarm or a waypoint leaves the object for it gone. A waypoint a
-client creates is not written into the save, so it does not outlive the game state it was
-created in.
+An Infernal Robotics servo group is identified by its vessel and the group's name. Renaming a
+group destroys every object for it, exactly as renaming a kerbal does, and the group has to be
+obtained again under the new name.
+
+An object for a record the game keeps looks that record up on every call. An alarm, a contract
+and its parameters, and a Kerbal Alarm Clock alarm all keep working across a load, and
+removing an alarm or a waypoint destroys the object for it. A waypoint created by a client is
+left out of the save, and lasts as long as the game state it was created in.
 
 A comm link is a hop in a vessel's control path, and reports the path as it currently is. If
 the path stops using that hop, the link reports itself as not connected, which is the
 not-loaded case above. It works again once the path uses the hop again.
 
-Where a mod is not installed, or is not ready to be asked, its objects report themselves as
-unavailable rather than gone, for the same reason a part that is not loaded does: nothing that
-can be asked has said the thing is not there.
+Objects from a mod that is not installed, or has yet to start, report themselves as
+unavailable in the same way.

--- a/doc/src/tutorials/object-lifetime.rst
+++ b/doc/src/tutorials/object-lifetime.rst
@@ -2,10 +2,10 @@ Object Lifetime
 ===============
 
 Many remote procedures return an object: a vessel, a part, a part module, a maneuver node, a
-reference frame. Such an object is a *name* for something in the game, not a copy of it and
-not a pointer into the game's memory. Every call made through it looks the thing up in the
-game again, which is what lets an object outlive the game tearing down and rebuilding what it
-names, and what lets the server say clearly when the thing is gone.
+reference frame. Each of these identifies something in the game, and every call made through
+it looks up that game state. An object therefore keeps working when the game destroys and
+rebuilds what it identifies, and raises ``KRPC.ObjectDestroyedException`` once it has been
+destroyed for good.
 
 Objects follow the game
 -----------------------
@@ -147,10 +147,9 @@ across a load; removing an alarm or a waypoint leaves the object for it gone. A 
 client creates is not written into the save, so it does not outlive the game state it was
 created in.
 
-A comm link is a hop in a vessel's control path, and reports that path as it is now rather
-than as it was when the object was obtained. A path that no longer takes the hop has lost
-contact rather than destroyed anything, so the link reports itself as not currently connected,
-which is the not-loaded case above, and works again if the path takes it again.
+A comm link is a hop in a vessel's control path, and reports the path as it currently is. If
+the path stops using that hop, the link reports itself as not connected, which is the
+not-loaded case above. It works again once the path uses the hop again.
 
 Where a mod is not installed, or is not ready to be asked, its objects report themselves as
 unavailable rather than gone, for the same reason a part that is not loaded does: nothing that

--- a/doc/src/tutorials/reference-frames.rst
+++ b/doc/src/tutorials/reference-frames.rst
@@ -324,12 +324,12 @@ orbited (inherited from :attr:`CelestialBody.reference_frame`). Hybrid
 reference frames can be constructed by calling
 :meth:`ReferenceFrame.create_hybrid`.
 
-Each call returns a new frame, which the server holds until it is removed or the
-client that created it disconnects: such a frame names nothing in the game, so
-nothing the game does ever says it is finished with. Call
-:meth:`ReferenceFrame.remove` on one that is no longer needed. A frame that has
-to follow something that moves should inherit that component from the frame of
-the thing itself, rather than be constructed again on every update.
+Each call returns a new frame, and the server holds it until the client removes
+it or disconnects. Call :meth:`ReferenceFrame.remove` on a frame once you are
+done with it.
+
+A frame that follows a moving object inherits that component from the frame of
+the object itself, instead of being constructed again on every update.
 
 The parent reference frame(s) of a custom reference frame can also be other
 custom reference frames. For example, you could combine the two example frames

--- a/doc/src/tutorials/user-interface.rst
+++ b/doc/src/tutorials/user-interface.rst
@@ -3,11 +3,10 @@ User Interface
 
 The following script demonstrates how to use the UI service to display text and
 handle basic user input. It adds a panel to the left side of the screen, which
-the user can drag around with the mouse. A vertical layout arranges the panel's
-contents in a column, so nothing needs positioning by hand: a button that sets
-the throttle to maximum, with a tooltip shown while the mouse rests on it, a
-slider that sets the throttle directly, and text displaying the current thrust
-produced by the vessel.
+can be dragged with the mouse. A vertical layout arranges its contents in a
+column: a button that sets the throttle to maximum, a slider that sets it
+directly, and text showing the current thrust produced by the vessel. A tooltip
+is shown while the mouse rests on the button.
 
 .. tabs::
 

--- a/server/CHANGELOG.md
+++ b/server/CHANGELOG.md
@@ -1,28 +1,19 @@
 ## [v0.7.0] - unreleased
 - Add the `TickHoldTimeout` setting, which bounds how long a client may hold the game on one
-  physics tick using `KRPC.HoldTick` (#1070)
-- The server now updates before the game collects control inputs, so a control input written by
-  a call takes effect on the tick the call is made in rather than on the tick after (#1070)
-- **Breaking:** KSP 1.12.5 is the minimum supported version, matching the maximum. Compatibility
-  code for older versions of the game has been removed (#1048)
-- Servers can now use the local socket protocol, chosen in the server window like any other. The
-  RPC and stream sockets default to paths in a directory belonging to the user running the game,
-  and no network port is opened (#1065)
+  physics tick (#1070)
+- The server updates before the game collects control inputs, so a control input takes effect
+  on the tick the call is made in (#1070)
+- **Breaking:** KSP 1.12.5 is the minimum supported version, matching the maximum (#1048)
+- Servers can use the local socket protocol, chosen in the server window like any other. No
+  network port is opened (#1065)
 - Fix the end of a long serial port name being neither visible nor editable in the server
-  window; the field now scrolls sideways to follow the caret (#1065)
-- The server is stopped whenever no game is loaded, so a client is disconnected when the player
-  quits to the main menu rather than being left waiting on a call that never returns. It starts
-  again with the next game if it is set to start automatically. State held for clients is released
-  at the same time, so user interface elements no longer stay on the screen for the whole of the
-  main menu (#1041)
+  window (#1065)
+- The server is stopped whenever no game is loaded, so a client is disconnected when the
+  player quits to the main menu (#1041)
 - Fix setting `KRPC.GameScene` from one editor straight to the other leaving the flight camera
-  unable to follow a vessel for the rest of the session. The switch also keeps the vessel that is
-  being constructed now, as the game's own switch editor button does (#1038)
+  unable to follow a vessel for the rest of the session (#1038)
 - Sweep objects whose game objects no longer exist out of the object store when the game
-  loads, quickloads or reverts a game state, or changes scene, when it destroys a part or a
-  vessel, and when a client removes something it owns such as a drawing, a user interface
-  element or a force, so an object that has become useless is let go of promptly rather than
-  at the next load (#1051)
+  loads, changes scene or destroys a part or a vessel (#1051)
 
 ## [v0.6.0]
 - Fix server version reported to clients (read from `KRPC.dll` not `KRPC.Core.dll`) (#848)

--- a/server/src/Addon.cs
+++ b/server/src/Addon.cs
@@ -9,17 +9,16 @@ namespace KRPC
     /// <summary>
     /// Main KRPC addon. Contains the kRPC core, config and UI.
     /// </summary>
-    // Ordered ahead of the game's own scripts so that the server executes a tick's calls before
-    // the game collects control inputs for it. Without that the order is Unity's default, which
-    // puts the control input first, and a value written by a call in one tick is not acted on
-    // until the next.
+    // Ordered ahead of the game's own scripts, so that the server executes a tick's calls
+    // before the game collects control inputs for it. Under Unity's default order a value
+    // written by a call in one tick is not acted on until the next
     [DefaultExecutionOrder (-100)]
     [KSPAddon (KSPAddon.Startup.AllGameScenes, false)]
     public sealed class Addon : MonoBehaviour
     {
-        // A new addon instance is created on every scene change (KSPAddon.AllGameScenes
-        // with once: false), so state that must survive scene switches — the loaded
-        // configuration, the running server core and cached button textures — is static.
+        // A new addon instance is created on every scene change (KSPAddon.AllGameScenes with
+        // once: false), so state that must survive scene switches is static: the loaded
+        // configuration, the running server core and the cached button textures
         internal static ConfigurationFile config;
         static Core core;
         static Texture textureOnline;
@@ -284,9 +283,9 @@ namespace KRPC
         void OnEditorShipModified(ShipConstruct ship)
         {
             // Anything no longer in the vessel under construction is gone, as the editor
-            // holds no other vessel it could be in. The game raises no part-died event in
-            // the editor, and fires this for every change to the vessel, a part deleted
-            // and a different craft loaded included.
+            // holds no other vessel. The game raises no part-died event in the editor, and
+            // fires this for every change to the vessel, including a deleted part and a
+            // newly loaded craft
             Service.GameState.RequestSweep();
         }
 
@@ -428,9 +427,9 @@ namespace KRPC
             GUILayoutExtensions.OnGUI ();
         }
 
-        // What the game had on the previous update of the sweep that is pending now: the
-        // number of vessels, or in an editor the number of parts in the vessel it has open.
-        // -1 means nothing counted yet.
+        // The count the game had on the previous update of the pending sweep: the number of
+        // vessels, or in an editor the number of parts in the vessel it has open. -1 means
+        // nothing counted yet
         static int lastCount = -1;
 
         /// <summary>
@@ -471,9 +470,8 @@ namespace KRPC
             if (settled) {
                 Service.GameState.Sweep ();
                 // After the store, so that the objects are classified with the game state
-                // settled, which is what the sweep itself records. A collection that drops
-                // something asks for a sweep, as letting go of an object always does, so
-                // this costs one further pass that finds nothing and asks for no more.
+                // settled. A collection that drops something requests a sweep, so this
+                // costs one further pass that finds nothing
                 ClientOwnedState.RemoveDestroyed ();
             }
         }

--- a/server/src/ConfigurationFile.cs
+++ b/server/src/ConfigurationFile.cs
@@ -78,9 +78,9 @@ namespace KRPC
         [Persistent] bool adaptiveRateControl;
         [Persistent] bool blockingRecv;
         [Persistent] uint recvTimeout;
-        // Defaulted here as well as in Configuration, since a settings file written before this
-        // setting existed has nothing to load into it, and a zero timeout would end every hold
-        // the moment it was taken.
+        // Defaulted here as well as in Configuration, since a settings file written before
+        // this setting existed has nothing to load into it, and a zero timeout would end
+        // every hold immediately
         [Persistent] uint tickHoldTimeout = 1000000;
 
         public ConfigurationFile (string filePath, Configuration configuration) : base (filePath, "KRPCConfiguration")

--- a/server/src/UI/EditServer.cs
+++ b/server/src/UI/EditServer.cs
@@ -76,8 +76,8 @@ namespace KRPC.UI
         readonly object stopBitsComboId = new object ();
 
         // Names for the fields whose value is too long for the field it is edited in, unique
-        // in the same way and for the same reason, and how far each has been scrolled
-        // sideways. The field is a window onto its value that follows the caret.
+        // in the same way, and how far each has been scrolled sideways. The field is a
+        // window onto its value that follows the caret
         readonly string rpcPathFieldName;
         readonly string streamPathFieldName;
         readonly string portNameFieldName;

--- a/server/src/UI/GUILayoutExtensions.cs
+++ b/server/src/UI/GUILayoutExtensions.cs
@@ -82,11 +82,10 @@ namespace KRPC.UI
             var area = GUILayoutUtility.GetRect (singleLine, style, GUILayout.ExpandWidth (true));
             var content = new GUIContent (value);
             var width = Mathf.Max (area.width, style.CalcSize (content).x + caretRoom);
-            // How wide a field is is only settled once the layout has been worked out, so the
-            // window onto its content moves on the passes that know and holds still on the one
-            // that does not. Taking the width as nothing there would leave no room around the
-            // caret, pinning the window to it so that the text slid along behind a caret that
-            // never moved.
+            // A field's width is only settled once the layout has been worked out, so the
+            // window onto its content moves on the passes that know it and holds still on
+            // the one that does not. A width of zero would pin the window to the caret, and
+            // slide the text along behind it
             if (Event.current.type != EventType.Layout)
                 offset = Mathf.Clamp (ScrolledTo (name, content, style, area.width, width, offset), 0, width - area.width);
             GUI.BeginGroup (area);
@@ -221,12 +220,11 @@ namespace KRPC.UI
         public static GUIStyle ComboOptionStyle ()
         {
             var style = new GUIStyle (Skin.DefaultSkin.label);
-            // Highlighting of the hovered option (a grey background and lighter text)
-            // is handled manually in ComboBoxWindow.Draw. Give the text a known base
-            // colour so the manual GUI.contentColor tint is predictable, and neutralise
-            // the built-in interactive states so they never recolour (or, in the case
-            // of the skin's default hover colour, hide) the text based on the stale
-            // hover position.
+            // Highlighting of the hovered option (a gray background and lighter text) is
+            // handled in ComboBoxWindow.Draw. Give the text a known base color so that the
+            // manual GUI.contentColor tint is predictable, and clear the built-in
+            // interactive states so that they never recolor the text from a stale hover
+            // position
             style.normal.textColor = Color.white;
             style.hover.textColor = style.normal.textColor;
             style.active.textColor = style.normal.textColor;
@@ -244,10 +242,10 @@ namespace KRPC.UI
 
         public static int ComboBox (object caller, int selectedItem, IList<string> entries, GUIStyle buttonStyle, GUIStyle optionsStyle, GUIStyle optionStyle)
         {
-            // Main button. Expand to fill the row so combo boxes line up with the
-            // (stretchy) text fields in the edit-server form, and left-align the label
-            // to match the left-aligned drop-down items. buttonStyle is shared with the
-            // action buttons, so its alignment is restored immediately after.
+            // Main button. Expand to fill the row so that combo boxes line up with the text
+            // fields in the edit-server form, and left-align the label to match the
+            // drop-down items. buttonStyle is shared with the action buttons, so its
+            // alignment is restored below
             var oldAlignment = buttonStyle.alignment;
             buttonStyle.alignment = TextAnchor.MiddleLeft;
             var clicked = GUILayout.Button (entries [selectedItem], buttonStyle, GUILayout.ExpandWidth (true));
@@ -342,15 +340,13 @@ namespace KRPC.UI
                 if (Options == null)
                     return;
 
-                // Highlight the option under the mouse using the live pointer position
-                // (Input.mousePosition) rather than the built-in hover state, which is
-                // driven by Event.current.mousePosition. In the KSP runtime the latter is
-                // only refreshed when an input event is processed, so the built-in
-                // highlight freezes between mouse movements (the classic "wiggle the mouse
-                // to update it" behaviour). The options do not move once the window is
-                // shown, so hit-testing against the rects captured on the last repaint is
-                // exact. Position is the window's top-left in screen space; Input.mousePosition
-                // is bottom-left origin, hence the y flip.
+                // Highlight the option under the mouse from the live pointer position. The
+                // built-in hover state is driven by Event.current.mousePosition, which the
+                // KSP runtime only refreshes when an input event is processed, so it
+                // freezes between mouse movements. The options do not move once the window
+                // is shown, so the rects captured on the last repaint are exact. Position
+                // is top-left in screen space and Input.mousePosition is bottom-left,
+                // hence the y flip
                 var mouse = new Vector2 (
                     Input.mousePosition.x - Position.x,
                     Screen.height - Input.mousePosition.y - Position.y);

--- a/server/src/UI/MainWindow.cs
+++ b/server/src/UI/MainWindow.cs
@@ -243,11 +243,10 @@ namespace KRPC.UI
 
             GUILayout.BeginHorizontal ();
             var icons = Icons.Instance;
-            // Vertically centre the expand/collapse arrow in the row; it is shorter
-            // than the activity light and name and would otherwise sit at the top.
-            // A fixed top space (rather than ExpandHeight + FlexibleSpace) is used so
-            // the column cannot grab the window's spare height and push the arrow onto
-            // its own line.
+            // Vertically center the expand/collapse arrow in the row. It is shorter than
+            // the activity light and name, and would otherwise sit at the top. A fixed top
+            // space keeps the column from grabbing the window's spare height and pushing
+            // the arrow onto its own line
             GUILayout.BeginVertical (GUILayout.Width (20));
             GUILayout.Space (Mathf.Max (0f, (Style.lineHeight - 16f) / 2f));
             GUILayout.Label (new GUIContent (expanded ? icons.ButtonCollapse : icons.ButtonExpand, expanded ? "Collapse" : "Expand"),

--- a/server/src/Utils/ClientOwnedOverrides.cs
+++ b/server/src/Utils/ClientOwnedOverrides.cs
@@ -29,9 +29,8 @@ namespace KRPC.Utils
         where TEntry : ClientOwnedEntry
     {
         readonly IDictionary<TKey, TEntry> entries = new Dictionary<TKey, TEntry> ();
-        // A list rather than a dictionary: a detach while an earlier detach is still
-        // waiting to be released must hold both entries, even for the same key, or the
-        // earlier override would never be released.
+        // A detach while an earlier detach is still waiting to be released must hold both
+        // entries, even for the same key, so these are a list and not a dictionary
         readonly List<KeyValuePair<TKey, TEntry>> detached =
             new List<KeyValuePair<TKey, TEntry>> ();
         readonly Func<TKey, TEntry> install;

--- a/server/src/Utils/ClientOwnedState.cs
+++ b/server/src/Utils/ClientOwnedState.cs
@@ -74,8 +74,8 @@ namespace KRPC.Utils
             try {
                 action ();
             } catch (Exception exn) {
-                // Anything at all, as what runs here is supplied by the services and acts
-                // on state whose subject the game may already have destroyed.
+                // Catch everything: the action comes from a service and acts on state whose
+                // game object may already be destroyed
                 Logger.WriteLine (failure + "; " + exn, Logger.Severity.Error);
             }
         }

--- a/server/src/Utils/GameSceneSwitcher.cs
+++ b/server/src/Utils/GameSceneSwitcher.cs
@@ -80,11 +80,10 @@ namespace KRPC.Utils
                 return;
             }
             // Loading the editor scene while it is already the loaded scene leaves the
-            // flight camera unable to target a vessel for the rest of the session, as it
-            // does not expect a scene load to be requested from the editor. The game's
-            // own switch button restarts the editor in place instead, which also carries
-            // the vessel being constructed across. There are only two editors, so a
-            // switch always lands on the one asked for.
+            // flight camera unable to target a vessel for the rest of the session. The
+            // game's own switch button restarts the editor in place, which also carries
+            // the vessel being constructed across. There are only two editors, so a switch
+            // always lands on the one wanted
             var driver = EditorDriver.fetch;
             var logic = EditorLogic.fetch;
             if (driver == null || logic == null || driver.restartingEditor)
@@ -113,12 +112,11 @@ namespace KRPC.Utils
             if ((current & GameScene.SpaceCenter) == 0)
                 throw new InvalidOperationException (
                     "Facilities can only be opened from the space center scene");
-            // Replicate the availability check that the in-game building click
-            // handlers apply (e.g. MissionControlBuilding.OnClicked). Facilities
-            // whose backing system is disabled in the current game mode - such as
-            // mission control, R&D and administration in a sandbox game - cannot be
-            // opened; firing their spawn event regardless makes KSP throw and
-            // wedges the game.
+            // Replicate the availability check that the in-game building click handlers
+            // apply (e.g. MissionControlBuilding.OnClicked). A facility whose backing
+            // system is disabled in the current game mode, such as mission control, R&D
+            // and administration in a sandbox game, cannot be opened. Firing its spawn
+            // event regardless makes KSP throw
             if (!available)
                 throw new InvalidOperationException (
                     "This facility is not available in the current game");

--- a/service/Debug/CHANGELOG.md
+++ b/service/Debug/CHANGELOG.md
@@ -1,8 +1,5 @@
 ## [v0.7.0] - unreleased
 
 - Initial version. Provides RPCs to modify the state of the simulation directly: teleporting a
-  vessel onto an orbit, onto the surface or into atmospheric flight, setting its position,
-  velocity, attitude and angular velocity, and filling its resource tanks. Also exposes the
-  game's debug menu cheats: the cheat option toggles, the gravity multiplier, and the career
-  cheats for funds, science, reputation, the technology tree, facility upgrades and kerbal
-  experience (#1033)
+  vessel, setting its position, velocity and attitude, filling its resource tanks, and the
+  game's debug menu cheats (#1033)

--- a/service/Debug/src/Debug.cs
+++ b/service/Debug/src/Debug.cs
@@ -131,9 +131,9 @@ namespace KRPC.Debug
             var internalVessel = ActiveVessel ();
             var celestialBody = body.InternalBody;
 
-            // Build the world-space attitude for the requested pitch/heading/roll using the same
-            // surface-frame convention (x = zenith, y = north, z = east) as the flight telemetry,
-            // evaluated at the target location rather than the vessel's current one.
+            // Build the world-space attitude for the requested pitch, heading and roll, using the
+            // same surface-frame convention as the flight telemetry (x = zenith, y = north,
+            // z = east), evaluated at the target location
             var worldPosition = celestialBody.GetWorldSurfacePosition (latitude, longitude, altitude);
             var positionFromBody = worldPosition - celestialBody.position;
             var toNorthPole = (celestialBody.position + (Vector3d)celestialBody.transform.up * celestialBody.Radius) - worldPosition;
@@ -612,7 +612,7 @@ namespace KRPC.Debug
             var orbit = new Orbit ();
             orbit.UpdateFromStateVectors (positionFromBody.xzy, worldVelocity.xzy, body, ut);
             // The throwaway orbit's epoch is now, so its mean anomaly at epoch is the mean anomaly
-            // at the current time, which is what the teleport wants.
+            // at the current time, which is what the teleport takes
             SetShipOrbit (
                 body, orbit.semiMajorAxis, orbit.eccentricity, orbit.inclination, orbit.LAN,
                 orbit.argumentOfPeriapsis, orbit.meanAnomalyAtEpoch);
@@ -629,8 +629,8 @@ namespace KRPC.Debug
             var meanAnomaly =
                 meanAnomalyAtEpoch + meanMotion * (Planetarium.GetUniversalTime () - epoch);
             if (eccentricity < 1) {
-                // A closed orbit repeats every revolution, so wrap instead of handing the game an
-                // angle of many thousands of radians for an epoch far in the past.
+                // A closed orbit repeats every revolution, so wrap the angle. An epoch far in the
+                // past otherwise gives the game many thousands of radians
                 meanAnomaly %= 2 * Math.PI;
                 if (meanAnomaly < 0)
                     meanAnomaly += 2 * Math.PI;
@@ -638,10 +638,10 @@ namespace KRPC.Debug
             return meanAnomaly;
         }
 
-        // A closed orbit (eccentricity below 1) has a positive semi-major axis and an open one has a
-        // negative semi-major axis. Given the two together the game cannot solve the orbit, and its
-        // patched-conic solver fills with NaN, which takes down the flight scene -- so derive the
-        // sign from the eccentricity rather than trusting the caller to supply it.
+        // A closed orbit (eccentricity below 1) has a positive semi-major axis and an open one has
+        // a negative semi-major axis. Given the two together the game cannot solve the orbit, its
+        // patched-conic solver fills with NaN, and the flight scene goes down. Derive the sign from
+        // the eccentricity.
         static double SignedSemiMajorAxis (double semiMajorAxis, double eccentricity)
         {
             var axis = Math.Abs (semiMajorAxis);
@@ -659,8 +659,8 @@ namespace KRPC.Debug
         }
 
         // Stop a vessel rotating without changing its attitude. SetRotation only reorients the part
-        // transforms; it leaves each rigidbody's angular velocity untouched, so without SAS the
-        // vessel keeps tumbling from the new attitude.
+        // transforms and leaves each rigidbody's angular velocity untouched, so without SAS the
+        // vessel keeps tumbling from the new attitude
         static void ZeroAngularVelocity (global::Vessel internalVessel)
         {
             SetWorldAngularVelocity (internalVessel, Vector3.zero);
@@ -715,7 +715,7 @@ namespace KRPC.Debug
         }
 
         // The vessel is placed with its lowest point just clear of the terrain, then falls the last
-        // fraction of a metre. Damp its motion each tick so it settles quickly instead of bouncing.
+        // fraction of a meter. Damp its motion each tick so it settles quickly
         static void WaitForLanded (int tick)
         {
             var active = FlightGlobals.ActiveVessel;
@@ -725,7 +725,7 @@ namespace KRPC.Debug
                     return;
                 active.ChangeWorldVelocity ((active.srf_velocity + active.upAxis) * -0.5);
             }
-            // Give up rather than wait forever if the vessel never settles.
+            // Give up if the vessel never settles
             if (tick < 1000)
                 throw new YieldException<Action> (() => WaitForLanded (tick + 1));
         }

--- a/service/Debug/src/Landing.cs
+++ b/service/Debug/src/Landing.cs
@@ -18,11 +18,10 @@ namespace KRPC.Debug
             if (body.pqsController == null)
                 throw new ArgumentException ("Cannot land on " + body.bodyName + ", it has no terrain");
 
-            // Distance from the center of mass down to the vessel's lowest point, measured
-            // now while the craft is loaded and its colliders are valid. The game classifies a
-            // craft teleported onto a near-surface orbit as landed wherever we place it (it
-            // does not re-seat it on the terrain), so we must place the lowest point on the
-            // ground ourselves rather than dropping it from a height.
+            // Distance from the center of mass down to the vessel's lowest point, measured now
+            // while the craft is loaded and its colliders are valid. The game classifies a craft
+            // teleported onto a near-surface orbit as landed wherever we place it, and does not
+            // re-seat it on the terrain, so we place the lowest point on the ground ourselves
             var clearance = GroundClearance (internalVessel);
 
             // Ideal (PQS) terrain height above sea level, clamped so we never target a

--- a/service/DockingCamera/CHANGELOG.md
+++ b/service/DockingCamera/CHANGELOG.md
@@ -1,8 +1,7 @@
 ## [v0.7.0] - unreleased
 
-- A `Camera` whose part the game has destroyed, or that is no longer a camera, raises
-  `KRPC.ObjectDestroyedException` rather than reaching into a part that is gone, and is
-  freed rather than kept for the rest of the session (#1051)
+- A `Camera` whose part is destroyed, or that is no longer a camera, raises
+  `KRPC.ObjectDestroyedException` (#1051)
 
 ## [v0.6.0]
 - Fix `DockingCamera.Available` incorrectly reporting false in game scenes other than flight (#937)

--- a/service/DockingCamera/src/Camera.cs
+++ b/service/DockingCamera/src/Camera.cs
@@ -24,9 +24,8 @@ namespace KRPC.DockingCamera
         }
 
         /// <summary>
-        /// What the game holds for the camera. It belongs to its part, so it is exactly as
-        /// live, dormant or destroyed as the part, and destroyed when a part that is there
-        /// to look at no longer carries the module.
+        /// The state of the camera. It takes the state of its part, and is destroyed once a
+        /// live part no longer carries the module.
         /// </summary>
         public GameObjectState GameObjectState
         {

--- a/service/DockingCamera/src/Camera.cs
+++ b/service/DockingCamera/src/Camera.cs
@@ -14,8 +14,8 @@ namespace KRPC.DockingCamera
     [KRPCClass(Service = "DockingCamera")]
     public class Camera : Equatable<Camera>, IGameObjectState
     {
-        // The module that makes a part a camera. The mod's API takes the part rather than the
-        // module, so the part is what identifies this and all it has to reach.
+        // The module that makes a part a camera. The mod's API takes the part, so the part
+        // identifies the camera
         const string moduleName = "PartCameraModule";
 
         internal static bool Is(SpaceCenter.Services.Parts.Part part)

--- a/service/Drawing/CHANGELOG.md
+++ b/service/Drawing/CHANGELOG.md
@@ -1,19 +1,13 @@
 ## [v0.7.0] - unreleased
 
-- **Breaking:** Removing a drawing object another client created, or one the server no
-  longer holds, reports that it is not among those this client created, rather than a bad
-  argument. Every other object a client asks the server to build already refused it that
-  way (#1072)
+- **Breaking:** Removing a drawing object another client created, or one the server no longer
+  holds, reports that it is not among those this client created (#1072)
 - Line, polygon, text and navball marker objects raise `KRPC.ObjectDestroyedException` once
-  the object they draw is gone, which removing it, `Drawing.Clear`, the client that made it
-  disconnecting and leaving the flight scene all do. They previously failed on a destroyed
-  game object, and were kept for the rest of the session (#1051)
+  the object they draw is gone, and are freed (#1051)
 - A drawing object whose reference frame is defined against something the game has destroyed
   is not drawn, rather than failing on every frame (#1051)
 - Add `Drawing.AddNavballMarker`, which draws a marker on the navball pointing in a given
-  direction, for example to show a script's target attitude while the player flies the vessel.
-  The marker's icon, color and size can be changed, and it hides and fades as the navball's own
-  markers do (#1037)
+  direction. Its icon, color and size can be changed (#1037)
 
 ## [v0.5.0]
 - Add `Drawing.AddDirectionFromCoM`

--- a/service/Drawing/src/Drawable.cs
+++ b/service/Drawing/src/Drawable.cs
@@ -13,9 +13,9 @@ namespace KRPC.Drawing
     public abstract class Drawable<T> : IDrawable
     {
         readonly Renderer renderer;
-        // Whether the drawable has been taken out of the scene. The game tears a game
-        // object down at the end of the frame, so this records that it is on its way out,
-        // and an object removed and read again in the same frame reports it gone.
+        // Whether the drawable has been taken out of the scene. The game tears a game object
+        // down at the end of the frame, so this records that it is going, and an object removed
+        // and read again in the same frame reports it gone
         bool removed;
 
         /// <summary>

--- a/service/Drawing/src/Drawable.cs
+++ b/service/Drawing/src/Drawable.cs
@@ -50,11 +50,10 @@ namespace KRPC.Drawing
         public GameObject GameObject { get; private set; }
 
         /// <summary>
-        /// What the game holds for the drawable. The drawable is the game object it was
-        /// made with, so it is live while the game still has that object, and destroyed
-        /// once it does not, which is what removing it, clearing the drawing objects,
-        /// disconnecting the client that made it and leaving the scene all do. Nothing
-        /// builds a client's drawing again, so there is no dormant state.
+        /// The state of the drawable, which is the game object it was made with. Removing
+        /// it, clearing the drawing objects, disconnecting the client that made it and
+        /// leaving the scene each destroy that object. A client's drawing is never built
+        /// again, so it has no dormant state.
         /// </summary>
         public GameObjectState GameObjectState {
             get {

--- a/service/Drawing/src/NavballMarker.cs
+++ b/service/Drawing/src/NavballMarker.cs
@@ -17,7 +17,7 @@ namespace KRPC.Drawing
     [KRPCClass (Service = "Drawing")]
     public class NavballMarker : IDrawable
     {
-        // Where the icons that a marker can be drawn with live in the game database.
+        // The game database directory holding the icons a marker can be drawn with
         const string iconDirectory = "Squad/Contracts/Icons/";
 
         // The game object for one of the navball's own markers, which is cloned to make a new one.
@@ -32,9 +32,9 @@ namespace KRPC.Drawing
         readonly UnityEngine.Material material;
         // The scale at which the game draws the navball's own markers, which a size of 1 matches.
         readonly Vector3 stockScale;
-        // Whether the marker has been taken out of the scene. The game tears a game object
-        // down at the end of the frame, so this records that it is on its way out, and a
-        // marker removed and read again in the same frame reports it gone.
+        // Whether the marker has been taken out of the scene. The game tears a game object down
+        // at the end of the frame, so this records that it is going, and a marker removed and
+        // read again in the same frame reports it gone
         bool removed;
         Vector3d direction;
         Tuple3 color;
@@ -88,9 +88,8 @@ namespace KRPC.Drawing
         /// </summary>
         public void Update ()
         {
-            // A marker is left where it is, rather than removed, when the frame its
-            // direction is measured in is defined against something the game has
-            // destroyed: the client can point it at another frame.
+            // A marker whose frame is defined against something the game has destroyed is left
+            // where it is, so the client can point it at another frame
             if (GameObjectState != GameObjectState.Live ||
                 ReferenceFrame.GameObjectState != GameObjectState.Live) {
                 GameObject.SetActive (false);
@@ -99,8 +98,8 @@ namespace KRPC.Drawing
             Vector3 worldDirection = ReferenceFrame.DirectionToWorldSpace (direction).normalized;
             var position = navBall.attitudeGymbal * (worldDirection * navBall.VectorUnitScale);
             GameObject.transform.localPosition = position;
-            // The marker faces the navball camera wherever on the ball it sits, so its
-            // rotation is fixed in world space rather than relative to the ball.
+            // The marker faces the navball camera wherever on the ball it sits, so its rotation
+            // is fixed in world space
             GameObject.transform.rotation = stockRotation;
             // A marker on the far side of the ball is hidden, and one near the edge fades out,
             // as the navball's own markers do.

--- a/service/Drawing/src/NavballMarker.cs
+++ b/service/Drawing/src/NavballMarker.cs
@@ -124,10 +124,9 @@ namespace KRPC.Drawing
         public GameObject GameObject { get; private set; }
 
         /// <summary>
-        /// What the game holds for the marker. The marker is the game object it was made
-        /// with, so it is live while the game still has that object, and destroyed once it
-        /// does not, which is what removing it, clearing the drawing objects, disconnecting
-        /// the client that made it and leaving the scene all do.
+        /// The state of the marker, which is the game object it was made with. Removing it,
+        /// clearing the drawing objects, disconnecting the client that made it and leaving
+        /// the scene each destroy that object.
         /// </summary>
         public GameObjectState GameObjectState {
             get {

--- a/service/Drawing/test/test_line.py
+++ b/service/Drawing/test/test_line.py
@@ -31,8 +31,8 @@ class TestLine(krpctest.TestCase):
     def test_reading_a_removed_line_raises(self):
         line = self.add_line()
         line.remove()
-        # What raises is what reaches into the game. The start, the end and the color are
-        # the line's own configuration, and answer as they always did.
+        # A member that reaches into the game raises. The start, the end and the color are
+        # the line's own configuration, and still answer.
         self.assertEqual((0, 0, 0), line.start)
         self.assertRaises(self.destroyed, getattr, line, "material")
         self.assertRaises(self.destroyed, setattr, line, "thickness", 1)

--- a/service/InfernalRobotics/CHANGELOG.md
+++ b/service/InfernalRobotics/CHANGELOG.md
@@ -1,16 +1,12 @@
 ## [v0.7.0] - unreleased
 
-- Fix `Servo` and `ServoGroup` objects accumulating for the rest of the session, one per
-  servo or group per call that lists any, and the same servo or group obtained twice
-  comparing unequal (#1051)
-- A servo and a servo group keep working across a quickload, driving what the game rebuilt
-  rather than what they were obtained from, and raise `KRPC.ObjectDestroyedException` once
-  the part or the vessel they belong to is gone. A servo is named by the part it is on, and
-  a group by its vessel and the group's name, so renaming a group leaves every object for
-  it, the one the rename was made through included, standing for a group that no longer
-  exists; an object for the group has to be obtained again under the new name (#1051)
-- `ServoGroup.Vessel` is the vessel the group was obtained for, and is no longer `null` when
-  Infernal Robotics does not report one (#1051)
+- Fix `Servo` and `ServoGroup` objects accumulating for the rest of the session, and the same
+  servo or group obtained twice comparing unequal (#1051)
+- A servo and a servo group keep working across a quickload, and raise
+  `KRPC.ObjectDestroyedException` once the part or the vessel they belong to is gone (#1051)
+- Renaming a servo group destroys every object for it, and the group has to be obtained again
+  under the new name (#1051)
+- `ServoGroup.Vessel` is the vessel the group was obtained for (#1051)
 
 ## [v0.6.0]
 - Add to `Servo`: `UID`, `Mode` (with a new `ServoMode` enum), `TargetPosition`, `TargetSpeed`,

--- a/service/InfernalRobotics/src/InfernalRobotics.cs
+++ b/service/InfernalRobotics/src/InfernalRobotics.cs
@@ -26,10 +26,10 @@ namespace KRPC.InfernalRobotics
         [KRPCProperty (GameScene = GameScene.All)]
         public static bool Available {
             get {
-                // IRWrapper.InitWrapper is only run by the addon when entering the
-                // flight scene. Run it here too so availability is reported correctly
-                // in any scene; it populates the controller type even when the full
-                // flight-only wrapping cannot finish.
+                // IRWrapper.InitWrapper is only run by the addon when entering the flight
+                // scene. Run it here too so availability is reported correctly in any scene.
+                // It populates the controller type even when the full flight-only wrapping
+                // cannot finish
                 if (!IRWrapper.AssemblyExists)
                     IRWrapper.InitWrapper ();
                 return IRWrapper.AssemblyExists;
@@ -44,8 +44,8 @@ namespace KRPC.InfernalRobotics
             get {
                 // The wrapper caches the controller's servo-group list when it first
                 // initializes at flight-scene load, before the mod has populated it.
-                // Re-initialize while the mod is present but not yet ready so readiness
-                // reflects the current state rather than that stale cache.
+                // Re-initialize while the mod is present but not yet ready, so that readiness
+                // reflects the current state and not that cache
                 if (IRWrapper.AssemblyExists && !IRWrapper.APIReady)
                     IRWrapper.InitWrapper ();
                 return IRWrapper.APIReady;

--- a/service/InfernalRobotics/src/Servo.cs
+++ b/service/InfernalRobotics/src/Servo.cs
@@ -50,9 +50,8 @@ namespace KRPC.InfernalRobotics
         }
 
         /// <summary>
-        /// What the game holds for the servo. It belongs to its part, so it is exactly as
-        /// live, dormant or destroyed as the part, and destroyed when a part that is there
-        /// to look at no longer carries the servo module.
+        /// The state of the servo. It takes the state of its part, and is destroyed once a
+        /// live part no longer carries the servo module.
         /// </summary>
         public GameObjectState GameObjectState {
             get {

--- a/service/InfernalRobotics/src/Servo.cs
+++ b/service/InfernalRobotics/src/Servo.cs
@@ -15,10 +15,10 @@ namespace KRPC.InfernalRobotics
     [KRPCClass (Service = "InfernalRobotics")]
     public class Servo : Equatable<Servo>, IGameObjectState
     {
-        // The part the servo is on, which is what identifies it: a servo is a module the mod
-        // adds to a part, and the mod names one by its part. The wrapper the mod hands out
-        // is built afresh every time a servo is listed, so holding one would leave two
-        // objects for one servo comparing unequal, and would keep a destroyed part alive.
+        // The part the servo is on, which identifies it: a servo is a module the mod adds to a
+        // part, and the mod names one by its part. The wrapper the mod hands out is built afresh
+        // every time a servo is listed, so holding one leaves two objects for one servo comparing
+        // unequal, and keeps a destroyed part alive
         readonly SpaceCenter.Services.Parts.Part part;
 
         internal Servo (SpaceCenter.Services.Parts.Part servoPart)
@@ -63,9 +63,8 @@ namespace KRPC.InfernalRobotics
             }
         }
 
-        // The servo the mod has on the part now. Every member reaches the mod through this,
-        // so a servo taken before a game state was replaced reads the one that stands in
-        // its place rather than the one it was built from.
+        // The servo the mod has on the part now. Every member reaches the mod through this, so a
+        // servo taken before a game state was replaced reads the one that stands in its place
         IRWrapper.IServo Internal {
             get {
                 var servo = IRWrapper.ServoOnPart (part.InternalPart);

--- a/service/InfernalRobotics/src/ServoGroup.cs
+++ b/service/InfernalRobotics/src/ServoGroup.cs
@@ -52,10 +52,10 @@ namespace KRPC.InfernalRobotics
         }
 
         /// <summary>
-        /// What the game holds for the group. It belongs to its vessel, so it is exactly as
-        /// live, dormant or destroyed as the vessel, and destroyed when a vessel that the
-        /// mod can be asked about has no group of the name. The mod not being ready says
-        /// nothing about any group: its controller only ever tracks the active vessel.
+        /// The state of the group. It takes the state of its vessel, and is destroyed once
+        /// a vessel the mod reports on has no group of the name. A mod that has yet to
+        /// start leaves the group dormant, as its controller tracks the active vessel
+        /// alone.
         /// </summary>
         public GameObjectState GameObjectState {
             get {
@@ -105,11 +105,9 @@ namespace KRPC.InfernalRobotics
         /// The name of the group.
         /// </summary>
         /// <remarks>
-        /// Renaming a group renames it for every servo in it. The name is what this object
-        /// names the group by, and is fixed for its lifetime, so every object for the group
-        /// stands for one the vessel no longer has once it is renamed, the object the rename
-        /// was made through included. An object for the group has to be obtained again under
-        /// the new name.
+        /// Renaming a group renames it for every servo in it. This object identifies the
+        /// group by its name, so a rename destroys every object for the group, including the
+        /// one the rename was made through. Obtain the group again under the new name.
         /// </remarks>
         [KRPCProperty]
         public string Name {

--- a/service/InfernalRobotics/src/ServoGroup.cs
+++ b/service/InfernalRobotics/src/ServoGroup.cs
@@ -15,13 +15,12 @@ namespace KRPC.InfernalRobotics
     [KRPCClass (Service = "InfernalRobotics")]
     public class ServoGroup : Equatable<ServoGroup>, IGameObjectState
     {
-        // The vessel the group belongs to and the name that picks it out among that
-        // vessel's groups, which is what the mod itself groups servos by. Both are fixed for
-        // the object's lifetime: the object store compares and hashes the objects it holds,
-        // so a name that moved would leave two objects naming one group, and the store
-        // unable to tell which entry belongs to which. The group object the mod hands out is
-        // built afresh every time the groups are listed, so holding one would instead leave
-        // two objects for one group comparing unequal.
+        // The vessel the group belongs to and the name that picks it out among that vessel's
+        // groups, which is how the mod itself groups servos. Both are fixed for the object's
+        // lifetime: the object store compares and hashes the objects it holds, so a name that
+        // moved leaves two objects naming one group. The group object the mod hands out is built
+        // afresh every time the groups are listed, so holding one leaves two objects for one
+        // group comparing unequal
         readonly SpaceCenter.Services.Vessel vessel;
         readonly string name;
 
@@ -79,9 +78,8 @@ namespace KRPC.InfernalRobotics
             return null;
         }
 
-        // The group the mod has on the vessel now. Every member reaches the mod through
-        // this, so a group taken before a game state was replaced drives the servos that
-        // stand in its place rather than the ones it was built from.
+        // The group the mod has on the vessel now. Every member reaches the mod through this, so
+        // a group taken before a game state was replaced drives the servos that stand in its place
         IRWrapper.IServoGroup Internal {
             get {
                 var group = Find ();

--- a/service/KerbalAlarmClock/CHANGELOG.md
+++ b/service/KerbalAlarmClock/CHANGELOG.md
@@ -1,10 +1,7 @@
 ## [v0.7.0] - unreleased
 
-- An alarm keeps working across a quickload, reading the alarm Kerbal Alarm Clock rebuilt
-  rather than the one it was obtained from, and raises `KRPC.ObjectDestroyedException` once
-  the mod no longer has an alarm with its id, which is what `Alarm.Remove` leaves behind. It
-  reports that it is unavailable, rather than gone, while the mod is not ready. Alarm
-  objects are freed rather than kept for the rest of the session (#1051)
+- An alarm keeps working across a quickload, and raises `KRPC.ObjectDestroyedException` once
+  the mod no longer has an alarm with its id (#1051)
 
 ## [v0.6.0]
 - Make available in all game scenes (#944)

--- a/service/KerbalAlarmClock/src/Alarm.cs
+++ b/service/KerbalAlarmClock/src/Alarm.cs
@@ -16,10 +16,9 @@ namespace KRPC.KerbalAlarmClock
     [KRPCClass (Service = "KerbalAlarmClock")]
     public class Alarm : Equatable<Alarm>, IGameObjectState
     {
-        // The identifier the mod knows the alarm by, which is what it creates and deletes
-        // alarms with. The alarm object the mod hands out is built afresh every time the
-        // alarms are listed, and belongs to the game state it was listed in, so holding one
-        // would leave this reading an alarm the mod no longer has.
+        // The identifier the mod creates and deletes alarms with. The alarm object the mod hands
+        // out is built afresh every time the alarms are listed, and belongs to the game state it
+        // was listed in, so the object itself is not held
         readonly string id;
 
         internal Alarm (KACWrapper.KACAPI.KACAlarm innerAlarm)
@@ -169,9 +168,8 @@ namespace KRPC.KerbalAlarmClock
         /// </summary>
         [KRPCProperty]
         public double Remaining {
-            // Computed from the alarm time rather than read through the wrapper:
-            // the mod stores its remaining time as a KSPTimeSpan object, which the
-            // wrapper cannot unbox to a double.
+            // Computed from the alarm time. The mod stores its remaining time as a KSPTimeSpan
+            // object, which the wrapper cannot unbox to a double
             get { return Internal.AlarmTime - Planetarium.GetUniversalTime (); }
         }
 

--- a/service/KerbalAlarmClock/src/Alarm.cs
+++ b/service/KerbalAlarmClock/src/Alarm.cs
@@ -47,10 +47,9 @@ namespace KRPC.KerbalAlarmClock
         }
 
         /// <summary>
-        /// What the game holds for the alarm. It is live while Kerbal Alarm Clock lists an
-        /// alarm with the identifier, and destroyed once the mod is there to ask and lists
-        /// none, as an alarm that is removed is gone for good. The mod not being ready says
-        /// nothing about any alarm.
+        /// The state of the alarm. It is live while Kerbal Alarm Clock lists an alarm with
+        /// the identifier, and destroyed once a running mod lists none. A mod that has yet
+        /// to start leaves the alarm dormant.
         /// </summary>
         public GameObjectState GameObjectState {
             get {

--- a/service/LiDAR/CHANGELOG.md
+++ b/service/LiDAR/CHANGELOG.md
@@ -1,8 +1,7 @@
 ## [v0.7.0] - unreleased
 
-- A `Laser` whose part the game has destroyed, or that is no longer a laser, raises
-  `KRPC.ObjectDestroyedException` rather than reaching into a part that is gone, and is
-  freed rather than kept for the rest of the session (#1051)
+- A `Laser` whose part is destroyed, or that is no longer a laser, raises
+  `KRPC.ObjectDestroyedException` (#1051)
 
 ## [v0.6.0]
 - Fix `LiDAR.Available` incorrectly reporting false in game scenes other than flight (#937)

--- a/service/LiDAR/src/Laser.cs
+++ b/service/LiDAR/src/Laser.cs
@@ -14,8 +14,8 @@ namespace KRPC.LiDAR
     [KRPCClass(Service = "LiDAR")]
     public class Laser : Equatable<Laser>, IGameObjectState
     {
-        // The module that makes a part a laser. The mod's API takes the part rather than
-        // the module, so the part is what identifies this and all it has to reach.
+        // The module that makes a part a laser. The mod's API takes the part, so the part
+        // identifies the laser
         const string moduleName = "LiDARModule";
 
         internal static bool Is(SpaceCenter.Services.Parts.Part part)

--- a/service/LiDAR/src/Laser.cs
+++ b/service/LiDAR/src/Laser.cs
@@ -24,9 +24,8 @@ namespace KRPC.LiDAR
         }
 
         /// <summary>
-        /// What the game holds for the laser. It belongs to its part, so it is exactly as
-        /// live, dormant or destroyed as the part, and destroyed when a part that is there
-        /// to look at no longer carries the module.
+        /// The state of the laser. It takes the state of its part, and is destroyed once a
+        /// live part no longer carries the module.
         /// </summary>
         public GameObjectState GameObjectState
         {

--- a/service/RemoteTech/CHANGELOG.md
+++ b/service/RemoteTech/CHANGELOG.md
@@ -1,9 +1,7 @@
 ## [v0.7.0] - unreleased
 
-- An `Antenna` whose part the game has destroyed, or that is no longer an antenna, and a
-  `Comms` whose vessel is gone, raise `KRPC.ObjectDestroyedException` rather than reaching
-  into what is no longer there, and are freed rather than kept for the rest of the session
-  (#1051)
+- An `Antenna` whose part is destroyed, or that is no longer an antenna, and a `Comms` whose
+  vessel is gone, raise `KRPC.ObjectDestroyedException` (#1051)
 
 ## [v0.6.0]
 - Fix `RemoteTech.Available` incorrectly reporting false in game scenes other than flight (#937)

--- a/service/RemoteTech/src/Antenna.cs
+++ b/service/RemoteTech/src/Antenna.cs
@@ -12,9 +12,8 @@ namespace KRPC.RemoteTech
     [KRPCClass (Service = "RemoteTech")]
     public class Antenna : Equatable<Antenna>, IGameObjectState
     {
-        // The module that makes a part an antenna. An antenna is a part carrying it, so the
-        // part is what identifies the antenna, and the mod's API takes the part rather than
-        // the module.
+        // The module that makes a part an antenna. The mod's API takes the part, so the part
+        // identifies the antenna
         const string moduleName = "ModuleRTAntenna";
 
         readonly SpaceCenter.Services.Parts.Part part;

--- a/service/RemoteTech/src/Antenna.cs
+++ b/service/RemoteTech/src/Antenna.cs
@@ -48,9 +48,8 @@ namespace KRPC.RemoteTech
         }
 
         /// <summary>
-        /// What the game holds for the antenna. It belongs to its part, so it is exactly as
-        /// live, dormant or destroyed as the part, and destroyed when a part that is there
-        /// to look at no longer carries the antenna module.
+        /// The state of the antenna. It takes the state of its part, and is destroyed once
+        /// a live part no longer carries the antenna module.
         /// </summary>
         public GameObjectState GameObjectState {
             get {

--- a/service/RemoteTech/src/Comms.cs
+++ b/service/RemoteTech/src/Comms.cs
@@ -30,9 +30,8 @@ namespace KRPC.RemoteTech
             get { return vessel.GameObjectState; }
         }
 
-        // The id of the vessel, which the mod's API takes, resolved first so that a vessel
-        // the game no longer has says so rather than the mod answering for an id that names
-        // nothing.
+        // The id of the vessel, which the mod's API takes. Resolved first, so that a vessel the
+        // game has dropped raises here and not inside the mod
         Guid VesselId {
             get { return vessel.InternalVessel.id; }
         }

--- a/service/RemoteTech/src/Comms.cs
+++ b/service/RemoteTech/src/Comms.cs
@@ -24,7 +24,7 @@ namespace KRPC.RemoteTech
         }
 
         /// <summary>
-        /// What the game holds for the vessel these communications belong to.
+        /// The state of the vessel these communications belong to.
         /// </summary>
         public GameObjectState GameObjectState {
             get { return vessel.GameObjectState; }

--- a/service/SpaceCenter/CHANGELOG.md
+++ b/service/SpaceCenter/CHANGELOG.md
@@ -2,339 +2,202 @@
 
 - Space center
   - **Breaking:** `SpaceCenter.LaunchVessel` takes its `crew` parameter as an exact
-    instruction, and the parameter is optional again. A `null` crew (the default) uses the
-    craft's default crew assignments; an empty list, which previously also used the default
-    assignments, launches with no crew; and a populated list seats exactly the named Kerbals,
-    in the order given. An unknown or unavailable Kerbal name, or a craft with too few seats,
-    raises an exception without launching (#1017)
+    instruction, and the parameter is optional again. A `null` crew uses the craft's default
+    assignments, an empty list launches with no crew, and a populated list seats the named
+    Kerbals in order (#1017)
   - **Breaking:** `SpaceCenter.Parts.Controlling` returns `null` when the vessel has no
-    control point, rather than its root part. A vessel separated from another one is given a
-    control point only when one of its parts is a command module with crew aboard, so a
-    vessel that the game merely orients by its root part is now distinguishable from one that
-    is deliberately controlled from it (#1043)
+    control point, rather than its root part (#1043)
   - `SpaceCenter.Control.State`, `SpaceCenter.Control.Source` and the members of
-    `SpaceCenter.Comms` no longer throw for a vessel that has no node in the communication
-    network, such as the debris a decoupler leaves behind. They report no control and no
-    communications instead. `Comms.Power` is zero for a vessel whose antennas supply no
-    power, including one that carries none (#1043)
-  - `SpaceCenter.Control.Source` is `None` whenever `SpaceCenter.Control.State` is `None`.
-    A vessel whose only command module is a command pod with no crew aboard reported that
-    it was controlled by a kerbal, because KSP reports the kind of command module the
-    vessel carries separately from whether it is giving any control (#1043)
-  - `SpaceCenter.Control.State` and `SpaceCenter.Control.Source` are taken from the control
-    level that KSP gates a vessel's control on, rather than from the vessel's node in the
-    communication network. The network describes a vessel only while CommNet is enabled, so
-    with CommNet switched off both properties described a game rule that was not in use
+    `SpaceCenter.Comms` report no control and no communications for a vessel with no node in
+    the communication network, rather than throwing (#1043)
+  - `SpaceCenter.Control.Source` is `None` whenever `SpaceCenter.Control.State` is `None`
     (#1043)
+  - `SpaceCenter.Control.State` and `SpaceCenter.Control.Source` are taken from the control
+    level that KSP gates a vessel's control on, rather than from its node in the communication
+    network (#1043)
   - `SpaceCenter.Decoupler.Decouple` returns the separated vessel when it fires an
-    omni-decoupler such as a stack separator. Such a decoupler detaches at every node at
-    once, leaving itself on a vessel of its own as well as the vessel it separated, and the
-    two vessels this produced raised an exception (#1043)
-  - Working with many stages, vessel resources, communication links or resource converters
-    no longer slows the server down. Two such objects could share a hash code, and the
-    server then searched them one by one (#1071)
+    omni-decoupler such as a stack separator (#1043)
+  - Working with many stages, vessel resources, communication links or resource converters no
+    longer slows the server down (#1071)
 
 - Editor
-  - Add `SpaceCenter.Editor`, available in the vehicle assembly building and the space
-    plane hangar, for inspecting the vessel that is being constructed. `Editor.Vessel`
-    gives its name, description, editor, size, mass, cost and crew capacity, and
-    `Editor.LoadVessel` loads a craft file into the open editor (#1038)
-  - `Editor.LaunchVessel` launches the vessel that is being constructed, from a given launch
-    site and with the same crew, recovery and mission flag options as
-    `SpaceCenter.LaunchVessel`. The vessel is written to the editor's auto-saved craft file
-    and launched from there, as the game's own launch button does, leaving the craft file it
-    was loaded from alone (#1038)
-  - `EditorVessel.Parts` gives the parts tree of the vessel under construction, as
-    `Vessel.Parts` does in flight. The members of `Part` and of the part-type classes that
-    describe the design are available; those that need a vessel in flight or running
-    physics, such as the thermal members, remain restricted to the flight scene.
-    `Engine.ThrustLimit` can be read and set from the editor (#1038)
+  - Add `SpaceCenter.Editor`, available in the vehicle assembly building and the space plane
+    hangar, for inspecting the vessel that is being constructed. `Editor.LoadVessel` loads a
+    craft file into the open editor (#1038)
+  - `Editor.LaunchVessel` launches the vessel that is being constructed, with the same crew,
+    recovery and mission flag options as `SpaceCenter.LaunchVessel` (#1038)
+  - `EditorVessel.Parts` gives the parts tree of the vessel under construction. The members of
+    `Part` and the part-type classes that describe the design are available (#1038)
   - `EditorVessel.Stages`, `EditorVessel.StageAt`, `EditorVessel.DecoupleStages` and
-    `EditorVessel.DecoupleStageAt` give the vessel's stages, with the same stock delta-v,
-    thrust, TWR, specific impulse and mass figures that `Stage` reports in flight, along
-    with `EditorVessel.DeltaV`, `VacuumDeltaV`, `SeaLevelDeltaV` and `BurnTime` for the
-    whole vessel. `Editor.DeltaVBody`, `Editor.DeltaVAltitude` and
-    `Editor.DeltaVSituation` set the situation those figures assume, as the game's own
-    delta-v app does. The figures are recalculated in the background after any change to
-    the vessel or the situation; `EditorVessel.DeltaVReady` reports whether they are
-    current, and reading them before they are raises rather than returning a stale
-    figure (#1038)
-  - `EditorVessel.Resources`, `Part.Resources` and `Stage.Resources` report the resources
-    the vessel under construction can hold, per vessel, per part and per stage, as they do
-    for a vessel in flight (#1038)
-  - A part of the vessel under construction raises `KRPC.ObjectDestroyedException` once it
-    is no longer in that vessel, and once the editor has loaded any vessel over it. A part
-    in the editor is named by an identifier that is only unique within one vessel, so a
-    part of a vessel that has been replaced cannot be told from the part of the new one
-    that answers to the same identifier. An undo or a redo rebuilds the vessel the editor
-    already has rather than loading a new one, so a part it leaves alone keeps working.
-    Leaving the editor destroys the vessel it had open, and everything reached through
-    it (#1051)
+    `EditorVessel.DecoupleStageAt` give the vessel's stages, with the same figures that
+    `Stage` reports in flight (#1038)
+  - Add `EditorVessel.DeltaV`, `VacuumDeltaV`, `SeaLevelDeltaV` and `BurnTime` for the whole
+    vessel, and `EditorVessel.DeltaVReady`, which reports whether the figures are current
+    (#1038)
+  - `Editor.DeltaVBody`, `Editor.DeltaVAltitude` and `Editor.DeltaVSituation` set the
+    situation those figures assume (#1038)
+  - `EditorVessel.Resources`, `Part.Resources` and `Stage.Resources` report the resources the
+    vessel under construction can hold (#1038)
+  - A part of the vessel under construction raises `KRPC.ObjectDestroyedException` once it is
+    no longer in that vessel, and once the editor has loaded any vessel over it (#1051)
   - Add `EditorVessel.CenterOfMass`, `EditorVessel.MomentOfInertia` and
-    `EditorVessel.InertiaTensor`, which report how the mass of the vessel under
-    construction is distributed, as `Vessel` does in flight. A part's inertia is
-    not available from physics in the editor, so it is worked out from the part's
-    colliders. `Part.MomentOfInertia` and `Part.InertiaTensor` are available in
-    the editor as well (#1059)
-  - `Part.Mass` and `Part.DryMass` no longer report 1000 kg for every part in the
-    editor. The rigidbody the game attaches there is an unconfigured placeholder
-    weighing Unity's default of one tonne, and the mass is now taken from the
-    part itself, including crew (#1059)
+    `EditorVessel.InertiaTensor`. `Part.MomentOfInertia` and `Part.InertiaTensor` are
+    available in the editor as well (#1059)
+  - `Part.Mass` and `Part.DryMass` no longer report 1000 kg for every part in the editor
+    (#1059)
   - `Part.Position`, `Part.CenterOfMass`, `Part.ReferenceFrame` and
-    `Part.CenterOfMassReferenceFrame` are available in the editor, so the
-    center of mass of a design can be related to the parts it is made of
-    (#1064)
+    `Part.CenterOfMassReferenceFrame` are available in the editor (#1064)
 
 - Vessels and crew
-  - `Vessel.InertiaTensor` is restricted to the flight scene, as
-    `Vessel.MomentOfInertia` already is. Outside flight it summed the parts'
-    rigidbodies and returned zeros (#1059)
-  - Add `CrewMember.EVA`, which sends a Kerbal outside through the hatch of the part it is
-    in and returns the vessel it becomes (#319)
+  - `Vessel.InertiaTensor` is restricted to the flight scene, as `Vessel.MomentOfInertia`
+    already is. Outside flight it returned zeros (#1059)
+  - Add `CrewMember.EVA`, which sends a Kerbal outside through the hatch of the part it is in
+    and returns the vessel it becomes (#319)
   - Add `Vessel.Terminate`, which removes a vessel and its parts from the game without
-    recovering anything, as terminating it from the tracking station does. Its crew are
-    reported missing. The active vessel cannot be terminated (#1034)
-  - `Vessel.Recover` now recovers non-active vessels without switching to
-     the space center scene, and the mission completion dialog is auto-closed. (#1021)
+    recovering anything (#1034)
+  - `Vessel.Recover` recovers non-active vessels without switching to the space center scene,
+    and the mission completion dialog is auto-closed (#1021)
   - Add `Vessel.OrbitSpeedReferenceFrame`, `Vessel.SurfaceSpeedReferenceFrame` and
-    `Vessel.TargetSpeedReferenceFrame`, one per navball speed mode. The velocity of the
-    vessel in one of these frames is the velocity the navball shows in that mode, and its
-    magnitude the speed displayed. Each frame is oriented with the prograde/normal/radial
-    directions the navball marks in that mode, arranged as in
-    `Vessel.OrbitalReferenceFrame`, so a direction of (0,1,0) in the frame is prograde
-    (#1029)
-  - Using a vessel that no longer exists raises `KRPC.ObjectDestroyedException`, saying that
-    the vessel is gone, rather than an argument error (#1051)
-  - A `CrewMember` is named by the kerbal's name and looks them up on the game's roster on
-    every call, so the same kerbal obtained twice is the same object and one obtained before
-    a load goes on working. A kerbal the roster no longer has raises
-    `KRPC.ObjectDestroyedException`. Renaming a kerbal by setting `CrewMember.Name` renames
-    them on the roster, so every object for that kerbal, the one renamed through included,
-    stands for a kerbal that no longer exists; a fresh object has to be obtained under the
-    new name (#1051)
+    `Vessel.TargetSpeedReferenceFrame`, one per navball speed mode. The velocity of the vessel
+    in one of these is the velocity the navball shows in that mode (#1029)
+  - Using a vessel that no longer exists raises `KRPC.ObjectDestroyedException` (#1051)
+  - A `CrewMember` looks the kerbal up on the game's roster on every call, so one obtained
+    before a load goes on working (#1051)
+  - Renaming a kerbal destroys every object for them, which have to be obtained again under
+    the new name (#1051)
 
 - Staging
   - Fix stages from `Vessel.Stages`, `Vessel.StageAt`, `Vessel.DecoupleStages` and
-    `Vessel.DecoupleStageAt` breaking after a Revert to Launch, reporting that delta-v had
-    not been calculated for the vessel. Stages requested after the revert were affected
-    too, so the game had to be restarted to get working stages back (#1023)
+    `Vessel.DecoupleStageAt` breaking after a Revert to Launch (#1023)
 
 - Autopilot
-  - Setting `AutoPilot.TargetDirection` keeps the target roll, rather than clearing it. It
-    re-aims the nose and nothing else, holding the commanded roll relative to
-    `AutoPilot.UpReference` as the scalar `TargetPitch` and `TargetHeading` setters do, so
-    tracking a moving direction such as prograde no longer drops the roll on every
-    update (#1054)
-  - The auto-pilot's control loop runs at a defined point in the server's update rather than
-    wherever the game happened to collect control inputs, so a target set during a tick is
-    flown on that tick instead of the next one. `AutoPilot.UpdateMode` chooses that point,
-    and in its manual mode `AutoPilot.Update` runs the loop, letting a program place it
-    among its own calls inside a held tick (#1070)
+  - Setting `AutoPilot.TargetDirection` keeps the target roll, rather than clearing it (#1054)
+  - The auto-pilot's control loop runs at a defined point in the server's update, so a target
+    set during a tick is flown on that tick. `AutoPilot.UpdateMode` chooses that point (#1070)
   - Fix an engaged auto-pilot failing on every physics tick once the vessel or part its
-    `AutoPilot.ReferenceFrame` is defined against is gone. The loop now waits for a frame
-    it can measure in, and releases the controls in the meantime, so pointing it at
-    another frame picks it back up (#1070)
+    `AutoPilot.ReferenceFrame` is defined against is gone (#1070)
 
 - Orbits, nodes and bodies
   - An `Orbit` reads the orbit of the vessel, celestial body or maneuver node it belongs to as
-    it is now, rather than the one the game had when it was obtained, so it keeps working
-    across a load instead of reporting the orbit of a game state that has been replaced.
-    Asking the same thing for its orbit again gives back the same object rather than a second
-    one (#764)
-  - A `ClosestApproach` is freed once either of the orbits it describes is gone, rather than
-    being kept for the rest of the session (#1051)
-  - Add `CelestialBody.SurfaceNormal`, `CelestialBody.BedrockNormal` and `CelestialBody.MSLNormal`
-    to get the slope of the terrain at a given latitude and longitude, as a unit vector normal to
-    the surface, to the sea-bed, or to the sphere at sea level (#1030)
-  - Fix `ClosestApproach.Velocity` and `ClosestApproach.TargetVelocity`, which were both
-    offset by the velocity of the frame the active vessel's reference body moves in, some
-    9284 m/s for a vessel in orbit around Kerbin. `ClosestApproach.RelativeVelocity` and
-    `ClosestApproach.RelativeSpeed` are the difference of the two and were unaffected
-    (#1047)
-  - Add `Orbit.CreateFromPositionAndVelocity`, which builds the orbit that passes through
-    a given position at a given velocity, and `Orbit.CreateFromOrbitalElements`, which
-    builds the orbit with a given semi-major axis, eccentricity, inclination, longitude of
-    ascending node, argument of periapsis and mean anomaly at an epoch. Either way the
-    orbit coasts freely under gravity, so it describes where an object left to fall from
-    that state would be at any later time, without there being such an object in the game.
-    (#1046)
+    it is now, so it keeps working across a load (#764)
+  - A `ClosestApproach` is freed once either of the orbits it describes is gone (#1051)
+  - Add `CelestialBody.SurfaceNormal`, `CelestialBody.BedrockNormal` and
+    `CelestialBody.MSLNormal`, the slope of the terrain at a given latitude and longitude
+    (#1030)
+  - Fix `ClosestApproach.Velocity` and `ClosestApproach.TargetVelocity` being offset by the
+    velocity of the frame the active vessel's reference body moves in (#1047)
+  - Add `Orbit.CreateFromPositionAndVelocity` and `Orbit.CreateFromOrbitalElements`, which
+    build an orbit that coasts freely under gravity without an object in the game to
+    follow (#1046)
   - Add `Orbit.ReferenceFrame` and `Orbit.OrbitalReferenceFrame`, centered on the point an
-    orbit has reached at the current time. The first is oriented in a fixed direction and
-    the second with the orbital prograde/normal/radial directions. Together with a
-    constructed orbit these give a reference frame that follows a coasting object that
-    need not exist (#1046)
-  - Add `Orbit.Remove`, which releases the memory the server holds for an orbit created
-    by `Orbit.CreateFromPositionAndVelocity` or `Orbit.CreateFromOrbitalElements`. Such an
-    orbit stands for nothing in the game, so nothing else says when it is finished with;
-    one that is not removed is held until the client that created it disconnects. A
-    reference frame defined against a removed orbit goes with it (#1072)
-  - **Breaking:** A `ClosestApproach` reads the two orbits as they are now rather than
-    describing the moment it was created, so its estimate follows them as the game runs.
-    Asking for the same approach again gives back the same object; the server previously
-    kept a separate one per call, so a script polling the approach to a target filled its
-    memory (#1072)
+    orbit has reached at the current time (#1046)
+  - Add `Orbit.Remove`, which releases the memory the server holds for a created orbit (#1072)
+  - **Breaking:** A `ClosestApproach` reads the two orbits as they are now, so its estimate
+    follows them as the game runs. Asking for the same approach again gives the same
+    object (#1072)
   - Add `Orbit.VelocityAt`, giving the velocity at a given time in a given reference
-    frame, alongside the existing `Orbit.PositionAt` (#1046)
-  - `Orbit.Epoch` is documented as the universal time at which the mean anomaly at epoch
-    is measured. It was described as the time since that point (#1046)
+    frame (#1046)
+  - `Orbit.Epoch` is documented as the universal time at which the mean anomaly at epoch is
+    measured. It was described as the time since that point (#1046)
 
 - Maneuver nodes
-  - Using a maneuver node that has been removed raises `KRPC.ObjectDestroyedException` rather
-    than reporting the call as invalid. Loading a game replaces the vessel's maneuver nodes,
-    so nodes obtained before the load are also gone (#1051)
+  - Using a maneuver node that has been removed raises `KRPC.ObjectDestroyedException`.
+    Loading a game replaces the vessel's maneuver nodes (#1051)
   - Fix removing a maneuver node leaking the object for the rest of the session (#771)
 
 - Reference frames
-  - Add `ReferenceFrame.Remove`, which releases the memory the server holds for a frame
-    created by `ReferenceFrame.CreateRelative` or `ReferenceFrame.CreateHybrid`. Such a
-    frame stands for nothing in the game, so nothing else says when it is finished with,
-    and a script creating one repeatedly needed a reload of the game to get the memory
-    back. One that is not removed is held until the client that created it disconnects
-    (#1072)
-  - `ReferenceFrame.CreateRelative` and `ReferenceFrame.CreateHybrid` return a new frame
-    on each call, rather than one object shared by every client that asks for the same
-    frame. A frame is now each client's own to remove (#1072)
+  - Add `ReferenceFrame.Remove`, which releases the memory the server holds for a created
+    frame (#1072)
+  - `ReferenceFrame.CreateRelative` and `ReferenceFrame.CreateHybrid` return a new frame on
+    each call, which is the creating client's own to remove (#1072)
   - `ReferenceFrame.CreateRelative` and `ReferenceFrame.CreateHybrid` raise an error when
-    given no frame to be defined against, rather than returning one that fails with a
-    `NullReferenceException` on first use (#1072)
-  - Creating many hybrid reference frames no longer slows the server down. A frame given
-    the same frame for two of its components, which the defaults of
-    `ReferenceFrame.CreateHybrid` do on their own, hashed the same as every other such
-    frame, and the server searched them one by one whenever a frame was passed to it or
-    returned (#1071)
-  - A reference frame taken from a docking port keeps working across a quickload, and says the
-    port is gone rather than failing with a null reference once its part is destroyed (#885,
-    #764)
+    given no frame to be defined against (#1072)
+  - Creating many hybrid reference frames no longer slows the server down (#1071)
+  - A reference frame taken from a docking port keeps working across a quickload (#885, #764)
 
 - Flight and aerodynamics
-  - Add `Flight.SurfaceNormal` to get the slope of the terrain under a vessel, as a unit vector
-    normal to the surface (#1030)
+  - Add `Flight.SurfaceNormal`, the slope of the terrain under a vessel (#1030)
   - Fix `Flight.AerodynamicForce` and `Flight.AerodynamicAcceleration` turning with the roll
-    of the vessel when Ferram Aerospace Research is installed. They were rebuilt from FAR's
-    lift and drag coefficients, which are scalars measured against the vessel's own axes, and
-    now report the force FAR applies to the vessel (#1032)
+    of the vessel when Ferram Aerospace Research is installed (#1032)
   - Add `Flight.SideForce`, the part of `Flight.AerodynamicForce` that acts across the air
-    stream and out of the vessel's side, which the air exerts on a vessel flying with
-    sideslip. `Flight.Lift`, `Flight.SideForce` and `Flight.Drag` are mutually perpendicular
-    and sum to `Flight.AerodynamicForce` (#1032)
+    stream and out of the vessel's side (#1032)
   - Fix `Flight.Lift` and `Flight.LiftAcceleration` reporting a force scaled by the cosine
-    squared of the sideslip angle, from a lift direction that was never normalized. A vessel
-    flying with no sideslip was unaffected; one flying at 20 degrees of sideslip had its lift
-    reported 12% low (#1032)
-  - `Flight.AerodynamicTorque` now works with Ferram Aerospace Research installed, reporting
-    the torque FAR applies about the vessel's center of mass. It previously refused,
-    reporting that it was unavailable (#1032)
+    squared of the sideslip angle (#1032)
+  - `Flight.AerodynamicTorque` works with Ferram Aerospace Research installed (#1032)
   - Fix `Flight.SimulateAerodynamicForceAt`, `Flight.SimulateAerodynamicTorqueAt` and
     `Flight.SimulateAerodynamicWrenchAt` returning `NaN` with Ferram Aerospace Research
-    installed when asked for a state with no relative airflow. They now report no force and
-    no torque, as they do without FAR (#1032)
-  - Fix `Flight.StallFraction` returning `NaN` for a vessel with no lifting surfaces, which
-    has nothing that can stall; it now reports no stall (#1032)
+    installed when there is no relative airflow (#1032)
+  - Fix `Flight.StallFraction` returning `NaN` for a vessel with no lifting surfaces (#1032)
 
 - Control
-  - A Kerbal on EVA can now be driven through `Vessel.Control`. `Control.Forward` and
-    `Control.Right` walk it about, relative to the direction it is facing, and all three
-    translation inputs fly its jetpack once deployed. `Control.Yaw` steers it as it walks,
-    and the rotation inputs turn its jetpack, at a rate proportional to the input.
-    `Control.RCS` deploys and stows the jetpack, and `Control.Lights` switches the helmet
-    lamp (#319)
-  - Add `Control.Board`, which climbs a Kerbal on EVA into the part whose hatch it is
-    standing at, and `Control.Airlock`, which reports that part. Add `Control.GrabLadder`
-    and `Control.ReleaseLadder` for the ladder it is alongside, and `Control.Ladder`, which
-    reports the ladder it is holding (#319)
-  - Setting `Control.StageLock` now leaves the in-game Alt+L shortcut in step with it, so the
-    next press of Alt+L locks or unlocks staging rather than being absorbed (#1022)
+  - A Kerbal on EVA can be driven through `Vessel.Control`. The translation inputs walk it
+    about and fly its jetpack, `Control.RCS` deploys and stows the jetpack, and
+    `Control.Lights` switches the helmet lamp (#319)
+  - Add `Control.Board` and `Control.Airlock`, for the part whose hatch a Kerbal on EVA is
+    standing at, and `Control.GrabLadder`, `Control.ReleaseLadder` and `Control.Ladder` for
+    the ladder it is alongside (#319)
+  - Setting `Control.StageLock` leaves the in-game Alt+L shortcut in step with it (#1022)
 
 - Parts
   - `Decoupler.IsOmniDecoupler` reports what the part is configured as for every decoupler,
-    including radial ones and any that a mod derives from the stock modules. It was false for
-    all of them regardless of their configuration. The stage a part is assigned to follows the
-    same value, so a vessel carrying such a decoupler can be staged differently (#1048)
+    including radial ones. It was false for all of them (#1048)
   - A force added with `Part.AddForce` stops being applied, and is freed, once its part is
-    destroyed. It previously failed on every physics update for the rest of the session. A
-    force on a part the game has unloaded, or measured in a reference frame that is defined
-    against something that is gone, waits rather than being applied (#1051)
+    destroyed (#1051)
   - `Force.Remove` leaves the object gone, so using one afterwards raises
-    `KRPC.ObjectDestroyedException` and the object is freed. A removed force previously went
-    on reporting the force it was applying, and was kept for the rest of the session (#1051)
-  - `Part.BoundingBox` and `Vessel.BoundingBox` now measure only the meshes of a part's own
-    model. The boxes no longer take in the models of physicsless child parts, nor any object
-    another mod has attached to a part, which could stretch a box to an arbitrary size (#1024)
+    `KRPC.ObjectDestroyedException` (#1051)
+  - `Part.BoundingBox` and `Vessel.BoundingBox` measure only the meshes of a part's own model,
+    leaving out physicsless child parts and objects another mod has attached (#1024)
   - Computing a bounding box no longer duplicates the meshes of every part it measures (#1024)
-  - Add support for [RealFuels](https://forum.kerbalspaceprogram.com/index.php?/topic/58236-*).
-    `SpaceCenter.RealFuelsAvailable` reports whether it is installed. On an engine it manages
-    (`Engine.HasRealFuels`), `Engine.Ignitions` and `Engine.IgnitionResources` give the
-    ignitions left and what each one consumes; `Engine.HasUllage`,
-    `Engine.PropellantStability` and `Engine.PropellantReliability` give how settled the
-    propellant is; and `Engine.PressureFed` and `Engine.HasFeedPressure` give whether the
-    engine needs tank pressure and whether it has it. On a tank it manages
-    (`Part.HasRealFuelsTank`), `Part.HighlyPressurized` and `Part.BoiloffRate` give the tank's
-    pressurization and how fast its cryogenic contents are boiling off (#1039)
+  - Add support for [RealFuels](https://forum.kerbalspaceprogram.com/index.php?/topic/58236-*),
+    reported by `SpaceCenter.RealFuelsAvailable`. On an engine it manages, `Engine.Ignitions`,
+    `Engine.IgnitionResources`, `Engine.HasUllage`, `Engine.PropellantStability`,
+    `Engine.PropellantReliability`, `Engine.PressureFed` and `Engine.HasFeedPressure` are
+    available; on a tank, `Part.HighlyPressurized` and `Part.BoiloffRate` (#1039)
   - Fix `ReactionWheel.AvailableTorque`, and the vessel level torque properties that include
     it, being scaled by the square of the wheel's authority limiter when KSPCommunityFixes is
     installed (#1042)
-  - Fix `Decoupler` objects accumulating for the rest of the session, one per call to
-    `Part.Decoupler`, and the same decoupler obtained twice comparing unequal (#1051)
+  - Fix `Decoupler` objects accumulating for the rest of the session, and the same decoupler
+    obtained twice comparing unequal (#1051)
   - A `Decoupler` finds its part's decoupler module again on every call, so it keeps working
-    across a quickload. One obtained before a load previously read the module the load
-    replaced, reporting the impulse and fired state it had beforehand and failing outright
-    when fired, while reporting itself as still there (#1051)
+    across a quickload (#1051)
   - Using a part that has been destroyed raises `KRPC.ObjectDestroyedException` instead of
     failing with a null reference (#885)
-  - Using a part module, or any of the objects built on one such as `Engine`, `Parachute`,
-    `Antenna` or `SolarPanel`, after its part has been destroyed raises
-    `KRPC.ObjectDestroyedException` instead of failing with a null reference (#885)
-  - Part modules, and the objects built on them, read the modules of the loaded game rather
-    than those of a game state that has been replaced, so they keep working across a
-    quickload instead of returning readings from before it (#764)
+  - Using a part module, or an object built on one such as `Engine` or `Parachute`, after its
+    part has been destroyed raises `KRPC.ObjectDestroyedException` (#885)
+  - Part modules, and the objects built on them, read the modules of the loaded game, so they
+    keep working across a quickload (#764)
   - Using a part of a vessel that the game has unloaded raises an error saying that the part
-    is not loaded. The part works again once the game loads the vessel, and is not treated as
-    destroyed in the meantime (#1051)
-  - The fields, events and actions of a part module read the loaded game's module rather than
-    one belonging to a replaced game state, and say the module is gone when it is (#764)
+    is not loaded (#1051)
+  - The fields, events and actions of a part module read the loaded game's module (#764)
   - A `ScienceSubject` belongs to the game state it was read from, and using one after that
-    state has been replaced raises `KRPC.ObjectDestroyedException` rather than returning the
-    replaced game's science. Reading `Experiment.ScienceSubject` repeatedly no longer adds a
-    new object for each read, and reads the science the game has banked against the subject
-    since the first of those reads (#771)
+    state has been replaced raises `KRPC.ObjectDestroyedException` (#771)
+  - Fix `Experiment.ScienceSubject` adding a new object for every read (#771)
   - Fix `ScienceSubject.Science` and `ScienceSubject.ScienceCap` scaling by the science gain
-    multiplier that was in force when the object was read, rather than the current one (#1051)
+    multiplier that was in force when the object was read (#1051)
 
 - Resources
-  - Add `ResourceTransfer.Cancel` to stop a transfer before it finishes; no more of the
-    resource is moved and the transfer is marked as complete (#1028)
+  - Add `ResourceTransfer.Cancel` to stop a transfer before it finishes (#1028)
   - Fix a resource transfer failing on every update, and never completing, once one of the
-    parts it runs between is destroyed; the transfer is now canceled. A transfer whose vessel
-    the game unloads waits for it rather than failing (#1051)
-  - Add `ResourceTransfer.Remove`, which stops a transfer and releases the memory the
-    server holds for it. A transfer that is left is held for as long as the game holds
-    the two parts it runs between, which may be the rest of the flight (#1072)
+    parts it runs between is destroyed (#1051)
+  - Add `ResourceTransfer.Remove`, which stops a transfer and releases the memory the server
+    holds for it (#1072)
 
 - Camera
-  - `Camera.NextCamera` and `Camera.PreviousCamera` now move the IVA view between the crew of
-    the active vessel without ever dropping out of IVA mode, and pass over crew that the game
-    has not placed in an interior. Previously, moving to the crew member already in view, as
-    happens on a vessel with a single crew member, switched to the flight camera instead (#1031)
+  - `Camera.NextCamera` and `Camera.PreviousCamera` move the IVA view between the crew of the
+    active vessel without dropping out of IVA mode (#1031)
   - Setting `Camera.FocussedCrewMember` to the crew member already in view no longer switches
-    to the flight camera. Setting it to a crew member who is not in the active vessel, or who
-    is not in the interior of a part, now raises an error rather than being ignored or failing
-    with a `NullReferenceException`, as does setting it to `null` (#1031)
-  - `Camera.FocussedCrewMember` returns `null` when no crew member is in view, instead of
-    failing with a `NullReferenceException` (#1031)
+    to the flight camera. Setting it to one who is not in view of a part interior raises an
+    error (#1031)
+  - `Camera.FocussedCrewMember` returns `null` when no crew member is in view (#1031)
 
 - Alarms, contracts and waypoints
-  - `SpaceCenter.Alarm`, `Contract`, `ContractParameter` and `Waypoint` objects find what
-    they stand for again on every call, rather than holding what the game gave them. They
-    keep working when the game rebuilds it, and never read a record belonging to a game
-    state that has since been replaced. One that the game no longer has raises
-    `KRPC.ObjectDestroyedException`, which is what `Alarm.Remove` and `Waypoint.Remove`
-    leave behind, and is freed rather than kept for the rest of the session (#1051)
+  - `SpaceCenter.Alarm`, `Contract`, `ContractParameter` and `Waypoint` objects look their
+    record up on every call, so they keep working when the game rebuilds it. One the game no
+    longer has raises `KRPC.ObjectDestroyedException` (#1051)
 
 - Communications
-  - A `CommLink` is named by the two nodes it joins and reports the link between them as it
-    is now. A link over which contact has been lost reports that the two nodes are not
-    connected, rather than the signal strength the link had when contact was lost, and one
-    whose nodes are gone raises `KRPC.ObjectDestroyedException` (#1051)
+  - A `CommLink` is identified by the two nodes it joins and reports the link between them as
+    it is now. One whose nodes are gone raises `KRPC.ObjectDestroyedException` (#1051)
 
 ## [v0.6.0]
 

--- a/service/SpaceCenter/InternalsVisibleTo.cs
+++ b/service/SpaceCenter/InternalsVisibleTo.cs
@@ -1,6 +1,6 @@
 using System.Runtime.CompilerServices;
 
-// For the Visual Studio solution / dotnet build. The Bazel build injects this
-// via rules_dotnet's internals_visible_to attr instead, so this file lives
-// outside src/ (which Bazel globs) to avoid a duplicate attribute.
+// For the Visual Studio solution and the dotnet build. The Bazel build injects the
+// attribute through rules_dotnet, so this file sits outside the src/ directory that
+// Bazel globs.
 [assembly: InternalsVisibleTo("TestingTools")]

--- a/service/SpaceCenter/src/AutoPilot/AttitudeController.cs
+++ b/service/SpaceCenter/src/AutoPilot/AttitudeController.cs
@@ -26,9 +26,9 @@ namespace KRPC.SpaceCenter.AutoPilot
     /// primitives act, making no decisions of their own. <see cref="DiagnosticLogBuffer"/> records a
     /// row per tick.
     ///
-    /// How the control law works — the cascade, the roll-invariant frame, the velocity profile, the
-    /// pole placement behind the auto-tuner and the oscillation mitigation — is documented in
-    /// doc/src/tutorials/autopilot.rst, under "How it works".
+    /// How the control law works is documented in doc/src/tutorials/autopilot.rst, under "How it
+    /// works": the cascade, the roll-invariant frame, the velocity profile, the pole placement
+    /// behind the auto-tuner and the oscillation mitigation.
     /// </summary>
     sealed class AttitudeController
     {
@@ -45,42 +45,41 @@ namespace KRPC.SpaceCenter.AutoPilot
         // the game is paused.
         float lastStepFixedTime = float.NaN;
         // The fixed time the loop was last tried at, whether or not it got to the end. Held
-        // apart from lastStepFixedTime so that a step which fails part way through neither runs
-        // again in the same tick nor leaves the output it did not produce looking recent.
+        // apart from lastStepFixedTime so that a step which fails part way through does not run
+        // again in the same tick, and does not make the output it did not produce look recent.
         float lastAttemptFixedTime = float.NaN;
-        // How long the last output stays usable. The loop runs once per tick, but the tick it is
+        // The time the last output stays usable. The loop runs once per tick, but the tick it is
         // applied in is not always the tick it ran in, and a program driving it by hand may miss
-        // one; holding the last command over a short gap is smoother than dropping to zero.
-        // Past this the command is stale and the auto-pilot contributes nothing, so a program
-        // that stops driving it cannot leave a deflection latched on the vessel.
+        // one. Holding the last command over a short gap is smoother than dropping to zero. Past
+        // this the command is stale and the auto-pilot contributes nothing, so a program that
+        // stops driving it cannot leave a deflection latched on the vessel.
         const float OutputHoldTime = 0.1f;
         public readonly PIDController PitchPID = new PIDController ();
         public readonly PIDController RollPID = new PIDController ();
         public readonly PIDController YawPID = new PIDController ();
 
-        // Target orientation — quaternion is the single source of truth.
-        // rollControlled=false means "suppress roll rotation" (don't hold a specific angle).
-        // targetRotation is the COMMANDED target (what the user set); the public getters and
-        // AutoPilot.Error read it. The control loop instead consumes effectiveRotation, which is
-        // slewed toward the commanded target over TargetSmoothingTime seconds (see Update). When
-        // smoothing is disabled (the default), effectiveRotation == targetRotation every tick.
+        // Target orientation. The quaternion is the single source of truth, and
+        // rollControlled=false suppresses roll rotation instead of holding a specific angle.
+        // targetRotation is the commanded target, which the public getters and AutoPilot.Error
+        // read. The control loop consumes effectiveRotation, slewed toward the commanded target
+        // over TargetSmoothingTime seconds (see Update). With smoothing disabled, the default,
+        // effectiveRotation equals targetRotation every tick.
         QuaternionD targetRotation;
         bool rollControlled;
-        // Persistent roll reference (a direction in the AP reference frame): TargetRoll is measured
-        // as the roll about the nose that aligns the vessel's dorsal ("roof") axis to this vector.
-        // Defaults to the frame's "up" (+x = zenith / radial-out in the surface frame), which
-        // reproduces the historical vertical-plane roll convention away from the vertical. Only
-        // SetTargetDirectionAndUp and the UpReference setter write it; TargetRotation,
-        // TargetDirection and the scalar pitch/heading setters leave it untouched. See the
-        // orientation-API design doc.
+        // Persistent roll reference, a direction in the AP reference frame. TargetRoll is
+        // measured as the roll about the nose that aligns the vessel's dorsal ("roof") axis to
+        // this vector. Defaults to the frame's "up", the zenith or radial-out in the surface
+        // frame, which is the vertical-plane roll convention away from the vertical. Only
+        // SetTargetDirectionAndUp and the UpReference setter write it. TargetRotation,
+        // TargetDirection and the scalar pitch and heading setters leave it untouched.
         Vector3d upReference;
-        // Target smoothing (slew): effectiveRotation is the slewed target the control loop tracks.
-        // Each tick it RotateTowards the commanded targetRotation at slewSpeed (deg/s). slewSpeed is
-        // latched whenever the target changes to (angle between effective and commanded) /
-        // targetSmoothingTime, so an isolated change arrives in exactly targetSmoothingTime seconds
-        // (constant angular rate), while a continuous stream of changes re-latches each tick and
-        // settles into a smooth, bounded lag (~targetSmoothingTime x change-rate) with no freeze at
-        // any update cadence. 0 = instant (no slew). slewPending is set by the (RPC-thread) setters
+        // Target smoothing (slew). effectiveRotation is the slewed target the control loop
+        // tracks. Each tick it RotateTowards the commanded targetRotation at slewSpeed (deg/s).
+        // slewSpeed is latched whenever the target changes, to the angle between effective and
+        // commanded over targetSmoothingTime, so an isolated change arrives in exactly
+        // targetSmoothingTime seconds at a constant angular rate. A continuous stream of changes
+        // re-latches each tick and settles into a smooth, bounded lag at any update cadence. A
+        // smoothing time of zero is instant. slewPending is set by the setters on the RPC thread
         // and consumed in Update, on the physics thread.
         QuaternionD effectiveRotation;
         double targetSmoothingTime;
@@ -92,9 +91,10 @@ namespace KRPC.SpaceCenter.AutoPilot
         Vector3d timeToPeak;
         Vector3d twiceZetaOmega = Vector3d.zero;
         Vector3d omegaSquared = Vector3d.zero;
-        // One-sided smoothed torque: tracks increases immediately, decays decreases at τ≈0.5s.
-        // Passed to DoAutoTune so a sudden drop (e.g. engine shutdown while a reaction wheel
-        // remains) does not cause a one-tick gain spike that jerks the gimbal.
+        // One-sided smoothed torque: tracks increases immediately, and decays decreases with a
+        // time constant of about 0.5 s. Passed to DoAutoTune so a sudden drop (e.g. engine
+        // shutdown while a reaction wheel remains) does not cause a one-tick gain spike that
+        // jerks the gimbal.
         Vector3d smoothedTorque;
         // Low-pass-filtered acceleration feedforward (see the feedforward filter in Update).
         Vector3d smoothedFfRi;
@@ -111,9 +111,10 @@ namespace KRPC.SpaceCenter.AutoPilot
         // The gating layer: tool routing, latch ramps, and the hold-gated mitigation level
         // (with the oscillation-control back-off). See MitigationPolicy.
         readonly MitigationPolicy policy = new MitigationPolicy ();
-        // Unfloored autotuned proportional gain per axis (2ζω₀·moi/smoothedTorque, recorded by
-        // DoAutoTuneAxis before the bandwidth-floor mitigation is applied). Consumed by
-        // ProfileKp so the velocity profile's linear stopping coefficient never sees the floor.
+        // Unfloored autotuned proportional gain per axis, 2 * zeta * omega0 * moi /
+        // smoothedTorque, recorded by DoAutoTuneAxis before the bandwidth-floor mitigation is
+        // applied. Consumed by ProfileKp so the velocity profile's linear stopping coefficient
+        // never sees the floor.
         readonly double[] unflooredKp = new double[3];
         // Per-group rate-filter mode (pitch/yaw coupled, roll on its own). Automatic routes by
         // the detector latch and the estimated frequency; Off disables rate filtering only (the
@@ -136,31 +137,30 @@ namespace KRPC.SpaceCenter.AutoPilot
         Services.MitigationMode feedforwardMode;
         Services.MitigationMode outputFilterMode;
         // Engagement soft-start: the actuator command is faded in over SoftStartTime seconds from
-        // each Start() so engagement does not deliver a near-max "kick" (large proportional +
-        // acceleration feedforward) that can impulsively excite a structural or in-band limit cycle
-        // — the transient the manual "settle before liftoff" pause avoids. engageFixedTime is the
-        // Time.fixedTime at the last Start(); the ramp is a function of elapsed time from it. While
-        // the craft is held on the launch clamps (PRELAUNCH) Update re-pins it each tick, so the fade
-        // begins at clamp release rather than at engagement.
+        // each Start(), so engagement does not deliver a near-max kick (a large proportional and
+        // acceleration feedforward) that can impulsively excite a structural or in-band limit
+        // cycle. engageFixedTime is the Time.fixedTime at the last Start(), and the ramp is a
+        // function of elapsed time from it. While the craft is held on the launch clamps
+        // (PRELAUNCH) Update re-pins it each tick, so the fade begins at clamp release.
         double softStartTime;
         double engageFixedTime;
-        // Continuity state for the roll-invariant frame. The pointing-only rotation (AP-frame up ->
-        // nose) used to be re-derived each tick as FromToRotation(up, nose), but that is singular when
-        // the nose passes through -up (e.g. due south on the horizon in the surface frame, where the
-        // y-axis is north): the minimal-arc rotation's axis is hypersensitive to transverse motion
-        // there, so a tiny control jitter whips the RI frame ~180 deg over a vanishing arc and the
-        // stateful feedforward/integral turn that into a full-deflection kick. Instead the rotation is
-        // carried forward by the well-conditioned minimal rotation between consecutive nose directions
-        // (the nose cannot reverse in one physics tick), so the frame never sees the antipode
-        // singularity. Seeded once per engage from the fixed reference; reset in Start.
+        // Continuity state for the roll-invariant frame. The pointing-only rotation, from the
+        // AP-frame up to the nose, is carried forward by the minimal rotation between consecutive
+        // nose directions, which is well conditioned because the nose cannot reverse in one
+        // physics tick. Re-deriving it each tick as FromToRotation(up, nose) is singular when the
+        // nose passes through -up, such as due south on the horizon in the surface frame: the
+        // minimal-arc rotation's axis is hypersensitive to transverse motion there, so a tiny
+        // control jitter whips the frame around 180 degrees over a vanishing arc and the stateful
+        // feedforward and integral turn that into a full-deflection kick. Seeded once per engage
+        // from the fixed reference, and reset in Start.
         Vector3d prevPointDirection;
         QuaternionD pointRotation;
         bool pointRotationValid;
-        // Antipodal-flip plane latch (see ResolveAntipodalAxis). When the error enters the antipode
-        // band with enough rotation to define a flip plane, the plane normal is captured once here
-        // and held for the rest of the pass; letting it track the live angular velocity instead
-        // feeds any out-of-plane drift back on itself and the flip tumbles. Cleared on leaving the
-        // band and on re-engage (Start).
+        // Antipodal-flip plane latch (see ResolveAntipodalAxis). When the error enters the
+        // antipode band with enough rotation to define a flip plane, the plane normal is captured
+        // once here and held for the rest of the pass. A normal that tracks the live angular
+        // velocity feeds any out-of-plane drift back on itself and the flip tumbles. Cleared on
+        // leaving the band and on re-engage (Start).
         Vector3d antipodeLatchedNormal;
         bool antipodeLatched;
         // Latched-plane blend weight [0,1] applied this tick (see ResolveAntipodalAxis),
@@ -189,82 +189,80 @@ namespace KRPC.SpaceCenter.AutoPilot
         // Long enough to attenuate the single-tick steps the bang-bang profile's slope
         // discontinuities produce, short enough that the feedforward lag stays negligible.
         const double FeedforwardSmoothTimeConstant = 0.05;
-        // Default per-group mode frequency (Hz): the manual notch/low-pass frequency and the
-        // Automatic-mode estimator seed before acquisition. 1.5 Hz is near the only in-game-measured
-        // low-frequency mode (the Ariane 5's ~1.4 Hz first lateral bending mode), so a freshly
-        // latched low-frequency axis routes to the notch branch and is never momentarily un-suppressed.
+        // Default per-group mode frequency (Hz): the manual notch and low-pass frequency, and the
+        // Automatic-mode estimator seed before acquisition. 1.5 Hz is near the lowest mode measured
+        // in game, the Ariane 5's first lateral bending mode at about 1.4 Hz, so a freshly latched
+        // low-frequency axis routes to the notch branch and stays suppressed throughout.
         const double DefaultOscillationFrequency = 1.5;
-        // Default notch quality factor: a higher Q is a narrower notch (less in-band phase lag but
-        // less tolerance to frequency drift); a lower Q is wider.
+        // Default notch quality factor. A higher Q is a narrower notch, with less in-band phase
+        // lag and less tolerance to frequency drift, and a lower Q is wider.
         const double DefaultNotchQ = 2.5;
         // Default inner-loop bandwidth floor (rad/s) a latched axis is reduced toward. This is the
-        // primary, frequency-independent gain-stabiliser: dropping the rate-loop crossover well below
-        // every structural mode (the stock flexible craft sit at ~1.4–25 Hz) stops the loop driving
-        // any of them, robustly and without needing an accurate mode-frequency estimate. The notch /
-        // low-pass clean the rate feedback on top; output smoothing caps any residual. Only ever
-        // lowers bandwidth (min against the autotuned value), so rigid craft — which never latch —
-        // are untouched. ~1.0 rad/s matches the value validated on the earlier adaptive design.
+        // primary, frequency-independent gain stabilizer: dropping the rate-loop crossover well
+        // below every structural mode, and the stock flexible craft sit between about 1.4 and 25 Hz,
+        // stops the loop driving any of them without an accurate mode-frequency estimate. The notch
+        // and low-pass clean the rate feedback on top, and output smoothing caps any residual. It
+        // only ever lowers bandwidth, taking the minimum against the autotuned value, so a rigid
+        // craft, which never latches, is untouched.
         const double DefaultBandwidthFloor = 1.0;
         // Pointing deadband on the target angular velocity (see DeadbandScale, applied in
-        // ComputePitchYawVelocity / ComputeAxisVelocity). As the error vanishes the commanded velocity
-        // setpoint is scaled linearly to zero — from full at the deadband high angle to zero below this
-        // fraction of it — so the craft coasts to a stop inside the band and the inner rate loop is no
-        // longer commanded to chase sub-band motion, which on a craft with a noisy root-part rate would
-        // dither the actuators. It is applied to the *setpoint* (outer loop), not the inner-loop gains, so
-        // the inner rate loop keeps its full proportional damping and stays well-damped at the hold point
-        // (scaling the inner proportional term instead removes that damping and the hold oscillates). This
-        // replaces the former logistic attenuation with a linear ramp that reaches exactly zero — a clean
-        // deadband rather than a residual tail. The high angle is the public PitchYawAttenuationAngle /
-        // RollAttenuationAngle (formerly the logistic half-width); the low edge is this fraction of it.
+        // ComputePitchYawVelocity and ComputeAxisVelocity). As the error vanishes the commanded
+        // velocity setpoint is scaled linearly to zero, from full at the deadband high angle to zero
+        // below this fraction of it, so the craft coasts to a stop inside the band and the inner
+        // rate loop stops chasing sub-band motion, which on a craft with a noisy root-part rate
+        // dithers the actuators. It is applied to the outer loop's setpoint and not to the
+        // inner-loop gains, so the inner rate loop keeps its full proportional damping and stays
+        // well damped at the hold point. Scaling the inner proportional term instead removes that
+        // damping and the hold oscillates. The high angle is the public PitchYawAttenuationAngle or
+        // RollAttenuationAngle, and the low edge is this fraction of it.
         const double DeadbandLowFraction = 0.5;
-        // Linear speed cone near the target: the commanded profile speed is capped at
-        // ProfileConeFraction·bw·|e_stop| (bw = the unfloored ProfileKp bandwidth, the same source
-        // as the linear stopping coefficient). The √(2α·e) profile has infinite slope at the origin
-        // and on a high-α craft commands speeds at small angles that the inner PI loop cannot
-        // decelerate inside the pointing deadband — the craft coasts through the band and is
-        // symmetrically re-accelerated on the far side, a sustained lossless limit cycle pinned
-        // just outside the band (measured: ±1.3°, ±0.35 rad/s on a α≈39 rad/s² craft). The cone
-        // pins the outer-loop pole at κ·bw, below the inner loop's crossover (cascade separation),
-        // so the command is always trackable down to zero. Sizing: with the stopping coefficient
-        // left at 1/bw the converged cone decay rate is κ·bw/(1+κ); the band-edge arrival speed
-        // r·θ_band must coast-stop within the half-band under PI damping (stop distance ≈ ω/bw),
-        // requiring κ/(1+κ) ≤ 1/2, i.e. κ ≤ 1. κ = 0.5 gives 2–3× margin. Like
-        // DeadbandLowFraction this is a stability-margin constant, not a per-craft tuning knob.
+        // Linear speed cone near the target. The commanded profile speed is capped at
+        // ProfileConeFraction * bw * |e_stop|, where bw is the unfloored ProfileKp bandwidth, the
+        // same source as the linear stopping coefficient. The sqrt(2 * alpha * e) profile has
+        // infinite slope at the origin, and on a high-acceleration craft it commands speeds at
+        // small angles that the inner PI loop cannot decelerate inside the pointing deadband. The
+        // craft then coasts through the band and is symmetrically re-accelerated on the far side, a
+        // sustained lossless limit cycle pinned just outside it, measured at 1.3 degrees and 0.35
+        // rad/s on a craft with an angular acceleration of 39 rad/s^2. The cone pins the outer-loop
+        // pole at k * bw, below the inner loop's crossover, so the command is trackable down to
+        // zero. Sizing: with the stopping coefficient left at 1/bw the converged cone decay rate is
+        // k * bw / (1 + k), and the band-edge arrival speed must coast-stop within the half-band
+        // under PI damping, requiring k <= 1. A k of 0.5 leaves a margin of 2 to 3. Like
+        // DeadbandLowFraction this is a stability-margin constant and not a per-craft tuning knob.
         const double ProfileConeFraction = 0.5;
         // A tick-to-tick change in the raw measured rate larger than this many times the
-        // physically-achievable change (α·dt at full authority) is structural excitation, not
-        // rigid-body response — the latter cannot change the rate faster than the torque allows.
+        // physically achievable change, alpha * dt at full authority, is structural excitation. A
+        // rigid-body response cannot change the rate faster than the torque allows.
         const double DefaultChatterDetectThreshold = 4.0;
         // Below this 2D error magnitude (radians) the joint pitch/yaw profile is skipped.
         const double MinThetaForJointProfile = 1e-10;
-        // Antipodal-flip plane hold (ResolveAntipodalAxis). A large slew toward ~180° (an "antipodal
-        // flip") must ride a single committed plane, but the live geodesic axis
+        // Antipodal-flip plane hold (ResolveAntipodalAxis). A large slew toward 180 degrees, an
+        // antipodal flip, has to ride a single committed plane. The live geodesic axis
         // FromToRotation(current, target) precesses fastest exactly when current and target are
-        // near-antipodal — and the vessel unavoidably crawls through that region while the rate loop
-        // ramps the angular velocity up against inertia. Chasing the precessing axis there pumps the
-        // nose out of plane; the slower the traverse the worse it is, so a from-rest or lightly-seeded
-        // flip (which crawls longest) bows the most, while a fast 90° slew — never near-antipodal — is
-        // untouched. So within AntipodeBlendAngle of antipodal the commanded axis is held to a plane
-        // *latched once* on entering the band, rather than tracking the precessing live axis: fully
-        // (weight 1) within AntipodeHoldAngle of antipodal — covering the crawl/pump region — then
-        // smoothstep-blended back to the live geodesic axis between AntipodeHoldAngle and
-        // AntipodeBlendAngle so the hand-back is continuous and ordinary (< AntipodeBlendAngle) slews
-        // are untouched. The latched plane is a great circle through the current nose and its
-        // antipode = the target, so holding it still carries the nose to the target.
+        // near-antipodal, and the vessel crawls through that region while the rate loop ramps the
+        // angular velocity up against inertia. Chasing the precessing axis there pumps the nose out
+        // of plane, and the slower the traverse the worse it is, so a from-rest or lightly seeded
+        // flip bows the most while a fast 90 degree slew is untouched. Within AntipodeBlendAngle of
+        // antipodal the commanded axis is therefore held to a plane latched once on entering the
+        // band: fully within AntipodeHoldAngle, covering the crawl region, then smoothstep-blended
+        // back to the live geodesic axis between AntipodeHoldAngle and AntipodeBlendAngle so the
+        // hand-back is continuous. The latched plane is a great circle through the current nose and
+        // its antipode, the target, so holding it carries the nose to the target.
         const double AntipodeBlendAngle = 50.0;
         const double AntipodeHoldAngle = 35.0;
         // Perpendicular-rate threshold (rad/s) selecting where the latched plane comes from
-        // (ResolveAntipodalAxis): above it the vessel is already committed to a rotation, so latch its
-        // plane (the cleanest definition of where the flip is going); below it — a from-rest flip —
-        // latch the arbitrary-but-consistent geodesic axis instead. Either way a plane is latched and
-        // held, so even a from-rest flip rides a fixed plane rather than the precessing live axis. Set
-        // well below a real flip's rate but above a settled craft's residual sensor/physics noise
-        // (~1e-4), so a light deliberate seed (~1e-2) still latches its own plane.
+        // (ResolveAntipodalAxis). Above it the vessel is already committed to a rotation, so its
+        // plane is latched, which is the cleanest definition of where the flip is going. Below it,
+        // a from-rest flip, the arbitrary but consistent geodesic axis is latched. Either way a
+        // plane is latched and held, so even a from-rest flip rides a fixed plane. Set well below a
+        // real flip's rate and above a settled craft's residual sensor and physics noise, around
+        // 1e-4, so a light deliberate seed of around 1e-2 still latches its own plane.
         const double AntipodeLeadRate = 0.004;
-        // Default engagement soft-start duration (seconds): the actuator command is faded in over
-        // this window from each engage so the engagement transient cannot kick a fresh, full-authority
-        // gimbal into a limit cycle. ~0.5 s is short enough to be imperceptible on a settled craft yet
-        // long enough to spread the engagement step over many physics ticks. Set to 0 to disable.
+        // Default engagement soft-start duration (seconds). The actuator command is faded in over
+        // this window from each engage, so the engagement transient cannot kick a fresh,
+        // full-authority gimbal into a limit cycle. Half a second is imperceptible on a settled
+        // craft and long enough to spread the engagement step over many physics ticks. Set to 0 to
+        // disable.
         const double DefaultSoftStartTime = 0.5;
 
         public AttitudeController (Vessel vessel)
@@ -276,10 +274,10 @@ namespace KRPC.SpaceCenter.AutoPilot
 
         public ReferenceFrame ReferenceFrame { get; set; }
 
-        // Demoted convenience scalars (heading-singular near the vertical). The getters read the
-        // surface-frame Euler decomposition; the setters re-aim the nose by (pitch, heading) while
-        // preserving the current roll relative to the up reference (so a pitch/heading change no
-        // longer perturbs roll near the vertical). See SetTargetDirection.
+        // Convenience scalars, heading-singular near the vertical. The getters read the
+        // surface-frame Euler decomposition. The setters re-aim the nose by pitch and heading while
+        // preserving the current roll relative to the up reference, so a pitch or heading change
+        // leaves roll alone near the vertical. See SetTargetDirection.
         public double TargetPitch {
             get { return targetRotation.PitchHeadingRoll ().x; }
             set { SetTargetDirection (DirectionFromPitchHeading (value, targetRotation.PitchHeadingRoll ().y)); }
@@ -290,10 +288,9 @@ namespace KRPC.SpaceCenter.AutoPilot
             set { SetTargetDirection (DirectionFromPitchHeading (targetRotation.PitchHeadingRoll ().x, value)); }
         }
 
-        // Roll about the nose measured relative to the up reference (roof aligned to the reference =
-        // roll 0), replacing the old pole-singular "roll from the vertical plane". NaN means roll is
-        // suppressed. Setting re-rolls the current target to the given angle (keeping the nose
-        // direction); NaN suppresses roll.
+        // Roll about the nose measured relative to the up reference, with the roof aligned to the
+        // reference at roll 0. NaN means roll is suppressed. Setting re-rolls the current target to
+        // the given angle, keeping the nose direction, and NaN suppresses roll.
         public double TargetRoll {
             get { return rollControlled ? RollRelativeTo (targetRotation, upReference) : double.NaN; }
             set {
@@ -325,9 +322,9 @@ namespace KRPC.SpaceCenter.AutoPilot
             get { return targetRotation; }
         }
 
-        // The effective (slewed) target — what the control loop is currently tracking. Equal to the
-        // commanded target above when smoothing is off; lags it during a slew. rollControlled is
-        // shared with the commanded target (a single mode flag), so the roll readouts match.
+        // The effective, slewed target that the control loop is tracking. Equal to the commanded
+        // target above when smoothing is off, and lagging it during a slew. rollControlled is a
+        // single mode flag shared with the commanded target, so the roll readouts match.
         public double EffectiveTargetPitch {
             get { return effectiveRotation.PitchHeadingRoll ().x; }
         }
@@ -353,9 +350,9 @@ namespace KRPC.SpaceCenter.AutoPilot
             set { targetSmoothingTime = Math.Max (0, value); }
         }
 
-        // Request the slew speed be (re)latched from the current effective-to-commanded gap. Called
-        // after every target change. The latch happens in Update (the physics thread); the setters
-        // may run on the RPC thread.
+        // Request the slew speed be re-latched from the current effective-to-commanded gap. Called
+        // after every target change. The latch happens in Update, on the physics thread, and the
+        // setters may run on the RPC thread.
         void BeginSlew ()
         {
             slewPending = true;
@@ -369,14 +366,14 @@ namespace KRPC.SpaceCenter.AutoPilot
             BeginSlew ();
         }
 
-        // Re-aim the nose to a new direction through the shared primitive, preserving roll relative
-        // to the up reference. When roll is controlled the current roll is kept, so re-aiming the
-        // nose never silently drops a commanded roll; when it is suppressed the target is built
-        // wings-level (roll 0 vs the reference) — matching the historical pitch/heading target and,
-        // crucially, giving consecutive targets a consistent roll so a smoothed slew between them
-        // stays a clean pure-pitch/heading path (FromToRotation's minimal-arc roll varies with
-        // direction and wanders the heading through the slerp). The rollControlled flag is left
-        // unchanged. Backs TargetDirection and the demoted TargetPitch/TargetHeading setters.
+        // Re-aim the nose to a new direction through the shared primitive, preserving roll
+        // relative to the up reference. When roll is controlled the current roll is kept, so
+        // re-aiming the nose keeps a commanded roll. When roll is suppressed the target is built
+        // wings-level, at roll 0 against the reference, which gives consecutive targets a
+        // consistent roll so a smoothed slew between them stays a clean pitch and heading path.
+        // FromToRotation's minimal-arc roll varies with direction and wanders the heading through
+        // the slerp. The rollControlled flag is left unchanged. Backs TargetDirection and the
+        // TargetPitch and TargetHeading setters.
         public void SetTargetDirection (Vector3d direction)
         {
             var roll = rollControlled ? RollRelativeTo (targetRotation, upReference) : 0.0;
@@ -396,7 +393,7 @@ namespace KRPC.SpaceCenter.AutoPilot
         /// ("roof") axis aligns with <paramref name="up"/> (its component perpendicular to the
         /// nose), then apply an optional <paramref name="roll"/> offset (degrees) about the nose.
         /// Stores <paramref name="up"/> as the persistent roll reference. Well-defined for every
-        /// nose direction except <c>up ∥ direction</c>, where it falls back to direction-only
+        /// nose direction except <c>up -par direction</c>, where it falls back to direction-only
         /// (roll suppressed).
         /// </summary>
         public void SetTargetDirectionAndUp (Vector3d direction, Vector3d up, double roll)
@@ -417,11 +414,11 @@ namespace KRPC.SpaceCenter.AutoPilot
 
         /// <summary>
         /// Build a target rotation that points the nose (body +y) along <paramref name="direction"/>
-        /// and rolls so the dorsal axis (body −z) aligns with <paramref name="up"/> projected
+        /// and rolls so the dorsal axis (body -z) aligns with <paramref name="up"/> projected
         /// perpendicular to the nose, plus a <paramref name="roll"/> offset (degrees, positive =
         /// right-wing-down, matching aircraft bank). Falls back to direction-only (roll unanchored)
         /// when <paramref name="up"/> is parallel to <paramref name="direction"/>. The roll offset is
-        /// applied as <c>align − roll</c> about the nose so its sign matches the kRPC roll convention
+        /// applied as <c>align - roll</c> about the nose so its sign matches the kRPC roll convention
         /// (positive roll relative to the reference banks right).
         /// </summary>
         static QuaternionD RotationFromDirectionUpRoll (Vector3d direction, Vector3d up, double roll)
@@ -438,7 +435,7 @@ namespace KRPC.SpaceCenter.AutoPilot
 
         /// <summary>
         /// The signed roll (degrees) of <paramref name="rotation"/> about its nose, measured relative
-        /// to <paramref name="up"/> — the inverse of the roll argument to
+        /// to <paramref name="up"/>, the inverse of the roll argument to
         /// <see cref="RotationFromDirectionUpRoll"/>. 0 when the roof aligns with the reference;
         /// positive banks right. Singular only when <paramref name="up"/> is parallel to the nose.
         /// </summary>
@@ -446,9 +443,9 @@ namespace KRPC.SpaceCenter.AutoPilot
         {
             var nose = (rotation * Vector3d.up).normalized;
             var reference = RotationFromDirectionUpRoll (nose, up, 0);
-            // reference shares the nose, so the residual is a pure rotation about it; its angle,
-            // projected onto the nose, is the roll. Negated to invert RotationFromDirectionUpRoll's
-            // align − roll (positive roll banks right).
+            // reference shares the nose, so the residual is a pure rotation about it, and its
+            // angle projected onto the nose is the roll. Negated to invert
+            // RotationFromDirectionUpRoll's align minus roll, so positive roll banks right.
             var residual = rotation * reference.Inverse ();
             double angle;
             Vector3d axis;
@@ -461,11 +458,11 @@ namespace KRPC.SpaceCenter.AutoPilot
 
         public Vector3d MaxAngularVelocity { get; set; }
 
-        // Pointing deadband high angle (degrees) for the roll axis: at/above this error the target roll
-        // velocity is commanded in full; below it the commanded velocity ramps linearly to zero by
-        // DeadbandLowFraction of it, so the craft coasts to a stop and the actuator stops dithering
-        // against measured-rate jitter once pointed. Formerly the logistic attenuation half-width; see the
-        // deadband note by DeadbandLowFraction.
+        // Pointing deadband high angle (degrees) for the roll axis. At or above this error the
+        // target roll velocity is commanded in full. Below it the commanded velocity ramps linearly
+        // to zero by DeadbandLowFraction of it, so the craft coasts to a stop and the actuator
+        // stops dithering against measured-rate jitter once pointed. See the deadband note by
+        // DeadbandLowFraction.
         public double RollAttenuationAngle { get; set; }
 
         // Pointing deadband high angle (degrees) for the coupled pitch/yaw group. As RollAttenuationAngle,
@@ -526,8 +523,8 @@ namespace KRPC.SpaceCenter.AutoPilot
         }
 
         // About-mean envelope of the delivered command above which a latched axis is treated as
-        // still limit-cycling (drives the policy back-off; exposed for the info window so it can
-        // colour the envelope readout against the engage threshold).
+        // still limit-cycling. Drives the policy back-off, and is exposed so the info window can
+        // color the envelope readout against the engage threshold.
         public double OscillationControlThreshold {
             get { return MitigationPolicy.EnvelopeThreshold; }
         }
@@ -582,12 +579,12 @@ namespace KRPC.SpaceCenter.AutoPilot
             get { return logTargetRi; }
         }
 
-        // Per-axis hold-gated mitigation weight in [0,1] (suppressionRamp · holdFactor): how fully
-        // the latched flexible-craft hold mitigation (bandwidth floor + feedforward cut) is engaged.
-        // Per-tick gate/mitigation state for the in-game info window: the pointing-error hold
-        // factor, the latch ramps, the back-off levels, the applied feedforward-cut fraction,
-        // the output-filter blend weight and the post-floor inner-loop bandwidth (rad/s; stale
-        // when AutoTune is off — the window blanks it there).
+        // Per-axis hold-gated mitigation weight in [0,1], suppressionRamp * holdFactor: the degree
+        // to which the latched flexible-craft hold mitigation, the bandwidth floor and the
+        // feedforward cut, is engaged. Per-tick gate and mitigation state for the in-game info
+        // window: the pointing-error hold factor, the latch ramps, the back-off levels, the applied
+        // feedforward-cut fraction, the output-filter blend weight and the post-floor inner-loop
+        // bandwidth (rad/s, stale when AutoTune is off, where the window blanks it).
         public double PitchYawHoldFactor {
             get { return logHoldFactorPitchYaw; }
         }
@@ -630,8 +627,8 @@ namespace KRPC.SpaceCenter.AutoPilot
             return 0;
         }
 
-        // The chatterLevel at which an axis latches as flexible (see UpdateChatterDetector). Exposed
-        // so the info UI can colour the OscillationLevel readout against the same threshold.
+        // The chatterLevel at which an axis latches as flexible (see UpdateChatterDetector).
+        // Exposed so the info UI can color the OscillationLevel readout against the same threshold.
         public double OscillationLatchThreshold {
             get { return OscillationDetectors.ChatterLatchThreshold; }
         }
@@ -738,25 +735,25 @@ namespace KRPC.SpaceCenter.AutoPilot
             feedforwardMode = Services.MitigationMode.Automatic;
             outputFilterMode = Services.MitigationMode.Automatic;
             Overshoot = new Vector3d (0.01, 0.01, 0.01);
-            // TimeToPeak sets the inner-loop bandwidth via omega0 = pi / (TimeToPeak * sqrt(1 - zeta^2)).
-            // Increasing it lowers the bandwidth, which is the lever for large, structurally flexible
-            // vehicles: when the bandwidth approaches the structural resonance frequency (e.g. the
-            // Ariane rocket, ~10 rad/s) the PID saturates in response to structural angular velocity
-            // oscillations and drives the bending mode. Such craft need a larger TimeToPeak. (The
-            // adaptive flexible-craft handling normally suppresses this automatically; see
-            // UpdateChatterDetector.)
+            // TimeToPeak sets the inner-loop bandwidth through
+            // omega0 = pi / (TimeToPeak * sqrt(1 - zeta^2)). Increasing it lowers the bandwidth,
+            // which is the lever for large, structurally flexible vehicles: when the bandwidth
+            // approaches the structural resonance frequency, around 10 rad/s on the Ariane rocket,
+            // the PID saturates in response to structural angular velocity oscillations and drives
+            // the bending mode. Such craft need a larger TimeToPeak. The adaptive flexible-craft
+            // handling normally suppresses this on its own, see UpdateChatterDetector.
             TimeToPeak = new Vector3d (1, 1, 1);
             SoftStartTime = DefaultSoftStartTime;
             targetSmoothingTime = 0;
             DiagnosticLogging = false;
-            // Default roll reference: the frame's up (+x = zenith in the surface frame), which
-            // makes TargetRoll reproduce the historical vertical-plane roll away from the vertical.
+            // Default roll reference: the frame's up, the zenith in the surface frame, which makes
+            // TargetRoll the vertical-plane roll away from the vertical.
             upReference = new Vector3d (1, 0, 0);
             SetTarget (0, 0, double.NaN);
-            // Reset is the user-facing return to initial conditions, so also clear the state
-            // that deliberately survives Start's per-engagement reset: the persistent chatter
-            // level (kept across engagements so a known-flexible craft re-latches quickly) and
-            // the one-sided smoothed torque (which otherwise decays a stale maximum at τ≈0.5s).
+            // Reset is the user-facing return to initial conditions, so also clear the state that
+            // survives Start's per-engagement reset: the persistent chatter level, kept across
+            // engagements so a known-flexible craft re-latches quickly, and the one-sided smoothed
+            // torque, which otherwise decays a stale maximum over about half a second.
             detectors.ResetChatterLevel ();
             smoothedTorque = Vector3d.zero;
             Start ();
@@ -765,8 +762,9 @@ namespace KRPC.SpaceCenter.AutoPilot
         public void Start ()
         {
             engageFixedTime = Time.fixedTime;
-            // Hold the current commanded target on engage — no phantom slew (engagement transients
-            // are handled separately by the soft-start). Smoothing only applies to later changes.
+            // Hold the current commanded target on engage, so there is no phantom slew.
+            // Engagement transients are handled by the soft-start, and smoothing applies only to
+            // later changes.
             effectiveRotation = targetRotation;
             slewSpeed = 0;
             slewPending = false;
@@ -826,9 +824,8 @@ namespace KRPC.SpaceCenter.AutoPilot
             lastAttemptFixedTime = Time.fixedTime;
             // Everything the loop measures is expressed in the reference frame, and there is no
             // client call here to raise at, so a frame that cannot be measured in makes the loop
-            // wait rather than fail. The frame is a settable property, so the client can point
-            // the auto-pilot at another one, and the output hold time releases the controls in
-            // the meantime.
+            // wait. The frame is a settable property, so the client can point the auto-pilot at
+            // another one, and the output hold time releases the controls in the meantime.
             if (ReferenceFrame.GameObjectState != GameObjectState.Live)
                 return;
             // The auto-pilot fights stock SAS, so hold it off while engaged.
@@ -847,15 +844,15 @@ namespace KRPC.SpaceCenter.AutoPilot
 
             // While the vessel sits on the launch clamps (PRELAUNCH) the autopilot is engaged but
             // must not act. The craft is physically held and the engines are unlit, so available
-            // torque is near-zero; running the loop would autotune enormous gains against that tiny
-            // torque (Kp ∝ moi/torque) and saturate the actuators against sensor jitter or a sub-
-            // degree pointing error — a full-deflection command that is then delivered as a kick the
-            // instant the clamps release and the gains collapse onto the now-large engine torque.
-            // Instead hold the controls at zero and keep the whole control loop in its freshly-
-            // engaged default state (Start re-pins the soft-start clock and clears all loop state),
-            // re-running it each tick so the engagement soft-start fade-in begins at clamp release
-            // rather than at engagement. Holding on the pad is thus equivalent to engaging the moment
-            // the clamps drop.
+            // torque is near zero. Running the loop would autotune enormous gains against that tiny
+            // torque, as Kp scales with moi over torque, and saturate the actuators against sensor
+            // jitter or a sub-degree pointing error. That full-deflection command is then delivered
+            // as a kick the instant the clamps release and the gains collapse onto the now-large
+            // engine torque. Hold the controls at zero and keep the whole control loop in its
+            // freshly engaged default state, with Start re-pinning the soft-start clock and
+            // clearing all loop state, re-running it each tick so the engagement soft-start fade-in
+            // begins at clamp release. Holding on the pad is equivalent to engaging the moment the
+            // clamps drop.
             if (internalVessel.situation == Vessel.Situations.PRELAUNCH) {
                 Start ();
                 state.Pitch = 0;
@@ -866,11 +863,11 @@ namespace KRPC.SpaceCenter.AutoPilot
                 return;
             }
 
-            // Target smoothing: advance the effective target (what the control loop tracks) toward
+            // Target smoothing: advance the effective target that the control loop tracks toward
             // the commanded target. With smoothing enabled, a change to the target ramps the
-            // effective target linearly (constant-rate slerp) over TargetSmoothingTime seconds,
-            // rather than stepping instantly — letting a slow control loop drive a smooth maneuver
-            // (e.g. a gravity turn) without exciting oscillation from stepwise target changes.
+            // effective target linearly over TargetSmoothingTime seconds, so a slow control loop
+            // can drive a smooth maneuver such as a gravity turn without exciting oscillation from
+            // stepwise target changes.
             if (slewPending) {
                 slewSpeed = targetSmoothingTime > 0
                     ? GeometryExtensions.Angle (effectiveRotation, targetRotation) / targetSmoothingTime
@@ -884,10 +881,10 @@ namespace KRPC.SpaceCenter.AutoPilot
                 effectiveRotation = targetRotation;
             }
 
-            // Engagement soft-start: a smoothstep 0→1 over SoftStartTime seconds from the last
-            // Start(). The final actuator command is scaled by this so engagement fades the control
-            // in rather than stepping to a near-max kick. Smoothstep (not a one-pole) has zero slope
-            // at t=0, so the onset is gentlest exactly when the loop is furthest from steady state.
+            // Engagement soft-start: a smoothstep from 0 to 1 over SoftStartTime seconds from the
+            // last Start(). The final actuator command is scaled by this, so engagement fades the
+            // control in. A smoothstep has zero slope at t=0, so the onset is gentlest exactly when
+            // the loop is furthest from steady state.
             var softStartLinear = softStartTime > 0
                 ? Math.Min (1.0, Math.Max (0.0, (Time.fixedTime - engageFixedTime) / softStartTime))
                 : 1.0;
@@ -901,15 +898,15 @@ namespace KRPC.SpaceCenter.AutoPilot
             double phi, cosPhi, sinPhi;
             ComputeRollInvariantFrame (internalVessel, out currentDirection, out phi, out cosPhi, out sinPhi);
 
-            // Measure the raw angular velocity (root-part rigidbody). On a structurally flexible
-            // craft it carries the bending mode on top of the rigid-body rate. The chatter detector
-            // and the frequency trackers always see this raw rate; only the control loops see the
-            // suppressed rate computed below (see the signal-routing note in the design doc).
+            // Measure the raw angular velocity from the root-part rigidbody. On a structurally
+            // flexible craft it carries the bending mode on top of the rigid-body rate. The chatter
+            // detector and the frequency trackers always see this raw rate, and only the control
+            // loops see the suppressed rate computed below.
             var currentRaw = (Vector3d)ComputeCurrentAngularVelocity ();
 
             // Update the structural-chatter detector from the raw rate. In Automatic mode the latch
-            // it produces decides *whether* suppression is applied; the frequency estimator below
-            // decides *which* tool (notch vs low-pass). A rigid craft never latches.
+            // it produces decides whether suppression is applied, and the frequency estimator below
+            // decides which tool, notch or low-pass. A rigid craft never latches.
             detectors.UpdateChatter (currentRaw, torque, moi, dt, DefaultChatterDetectThreshold);
 
             // Feed the frequency trackers the oscillation in the raw rate every tick,
@@ -918,9 +915,9 @@ namespace KRPC.SpaceCenter.AutoPilot
             detectors.UpdateTrackers (currentRaw, dt);
 
             // Select and apply the suppression tool per axis group, producing the rate the control
-            // loops consume. Each axis is notched, low-passed, or passed through — never both — with
-            // the inactive filter's state held reset so a regime change injects no transient. The
-            // per-axis suppressionActiveAxis record written here is read by DoAutoTuneAxis.
+            // loops consume. Each axis is notched, low-passed or passed through, one of the three,
+            // with the inactive filter's state held reset so a regime change injects no transient.
+            // The per-axis suppressionActiveAxis record written here is read by DoAutoTuneAxis.
             int pitchYawTool;
             double pitchYawFreq;
             MitigationPolicy.SelectTool (pitchYawRateFilterMode, detectors.PitchYawLatched,
@@ -938,13 +935,14 @@ namespace KRPC.SpaceCenter.AutoPilot
                 rateFilter.Apply (2, currentRaw.z, pitchYawTool, pitchYawFreq, oscillationNotchQ,
                     MitigationPolicy.LowPassSeparation, MitigationPolicy.LowPassCornerMin, dt));
 
-            // Light measured-rate low-pass on a detector-firing but *unlatched* axis (see
-            // DetectorRateFilterTimeConstant). The suppression above only runs on a latched axis; here the
-            // axis passed through, but its rate still carries the root-part jitter that the full-bandwidth
-            // inner loop turns into actuator chatter and that the stopping-distance term re-injects into
-            // the feedforward. Blend a lightly low-passed copy in by chatterLevel — rigid axes (level ~0)
-            // untouched, latched axes skipped (the heavier suppression handles them) — so both the inner
-            // loop and the outer stopping term below act on a quieter rate.
+            // Light measured-rate low-pass on a detector-firing but unlatched axis (see
+            // DetectorRateFilterTimeConstant). The suppression above runs only on a latched axis,
+            // and an axis that passed through still carries the root-part jitter that the
+            // full-bandwidth inner loop turns into actuator chatter and that the stopping-distance
+            // term re-injects into the feedforward. Blend a lightly low-passed copy in by
+            // chatterLevel, leaving rigid axes untouched and skipping latched axes, which the
+            // heavier suppression handles, so both the inner loop and the outer stopping term below
+            // act on a quieter rate.
             var inputBlend = Vector3d.zero;
             for (int i = 0; i < 3; i++) {
                 var w = detectors.ChatterLatched (i) ? 0.0 : detectors.ChatterLevel [i];
@@ -952,9 +950,10 @@ namespace KRPC.SpaceCenter.AutoPilot
                 current [i] = rateFilter.BlendInput (i, current [i], w, dt);
             }
 
-            // Ramp the latched bandwidth reduction and output smoothing in/out per axis (gated on
-            // suppression being active — the persistent latch, not the decaying chatterLevel — so
-            // they hold for as long as the craft is treated as flexible and do not step at engage).
+            // Ramp the latched bandwidth reduction and output smoothing in and out per axis, gated
+            // on suppression being active, which is the persistent latch and not the decaying
+            // chatterLevel, so they hold for as long as the craft is treated as flexible and do not
+            // step at engage.
             policy.UpdateRamps (rateFilter, dt);
 
 
@@ -965,29 +964,30 @@ namespace KRPC.SpaceCenter.AutoPilot
             var target = ComputeTargetAngularVelocity (torque, moi, current, currentDirection,
                 cosPhi, sinPhi, out pySampleFull, out rollSampleFull);
 
-            // Roll setpoint is already weighted to zero inside ComputeTargetAngularVelocity when the
-            // vessel is far from the direction target; clear the integral there to prevent windup.
+            // Roll setpoint is already weighted to zero inside ComputeTargetAngularVelocity when
+            // the vessel is far from the direction target, so clear the integral there to prevent
+            // windup.
             if (!rollControlled) {
                 target.y = 0;
             } else {
                 ClearRollWindupIfDisengaged (currentDirection);
             }
 
-            // Continuous hold gate: 1 while holding (error ≤ HoldErrorFull), 0 while slewing
-            // (≥ HoldErrorNone), linear between. Combined with suppressionRamp it gives the per-axis
-            // mitigation weight — only a latched axis that is also holding is floored and has its
-            // feedforward cut. (The linear stopping coefficient is computed from the unfloored gain
-            // — see ProfileKp — so the setpoint needs no separate hold-time profile.)
-            // The hold factor is per axis group: pitch/yaw key on the pointing error; roll keys on
-            // the LARGER of the pointing error and the roll error. Keying roll on the pointing
-            // error alone left a latched roll axis floored (with its feedforward cut) through a
-            // pure roll maneuver — the pointing error stays ~0 there, so the mitigation never
-            // released and the floored integrator crawled through the turn (measured in-game: a
-            // 20° roll's tail creeping once roll latched mid-slew). Taking the max means roll also
-            // releases during a pointing slew, exactly as before. logAngles.y is the roll residual
-            // the profile acts on (degrees; ≡ 0 when roll is not controlled, so behaviour there is
-            // unchanged). A pure roll maneuver does NOT release latched pitch/yaw — they really
-            // are holding.
+            // Continuous hold gate: 1 while holding, at or below HoldErrorFull, 0 while slewing,
+            // at or above HoldErrorNone, and linear between. Combined with suppressionRamp it gives
+            // the per-axis mitigation weight, so only a latched axis that is also holding is
+            // floored and has its feedforward cut. The linear stopping coefficient is computed from
+            // the unfloored gain (see ProfileKp), so the setpoint needs no separate hold-time
+            // profile.
+            //
+            // The hold factor is per axis group. Pitch and yaw key on the pointing error, and roll
+            // keys on the larger of the pointing error and the roll error. The pointing error stays
+            // near zero through a pure roll maneuver, so keying roll on it alone leaves a latched
+            // roll axis floored, with its feedforward cut, and the floored integrator crawls
+            // through the turn. Taking the larger of the two means roll also releases during a
+            // pointing slew. logAngles.y is the roll residual the profile acts on, in degrees, and
+            // is zero when roll is not controlled. A pure roll maneuver does not release latched
+            // pitch and yaw, which really are holding.
             var pointingError = Vector3.Angle (currentDirection, EffectiveTargetDirection);
             var holdFactorPitchYaw = OscillationDetectors.HoldFactor (pointingError);
             var rollErrorDeg = Math.Abs (logAngles.y);
@@ -995,14 +995,14 @@ namespace KRPC.SpaceCenter.AutoPilot
                 OscillationDetectors.HoldFactor (Math.Max (pointingError, rollErrorDeg));
             logHoldFactorPitchYaw = holdFactorPitchYaw;
             logHoldFactorRoll = holdFactorRoll;
-            // Oscillation-control back-off, OR'd into the hold gate via max() below: lets the latched
-            // mitigation engage independent of pointing error — the hold gate's blind spot during a
-            // maneuver, where a released gate restores the feedforward that re-drives the bending mode.
-            // The trigger is the about-mean envelope of the delivered command (built by the detectors
-            // from the previous tick, since this tick's command does not exist yet): a sustained limit
-            // cycle has a large envelope while a steady slew (one-sign ramp, tracked by the trim mean)
-            // does not. It rises fast / decays slow so a one-shot transient does not pin it, and only
-            // a latched axis can trigger.
+            // Oscillation-control back-off, combined into the hold gate with max() below. It lets
+            // the latched mitigation engage independent of pointing error, covering the hold gate's
+            // blind spot during a maneuver, where a released gate restores the feedforward that
+            // re-drives the bending mode. The trigger is the about-mean envelope of the delivered
+            // command, built by the detectors from the previous tick since this tick's command does
+            // not exist yet: a sustained limit cycle has a large envelope, and a steady one-sign
+            // ramp tracked by the trim mean does not. It rises fast and decays slow, so a one-shot
+            // transient does not pin it, and only a latched axis can trigger it.
             detectors.UpdateControlEnvelope (dt);
             var gate = policy.UpdateGate (detectors, dt, holdFactorPitchYaw, holdFactorRoll);
 
@@ -1010,11 +1010,10 @@ namespace KRPC.SpaceCenter.AutoPilot
             logTargetRi = target;
 
             // Analytic acceleration feedforward: the profile's planned acceleration computed
-            // algebraically from the ProfileSamples — no finite differencing, so none of the
-            // 1/(dt·α)-amplified measured-rate jitter or setpoint-direction whip spikes the
-            // numeric form carries (measured in-game: the numeric form spikes to ~92× full scale
-            // in the transverse-nudge regime during the transition comparison; the analytic form
-            // stays bounded ~1.5).
+            // algebraically from the ProfileSamples, with no finite differencing. A numeric form
+            // amplifies measured-rate jitter by 1 / (dt * alpha) and whips with the setpoint
+            // direction, and was measured spiking to about 92 times full scale in the
+            // transverse-nudge regime, where the analytic form stays bounded around 1.5.
             var slewActive = targetSmoothingTime > 0
                 && GeometryExtensions.Angle (effectiveRotation, targetRotation) > 1e-9;
             var slewRateRad = slewActive ? GeometryExtensions.ToRadians (slewSpeed) : 0.0;
@@ -1024,21 +1023,22 @@ namespace KRPC.SpaceCenter.AutoPilot
             if (!rollControlled)
                 ffAnalyticRi.y = 0;
 
-            // Low-pass filter the feedforward. The analytic value steps by a bounded amount at
-            // the profile's branch seams — the min()/max() switches (velocity cap, quad/linear
-            // stopping term) and the sign flip through the target — and, summed with the PID
-            // output and clamped, a step would briefly saturate the actuators. A short
-            // first-order filter smears these few genuine transitions over ~3 physics ticks; the
-            // resulting lag is small and the PI loop absorbs it.
+            // Low-pass filter the feedforward. The analytic value steps by a bounded amount at the
+            // profile's branch seams, the min() and max() switches for the velocity cap and the
+            // quadratic and linear stopping terms, and the sign flip through the target. Summed
+            // with the PID output and clamped, such a step would briefly saturate the actuators. A
+            // short first-order filter smears these few genuine transitions over about three
+            // physics ticks, and the PI loop absorbs the small lag.
             var ffBeta = 1.0 - Math.Exp (-dt / FeedforwardSmoothTimeConstant);
             smoothedFfRi = new Vector3d (
                 smoothedFfRi.x + ffBeta * (ffAnalyticRi.x - smoothedFfRi.x),
                 smoothedFfRi.y + ffBeta * (ffAnalyticRi.y - smoothedFfRi.y),
                 smoothedFfRi.z + ffBeta * (ffAnalyticRi.z - smoothedFfRi.z));
-            // Cut the feedforward by the hold gate: it is an open-loop plant inversion (gain ∝
-            // frequency) and is the loop path most able to drive a flexible mode once the bandwidth is
-            // floored, but only a holding flexible axis needs it gone — while slewing the axis keeps
-            // its feedforward to track the manoeuvre, and a rigid axis keeps it throughout.
+            // Cut the feedforward by the hold gate. It is an open-loop plant inversion, with gain
+            // proportional to frequency, and is the loop path most able to drive a flexible mode
+            // once the bandwidth is floored. Only a holding flexible axis needs it gone: a slewing
+            // axis keeps its feedforward to track the maneuver, and a rigid axis keeps it
+            // throughout.
             var ffScale = new Vector3d (
                 FeedforwardScale (gate.x), FeedforwardScale (gate.y), FeedforwardScale (gate.z));
             logFfCut = new Vector3d (1.0 - ffScale.x, 1.0 - ffScale.y, 1.0 - ffScale.z);
@@ -1053,12 +1053,12 @@ namespace KRPC.SpaceCenter.AutoPilot
             if (AutoTune)
                 DoAutoTune (smoothedTorque, moi);
 
-            // Zero the integral terms throughout the engagement soft-start (the on-pad PRELAUNCH
-            // case is handled by the early return above). During the fade the scaled-down command
-            // under-drives the plant, so the error persists and the integrator would wind up — then
-            // deliver the very kick the soft-start removes the moment the ramp completes. Holding it
-            // cleared means integration starts from zero exactly at softStart == 1, with no step (the
-            // proportional/feedforward output is faded too).
+            // Zero the integral terms throughout the engagement soft-start. The on-pad PRELAUNCH
+            // case is handled by the early return above. During the fade the scaled-down command
+            // under-drives the plant, so the error persists and the integrator winds up, then
+            // delivers the kick the soft-start removes the moment the ramp completes. Held clear,
+            // integration starts from zero exactly at a soft-start of 1, with no step, and the
+            // proportional and feedforward output is faded too.
             if (softStart < 1.0) {
                 PitchPID.ClearIntegralTerm ();
                 RollPID.ClearIntegralTerm ();
@@ -1066,8 +1066,8 @@ namespace KRPC.SpaceCenter.AutoPilot
             }
 
             // Inner rate loop (the inner stage of the cascade). The outer loop above turned the
-            // attitude error into a target angular velocity; this stage drives the *suppressed*
-            // measured rate (currentRi) onto that target. Each PI is physics-normalised — its
+            // attitude error into a target angular velocity, and this stage drives the suppressed
+            // measured rate (currentRi) onto that target. Each PI is physics-normalized, and its
             // autotuned gains carry the moi/torque factor, so the closed rate-loop bandwidth is set
             // by TimeToPeak/Overshoot and is independent of the craft's authority. Because it tracks
             // the suppressed rate, the loop has no gain at the bending frequency and cannot excite a
@@ -1083,7 +1083,7 @@ namespace KRPC.SpaceCenter.AutoPilot
             var virtualYaw = (pidOut.z + ffRi.z).Clamp (-1, 1);
             var bodyControl = FromRollInvariant (new Vector3d (virtualPitch, 0, virtualYaw), cosPhi, sinPhi);
 
-            // Gyroscopic feedforward: the per-axis plant model (τ = I·ω̇) ignores the ω×(Iω) term in
+            // Gyroscopic feedforward: the per-axis plant model (tau = I*omega-dot) ignores the omega x (Iomega) term in
             // Euler's rigid-body equation. Add a control fraction that cancels it, in the body frame
             // where the inertia and available torque are per-axis, then sum with the control and
             // clamp to [-1, 1].
@@ -1110,8 +1110,8 @@ namespace KRPC.SpaceCenter.AutoPilot
                     pySampleFull, rollSampleFull, ffAnalyticRi, ffRi, ffDiag, gyro, pidOut,
                     new Vector3d (uPitch, uRoll, uYaw), softStart,
                     slewActive ? slewSpeed : 0.0, pitchYawFreq, rollFreq, inputBlend);
-                // The log is capped (one minute at 50 Hz); when full, logging switches itself
-                // off — the buffer holds the window following the enable, and memory is bounded.
+                // The log is capped at one minute at 50 Hz. When full, logging switches itself
+                // off, so the buffer holds the window following the enable and memory is bounded.
                 if (diagnosticLog.Full)
                     diagnosticLogging = false;
             }
@@ -1206,7 +1206,7 @@ namespace KRPC.SpaceCenter.AutoPilot
         /// Roll error (degrees, unsigned) between the vessel's current attitude and the given target,
         /// measured about the nose axis. Well-defined near the vertical singularity, unlike a
         /// pitch/heading/roll Euler subtraction: it is the roll component of the rotation left after
-        /// the pointing error is removed, projected onto the nose axis — the same quantity the control
+        /// the pointing error is removed, projected onto the nose axis, the same quantity the control
         /// loop acts on in <see cref="ComputeTargetAngularVelocity"/>, but ungated by the roll blend
         /// weight so it is a valid readout regardless of pointing error.
         /// </summary>
@@ -1231,7 +1231,7 @@ namespace KRPC.SpaceCenter.AutoPilot
 
         /// <summary>
         /// The per-axis attitude error (pitch, yaw, roll) in degrees between the vessel's current
-        /// attitude and the given target, from one residual decomposition — the same singularity-free
+        /// attitude and the given target, from one residual decomposition, the same singularity-free
         /// machinery as <see cref="RollErrorTo"/>. All three components stay well-defined near the
         /// vertical, unlike a pitch/heading/roll Euler subtraction. Pitch and yaw are the direction
         /// error resolved onto the vessel's body pitch axis (x) and yaw axis (z); roll is the
@@ -1245,12 +1245,12 @@ namespace KRPC.SpaceCenter.AutoPilot
             var currentRotation = ReferenceFrame.RotationFromWorldSpace (internalVessel.ReferenceTransform.rotation);
             var currentDirection = ReferenceFrame.DirectionFromWorldSpace (internalVessel.ReferenceTransform.up);
 
-            // Pitch/yaw: the direction error's minimum-arc axis (⊥ the nose, so no roll component),
-            // expressed in the vessel body frame — body x is the pitch axis, body z the yaw axis
-            // (matching the control-input mapping). Body frame, not the roll-invariant frame: this is
-            // a readout about the vessel's actual pitch/yaw control axes, whereas the roll-invariant
-            // frame's axes carry the pointing rotation's own twist and would swap pitch↔yaw depending
-            // on where the nose points.
+            // Pitch and yaw: the direction error's minimum-arc axis, perpendicular to the nose so
+            // it has no roll component, expressed in the vessel body frame. Body x is the pitch axis
+            // and body z the yaw axis, matching the control-input mapping. This is a readout about
+            // the vessel's actual pitch and yaw control axes, where the roll-invariant frame's axes
+            // carry the pointing rotation's own twist and would swap pitch and yaw depending on
+            // where the nose points.
             var dirRotation = GeometryExtensions.FromToRotation (currentDirection, targetDirection);
             double dirAngle;
             Vector3d dirAxis;
@@ -1275,7 +1275,7 @@ namespace KRPC.SpaceCenter.AutoPilot
 
         /// <summary>
         /// Update the one-sided torque smoothing: track increases immediately (gains going down is
-        /// safe) but decay decreases at τ≈0.5s so a sudden torque drop (e.g. engine shutdown while a
+        /// safe) but decay decreases at tauabout 0.5s so a sudden torque drop (e.g. engine shutdown while a
         /// small reaction wheel keeps torque > 0) does not cause a single-tick gain spike. The
         /// velocity profile still uses the actual torque so the setpoint immediately reflects the
         /// reduced authority.
@@ -1359,7 +1359,7 @@ namespace KRPC.SpaceCenter.AutoPilot
                 antipodeLatched ? antipodeLatchedNormal : Vector3d.zero, "F3");
 
             // Measured state: vessel roll relative to the RI frame, the raw and suppressed
-            // rates (RI frame, rad/s), and the plant model (raw and smoothed torque, MoI, α).
+            // rates (RI frame, rad/s), and the plant model (raw and smoothed torque, MoI, alpha).
             log.Add ("phi", phi * 180.0 / Math.PI, "F2");
             log.AddVector ("omega_raw", logRawOmegaRi, "F4");
             log.AddVector ("omega_ri", currentRi, "F4");
@@ -1382,9 +1382,9 @@ namespace KRPC.SpaceCenter.AutoPilot
                 PitchPID.IntegralTerm, RollPID.IntegralTerm, YawPID.IntegralTerm), "F4");
 
             // Outer loop: the target angular velocity and the velocity profile's decisions per
-            // axis group — branch (cone/cap/linear/quad/idle), speed, deadband scale, pure and
-            // ω-corrected error magnitudes (rad), cone slope, linear-branch bandwidth and the
-            // stopping-point direction ŝ.
+            // axis group: branch (cone/cap/linear/quad/idle), speed, deadband scale, pure and
+            // omega-corrected error magnitudes (rad), cone slope, linear-branch bandwidth and the
+            // stopping-point direction s-hat.
             log.AddVector ("tgt_omega_ri", logTargetRi, "F4");
             log.Add ("roll_weight", rollControlled ? RollWeight (dirErr) : 0.0, "F2");
             log.Add ("prof.py", ProfileBranchTag (pySample));
@@ -1399,7 +1399,7 @@ namespace KRPC.SpaceCenter.AutoPilot
             log.Add ("prof_s.r", rollSample.SPitch, "F3");
             log.Add ("prof_s.y", pySample.SYaw, "F3");
 
-            // Feedforward pipeline: the gates and planned rate ġ, then the raw analytic value,
+            // Feedforward pipeline: the gates and planned rate g-dot, then the raw analytic value,
             // the low-passed copy, the applied (post hold-gate cut) value and the gyroscopic
             // term.
             log.AddGroup ("ff_track", ffDiag.PitchYawTracking, ffDiag.RollTracking, "F3");
@@ -1417,7 +1417,7 @@ namespace KRPC.SpaceCenter.AutoPilot
             log.AddVector ("ctrl", new Vector3d (state.Pitch, state.Roll, state.Yaw), "F3");
 
             // Oscillation detectors (info window: STRUC / CTRL / FREQ): chatter level and the
-            // raw per-tick trigger margin (≥1 fires), the control-output envelope, and the
+            // raw per-tick trigger margin (>=1 fires), the control-output envelope, and the
             // held/live frequency estimates with acquisition progress.
             log.AddVector ("chatter", detectors.ChatterLevel, "F3");
             log.AddVector ("chatter_margin", detectors.ChatterMargin, "F2");
@@ -1484,10 +1484,10 @@ namespace KRPC.SpaceCenter.AutoPilot
 
         /// <summary>
         /// Output smoothing (see OutputFilter): the policy decision of blend weight and corner. A
-        /// latched axis uses the ramped suppression weight and the heavier (2 Hz) corner — the
+        /// latched axis uses the ramped suppression weight and the heavier 2 Hz corner, and the
         /// flexible-craft path. An unlatched axis whose detector is firing (the noisy-but-
         /// controllable craft) blends by chatterLevel at the lighter corner, smoothing the
-        /// delivered command without the phase cost of the 2 Hz filter destabilising the
+        /// delivered command without the phase cost of the 2 Hz filter destabilizing the
         /// full-bandwidth loop. A rigid axis (chatterLevel ~0, never latched) gets weight 0 and
         /// passes through.
         /// </summary>
@@ -1511,7 +1511,7 @@ namespace KRPC.SpaceCenter.AutoPilot
 
         /// <summary>
         /// The feedforward-cut mitigation: the scale applied to the acceleration feedforward on
-        /// one axis. Automatic follows the hold gate (1−gate: cut only on a latched, holding
+        /// one axis. Automatic follows the hold gate (1-gate: cut only on a latched, holding
         /// axis); Off never cuts; Forced always cuts fully.
         /// </summary>
         double FeedforwardScale (double gateComponent)
@@ -1527,16 +1527,16 @@ namespace KRPC.SpaceCenter.AutoPilot
         /// Gyroscopic feedforward in the body frame, returned as a per-axis control fraction.
         /// </summary>
         /// <remarks>
-        /// The PID controllers and the autotuner model the plant as τ = I·ω̇ independently per axis,
-        /// but the rigid-body equation of motion is τ = I·ω̇ + ω×(Iω). The cross term ω×(Iω) is a
+        /// The PID controllers and the autotuner model the plant as tau = I*omega-dot independently per axis,
+        /// but the rigid-body equation of motion is tau = I*omega-dot + omega x (Iomega). The cross term omega x (Iomega) is a
         /// torque the controller would otherwise have to reject as a disturbance. This returns the
-        /// control fraction that cancels it: -(ω×(Iω))ᵢ / τ_max,ᵢ per axis (a diagonal inertia is
-        /// assumed, matching the rest of the controller). The term is quadratic in ω, so it is
-        /// negligible at the low rates of normal attitude holding — including structural bending
-        /// oscillation — and only matters for fast slews or strongly asymmetric inertia.
+        /// control fraction that cancels it: -(omega x (Iomega))_i / tau_max_i per axis (a diagonal inertia is
+        /// assumed, matching the rest of the controller). The term is quadratic in omega, so it is
+        /// negligible at the low rates of normal attitude holding, structural bending oscillation
+        /// included, and only matters for fast slews or strongly asymmetric inertia.
         ///
-        /// ω is passed in the controller's negated sign convention (see ComputeCurrentAngularVelocity),
-        /// but ω×(Iω) is quadratic in ω and so is invariant under that negation — it gives the correct
+        /// omega is passed in the controller's negated sign convention (see ComputeCurrentAngularVelocity),
+        /// but omega x (Iomega) is quadratic in omega and so is invariant under that negation, and gives the correct
         /// body-frame gyroscopic torque either way.
         /// </remarks>
         Vector3d GyroscopicFeedforward (Vector3d omega, Vector3d moi, Vector3d torque)
@@ -1550,14 +1550,14 @@ namespace KRPC.SpaceCenter.AutoPilot
         }
 
         /// <summary>
-        /// Resolve the direction-error rotation axis through the 180° (antipodal) singularity.
+        /// Resolve the direction-error rotation axis through the 180 degrees (antipodal) singularity.
         /// </summary>
         /// <remarks>
         /// <c>FromToRotation(current, target)</c> returns an arbitrary axis when the target is
         /// directly behind the nose (the minimum-arc rotation's plane is undefined), so a flip there
         /// would tumble in a random plane. When the vessel enters the antipode band already rotating,
-        /// <em>latch</em> the flip-plane normal once — from the angular velocity perpendicular to the
-        /// nose at that moment — and hold it for the rest of the pass. The commanded axis is then
+        /// latch the flip-plane normal once, from the angular velocity perpendicular to the nose at
+        /// that moment, and hold it for the rest of the pass. The commanded axis is then
         /// rebuilt each tick from that fixed plane, not from the live angular velocity: tracking the
         /// live rate instead lets any out-of-plane drift the inner loop introduces feed back on
         /// itself (the axis follows the drifting rate, which drives more drift), and the flip tumbles.
@@ -1567,7 +1567,7 @@ namespace KRPC.SpaceCenter.AutoPilot
         /// Active only within <see cref="AntipodeBlendAngle"/> of antipodal. The plane is latched from
         /// the perpendicular rate when the vessel is already turning, else from
         /// <paramref name="fromToAxis"/> for a from-rest flip; either way a plane is held rather than
-        /// tracking the precessing live axis. The commanded axis is rebuilt as nose × tangent from a
+        /// tracking the precessing live axis. The commanded axis is rebuilt as nose x tangent from a
         /// blend of the geodesic tangent (toward the target) and the latched-plane tangent, weighted
         /// fully to the latched plane within <see cref="AntipodeHoldAngle"/> (the crawl/pump region)
         /// and smoothstep-blended to pure geodesic by <see cref="AntipodeBlendAngle"/>, so the
@@ -1586,8 +1586,8 @@ namespace KRPC.SpaceCenter.AutoPilot
             // Latch the flip-plane normal the first time we enter the band. Once latched it is held
             // (never re-read from the live rate) until the error leaves the band. If the vessel is
             // already committed to a rotation, latch its plane (from the perpendicular rate); a
-            // from-rest flip has no committed plane, so latch the arbitrary-but-consistent geodesic
-            // axis instead — either way the flip then rides a fixed plane, not the precessing live axis.
+            // from-rest flip has no committed plane, so latch the arbitrary but consistent
+            // geodesic axis. Either way the flip rides a fixed plane and not the precessing axis.
             if (!antipodeLatched) {
                 var worldOmega = vessel.InternalVessel.WorldAngularVelocity ();
                 Vector3d omegaAp = ReferenceFrame.AngularVelocityFromWorldSpace (worldOmega);
@@ -1598,8 +1598,8 @@ namespace KRPC.SpaceCenter.AutoPilot
                 antipodeLatched = true;
             }
 
-            // Latched-plane weight: fully held (1) within AntipodeHoldAngle of antipodal — spanning
-            // the crawl/pump region — then smoothstep down to 0 (pure live geodesic) by
+            // Latched-plane weight: fully held at 1 within AntipodeHoldAngle of antipodal, which
+            // spans the crawl region, then smoothstep down to a pure live geodesic by
             // AntipodeBlendAngle, so the hand-back to normal tracking is continuous.
             double wAngle;
             if (fromAntipode <= AntipodeHoldAngle) {
@@ -1611,7 +1611,7 @@ namespace KRPC.SpaceCenter.AutoPilot
             logAntipodeWeight = wAngle;
 
             // Tangents perpendicular to the nose: toward the target (the geodesic) and forward in the
-            // latched plane. nose × tangent rebuilds the rotation axis; at wAngle = 0 (band edge) this
+            // latched plane. nose x tangent rebuilds the rotation axis; at wAngle = 0 (band edge) this
             // is exactly fromToAxis, at wAngle = 1 (the held region) it is the fixed latched plane.
             var tTarget = targetDirection - Vector3d.Dot (targetDirection, currentDirection) * currentDirection;
             var tLatched = Vector3d.Cross (antipodeLatchedNormal, currentDirection);
@@ -1626,56 +1626,56 @@ namespace KRPC.SpaceCenter.AutoPilot
         /// <summary>
         /// One velocity-profile evaluation for an axis group (pitch/yaw jointly, or roll alone),
         /// recording which branches the profile arithmetic took together with the quantities the
-        /// acceleration feedforward needs — so the feedforward can be derived from the profile's
+        /// acceleration feedforward needs, so the feedforward can be derived from the profile's
         /// own decisions rather than re-derived from thresholds (which would disagree at the
         /// seams) or numerically differenced (which amplifies measured-rate jitter by 1/dt).
         /// </summary>
         struct ProfileSample
         {
-            // Unit stopping-point direction ŝ = e_stop/|e_stop| in the roll-invariant xz-plane;
-            // the command is ω_ref = −ŝ·Speed·Deadband. For roll (1D) SPitch carries sign(θ_ff)
-            // — the same convention — and SYaw is 0.
+            // Unit stopping-point direction s-hat = e_stop/|e_stop| in the roll-invariant xz-plane;
+            // the command is omega_ref = -s-hat*Speed*Deadband. For roll (1D) SPitch carries sign(theta_ff)
+            // in the same convention, and SYaw is 0.
             public double SPitch;
             public double SYaw;
-            // Signed pure pointing error (rad, before the ω-dependent stopping correction):
+            // Signed pure pointing error (rad, before the omega-dependent stopping correction):
             // the vector (ThetaPitch, ThetaYaw) for pitch/yaw, the scalar in ThetaPitch for roll.
             // Theta below is its magnitude. Used for the deadband-slope term of the feedforward
-            // (d|θ|/dt needs the direction of θ, which |θ| alone does not carry).
+            // (d|theta|/dt needs the direction of theta, which |theta| alone does not carry).
             public double ThetaPitch;
             public double ThetaYaw;
             // Commanded speed before the deadband scale (rad/s, >= 0).
             public double Speed;
-            // Full-authority acceleration α the profile used, projected along ŝ (rad/s²).
+            // Full-authority acceleration alpha the profile used, projected along s-hat (rad/s^2).
             public double Alpha;
-            // PID bandwidth (projected along ω̂) when the linear stopping coefficient won the
+            // PID bandwidth (projected along omega-hat) when the linear stopping coefficient won the
             // max() against the quadratic one; 0 otherwise.
             public double Bandwidth;
             // The velocity cap (MaxAngularVelocity), not the sqrt profile, set the speed.
             public bool CapActive;
-            // The linear speed cone (ProfileConeFraction·bw·|e_stop|) set the speed. Mutually
-            // exclusive with CapActive — exactly one of {cone, cap, sqrt} owns the branch, so the
+            // The linear speed cone (ProfileConeFraction*bw*|e_stop|) set the speed. Mutually
+            // exclusive with CapActive: exactly one of {cone, cap, sqrt} owns the branch, so the
             // feedforward closed forms never double count.
             public bool ConeActive;
-            // Cone slope c = ProfileConeFraction·bw (1/s), recorded whenever a bandwidth is
-            // available (0 otherwise). Uses the ŝ-projected bandwidth — the speed map lives along
-            // ŝ — while Bandwidth below stays ω̂-projected (the brake path lives along ω̂),
-            // mirroring how α is projected for each use. Deliberate, not an inconsistency.
+            // Cone slope c = ProfileConeFraction*bw (1/s), recorded whenever a bandwidth is
+            // available, 0 otherwise. Uses the s-hat-projected bandwidth, as the speed map lives
+            // along s-hat, while Bandwidth below stays omega-hat-projected, as the brake path lives
+            // along omega-hat, mirroring how alpha is projected for each use.
             public double ConeSlope;
-            // The linear (1/bandwidth) stopping coefficient beat the quadratic (ω/2α) one.
+            // The linear (1/bandwidth) stopping coefficient beat the quadratic (omega/2alpha) one.
             public bool LinearActive;
-            // Pointing-deadband scale D(θ) in [0,1] applied to the setpoint.
+            // Pointing-deadband scale D(theta) in [0,1] applied to the setpoint.
             public double Deadband;
-            // |θ| (pure pointing error, rad) the deadband was keyed on.
+            // |theta| (pure pointing error, rad) the deadband was keyed on.
             public double Theta;
-            // |e_stop| (rad): the ω-corrected error magnitude the speed profile was keyed on.
+            // |e_stop| (rad): the omega-corrected error magnitude the speed profile was keyed on.
             public double EStop;
             // False when the profile commanded nothing (no authority, or the e_stop guard).
             public bool Valid;
         }
 
         /// <summary>
-        /// Per-tick internals of the analytic feedforward, per axis group — the tracking
-        /// fraction and overshoot gate that scale it and the planned command-magnitude rate ġ
+        /// Per-tick internals of the analytic feedforward, per axis group: the tracking
+        /// fraction and overshoot gate that scale it and the planned command-magnitude rate g-dot
         /// they scale. Computed inside <see cref="PitchYawAnalyticFf"/> /
         /// <see cref="RollAnalyticFf"/> and surfaced only for the diagnostic log.
         /// </summary>
@@ -1705,7 +1705,7 @@ namespace KRPC.SpaceCenter.AutoPilot
             // Direction error: FromToRotation gives a minimum-arc rotation whose axis is
             // perpendicular to both currentDirection and targetDirection. Because the vessel's
             // nose IS currentDirection (body y-axis), this rotation axis has no y-component in
-            // body frame — it carries pure pitch/yaw, no roll.
+            // body frame, so it carries pure pitch and yaw.
             QuaternionD dirRotation = GeometryExtensions.FromToRotation (currentDirection, targetDirection);
 
             double angle;
@@ -1713,12 +1713,12 @@ namespace KRPC.SpaceCenter.AutoPilot
             GeometryExtensions.ToAngleAxis (dirRotation, out angle, out axis);
             angle = GeometryExtensions.ClampAngle180 (angle);
 
-            // Resolve the error axis through the 180° (antipodal) singularity, where FromToRotation's
+            // Resolve the error axis through the 180 degrees (antipodal) singularity, where FromToRotation's
             // axis is arbitrary: if the vessel is already rotating, continue in that plane.
             axis = ResolveAntipodalAxis (axis, angle, currentDirection, targetDirection);
 
             // Transform direction error from AP frame to body frame, then to roll-invariant frame.
-            // The y-component is ~0 by construction (direction error ⊥ nose) and is forced to zero
+            // The y-component is ~0 by construction (direction error perpendicular to nose) and is forced to zero
             // so only x and z carry pitch/yaw.
             var dirAnglesBody = ApToBody (axis * angle);
             var anglesRI = ToRollInvariant (dirAnglesBody, cosPhi, sinPhi);
@@ -1727,8 +1727,8 @@ namespace KRPC.SpaceCenter.AutoPilot
             // Roll error: computed separately from the roll residual after direction alignment,
             // projected onto the body y-axis (nose = roll axis). Mixing roll residual into the
             // direction-error vector contaminates pitch/yaw because the residual axis is not
-            // aligned with the nose when direction error is large — causing a curved path and
-            // roll oscillations. Projecting onto the y-axis extracts the pure roll component.
+            // aligned with the nose when the direction error is large, which curves the path and
+            // brings roll oscillations. Projecting onto the y-axis extracts the pure roll component.
             if (rollControlled) {
                 var dirError = Vector3d.Angle (currentDirection, targetDirection);
                 var rollWeight = RollWeight (dirError);
@@ -1756,7 +1756,7 @@ namespace KRPC.SpaceCenter.AutoPilot
             var result = Vector3d.zero;
 
             // Roll: 1D per-axis (y-axis is unchanged by the roll-invariant rotation). The linear
-            // stopping coefficient uses the unfloored gain — see the note in ComputePitchYawVelocity.
+            // stopping coefficient uses the unfloored gain, see the note in ComputePitchYawVelocity.
             var rollBandwidth = moi [1] > 0 ? ProfileKp (1, RollPID) * torque [1] / moi [1] : 0.0;
             result.y = ComputeAxisVelocity (anglesRI.y, torque [1], moi [1], currentOmegaRi.y,
                 MaxAngularVelocity [1], RollAttenuationAngle, rollBandwidth, out rollSample);
@@ -1777,29 +1777,29 @@ namespace KRPC.SpaceCenter.AutoPilot
         /// </summary>
         /// <remarks>
         /// Predict where the nose coasts to if the current angular velocity is braked at full
-        /// authority — the stopping point as a *vector* — and command the profile straight at it:
+        /// authority, the stopping point as a vector, and command the profile straight at it:
         /// <code>
-        ///   e_stop = θ + coeff·ω          (coeff·ω is the full-authority stopping displacement)
-        ///   ŝ      = e_stop / |e_stop|
-        ///   ω_ref  = -ŝ · speed(|e_stop|)
+        /// e_stop = theta + coeff*omega (coeff*omega is the full-authority stopping displacement)
+        /// s-hat = e_stop / |e_stop|
+        /// omega_ref = -s-hat * speed(|e_stop|)
         /// </code>
-        /// Tangential damping emerges from the geometry: a sideways drift gives <c>coeff·ω</c> an
-        /// off-axis component, tilting <c>e_stop</c> and rotating <c>ŝ</c> so the command acquires a
-        /// component opposing the drift. No separate <c>-ω⊥</c> term is needed — the controller leads
-        /// the turn to place the predicted stopping point on the target instead of correcting the
-        /// orbit after the fact.
+        /// Tangential damping emerges from the geometry: a sideways drift gives <c>coeff*omega</c> an
+        /// off-axis component, tilting <c>e_stop</c> and rotating <c>s-hat</c> so the command acquires a
+        /// component opposing the drift. No separate perpendicular damping term is needed: the
+        /// controller leads the turn to place the predicted stopping point on the target, and does
+        /// not correct the orbit after the fact.
         ///
-        /// When ω is purely radial (ω⊥ = 0) the command reduces to a pure 1D bang-bang profile along
-        /// the error direction: with ω = ω∥·ê, <c>coeff·ω = ½ω∥|ω∥|/α · ê</c>, so
-        /// <c>e_stop = θ_ff·ê</c>, <c>ŝ = sign(θ_ff)·ê</c> and great-circle slews and radial settling
-        /// are a straight-line speed profile. The off-axis behaviour appears only when ω⊥ ≠ 0 — the
-        /// nudge/orbit regime. The stopping displacement is C1 in ω (no radial/tangential seam, no
-        /// <c>-ω⊥</c> step), so the acceleration feedforward does not step.
+        /// When omega is purely radial, with no perpendicular component, the command reduces to a pure
+        /// the error direction: with omega = omega-par * e-hat, <c>coeff*omega = omega-par*|omega-par| / (2*alpha) * e-hat</c>, so
+        /// <c>e_stop = theta_ff * e-hat</c>, <c>s-hat = sign(theta_ff) * e-hat</c> and great-circle slews and radial settling
+        /// are a straight-line speed profile. The off-axis behavior appears only when omega has a
+        /// perpendicular component, the nudge and orbit regime. The stopping displacement is C1 in
+        /// omega, with no radial or tangential seam, so the acceleration feedforward does not step.
         ///
-        /// Anisotropy (design §6, option b): project α (and the PID bandwidth) along ω̂ for the
-        /// prediction and along ŝ for the speed profile. Projecting the prediction along ω̂ rather
-        /// than ê is what makes <c>e_stop</c> well-defined even at θ = 0, and it coincides with ê
-        /// when ω is radial, so the radial reduction above is preserved.
+        /// Anisotropy: project alpha, and the PID bandwidth, along omega-hat for the
+        /// prediction and along s-hat for the speed profile. Projecting the prediction along omega-hat rather
+        /// than e-hat makes <c>e_stop</c> well-defined even at theta = 0, and it coincides with e-hat
+        /// when omega is radial, so the radial reduction above is preserved.
         /// </remarks>
         void ComputePitchYawVelocity (Vector3d anglesRI, Vector3d currentOmegaRi, Vector3d torque,
             Vector3d moi, out double pitchVelocity, out double yawVelocity,
@@ -1815,22 +1815,22 @@ namespace KRPC.SpaceCenter.AutoPilot
             var alphaPitch = moi [0] > 0 ? torque [0] / moi [0] : 0.0;
             var alphaYaw = moi [2] > 0 ? torque [2] / moi [2] : 0.0;
 
-            // Stopping-displacement coefficient (>= 0): e_stop = θ + coeff·ω. The quadratic
-            // (bang-bang, ω²/2α) and linear (PID-lag, ω/bandwidth) stopping displacements are both
-            // collinear with ω, so taking the larger collapses to a scalar max of their coefficients.
-            // α and the bandwidth are projected along ω̂ (the brake path is along ω); this coincides
-            // with the error-direction projection when ω is radial, preserving the legacy reduction,
-            // and stays defined as θ → 0.
+            // Stopping-displacement coefficient (>= 0): e_stop = theta + coeff*omega. The quadratic
+            // (bang-bang, omega^2/2alpha) and linear (PID-lag, omega/bandwidth) stopping displacements are both
+            // collinear with omega, so taking the larger collapses to a scalar max of their coefficients.
+            // alpha and the bandwidth are projected along omega-hat (the brake path is along omega); this coincides
+            // with the error-direction projection when omega is radial, preserving that reduction,
+            // and stays defined as theta -> 0.
             var omegaPitch = currentOmegaRi.x;
             var omegaYaw = currentOmegaRi.z;
             var omegaMag = Math.Sqrt (omegaPitch * omegaPitch + omegaYaw * omegaYaw);
 
-            // Per-axis UNFLOORED bandwidths (ProfileKp): used by both the linear stopping
-            // coefficient (projected along ω̂ below) and the speed cone (projected along ŝ). The
-            // bandwidth floor lowers the loop gain but must never inflate 1/bw or deflate the cone
-            // here — at the floored bandwidth the stopping coefficient would balloon ~5× and
-            // re-inject the residual measured-rate jitter into the setpoint at large gain (the
-            // limit cycle the old dual "nominal target" machinery existed to avoid).
+            // Per-axis unfloored bandwidths (ProfileKp), used by both the linear stopping
+            // coefficient, projected along omega-hat below, and the speed cone, projected along
+            // s-hat. The bandwidth floor lowers the loop gain, and must not inflate 1/bw or deflate
+            // the cone here: at the floored bandwidth the stopping coefficient balloons about
+            // fivefold and re-injects the residual measured-rate jitter into the setpoint at large
+            // gain, which is a limit cycle.
             var bw0 = moi [0] > 0 ? ProfileKp (0, PitchPID) * torque [0] / moi [0] : 0.0;
             var bw2 = moi [2] > 0 ? ProfileKp (2, YawPID) * torque [2] / moi [2] : 0.0;
 
@@ -1857,8 +1857,8 @@ namespace KRPC.SpaceCenter.AutoPilot
             var eStopYaw = thetaYaw + coeff * omegaYaw;
             var eStopMag = Math.Sqrt (eStopPitch * eStopPitch + eStopYaw * eStopYaw);
 
-            // Singularity guard on |e_stop| (not θ): both the error and the predicted drift must
-            // vanish before there is nothing to command. If e_stop ≈ 0 the nose is predicted to
+            // Singularity guard on |e_stop| (not theta): both the error and the predicted drift must
+            // vanish before there is nothing to command. If e_stop is near 0 the nose is predicted to
             // coast exactly to the target, so commanding zero is correct.
             if (eStopMag <= MinThetaForJointProfile)
                 return;
@@ -1866,8 +1866,8 @@ namespace KRPC.SpaceCenter.AutoPilot
             var sPitch = eStopPitch / eStopMag;
             var sYaw = eStopYaw / eStopMag;
 
-            // Speed profile along the stopping-point direction ŝ: project α and the max-velocity
-            // constraint ellipse along ŝ.
+            // Speed profile along the stopping-point direction s-hat: project alpha and the max-velocity
+            // constraint ellipse along s-hat.
             var alpha2d = sPitch * sPitch * alphaPitch + sYaw * sYaw * alphaYaw;
 
             var maxVPitch = MaxAngularVelocity [0];
@@ -1877,11 +1877,11 @@ namespace KRPC.SpaceCenter.AutoPilot
                 : Math.Min (maxVPitch, maxVYaw);
 
             // Linear speed cone (see ProfileConeFraction): cap the command at what the inner PI
-            // loop can track down to zero. Bandwidth projected along ŝ, like α and the velocity
-            // cap — the speed map lives along ŝ (the stopping coefficient above stays ω̂-projected;
-            // the brake path lives along ω̂). Computed unconditionally (not inside the ω-dependent
-            // stopping block): the cone must be live at ω = 0, where a limit cycle's turnaround
-            // re-acceleration happens.
+            // loop can track down to zero. Bandwidth projected along s-hat, like alpha and the
+            // velocity cap, as the speed map lives along s-hat, where the stopping coefficient above
+            // stays omega-hat-projected because the brake path lives along omega-hat. Computed
+            // unconditionally, outside the omega-dependent stopping block, as the cone has to be
+            // live at omega = 0, where a limit cycle's turnaround re-acceleration happens.
             var bwS = sPitch * sPitch * bw0 + sYaw * sYaw * bw2;
             var coneSlope = ProfileConeFraction * bwS;
 
@@ -1899,15 +1899,17 @@ namespace KRPC.SpaceCenter.AutoPilot
 
             // Command toward the stopping point, scaled by the linear pointing deadband (see
             // DeadbandScale): the commanded speed fades to zero as the predicted stopping point
-            // approaches the target, so the craft coasts to a stop inside the band rather than the inner
-            // loop chasing sub-band jitter into the actuators. Applied to the *setpoint* (outer loop), so
+            // approaches the target, so the craft coasts to a stop inside the band and the inner
+            // loop does not chase sub-band jitter into the actuators. Applied to the outer loop's setpoint, so
             // the inner rate loop keeps its full proportional rate damping and stays well-damped at the
-            // hold point. The leading minus defines the controller's positive angular-velocity direction
-            // (left-handed sense; matched to the negation in ComputeCurrentAngularVelocity), exactly as
-            // the legacy -Math.Sign(θ_ff) did.
-            // Key the deadband on the pure pointing error θ, not e_stop: e_stop = θ + coeff·ω carries the
-            // measured rate ω, so scaling by it would feed the ±mrad/s rate jitter through the ramp's
-            // slope into the setpoint and feedforward. θ is jitter-free, so the deadband edge is quiet.
+            // hold point. The leading minus defines the controller's positive angular-velocity
+            // direction, the left-handed sense, matched to the negation in
+            // ComputeCurrentAngularVelocity.
+            //
+            // The deadband is keyed on the pure pointing error theta. e_stop = theta + coeff * omega
+            // carries the measured rate, so keying on it would feed the rate jitter through the
+            // ramp's slope into the setpoint and feedforward. theta is jitter-free, so the deadband
+            // edge is quiet.
             var thetaMag = Math.Sqrt (thetaPitch * thetaPitch + thetaYaw * thetaYaw);
             var deadband = DeadbandScale (thetaMag, PitchYawAttenuationAngle);
             sample.SPitch = sPitch;
@@ -1932,10 +1934,10 @@ namespace KRPC.SpaceCenter.AutoPilot
         /// <summary>
         /// Linear pointing-deadband scale in [0,1] applied to the target angular velocity: 1 at and above
         /// the high angle, ramping linearly to 0 at <see cref="DeadbandLowFraction"/> of it, and 0 below.
-        /// Replaces the former logistic attenuation — same role (drive the velocity setpoint to zero as
-        /// the error vanishes so the craft coasts to a stop without the inner loop chasing sub-band jitter
-        /// into the actuators) but with a linear ramp that reaches exactly zero, giving a clean deadband
-        /// rather than a residual tail. <paramref name="errorRad"/> and the returned band are in radians /
+        /// It drives the velocity setpoint to zero as the error vanishes, so the craft coasts to a
+        /// stop without the inner loop chasing sub-band jitter into the actuators. The ramp reaches
+        /// exactly zero, giving a clean deadband with no residual tail.
+        /// <paramref name="errorRad"/> and the returned band are in radians /
         /// degrees respectively.
         /// </summary>
         static double DeadbandScale (double errorRad, double highAngleDeg)
@@ -1973,15 +1975,15 @@ namespace KRPC.SpaceCenter.AutoPilot
             // the left-handed sense about the axis; it is the matched partner of the negation in
             // ComputeCurrentAngularVelocity. Flip one without the other and the PI loop diverges.
             // Linear pointing deadband on the target velocity (see DeadbandScale), keyed on the pure error
-            // thetaPure (not the ω-corrected theta) so the measured-rate jitter is not fed through the
+            // thetaPure (not the omega-corrected theta) so the measured-rate jitter is not fed through the
             // ramp slope: the commanded speed fades to zero as the error approaches the target, so the
             // craft coasts to a stop inside the band. Applied to the setpoint, so the inner rate loop keeps
             // full damping.
             var speedUnclamped = maxAcceleration > 0
                 ? Math.Sqrt (2.0 * Math.Abs (theta) * maxAcceleration) : 0.0;
             var speed = Math.Min (maxVelocity, speedUnclamped);
-            // Linear speed cone (see ProfileConeFraction), keyed on the ω-corrected error — the
-            // 1D analogue of |e_stop| in ComputePitchYawVelocity.
+            // Linear speed cone (see ProfileConeFraction), keyed on the omega-corrected error, the
+            // one-dimensional analog of |e_stop| in ComputePitchYawVelocity.
             var coneSlope = ProfileConeFraction * pidBandwidth;
             var coneActive = false;
             if (maxAcceleration > 0 && coneSlope > 0 && coneSlope * Math.Abs (theta) < speed) {
@@ -2008,33 +2010,33 @@ namespace KRPC.SpaceCenter.AutoPilot
         }
 
         /// <summary>
-        /// Rate of change ġ (rad/s²) of one profile sample's commanded magnitude
-        /// g = Speed·Deadband, from the profile's own branch decisions — the planned
+        /// Rate of change g-dot (rad/s^2) of one profile sample's commanded magnitude
+        /// g = Speed*Deadband, from the profile's own branch decisions: the planned
         /// acceleration magnitude of the analytic feedforward. No finite differencing: every
         /// term is an algebraic product of current state with bounded coefficients, so the
         /// measured-rate jitter is never amplified by 1/dt.
         /// </summary>
         /// <remarks>
-        /// d(speed)/dt = (α/speed)·ė with speed = √(2eα), and ė per branch:
+        /// d(speed)/dt = (alpha/speed)*e-dot with speed = sqrt(2ealpha), and e-dot per branch:
         /// <list type="bullet">
-        /// <item>quadratic stopping (bang-bang): on-profile ė = −speed/2, giving the
-        /// self-consistent d(speed)/dt = −α/2. The stopping term sits <em>inside</em> e_stop,
-        /// so the converged trajectory is the half-authority curve ω = √(αθ), not the
-        /// full-authority one — this matches what numerically differentiating the setpoint
+        /// <item>quadratic stopping (bang-bang): on-profile e-dot = -speed/2, giving the
+        /// self-consistent d(speed)/dt = -alpha/2. The stopping term sits <em>inside</em> e_stop,
+        /// so the converged trajectory is the half-authority curve omega = sqrt(alphatheta), not the
+        /// full-authority one, which matches what numerically differentiating the setpoint
         /// measures during a steady brake (~0.5, not 1.0).</item>
-        /// <item>linear stopping (1/bw won the max): ė = −bw·speed²/(bw·speed + α), giving
-        /// d(speed)/dt → −bw·speed as speed → 0 — the PID-lag exponential the linear term
+        /// <item>linear stopping (1/bw won the max): e-dot = -bw*speed^2/(bw*speed + alpha), giving
+        /// d(speed)/dt -> -bw*speed as speed -> 0, the PID-lag exponential the linear term
         /// models.</item>
         /// <item>velocity cap: d(speed)/dt = 0.</item>
-        /// <item>speed cone (c·|e_stop| won the min): d(speed)/dt = c·ė with the constant cone
-        /// slope c, and ė = −speed·bw/(bw+c) (linear stopping) or −speed·α/(α+c·speed)
-        /// (quadratic) — the same self-consistent on-profile forms with d(speed)/de = c
-        /// substituted for α/speed.</item>
+        /// <item>speed cone (c*|e_stop| won the min): d(speed)/dt = c*e-dot with the constant cone
+        /// slope c, and e-dot = -speed*bw/(bw+c) (linear stopping) or -speed*alpha/(alpha+c*speed)
+        /// (quadratic), the same self-consistent on-profile forms with d(speed)/de = c
+        /// substituted for alpha/speed.</item>
         /// </list>
-        /// A slewing target (TargetSmoothingTime) grows e at ≈ the slew rate, added to ė. The
-        /// deadband factor contributes speed·D′·θ̇ on the ramp (D′ = 1/(high−low), constant);
-        /// the pure-error rate θ̇ is passed in by the caller, which knows the direction of θ.
-        /// The branch seams (cap↔brake, quad↔linear) step the value by a bounded amount; the
+        /// A slewing target (TargetSmoothingTime) grows e at about the slew rate, added to e-dot. The
+        /// deadband factor contributes speed*D'*theta-dot on the ramp (D' = 1/(high-low), constant);
+        /// the pure-error rate theta-dot is passed in by the caller, which knows the direction of theta.
+        /// The branch seams (cap and brake, quad and linear) step the value by a bounded amount; the
         /// feedforward low-pass in Update smears those few genuine transitions over ~3 ticks.
         /// </remarks>
         double ProfileMagnitudeRate (ProfileSample s, double thetaDotPure, double slewRateRad,
@@ -2042,30 +2044,31 @@ namespace KRPC.SpaceCenter.AutoPilot
         {
             double speedRate = 0.0;
             if (s.ConeActive && s.Speed > 1e-9) {
-                // Cone branch: the profile slope is the constant c = ConeSlope (not α/speed), so
-                // d(speed)/dt = c·ė. On-profile ė with the stopping correction folded in once
+                // Cone branch: the profile slope is the constant c = ConeSlope (not alpha/speed), so
+                // d(speed)/dt = c*e-dot. On-profile e-dot with the stopping correction folded in once
                 // (same self-consistency convention as the sqrt branches below):
-                //   linear stopping (e = θ − ω/bw):   ė = −speed·bw/(bw + c)
-                //   quadratic stopping (e = θ − ω²/2α): ė = −speed·α/(α + c·speed)
-                // Both bounded, ≤ 0, → −speed in the infinite-authority limit. The sqrt↔cone seam
-                // at e* = 2α/c² steps ġ by ≲ 0.17 of authority — smaller than the cap↔brake seam
-                // below — and is smeared over ~3 ticks by the feedforward low-pass, same treatment.
+                // linear stopping (e = theta - omega/bw): e-dot = -speed*bw/(bw + c)
+                // quadratic stopping (e = theta - omega^2/2alpha): e-dot = -speed*alpha/(alpha + c*speed)
+                // Both bounded, <= 0, and tend to -speed in the infinite-authority limit. The sqrt
+                // and cone seam at e* = 2alpha/c^2 steps g-dot by at most 0.17 of authority, smaller
+                // than the cap and brake seam below, and is smeared over about three ticks by the
+                // feedforward low-pass.
                 var eDotTrack = s.LinearActive
                     ? -s.Speed * s.Bandwidth / (s.Bandwidth + s.ConeSlope)
                     : -s.Speed * s.Alpha / (s.Alpha + s.ConeSlope * s.Speed);
                 speedRate = s.ConeSlope * (eDotTrack * trackingFraction + slewRateRad);
             } else if (!s.CapActive && s.Speed > 1e-9) {
-                // The closed forms below are the ON-PROFILE accelerations — valid only while the
-                // craft is actually tracking the profile down toward the target. Off-profile
-                // (maneuver start: ω ≈ 0, far below the commanded speed) the planned braking is
-                // fiction, and on the linear branch it evaluates to −bw·s/(bw·s+α) ≈ −0.95 of
-                // full authority on a low-α axis — measured in-game fighting the saturated PI to
-                // a ~5%-authority crawl through most of a 20° roll maneuver. Scale the braking
-                // terms by the caller's trackingFraction (attained fraction of the commanded
-                // speed along the command direction, clamped to [0,1]): ~0 at spin-up (the
-                // saturated PI provides the bang-bang acceleration phase; the feedforward stays
-                // a braking-anticipation device), → 1 when tracking, where the closed forms are
-                // exact. Continuous and stateless, so no seam is introduced.
+                // The closed forms below are on-profile accelerations, valid only while the craft
+                // is tracking the profile down toward the target. Off profile, at a maneuver start
+                // where omega is near 0 and far below the commanded speed, the planned braking is
+                // fiction: on the linear branch it evaluates to about -0.95 of full authority on a
+                // low-alpha axis, which fights the saturated PI down to a 5% authority crawl through
+                // most of a 20 degree roll maneuver. Scale the braking terms by the caller's
+                // trackingFraction, the attained fraction of the commanded speed along the command
+                // direction clamped to [0,1]. It is near 0 at spin-up, where the saturated PI
+                // provides the bang-bang acceleration phase and the feedforward stays a
+                // braking-anticipation device, and 1 when tracking, where the closed forms are
+                // exact. Continuous and stateless, so it introduces no seam.
                 var eDotTrack = s.LinearActive
                     ? -(s.Bandwidth * s.Speed * s.Speed) / (s.Bandwidth * s.Speed + s.Alpha)
                     : -0.5 * s.Speed;
@@ -2075,17 +2078,17 @@ namespace KRPC.SpaceCenter.AutoPilot
             if (s.Deadband > 0.0 && s.Deadband < 1.0) {
                 var high = GeometryExtensions.ToRadians (deadbandHighDeg);
                 var low = DeadbandLowFraction * high;
-                // The ramp slope is an on-profile value too: it is the acceleration needed for ω
-                // to follow the collapsing command g = speed·D through the band, meaningful only
-                // while ω is actually tracking the command. Off-profile it is worse than the
-                // braking terms — when a fast crossing flips ŝ (e_stop past the target) the
-                // measured θ̇ is large and ω is ANTI-parallel to the command, so −ŝ·ġ points
-                // along ω, across the target: a full-authority kick per crossing that pumps a
-                // limit cycle on a high-α craft (the residual test_nudge_mid_slew failure after
-                // the overshoot gate, which is 1 for ω∥ ≤ 0 by design and so exempts exactly
-                // this regime). Scale by the tracking fraction like the braking terms: 1 on a
-                // steady in-band brake or slew-track (θ̇ ≈ −ω∥), 0 once ω opposes the command,
-                // handing the recovery to the (well-damped, saturating) PI.
+                // The ramp slope is an on-profile value too: it is the acceleration needed for omega
+                // to follow the collapsing command g = speed*D through the band, meaningful only
+                // while omega is tracking the command. Off profile it is worse than the braking
+                // terms: when a fast crossing flips s-hat, with e_stop past the target, the measured
+                // theta-dot is large and omega is anti-parallel to the command, so -s-hat * g-dot
+                // points along omega and across the target. That is a full-authority kick per
+                // crossing, which pumps a limit cycle on a high-alpha craft. The overshoot gate is 1
+                // for omega-par <= 0 by design, and so exempts exactly this regime. Scale by the
+                // tracking fraction like the braking terms: 1 on a steady in-band brake or slew
+                // track, 0 once omega opposes the command, handing the recovery to the well-damped,
+                // saturating PI.
                 if (high > low)
                     deadbandRate = s.Speed * (1.0 / (high - low)) * thetaDotPure
                         * trackingFraction;
@@ -2095,8 +2098,8 @@ namespace KRPC.SpaceCenter.AutoPilot
 
         /// <summary>
         /// Per-axis analytic feedforward control fractions for the pitch/yaw group from one
-        /// profile sample: FF_i = −ŝ_i·ġ/α_i. The rotation of ŝ itself (ŝ̇·speed) is neglected
-        /// — it matters only in the nudge/orbit regime and near an antipodal flip, and the
+        /// profile sample: FF_i = -s-hat_i * g-dot / alpha_i. The rotation of s-hat itself is neglected
+        /// It matters only in the nudge and orbit regime and near an antipodal flip, and the
         /// deadband caps it near the hold point (validated against the numeric feedforward in
         /// the transition logs; see the redesign design doc).
         /// </summary>
@@ -2111,28 +2114,29 @@ namespace KRPC.SpaceCenter.AutoPilot
             gDotOut = 0.0;
             if (!s.Valid)
                 return;
-            // d|θ|/dt = θ̂·ω in the controller's sign convention (the negated measurement makes
-            // the error shrink along +ω; see ComputeCurrentAngularVelocity), plus slew growth.
+            // d|theta|/dt = theta-hat*omega in the controller's sign convention (the negated measurement makes
+            // the error shrink along +omega; see ComputeCurrentAngularVelocity), plus slew growth.
             var thetaDot = slewRateRad;
             if (s.Theta > 1e-12)
                 thetaDot += (s.ThetaPitch * omegaRi.x + s.ThetaYaw * omegaRi.z) / s.Theta;
-            // Attained fraction of the commanded speed along the command direction −ŝ
+            // Attained fraction of the commanded speed along the command direction -s-hat
             // (see the off-profile note in ProfileMagnitudeRate).
             var omegaAlongCommand = -(s.SPitch * omegaRi.x + s.SYaw * omegaRi.z);
             var tracking = s.Speed > 1e-9
                 ? Math.Min (1.0, Math.Max (0.0, omegaAlongCommand / s.Speed)) : 0.0;
             var gDot = ProfileMagnitudeRate (s, thetaDot, slewRateRad, tracking,
                 PitchYawAttenuationAngle);
-            // Overshoot gate — the on-trajectory-gating lesson of c3522a052 applied to the OTHER
+            // Overshoot gate, the same on-trajectory gating applied to the other
             // side. trackingFraction attenuates the FF when the craft is slower than the profile
-            // (spin-up); this attenuates it when the craft is FASTER (overshoot). When the profile
-            // speed collapses near the target but the craft is still crossing fast, e_stop flips ŝ
+            // at spin-up, and this attenuates it when the craft is faster, an overshoot. When the profile
+            // speed collapses near the target but the craft is still crossing fast, e_stop flips s-hat
             // toward the overshoot side and the whole analytic FF (dominated by the deadband slope
-            // speed·D′·θ̇) then feeds the overshoot forward at near-full authority, pumping a limit
-            // cycle on a high-authority craft. Scaling by speed/ω∥ lets the (stable) PI + setpoint
-            // do the braking instead. ≈1 on-profile (ω∥ ≈ speed) and when moving away (ω∥ ≤ 0), so
-            // normal slews, holds and the floored-hold FF authority are untouched; continuous and
-            // stateless like trackingFraction.
+            // speed*D'*theta-dot) then feeds the overshoot forward at near-full authority, pumping a limit
+            // cycle on a high-authority craft. Scaling by speed/omega-par lets the (stable) PI + setpoint
+            // do the braking instead. It is near 1 on profile, where omega-par is near the speed,
+            // and when moving away, where omega-par <= 0, so normal slews, holds and the
+            // floored-hold feedforward authority are untouched. Continuous and stateless, like
+            // trackingFraction.
             var overshootScale = s.Speed > 1e-9
                 ? Math.Min (1.0, s.Speed / Math.Max (s.Speed, omegaAlongCommand)) : 1.0;
             if (alphaPitch > 0)
@@ -2158,7 +2162,7 @@ namespace KRPC.SpaceCenter.AutoPilot
             var thetaDot = slewRateRad;
             if (s.Theta > 1e-12)
                 thetaDot += Math.Sign (s.ThetaPitch) * omegaRollRi;
-            // Attained fraction of the commanded speed along the command direction −ŝ
+            // Attained fraction of the commanded speed along the command direction -s-hat
             // (see the off-profile note in ProfileMagnitudeRate).
             var omegaAlongCommand = -(s.SPitch * omegaRollRi);
             var tracking = s.Speed > 1e-9
@@ -2167,7 +2171,7 @@ namespace KRPC.SpaceCenter.AutoPilot
                 RollAttenuationAngle);
             // Overshoot gate (see PitchYawAnalyticFf): attenuate the FF when the roll rate along
             // the command exceeds the commanded profile speed, so a fast crossing is not fed
-            // forward into an overshoot. ≈1 on-profile and when moving away.
+            // forward into an overshoot. Near 1 on profile and when moving away.
             var overshootScale = s.Speed > 1e-9
                 ? Math.Min (1.0, s.Speed / Math.Max (s.Speed, omegaAlongCommand)) : 1.0;
             trackingOut = tracking;
@@ -2209,7 +2213,7 @@ namespace KRPC.SpaceCenter.AutoPilot
         /// The proportional gain the velocity profile's linear stopping coefficient is computed
         /// from: the UNFLOORED autotuned gain (recorded by DoAutoTuneAxis before the
         /// bandwidth-floor mitigation), so flooring the loop can never inflate the 1/bw
-        /// coefficient. With auto-tuning off the live pid gain is used — it is never floored
+        /// coefficient. With auto-tuning off the live pid gain is used, and it is never floored
         /// (the floor only applies inside DoAutoTuneAxis).
         /// </summary>
         double ProfileKp (int index, PIDController pid)
@@ -2228,13 +2232,14 @@ namespace KRPC.SpaceCenter.AutoPilot
             unflooredKp [index] = twiceZetaOmega [index] * accelerationInv;
 
             // Latched bandwidth reduction: a latched (flexible) axis has its rate-loop bandwidth
-            // (2ζω₀ = twiceZetaOmega, since Kp·α = 2ζω₀) pulled down toward oscillationBandwidthFloor,
-            // the primary gain-stabiliser — dropping the crossover well below every structural mode so
-            // the loop cannot drive any of them. It only ever lowers bandwidth (min against the
-            // autotuned value). It is gated on the hold-gated mitigationLevel (latch · holdFactor), so
-            // the axis is floored only while *holding* and runs at full bandwidth while *slewing* —
-            // the notch/low-pass keeps the slew responsive, while the floor quiets the hold. ω₀ scales
-            // with the bandwidth, so Kp scales linearly and Ki quadratically and the damping ratio ζ
+            // 2 * zeta * omega0 = twiceZetaOmega, since Kp * alpha = 2 * zeta * omega0, pulled down
+            // toward oscillationBandwidthFloor, the primary gain stabilizer, dropping the crossover
+            // well below every structural mode so the loop cannot drive any of them. It only ever
+            // lowers bandwidth, taking the minimum against the autotuned value. It is gated on the
+            // hold-gated mitigationLevel, latch * holdFactor, so the axis is floored only while
+            // holding and runs at full bandwidth while slewing: the notch and low-pass keep the slew
+            // responsive, and the floor quiets the hold. omega0 scales
+            // with the bandwidth, so Kp scales linearly and Ki quadratically and the damping ratio zeta
             // (the overshoot target) is preserved. A rigid craft never latches, so keeps full bandwidth.
             // The bandwidth-floor mitigation mode: Automatic follows the hold-gated mitigation
             // level; Off never floors; Forced floors fully regardless of the detector.

--- a/service/SpaceCenter/src/AutoPilot/DiagnosticLogBuffer.cs
+++ b/service/SpaceCenter/src/AutoPilot/DiagnosticLogBuffer.cs
@@ -7,7 +7,7 @@ namespace KRPC.SpaceCenter.AutoPilot
     /// <summary>
     /// The attitude controller's diagnostic log: CSV, one data row per physics tick, first row a
     /// header naming every column. Vector-valued channels occupy one column per component,
-    /// suffixed <c>.p/.r/.y</c> (pitch, roll, yaw — the controller's x, y, z axes); axis-group
+    /// suffixed <c>.p/.r/.y</c> (pitch, roll, yaw, the controller's x, y and z axes). Axis-group
     /// channels (pitch/yaw coupled, roll separate) are suffixed <c>.py/.roll</c>. Values use the
     /// invariant culture so the output is valid CSV regardless of the OS locale.
     ///
@@ -88,7 +88,7 @@ namespace KRPC.SpaceCenter.AutoPilot
         }
 
         /// <summary>
-        /// One column per component, named <c>name.p/.r/.y</c> (pitch, roll, yaw — the
+        /// One column per component, named <c>name.p/.r/.y</c> (pitch, roll, yaw, the
         /// vector's x, y, z components in the controller's axis convention).
         /// </summary>
         public void AddVector (string name, Vector3d value, string format)

--- a/service/SpaceCenter/src/AutoPilot/MitigationPolicy.cs
+++ b/service/SpaceCenter/src/AutoPilot/MitigationPolicy.cs
@@ -5,7 +5,7 @@ namespace KRPC.SpaceCenter.AutoPilot
 {
     /// <summary>
     /// The gating layer of the flexible-craft handling: maps the detector signals
-    /// (<see cref="OscillationDetectors"/>) to per-tick mitigation decisions — which rate-filter
+    /// (<see cref="OscillationDetectors"/>) to per-tick mitigation decisions: which rate-filter
     /// tool runs at what frequency, how strongly each mitigation is engaged (the eased latch
     /// ramp and the hold-gated mitigation level), and the output-filter corner/weight choice.
     /// All the routing thresholds and gating time constants live here; the mitigation
@@ -15,12 +15,11 @@ namespace KRPC.SpaceCenter.AutoPilot
     /// </summary>
     sealed class MitigationPolicy
     {
-        // Routing threshold (Hz): a detected mode below this is well-conditioned for a notch
-        // (K = tan(π·f·dt) < 1 up to 12.5 Hz at 50 Hz physics) and close enough to the band that
-        // a low-pass would add too much crossover phase lag; above it the notch degrades toward
-        // the Nyquist singularity and the low-pass is the right tool. Set to 12 Hz on measured
-        // data: the stock flexible test craft sit at ~2.5–8.5 Hz (notch) with only near-Nyquist
-        // roll modes (~21–25 Hz) on the low-pass.
+        // Routing threshold (Hz). A detected mode below this is well conditioned for a notch,
+        // where K = tan(pi * f * dt) < 1 up to 12.5 Hz at 50 Hz physics, and close enough to the
+        // band that a low-pass would add too much crossover phase lag. Above it the notch
+        // degrades toward the Nyquist singularity and the low-pass is the right tool. The stock
+        // flexible craft sit around 2.5 to 8.5 Hz, with only near-Nyquist roll modes above.
         internal const double SplitFrequency = 12.0;
         // Low-pass corner separation: the high-frequency-branch corner is f_detected / L_lp,
         // clamped to LowPassCornerMin (Hz) so it never drifts down into the sub-Hz control band.
@@ -28,25 +27,25 @@ namespace KRPC.SpaceCenter.AutoPilot
         internal const double LowPassCornerMin = 2.0;
         // Time constant of the one-pole ramp easing the latched mitigations in/out.
         const double RampTimeConstant = 0.5;
-        // Control-output oscillation envelope (the runtime analogue of the test suite's
-        // control_oscillation_amplitude) above which a latched axis is treated as still
-        // limit-cycling, so the hold mitigation engages regardless of pointing error. A settled
-        // hold sits near 0.008 and a limit cycle saturates toward ~1, so 0.2 has wide margin.
+        // Control-output oscillation envelope, the runtime analog of the test suite's
+        // control_oscillation_amplitude, above which a latched axis is treated as still
+        // limit-cycling, so the hold mitigation engages whatever the pointing error. A settled
+        // hold sits near 0.008 and a limit cycle saturates toward 1.
         internal const double EnvelopeThreshold = 0.2;
 
-        // Per-axis one-pole ramp [0,1] easing the latched mitigations in/out so the control does
-        // not step when suppression engages/releases.
+        // Per-axis one-pole ramp [0,1] easing the latched mitigations in and out, so the control
+        // does not step when suppression engages or releases.
         readonly double[] suppressionRamp = new double[3];
         // Automatic (envelope-driven) component of the oscillation-control back-off: the
         // per-axis ramp that rises while a latched axis limit-cycles and decays slowly when
         // quiet. The manual override level is a floor under it.
         readonly double[] oscControlAuto = new double[3];
         readonly double[] oscControlBackoff = new double[3];
-        // Per-axis hold-gated mitigation weight (suppressionRamp · max(holdFactor, backoff)):
-        // how fully the latched hold mitigation (bandwidth floor + feedforward cut + nominal
-        // target) is engaged. The floor follows this, not suppressionRamp, so a latched axis
-        // runs at full bandwidth while slewing and is floored only while holding (or while the
-        // back-off reports a limit cycle).
+        // Per-axis hold-gated mitigation weight, suppressionRamp * max(holdFactor, backoff):
+        // the degree to which the latched hold mitigation (bandwidth floor, feedforward cut and
+        // nominal target) is engaged. The floor follows this and not suppressionRamp, so a
+        // latched axis runs at full bandwidth while slewing and is floored only while holding, or
+        // while the back-off reports a limit cycle.
         readonly double[] mitigationLevel = new double[3];
 
         public double SuppressionRamp (int index)
@@ -79,8 +78,8 @@ namespace KRPC.SpaceCenter.AutoPilot
         /// (none), 1 (notch) or 2 (low-pass). In <c>Automatic</c> mode suppression is active
         /// only while the group is latched, and is routed by the estimated frequency (notch
         /// below <see cref="SplitFrequency"/>, low-pass above), with a frequency-independent
-        /// broadband low-pass fallback while the estimator has not locked — the estimator is
-        /// unreliable on some craft, so this fallback (plus the gain-stabilising bandwidth
+        /// broadband low-pass fallback while the estimator has not locked. The estimator is
+        /// unreliable on some craft, so this fallback (plus the gain-stabilizing bandwidth
         /// floor) is what makes suppression robust without a confident estimate.
         /// <c>Notch</c>/<c>LowPass</c> force that tool at the manual frequency; <c>Off</c>
         /// applies nothing.
@@ -118,7 +117,7 @@ namespace KRPC.SpaceCenter.AutoPilot
 
         /// <summary>
         /// Ease the latched mitigations in/out per axis, gated on the rate filter's
-        /// suppression-active record — the persistent latch, not the decaying chatter level —
+        /// suppression-active record, the persistent latch and not the decaying chatter level,
         /// so they hold for as long as the craft is treated as flexible and do not step at
         /// engage.
         /// </summary>
@@ -131,13 +130,13 @@ namespace KRPC.SpaceCenter.AutoPilot
         }
 
         /// <summary>
-        /// Compute the per-axis hold-gated mitigation level (the "gate"): suppressionRamp ·
+        /// Compute the per-axis hold-gated mitigation level (the "gate"): suppressionRamp *
         /// max(holdFactor, oscillation-control back-off). The back-off is the hold gate's
-        /// blind-spot closure: a manoeuvre that pushes the pointing error above the hold band
+        /// blind-spot closure: a maneuver that pushes the pointing error above the hold band
         /// would release the mitigation, which on a flexible craft can re-excite the bending
         /// mode into a limit cycle that parks the error across the band. The trigger is the
-        /// detectors' about-mean delivered-command envelope — a sustained limit cycle has a
-        /// large envelope while a steady slew does not — rising fast / decaying slow, only on a
+        /// detectors' about-mean delivered-command envelope: a sustained limit cycle has a
+        /// large envelope where a steady slew does not. It rises fast and decays slow, only on a
         /// latched axis. Pitch (x) and yaw (z) are coupled (mirroring the chatter detector) and
         /// use <paramref name="pitchYawHold"/>; roll (y) is on its own and uses
         /// <paramref name="rollHold"/>, which its caller keys on the roll error as well as the
@@ -172,7 +171,7 @@ namespace KRPC.SpaceCenter.AutoPilot
         /// The output-filter decision for one axis: a latched axis uses the ramped suppression
         /// weight at the heavier corner (the flexible-craft path); an unlatched axis whose
         /// detector is firing blends by chatterLevel at the lighter corner (smoothing the
-        /// delivered command without the phase cost of the heavy corner destabilising the
+        /// delivered command without the phase cost of the heavy corner destabilizing the
         /// full-bandwidth loop); a rigid axis gets weight 0 and passes through.
         /// </summary>
         public void ChooseOutputFilter (OscillationDetectors detectors, int index,

--- a/service/SpaceCenter/src/AutoPilot/OscillationDetectors.cs
+++ b/service/SpaceCenter/src/AutoPilot/OscillationDetectors.cs
@@ -24,33 +24,33 @@ namespace KRPC.SpaceCenter.AutoPilot
         // but well above any transient a rigid craft produces.
         internal const double ChatterLatchThreshold = 0.6;
         // Time constant of the slow mean subtracted from the raw rate to high-pass it for the
-        // frequency trackers (~0.5 Hz corner): well below the structural modes (≥1 Hz) so they
+        // frequency trackers (~0.5 Hz corner): well below the structural modes (>=1 Hz) so they
         // pass, but high enough to remove DC and slew trends.
         const double FrequencyHighpassTimeConstant = 0.3;
-        // Time constant of the slow per-axis envelope of |high-passed ω| used to pick the
+        // Time constant of the slow per-axis envelope of |high-passed omega| used to pick the
         // stronger transverse axis for the pitch/yaw group estimate.
         const double AbsHighpassEnvelopeTimeConstant = 0.5;
         // Time constant of the slow "trim" mean subtracted from the delivered command to form
         // the about-mean envelope: long enough to track a steady slew (so a one-sign ramp is not
         // counted as oscillation) yet shorter than the limit-cycle period (~0.7 s).
         const double OscControlMeanTimeConstant = 0.5;
-        // Time constant smoothing the |command − trim| envelope (a few cycles).
+        // Time constant smoothing the |command - trim| envelope (a few cycles).
         const double OscControlEnvelopeTimeConstant = 0.3;
         // Pointing-error band (degrees) for the continuous hold factor: 1 while holding
-        // (error ≤ HoldErrorFull), 0 while slewing (≥ HoldErrorNone), linear between.
+        // (error <= HoldErrorFull), 0 while slewing (>= HoldErrorNone), linear between.
         const double HoldErrorFull = 1.0;
         const double HoldErrorNone = 2.5;
 
         // Chatter-detector state. chatterLevel is a per-axis [0,1] measure of how strongly an
         // axis is in a structural limit cycle; chatterLatched is the per-engagement memory that
         // "this craft is flexible" (cleared only in Reset; the level persists across
-        // re-engagements, decaying at τ = 30 s).
+        // re-engagements, decaying at tau = 30 s).
         Vector3d prevDetectorOmega;
         bool prevDetectorOmegaValid;
         Vector3d chatterLevel = Vector3d.zero;
         readonly bool[] chatterLatched = new bool[3];
-        // Per-axis trigger margin of the last chatter sample: |Δω| / (threshold·α·dt), the
-        // ratio the detector fires on (≥ 1 counts as excitation). Recorded for the diagnostic
+        // Per-axis trigger margin of the last chatter sample: |deltaomega| / (threshold*alpha*dt), the
+        // ratio the detector fires on (>= 1 counts as excitation). Recorded for the diagnostic
         // log so how close each tick came to firing is visible, not just the smoothed level.
         Vector3d chatterMargin = Vector3d.zero;
         // Online frequency estimators, fed the high-passed rate every tick, and the sticky held
@@ -60,7 +60,7 @@ namespace KRPC.SpaceCenter.AutoPilot
         readonly FrequencyTracker rollFreqTracker = new FrequencyTracker ();
         double pitchYawHeldHz = double.NaN;
         double rollHeldHz = double.NaN;
-        // High-pass bookkeeping for the trackers (slow mean of ω, envelope of |high-passed ω|).
+        // High-pass bookkeeping for the trackers (slow mean of omega, envelope of |high-passed omega|).
         Vector3d emaOmega;
         bool emaOmegaValid;
         Vector3d emaAbsHp = Vector3d.zero;
@@ -103,7 +103,7 @@ namespace KRPC.SpaceCenter.AutoPilot
         }
 
         // The trackers' live estimates (NaN whenever the mode is not currently acquired) and
-        // acquisition progress, alongside the sticky held values above — for the diagnostic
+        // acquisition progress, alongside the sticky held values above, for the diagnostic
         // log, so acquisition/loss dynamics are visible.
         public double PitchYawLiveHz {
             get { return pitchYawFreqTracker.EstimatedHz; }
@@ -126,8 +126,8 @@ namespace KRPC.SpaceCenter.AutoPilot
         }
 
         /// <summary>
-        /// Reset per-engagement state. chatterLevel is deliberately NOT reset — the level
-        /// persists across re-engagements (decaying at τ = 30 s); only the latch is
+        /// Reset per-engagement state. chatterLevel is deliberately kept, as the level
+        /// persists across re-engagements (decaying at tau = 30 s); only the latch is
         /// per-engagement. A full reset clears the level too, via
         /// <see cref="ResetChatterLevel"/>.
         /// </summary>
@@ -154,12 +154,12 @@ namespace KRPC.SpaceCenter.AutoPilot
         /// <remarks>
         /// The signature of a bending-mode limit cycle is the measured rate (sampled at the root
         /// part) changing tick-to-tick by more than the available torque could physically
-        /// produce: rigid-body motion is bounded by <c>α·dt</c> at full authority, so a jump
+        /// produce: rigid-body motion is bounded by <c>alpha*dt</c> at full authority, so a jump
         /// several times larger is structural oscillation, not a response to the controller.
         /// Gain-independent and maneuver-independent. The level rises quickly and decays slowly;
         /// crossing <see cref="ChatterLatchThreshold"/> latches the axis as flexible for the
         /// engagement. A heavy, low-authority craft *can* latch on benign measurement jitter
-        /// (the bound k·α·dt is authority-relative) and no measured signal separates that from a
+        /// (the bound k*alpha*dt is authority-relative) and no measured signal separates that from a
         /// genuine bending mode (see the latch-discrimination design doc), so the latch is
         /// deliberately permissive and the latched mitigation itself is required to be benign on
         /// a craft that did not need it. Pitch (0) and yaw (2) latch together: a long vehicle's
@@ -194,7 +194,7 @@ namespace KRPC.SpaceCenter.AutoPilot
         /// <summary>
         /// Clear the persistent chatter level, on top of what <see cref="Reset"/> clears. Kept
         /// out of Reset so the level survives re-engagements (a craft known to be flexible
-        /// re-latches quickly); called only by the full controller reset — the user-facing
+        /// re-latches quickly). Called only by the full controller reset, the user-facing
         /// return to initial conditions.
         /// </summary>
         public void ResetChatterLevel ()
@@ -214,10 +214,10 @@ namespace KRPC.SpaceCenter.AutoPilot
         }
 
         /// <summary>
-        /// Feed the frequency trackers the oscillation in the raw rate — unconditionally, so an
+        /// Feed the frequency trackers the oscillation in the raw rate, unconditionally, so an
         /// estimate is always warm the moment an axis latches. The rate is high-passed (slow
         /// mean subtracted) so the trackers see the structural oscillation without DC or slew
-        /// trends, and without the high-frequency bias a raw Δω (derivative) would impose. The
+        /// trends, and without the high-frequency bias a raw deltaomega (derivative) would impose. The
         /// pitch/yaw tracker is fed whichever transverse axis currently carries more oscillation
         /// (larger envelope, the lateral mode being ~axisymmetric); roll is fed directly. The
         /// held estimates latch the last acquired value.
@@ -249,8 +249,8 @@ namespace KRPC.SpaceCenter.AutoPilot
         }
 
         /// <summary>
-        /// Continuous hold factor: 1 while holding (pointing error ≤ HoldErrorFull), 0 while
-        /// slewing (≥ HoldErrorNone), linear between. A smooth function of error — no
+        /// Continuous hold factor: 1 while holding, at or below HoldErrorFull, and 0 while
+        /// slewing, at or above HoldErrorNone, linear between. A smooth function of error, with no
         /// hysteresis state machine.
         /// </summary>
         public static double HoldFactor (double pointingErrorDeg)

--- a/service/SpaceCenter/src/AutoPilot/OscillationFilters.cs
+++ b/service/SpaceCenter/src/AutoPilot/OscillationFilters.cs
@@ -6,13 +6,13 @@ namespace KRPC.SpaceCenter.AutoPilot
     /// A second-order (biquad) notch filter, implemented with bilinear-transform coefficients and
     /// a Direct Form II Transposed state. Used by <see cref="AttitudeController"/> to reject a
     /// low-frequency structural bending mode from the measured angular velocity while staying
-    /// transparent everywhere outside its narrow rejection band — so it can sit permanently on a
+    /// transparent everywhere outside its narrow rejection band, so it can sit permanently on a
     /// latched axis without smearing the sub-Hz control band the way a broadband low-pass would.
     /// </summary>
     /// <remarks>
-    /// The notch has unity gain at DC and at the Nyquist frequency and zero gain at f₀; Q controls
+    /// The notch has unity gain at DC and at the Nyquist frequency and zero gain at f0; Q controls
     /// the width (higher Q is narrower: less in-band phase lag but less tolerance to frequency
-    /// drift). Because the coefficient <c>K = tan(π·f₀·dt)</c> diverges as f₀ approaches Nyquist and
+    /// drift). Because the coefficient <c>K = tan(pi*f0*dt)</c> diverges as f0 approaches Nyquist and
     /// the filter has unity gain at Nyquist by construction, a notch cannot reject a near-Nyquist
     /// mode; the controller routes those to a low-pass instead.
     /// </remarks>
@@ -43,7 +43,7 @@ namespace KRPC.SpaceCenter.AutoPilot
         }
 
         /// <summary>
-        /// Compute the biquad coefficients for the given centre frequency, quality factor and
+        /// Compute the biquad coefficients for the given center frequency, quality factor and
         /// sampling period. Does not touch the running state, so a live filter can be retuned to
         /// track a slowly drifting mode without a reset (only the coefficients change).
         /// </summary>
@@ -71,7 +71,7 @@ namespace KRPC.SpaceCenter.AutoPilot
         {
             if (!seeded) {
                 // Steady state for a constant input x (notch has unity DC gain): s1 = 0 since
-                // b1 == a1, and s2 = (b2 - a2)·x.
+                // b1 == a1, and s2 = (b2 - a2)*x.
                 s1 = 0;
                 s2 = (b2 - a2) * x;
                 seeded = true;
@@ -93,12 +93,12 @@ namespace KRPC.SpaceCenter.AutoPilot
 
     /// <summary>
     /// Online estimator of a structural oscillation frequency, tracked from the interval between
-    /// sign changes of the tick-to-tick rate change (Δω). One instance per axis group (pitch/yaw,
-    /// roll). It is fed every physics tick regardless of whether suppression is engaged — it costs
-    /// only a handful of adds — so an estimate is always warm the moment an axis is deemed flexible.
+    /// sign changes of the tick-to-tick rate change (deltaomega). One instance per axis group (pitch/yaw,
+    /// roll). It is fed every physics tick whether or not suppression is engaged, at a cost of a
+    /// handful of adds, so an estimate is always warm the moment an axis is deemed flexible.
     /// </summary>
     /// <remarks>
-    /// Δω changes sign at each extremum of ω — twice per oscillation cycle — so the interval between
+    /// deltaomega changes sign at each extremum of omega, twice per oscillation cycle, so the interval between
     /// accepted sign flips is a *half* period and the full period is twice that. A hysteresis
     /// deadband on the zero crossing rejects jitter around an extremum; a plausibility gate rejects
     /// slew transients (too slow) and single-tick noise (too fast); and the estimate stays NaN until
@@ -106,16 +106,16 @@ namespace KRPC.SpaceCenter.AutoPilot
     /// </remarks>
     sealed class FrequencyTracker
     {
-        // Deadband as a fraction of the smoothed |Δω| (κ): a crossing must exceed this to count.
+        // Deadband as a fraction of the smoothed |deltaomega| (kappa): a crossing must exceed this to count.
         const double DeadbandFactor = 0.25;
-        // EMA time constant for the smoothed |Δω| that sets the deadband, and for the period.
+        // EMA time constant for the smoothed |deltaomega| that sets the deadband, and for the period.
         const double AbsDeltaTimeConstant = 0.5;
         const double PeriodTimeConstant = 0.5;
         // Plausibility gate (Hz). f_min rejects slew transients (too slow). The upper bound is
         // Nyquist (0.5/dt, = 25 Hz at 50 Hz physics), computed per tick from dt: a near-Nyquist
         // structural mode (e.g. the every-other-tick ~25 Hz chatter of a craft with tip-mounted
-        // actuators) alternates Δω every tick, giving a one-tick half-period at exactly Nyquist, so
-        // the cap must include it — it is then acquired and routed to the low-pass branch. Single-
+        // actuators) alternates deltaomega every tick, giving a one-tick half-period at exactly Nyquist, so
+        // the cap must include it, and it is then acquired and routed to the low-pass branch. Single-
         // tick noise also reads at Nyquist but is rejected by the AcquireCount agreement gate.
         const double MinFrequency = 0.5;
         // Consecutive accepted half-periods that must agree (within AgreeTolerance) before the
@@ -160,7 +160,7 @@ namespace KRPC.SpaceCenter.AutoPilot
         }
 
         /// <summary>
-        /// Feed one tick's Δω (the raw, pre-suppression rate change on the tracked axis).
+        /// Feed one tick's deltaomega (the raw, pre-suppression rate change on the tracked axis).
         /// </summary>
         public void Update (double delta, double dt)
         {

--- a/service/SpaceCenter/src/AutoPilot/OscillationMitigations.cs
+++ b/service/SpaceCenter/src/AutoPilot/OscillationMitigations.cs
@@ -6,8 +6,8 @@ namespace KRPC.SpaceCenter.AutoPilot
     /// The rate-feedback mitigation primitive: per-axis filtering of the measured angular
     /// velocity. Two independent stages, both owned here so a regime change never injects a
     /// state transient:
-    /// a heavy stage — notch(f, Q) or two cascaded first-order low-passes or pass-through,
-    /// selected per tick by the mitigation policy (the latched flexible-craft suppression) —
+    /// a heavy stage, notch(f, Q) or two cascaded first-order low-passes or pass-through,
+    /// selected per tick by the mitigation policy (the latched flexible-craft suppression),
     /// and a light one-pole stage blended in by a [0,1] weight (the detector-firing-but-
     /// unlatched measured-rate low-pass). Which stage runs, at what configuration and weight,
     /// is entirely the policy's decision; this class only owns the filter state and arithmetic.
@@ -16,7 +16,7 @@ namespace KRPC.SpaceCenter.AutoPilot
     {
         // Time constant of the light input stage (~5 Hz corner): stops the full-bandwidth inner
         // loop (and the stopping term) chasing root-part rate jitter on an unlatched noisy
-        // craft. It sits inside the loop, so its phase counts: ~16° at the ~1.4 Hz crossover.
+        // craft. It sits inside the loop, so its phase counts: ~16 degrees at the ~1.4 Hz crossover.
         internal const double DetectorInputTimeConstant = 0.03;
 
         // Heavy stage: one notch per axis and the 2-stage low-pass state. The low-pass state is
@@ -130,8 +130,8 @@ namespace KRPC.SpaceCenter.AutoPilot
 
     /// <summary>
     /// The output-smoothing mitigation primitive: a per-axis first-order low-pass on the final
-    /// actuator command, blended in by a [0,1] weight. Caps residual control chatter directly —
-    /// gain-independent and needing no frequency estimate — backstopping the rate filtering,
+    /// actuator command, blended in by a [0,1] weight. Caps residual control chatter directly,
+    /// gain-independent and needing no frequency estimate, backstopping the rate filtering,
     /// which cleans the feedback but not whatever the loop's own gain still produces at the
     /// mode. The corner and weight are the policy's per-tick decision (latched axes use the
     /// heavier corner at the suppression-ramp weight; detector-firing unlatched axes the lighter
@@ -143,8 +143,8 @@ namespace KRPC.SpaceCenter.AutoPilot
         // cost at the floored (~0.16 Hz) crossover.
         internal const double LatchedTimeConstant = 0.08;
         // Corner for a detector-firing but unlatched axis (~4.5 Hz): the loop still runs at full
-        // bandwidth there, so the latched corner would cost ~36° of phase margin and risk
-        // oscillation; ~4.5 Hz costs only ~16° while attenuating near-Nyquist buzz ~5×.
+        // bandwidth there, so the latched corner would cost ~36 degrees of phase margin and risk
+        // oscillation; ~4.5 Hz costs only ~16 degrees while attenuating near-Nyquist buzz ~5 x .
         internal const double DetectorTimeConstant = 0.035;
 
         readonly double[] state = new double[3];

--- a/service/SpaceCenter/src/AutoPilot/PIDController.cs
+++ b/service/SpaceCenter/src/AutoPilot/PIDController.cs
@@ -23,7 +23,7 @@ namespace KRPC.SpaceCenter.AutoPilot
 
         /// <summary>
         /// The accumulated integral term (already scaled by Ki, clamped to the output range).
-        /// Read-only observability for the diagnostic log — windup and integral creep are
+        /// Read-only observability for the diagnostic log. Windup and integral creep are
         /// otherwise invisible from outside.
         /// </summary>
         public double IntegralTerm {

--- a/service/SpaceCenter/src/AutoPilotInfoWindow.cs
+++ b/service/SpaceCenter/src/AutoPilotInfoWindow.cs
@@ -15,14 +15,14 @@ namespace KRPC.SpaceCenter
     /// </summary>
     public class AutoPilotInfoWindow : Window
     {
-        // Panel colours, matched to the stock navball's speed display: the register text and the
-        // ENGAGED lamp use the navball's readout green, amber is the caution colour.
+        // Panel colors, matched to the stock navball's speed display: the register text and the
+        // ENGAGED lamp use the navball's readout green, amber is the caution color.
         static readonly Color green = new Color (0.00f, 1.00f, 0.00f);
         static readonly Color amber = new Color (1.00f, 0.72f, 0.10f);
-        // Background of the digital registers, and the unlit lamp colour, so an off lamp matches a
-        // register cell — the dark grey behind the navball's speed text (#3A3A3F).
+        // Background of the digital registers, and the unlit lamp color, so an off lamp matches
+        // a register cell: the dark gray behind the navball's speed text (#3A3A3F).
         static readonly Color registerBackground = new Color (0.227f, 0.227f, 0.247f);
-        // Text colour of an unlit status lamp (and of a data lamp that is not live): faint grey
+        // Text color of an unlit status lamp (and of a data lamp that is not live): faint gray
         // "engraved" text on the dark lamp background.
         static readonly Color engravedGrey = new Color (0.55f, 0.55f, 0.55f);
 
@@ -40,21 +40,19 @@ namespace KRPC.SpaceCenter
         Font monoFont;
 
         // Description of the row currently under the mouse (or null), and that row's rect, which
-        // the tooltip is anchored to — a row's tooltip always appears in the same place, rather
-        // than following the mouse around. Captured by RowTooltip as the rows are drawn each
-        // Repaint pass and rendered by DrawTooltip at the end of the pass, so the tooltip box
-        // draws on top of the panel.
+        // the tooltip is anchored to, so a row's tooltip always appears in the same place.
+        // Captured by RowTooltip as the rows are drawn each Repaint pass and rendered by
+        // DrawTooltip at the end of the pass, so the tooltip box draws on top of the panel.
         string activeTooltip;
         Rect activeTooltipRow;
 
-        // The panel body is a grid of 4 equal-width columns filling the window: every cell is
+        // The panel body is a grid of 4 equal-width columns filling the window. Every cell is
         // fixed to a whole number of columns (spanOptions [n] sizes an n-column cell), so cells
-        // line up vertically across rows regardless of how many cells each row has — a per-axis
-        // row is label + 3 values, a PCH/YAW+RLL group row is label + a 2-column cell + 1, the
-        // engagement lamp spans all 4. Fixed widths (rather than stretch weights) are needed
-        // because IMGUI distributes surplus width in proportion to each cell's content-derived
-        // size, which would let wider text steal width and break the vertical alignment.
-        // Rebuilt by ComputeGrid on rescale.
+        // line up vertically across rows however many cells each row has: a per-axis row is
+        // label + 3 values, a PCH/YAW+RLL group row is label + a 2-column cell + 1, and the
+        // engagement lamp spans all 4. The widths are fixed because IMGUI distributes surplus
+        // width in proportion to each cell's content-derived size, which would let wider text
+        // steal width and break the vertical alignment. Rebuilt by ComputeGrid on rescale.
         GUILayoutOption[][] spanOptions;
 
         // The horizontal gap IMGUI leaves between adjacent cells and at the row edges: the cells'
@@ -70,7 +68,7 @@ namespace KRPC.SpaceCenter
             return texture;
         }
 
-        // A 3×3 texture with a 1px border colour around a fill colour. Drawn with a style whose
+        // A 3x3 texture with a 1px border color around a fill color. Drawn with a style whose
         // border is 1px, the edge pixels become a crisp 1px outline at any box size (point
         // filtering stops the border bleeding into the fill when stretched).
         static Texture2D BorderedTexture (Color border, Color fill)
@@ -93,8 +91,8 @@ namespace KRPC.SpaceCenter
 
             lampTexture = FlatTexture (Color.white);
             registerTexture = FlatTexture (registerBackground);
-            // Darker than the registers so the floating tooltip reads as a layer above them, with
-            // a grey outline to separate it from whatever it happens to overlap.
+            // Darker than the registers so the floating tooltip reads as a layer above them,
+            // with a gray outline to separate it from whatever it overlaps.
             tooltipTexture = BorderedTexture (new Color (0.55f, 0.55f, 0.55f), new Color (0.10f, 0.10f, 0.12f));
 
             lampStyle = new GUIStyle (skin.box) {
@@ -114,11 +112,11 @@ namespace KRPC.SpaceCenter
                 stretchWidth = true
             };
             registerStyle.normal.background = registerTexture;
-            // Registers carry data, not status, so they read in plain white — status is the
-            // lamps' job.
+            // Registers carry data, and the lamps carry status, so the registers read in plain
+            // white.
             registerStyle.normal.textColor = Color.white;
 
-            // Centre-aligned register, for cells whose content reads better centred than
+            // Center-aligned register, for cells whose content reads better centered than
             // right-aligned (the resolved tool name, the percentage readouts).
             registerCenterStyle = new GUIStyle (registerStyle) {
                 alignment = TextAnchor.MiddleCenter
@@ -169,10 +167,10 @@ namespace KRPC.SpaceCenter
 
             ComputeGrid ();
 
-            // Use a fixed-width (monospace) font across the whole panel so the digital readouts and
-            // columns line up. Several common OS monospace fonts are listed so it resolves on both
-            // Windows and Linux. The title bar is unaffected: it is drawn with the window Style, which
-            // keeps the stock font.
+            // Use a fixed-width (monospace) font across the whole panel so the digital readouts
+            // and columns line up. Several common OS monospace fonts are listed so it resolves on
+            // both Windows and Linux. The title bar is unaffected: it is drawn with the window
+            // Style, which keeps the stock font.
             monoFont = Font.CreateDynamicFontFromOSFont (
                 new[] { "Consolas", "Courier New", "DejaVu Sans Mono", "Liberation Mono", "monospace" },
                 (int) (BodyFontSize * GameSettings.UI_SCALE));
@@ -183,10 +181,10 @@ namespace KRPC.SpaceCenter
             ApplyFontSizes (GameSettings.UI_SCALE);
         }
 
-        // Recomputes the 4-column grid from the window's current fixed width: the column width is
-        // what makes 4 columns, the 3 gaps between them and the 2 edge gaps exactly fill the
-        // window's content area. The row-label style is pinned to one column so plain
-        // registerLabelStyle labels land on the grid too.
+        // Recomputes the 4-column grid from the window's current fixed width. The column width
+        // makes 4 columns, the 3 gaps between them and the 2 edge gaps exactly fill the window's
+        // content area. The row-label style is pinned to one column so plain registerLabelStyle
+        // labels land on the grid too.
         void ComputeGrid ()
         {
             float contentWidth = Style.fixedWidth - Style.padding.left - Style.padding.right;
@@ -243,12 +241,11 @@ namespace KRPC.SpaceCenter
             GUILayout.EndHorizontal ();
             RowTooltip ("Auto-pilot engagement. HELD: engaged but held inert on the launch clamps.");
 
-            // Target: axis column headers, then the current target (CURRENT, what the auto-pilot
-            // is tracking right now) and below it the commanded target (COMMAND, what was
-            // requested). COMMAND is shown only while smoothing is active (TargetSmoothingTime
-            // > 0); without smoothing CURRENT always equals the command, so the whole COMMAND
-            // row is blanked. RLL is blank when no
-            // specific roll is held. Values carry a degree symbol, so the section needs no unit label.
+            // Target: axis column headers, then the target the auto-pilot is tracking right now
+            // (CURRENT) and below it the commanded target (COMMAND). COMMAND is shown only while
+            // smoothing is active (TargetSmoothingTime > 0), as CURRENT always equals the command
+            // without it. RLL is blank when no specific roll is held. Values carry a degree
+            // symbol, so the section needs no unit label.
             bool showCmd = engaged && ap.TargetSmoothingTime > 0;
             Header ("TARGET", null);
             AxisColumnHeader ("PCH", "HDG", "RLL");
@@ -267,10 +264,10 @@ namespace KRPC.SpaceCenter
             GUILayout.EndHorizontal ();
             RowTooltip ("Commanded (requested) target; shown while target smoothing is still slewing CURRENT toward it.");
 
-            // Attitude error: the four axis column headers on one row, error lamps on the next, each
-            // dim within the AutoPilot.Wait() stopping angle threshold and amber outside it. These
-            // are errors to the CURRENT (tracked) target, not the commanded one, so they stay small
-            // while a smoothed change is being slewed in (the craft is tracking CURRENT, not COMMAND).
+            // Attitude error: the four axis column headers on one row, error lamps on the next,
+            // each dim within the AutoPilot.Wait() stopping angle threshold and amber outside it.
+            // These are errors to the CURRENT (tracked) target, so they stay small while a
+            // smoothed change is being slewed in.
             Header ("ATTITUDE ERROR", null);
             GUILayout.BeginHorizontal ();
             ColumnHead ("TOT");
@@ -312,13 +309,12 @@ namespace KRPC.SpaceCenter
             GUILayout.EndHorizontal ();
             RowTooltip ("Inner rate-loop integral gain (set by the autotuner each tick when auto-tune is on).");
 
-            // Oscillation handling, mirroring the controller's detector → gates → mitigations
-            // structure. DETECTOR: what the runtime observes (per-axis structural level, the
-            // post-floor loop bandwidth, the estimated mode frequency and the control-output
-            // envelope). GATES: the [0,1] weights that decide how strongly the mitigations
-            // engage. MITIGATIONS: one combined mode+engagement lamp per individually
-            // controllable mitigation — dim whenever the mitigation is not acting (manually Off
-            // or automatically idle), amber when engaged.
+            // Oscillation handling, mirroring the controller's detector, gates and mitigations
+            // structure. DETECTOR: the per-axis structural level, the post-floor loop bandwidth,
+            // the estimated mode frequency and the control-output envelope. GATES: the [0,1]
+            // weights that decide how strongly the mitigations engage. MITIGATIONS: one combined
+            // mode and engagement lamp per individually controllable mitigation, dim whenever the
+            // mitigation is not acting (manually Off or automatically idle), amber when engaged.
             Header ("OSCILLATION", null);
             var level = engaged ? ap.OscillationLevel : null;
             // Beyond reach of a level of 0 when disengaged, so the lamp stays green while not engaged.
@@ -335,8 +331,9 @@ namespace KRPC.SpaceCenter
 
             TwoColumnHeader ("PCH/YAW", "RLL");
 
-            // Control-output oscillation envelope per group: the about-mean amplitude of the delivered
-            // command that drives the back-off gate, lit amber at/above the engage threshold.
+            // Control-output oscillation envelope per group: the about-mean amplitude of the
+            // delivered command that drives the back-off gate, lit amber at or above the engage
+            // threshold.
             var oscThreshold = engaged ? ap.OscillationControlThreshold : double.PositiveInfinity;
             GUILayout.BeginHorizontal ();
             GUILayout.Label ("CTRL", registerLabelStyle);
@@ -356,7 +353,7 @@ namespace KRPC.SpaceCenter
             // The gates: HOLD (the pointing-error hold factor, global), LATCH (the detector's
             // persistent flexible-craft verdict), RAMP (the eased latch weight), BACKOFF (the
             // limit-cycle back-off) and GATE (the net hold-gated mitigation level,
-            // ramp · max(hold, bko), which drives the floor and the feedforward cut).
+            // ramp * max(hold, bko), which drives the floor and the feedforward cut).
             Header ("GATES", null);
             var ramp = engaged ? ap.SuppressionRamp : null;
             var backoff = engaged ? ap.OscillationBackoff : null;
@@ -393,10 +390,10 @@ namespace KRPC.SpaceCenter
             GUILayout.EndHorizontal ();
             RowTooltip ("Net mitigation level, RAMP × max(HOLD, BACKOFF); drives FLOOR and FFCUT.");
 
-            // The mitigations, one combined mode+engagement lamp each. FILTER is the rate filter
-            // (per group, showing the tool Automatic routed to, or the forced tool); FLOOR the
-            // bandwidth-floor engagement; FFCUT the applied feedforward-cut fraction; SMOOTH the
-            // output-smoothing blend weight.
+            // The mitigations, one combined mode and engagement lamp each. FILTER is the rate
+            // filter, per group, showing the tool Automatic routed to or the forced tool. FLOOR is
+            // the bandwidth-floor engagement, FFCUT the applied feedforward-cut fraction, and
+            // SMOOTH the output-smoothing blend weight.
             Header ("MITIGATIONS", null);
             var ffCut = engaged ? ap.FeedforwardCut : null;
             var outWeight = engaged ? ap.OutputFilterWeight : null;
@@ -449,7 +446,7 @@ namespace KRPC.SpaceCenter
             var row = GUILayoutUtility.GetLastRect ();
             // Grow the hit area past the 1px margins between rows, so a slow vertical sweep of
             // the mouse does not drop the tooltip on the seam where neither row is hit. Adjacent
-            // grown rects overlap slightly; the later (lower) row wins, since it overwrites.
+            // grown rects overlap slightly, and the later (lower) row overwrites the earlier one.
             row.yMin -= 2f;
             row.yMax += 2f;
             if (row.Contains (Event.current.mousePosition)) {
@@ -459,11 +456,10 @@ namespace KRPC.SpaceCenter
         }
 
         // Draws the captured tooltip anchored to the hovered row: just below it, or just above it
-        // when too close to the window's bottom edge. Anchoring to the row (never the mouse)
-        // keeps the tooltip still while the mouse moves around within the row. The tooltip is
-        // drawn with GUI (not GUILayout) so it overlays the panel without affecting the window's
-        // auto-layout height, and stays inside the window rect because GUI.Window clips its
-        // contents.
+        // when too close to the window's bottom edge. Anchoring to the row keeps the tooltip still
+        // while the mouse moves within the row. The tooltip is drawn with GUI, so it overlays the
+        // panel without affecting the window's auto-layout height, and stays inside the window
+        // rect because GUI.Window clips its contents.
         void DrawTooltip ()
         {
             if (activeTooltip == null || Event.current.type != EventType.Repaint)
@@ -480,19 +476,18 @@ namespace KRPC.SpaceCenter
         }
 
         // Draws one square backlit annunciator lamp spanning the given number of grid columns.
-        // When unlit, the lamp shows the register background with faint grey "engraved" text;
-        // when lit, the full colour with black text. The lamp is purely informational (drawn as
-        // a box, never interactive).
+        // When unlit, the lamp shows the register background with faint gray "engraved" text.
+        // When lit, it shows the full color with black text. The lamp is purely informational,
+        // drawn as a box and never interactive.
         void Lamp (string label, bool lit, Color colour, int span = 1)
         {
             Lamp (label, lit, colour, engravedGrey, span);
         }
 
-        // Lamp variant for cells that carry a data readout as well as a status colour (attitude
-        // error, STRUC, CTRL): the unlit text stays plain white — the value must remain readable
-        // when the status is nominal — rather than the engraved grey of a pure status lamp.
-        // Callers blank the label when there is no live value (auto-pilot disengaged), so white
-        // never shows a stale or placeholder reading.
+        // Lamp variant for cells that carry a data readout as well as a status color (attitude
+        // error, STRUC, CTRL). The unlit text stays plain white, so the value remains readable
+        // when the status is nominal. Callers blank the label when there is no live value
+        // (auto-pilot disengaged), so white never shows a stale or placeholder reading.
         void DataLamp (string label, bool lit, Color colour, int span = 1)
         {
             Lamp (label, lit, colour, Color.white, span);
@@ -505,36 +500,34 @@ namespace KRPC.SpaceCenter
             lampStyle.normal.textColor = lit ? Color.black : unlitText;
             // A box with no measurable content picks up a slightly different line height, so a
             // blank lamp (e.g. RLL when no roll is held) would render taller than its lit
-            // neighbours. A plain space does not fix this: IMGUI trims trailing whitespace when
-            // measuring, so it still measures as empty. A non-breaking space is measured as a
-            // real glyph, keeping the box geometry identical to a populated cell while still
-            // reading as blank.
+            // neighbors. IMGUI trims trailing whitespace when measuring, so a plain space still
+            // measures as empty. A non-breaking space is measured as a real glyph, keeping the
+            // box geometry identical to a populated cell while still reading as blank.
             GUILayout.Box (string.IsNullOrEmpty (label) ? NonBreakingSpace : label, lampStyle, spanOptions [span]);
             GUI.backgroundColor = prevBg;
         }
 
-        // One control-oscillation envelope lamp (matching the structural LevelLamp): lit amber
-        // at/above the engage threshold, green below, dim when disengaged.
+        // One control-oscillation envelope lamp, matching the structural LevelLamp: lit amber at
+        // or above the engage threshold, green below, dim when disengaged.
         void OscCell (bool engaged, double level, double threshold, int span = 1)
         {
             DataLamp (engaged ? Percent (level) : Blank, engaged && level >= threshold, amber, span);
         }
 
         // Attitude-error lamp: green when the axis error is within the AutoPilot.Wait() stopping
-        // angle threshold, amber when outside it. Dim/blank when not shown (disengaged, or roll on an
-        // axis whose roll is not held).
+        // angle threshold, amber when outside it. Dim and blank when not shown (disengaged, or
+        // roll on an axis whose roll is not held).
         void ErrorLamp (bool show, float error, float threshold)
         {
             DataLamp (show ? Deg (error) : Blank, show && Math.Abs (error) > threshold, amber);
         }
 
         // Heading-error lamp. Heading is a coordinate singularity at the poles: near vertical
-        // (pitch → ±90°) swinging the heading barely moves where the craft actually points, so a
-        // negligible pointing error shows up as a huge heading-angle error and would pin the lamp
-        // permanently lit. Gate on the heading error's true contribution to the pointing error,
-        // error·cos(pitch), rather than the raw error — this widens the allowed heading error as
-        // the craft nears vertical and drops it to zero exactly at the pole. The displayed value
-        // is still the raw heading error.
+        // pitch, swinging the heading barely moves where the craft points, so a negligible
+        // pointing error shows up as a huge heading-angle error and would pin the lamp
+        // permanently lit. Gate on the heading error's contribution to the pointing error,
+        // error * cos(pitch), which widens the allowed heading error as the craft nears vertical
+        // and drops it to zero at the pole. The displayed value is still the raw heading error.
         void HeadingErrorLamp (bool show, float error, float threshold, float pitch)
         {
             double effective = Math.Abs (error) * Math.Abs (Math.Cos (pitch * Math.PI / 180.0));
@@ -542,8 +535,8 @@ namespace KRPC.SpaceCenter
         }
 
         // Frequency lamp: green showing the detected structural frequency once the tracker has a
-        // lock, amber em dash until then (and dim when disengaged). A single glyph so it fits the
-        // one-column RLL cell without word-wrapping the way "NO LOCK" did.
+        // lock, amber em dash until then, and dim when disengaged. A single glyph, so it fits the
+        // one-column RLL cell without word-wrapping.
         static string FreqText (double freq)
         {
             return double.IsNaN (freq) ? "—" : string.Format ("{0:F1}Hz", freq);
@@ -552,13 +545,13 @@ namespace KRPC.SpaceCenter
         // The axis is identified by the PCH/YAW/RLL column header, so the lamp shows only the level value.
         void LevelLamp (bool engaged, double level, bool latched, double latchThreshold)
         {
-            // Amber once the level reaches the controller's latch threshold (so it is in the range
-            // that triggers the latch), or the axis has already latched; dim below.
+            // Amber once the level reaches the controller's latch threshold, so it is in the
+            // range that triggers the latch, or the axis has already latched. Dim below.
             DataLamp (engaged ? Percent (level) : Blank, engaged && (latched || level >= latchThreshold), amber);
         }
 
-        // Latch lamp: amber ENGAGED once the axis group has latched as flexible; blank (not
-        // engraved) when unlatched or disengaged, so the word only ever appears lit.
+        // Latch lamp: amber ENGAGED once the axis group has latched as flexible, and blank when
+        // unlatched or disengaged, so the word only ever appears lit.
         void LatchLamp (bool latched, int span)
         {
             Lamp (latched ? "ENGAGED" : Blank, latched, amber, span);
@@ -570,10 +563,10 @@ namespace KRPC.SpaceCenter
             Lamp (engaged ? Percent (level) : Blank, engaged && level > 0.01, amber, span);
         }
 
-        // Combined mode + engagement lamp for one mitigation cell: dim whenever the mitigation
-        // is not acting (manually Off, or automatically idle at ~0), amber when engaged. The
+        // Combined mode and engagement lamp for one mitigation cell: dim whenever the mitigation
+        // is not acting (manually Off, or automatically idle at about 0), amber when engaged. The
         // label carries the mode (OFF) or the engagement level. Forced pins the mitigation fully
-        // on, so its lamp reads 100% regardless of the gate.
+        // on, so its lamp reads 100% whatever the gate.
         void MitigationLamp (bool engaged, Services.MitigationMode mode, double level, int span = 1)
         {
             if (engaged && mode == Services.MitigationMode.Off) {
@@ -585,9 +578,9 @@ namespace KRPC.SpaceCenter
             Lamp (engaged ? Percent (level) : Blank, engaged && level > 0.01, amber, span);
         }
 
-        // Combined mode + engagement lamp for the rate filter on one axis group: dim when Off or
-        // while Automatic has no tool engaged, amber with the tool name whenever a filter is
-        // actually running (automatic-routed or forced).
+        // Combined mode and engagement lamp for the rate filter on one axis group: dim when Off
+        // or while Automatic has no tool engaged, amber with the tool name whenever a filter is
+        // running, automatic-routed or forced.
         void RateFilterLamp (bool engaged, Services.RateFilterMode mode, int tool, int span = 1)
         {
             if (engaged && mode == Services.RateFilterMode.Off) {
@@ -635,7 +628,7 @@ namespace KRPC.SpaceCenter
             GUILayout.Label (value, registerStyle, spanOptions [span]);
         }
 
-        // As Register, but the content is centred rather than right-aligned.
+        // As Register, but the content is centered and not right-aligned.
         void RegisterCentered (string value, int span = 1)
         {
             GUILayout.Label (value, registerCenterStyle, spanOptions [span]);
@@ -679,9 +672,9 @@ namespace KRPC.SpaceCenter
             GUILayout.EndHorizontal ();
         }
 
-        // Rounds to the displayed number of decimals and normalises negative zero to positive zero,
-        // so a value dithering either side of zero settles on a single displayed form (e.g. "+0.000",
-        // "0.0°") instead of flickering its sign between frames.
+        // Rounds to the displayed number of decimals and normalizes negative zero to positive
+        // zero, so a value dithering either side of zero settles on a single displayed form (e.g.
+        // "+0.000") and keeps its sign between frames.
         static double Stable (double value, int decimals)
         {
             double rounded = Math.Round (value, decimals);
@@ -700,10 +693,10 @@ namespace KRPC.SpaceCenter
             return string.Format ("{0:0.0}", Stable (value, 1));
         }
 
-        // A 0–1 fraction (oscillation level, control-output envelope, hold-mitigation weight) shown
-        // as a whole-number percentage. The number is left-padded to three figure-spaces (U+2007,
-        // digit-width) so the trailing "%" stays in a fixed position as the value gains or loses a
-        // digit (e.g. 10% -> 9%) even when the cell is centre-aligned.
+        // A fraction from 0 to 1 (oscillation level, control-output envelope, hold-mitigation
+        // weight) shown as a whole-number percentage. The number is left-padded to three
+        // figure-spaces (U+2007, digit-width) so the trailing "%" stays in a fixed position as the
+        // value gains or loses a digit (e.g. 10% to 9%) even when the cell is center-aligned.
         static string Percent (double value)
         {
             return ((int) Math.Round (value * 100.0)).ToString ().PadLeft (3, ' ') + "%";
@@ -721,8 +714,8 @@ namespace KRPC.SpaceCenter
             }
         }
 
-        // Empty cells are drawn blank (no placeholder glyphs) — less visually distracting than a
-        // dashed filler in every disengaged/unset readout.
+        // Empty cells are drawn blank, with no placeholder glyph in every disengaged or unset
+        // readout.
         const string Blank = "";
 
         // U+00A0 non-breaking space. Used as the content of a blank lamp box: a plain space is
@@ -730,12 +723,12 @@ namespace KRPC.SpaceCenter
         // not stretch to fill its column, but a non-breaking space measures as a real glyph.
         const string NonBreakingSpace = " ";
 
-        // An angle readout that is blank for an unset (NaN) roll target, otherwise the degrees. Roll
-        // (unlike pitch and heading) can reach ±180, and "-100.0°" is 7 glyphs — one too many for the
-        // one-column RLL cell, which wraps it the way "12.3 Hz" wrapped before it lost its space. Drop
-        // the fractional degree once past ±100° so the readout stays inside the cell; the cutoff is on
-        // the magnitude so both signs are shown the same way, and the common sub-100° case keeps its
-        // 0.1° resolution.
+        // An angle readout that is blank for an unset (NaN) roll target, otherwise the degrees.
+        // Roll, unlike pitch and heading, can reach 180 degrees, and "-100.0" with its degree sign
+        // is 7 glyphs, one too many for the one-column RLL cell, which wraps it. Drop the
+        // fractional degree once past 100 degrees so that the readout stays inside the cell. The
+        // cutoff is on the magnitude, so both signs are shown the same way and the common case
+        // keeps its 0.1 degree resolution.
         static string DegOrBlank (float value)
         {
             if (float.IsNaN (value))

--- a/service/SpaceCenter/src/CameraAddon.cs
+++ b/service/SpaceCenter/src/CameraAddon.cs
@@ -45,16 +45,14 @@ namespace KRPC.SpaceCenter
             public int SettledFrames;
         }
 
-        // Consecutive frames the live value must hold on its own (no re-apply needed)
-        // before the write is considered settled and cleared. Long enough to outlast the
-        // brief snap-backs during a transition, short enough to release promptly once the
-        // camera settles. Update runs on the render tick, so this is rendered frames.
+        // Consecutive frames the live value must hold on its own before the write is
+        // considered settled and cleared, long enough to outlast the brief snap-backs
+        // during a transition. Update runs on the render tick, so these are rendered frames
         const int SettleFrames = 30;
 
-        // Overall budget to keep re-applying a write before giving up, comfortably longer
-        // than the longest mode-switch settle. Guards a value the camera never accepts
-        // (e.g. requested out of range) or a target mode that never arrives because the
-        // script switched again, so neither can pin a write forever.
+        // Overall budget to keep re-applying a write before giving up, longer than the
+        // longest mode-switch settle. Guards a value the camera never accepts (e.g.
+        // requested out of range), or a target mode that never arrives
         const int RetryFrames = 1200;
 
         static readonly Dictionary<CameraProperty, PendingWrite> pending =
@@ -119,8 +117,7 @@ namespace KRPC.SpaceCenter
                 try {
                     // The live value is read before re-applying, so it reflects whether
                     // the previous frame's write survived the camera's own updates. Once
-                    // it has held on its own for the settle window the camera has stopped
-                    // overwriting it and the write is done; until then, re-apply it.
+                    // it has held for the settle window the write is done
                     if (Camera.Converged (property, entry.Value)) {
                         if (++entry.SettledFrames >= SettleFrames)
                             pending.Remove (property);

--- a/service/SpaceCenter/src/EVAAddon.cs
+++ b/service/SpaceCenter/src/EVAAddon.cs
@@ -203,10 +203,9 @@ namespace KRPC.SpaceCenter
             var inputs = PilotAddon.Get (vessel);
             var transform = eva.transform;
 
-            // On foot the kerbal walks; off it, the jetpack flies it. The two are driven by
-            // the same inputs, and which one has any effect is left to the game: it walks
-            // the kerbal only while it is on a surface, and thrusts only while the jetpack
-            // is deployed.
+            // On foot the kerbal walks, and off it the jetpack flies it. Both are driven by
+            // the same inputs: the game walks the kerbal only while it is on a surface, and
+            // thrusts only while the jetpack is deployed
             var onFoot = vessel.LandedOrSplashed;
             var walking = onFoot && (inputs.Forward != 0f || inputs.Right != 0f);
 
@@ -217,11 +216,10 @@ namespace KRPC.SpaceCenter
             if (translate != Vector3.zero)
                 Set (Commands.Translation, eva, Get (Commands.Translation, eva) + translate);
 
-            // On foot a kerbal can only turn, and only while it is walking, and on a
-            // ladder it is held by its hands and cannot turn at all, so the rotation
-            // inputs are the free-flying jetpack's alone. On a ladder it also cannot be
-            // stopped, so trying would leave the torque command latched on against
-            // whatever motion the ladder imposes.
+            // On foot a kerbal can only turn, and only while walking. On a ladder it is
+            // held by its hands and cannot turn at all, so the rotation inputs are the
+            // jetpack's alone. A command sent on a ladder would stay latched against the
+            // motion the ladder imposes
             if (onFoot || eva.OnALadder)
                 ReleaseRotation (eva);
             else

--- a/service/SpaceCenter/src/ExtensionMethods/EditorExtensions.cs
+++ b/service/SpaceCenter/src/ExtensionMethods/EditorExtensions.cs
@@ -58,10 +58,9 @@ namespace KRPC.SpaceCenter
                     (lastShip == null || !ReferenceEquals (lastShip.Target, ship))) {
                     lastShip = new WeakReference (ship);
                     // An undo or a redo hands back a vessel object of its own, built from
-                    // the game's backup, so the object changing is not on its own a new
-                    // vessel. The parts it builds carry the craft ids they had, so what
-                    // a part object names is unchanged; one whose part the undo took away
-                    // is simply no longer there to be found.
+                    // the game's backup, so a changed object is not on its own a new
+                    // vessel. The parts it builds carry the craft ids they had, so a part
+                    // object still names the same part
                     var wasRestored = restoredShip != null &&
                                       ReferenceEquals (restoredShip.Target, ship);
                     restoredShip = null;
@@ -73,10 +72,9 @@ namespace KRPC.SpaceCenter
         }
 
         // The vessel the editor last restored from its own backup, held weakly. Set from
-        // EditorShipAddon, which hears the game say so. It is the vessel rather than the
-        // fact that one was restored, because a vessel is only adopted once and nothing
-        // says when that has happened: a flag would still be set when the next craft was
-        // loaded, and would take that craft for the vessel the editor already had.
+        // EditorShipAddon. A vessel is adopted once, and nothing marks when that has
+        // happened, so this holds the vessel and not a flag: a flag would still be set
+        // when the next craft was loaded
         static WeakReference restoredShip;
 
         /// <summary>

--- a/service/SpaceCenter/src/ExtensionMethods/EditorExtensions.cs
+++ b/service/SpaceCenter/src/ExtensionMethods/EditorExtensions.cs
@@ -89,11 +89,10 @@ namespace KRPC.SpaceCenter
         }
 
         /// <summary>
-        /// What the game holds for the vessel in the editor. The editor holds one vessel
-        /// while it is open and takes it with it when it is left, so anything named
-        /// against that vessel is live until the game leaves the editor, and gone
-        /// afterwards. An editor that is still starting up has no vessel yet, and nothing
-        /// is concluded from that.
+        /// The state of the vessel in the editor. The editor holds one vessel while it is
+        /// open and destroys it on leaving, so anything identified against that vessel is
+        /// live until the game leaves the editor. An editor that is still starting up
+        /// leaves the vessel dormant.
         /// </summary>
         public static GameObjectState ShipState {
             get {

--- a/service/SpaceCenter/src/ExtensionMethods/FlightGlobalsExtensions.cs
+++ b/service/SpaceCenter/src/ExtensionMethods/FlightGlobalsExtensions.cs
@@ -48,11 +48,9 @@ namespace KRPC.SpaceCenter
         }
 
         /// <summary>
-        /// What the game holds for the vessel with the given id. A vessel is either there
-        /// to be found, loaded or not, or it is gone for good; it has no unloaded form
-        /// that the game can bring back. A game that does not currently know what vessels
-        /// exist says nothing about any of them, so a vessel it cannot find then is
-        /// dormant, and nothing standing for one is dropped on the strength of it.
+        /// The state of the vessel with the given id. A vessel is live whether it is loaded
+        /// or not, and destroyed once the game holds no vessel with the id. A game between
+        /// states holds no list of vessels, and leaves the vessel dormant.
         /// </summary>
         public static GameObjectState VesselState (Guid id)
         {

--- a/service/SpaceCenter/src/ExtensionMethods/FlightGlobalsExtensions.cs
+++ b/service/SpaceCenter/src/ExtensionMethods/FlightGlobalsExtensions.cs
@@ -34,10 +34,10 @@ namespace KRPC.SpaceCenter
             var active = FlightGlobals.ActiveVessel;
             if (active != null && active.id == id)
                 return active;
-            // A game that is not listing vessels has none to find. Answering that, rather
-            // than raising, is what leaves VesselsKnown to say what the absence means, and
-            // it has to be an answer: the object store asks every vessel it holds for its
-            // state in one pass, and one that raises must not stop the rest being checked.
+            // A game that is not listing vessels has none to find. Return an empty list,
+            // which leaves VesselsKnown to say what the absence means: the object store
+            // checks every vessel it holds in one pass, and one that raises must not stop
+            // the rest
             var vessels = FlightGlobals.Vessels;
             if (vessels == null)
                 return null;

--- a/service/SpaceCenter/src/ExtensionMethods/GeometryExtensions.cs
+++ b/service/SpaceCenter/src/ExtensionMethods/GeometryExtensions.cs
@@ -320,7 +320,7 @@ namespace KRPC.SpaceCenter.ExtensionMethods
             if (dot >= 1.0 - 1e-10)
                 return QuaternionD.identity;
             if (dot <= -1.0 + 1e-10) {
-                // 180° rotation — pick an arbitrary perpendicular axis
+                // A 180 degree rotation, so pick an arbitrary perpendicular axis
                 var perp = Math.Abs (from.x) < 0.9 ? Vector3d.Cross (from, Vector3d.right) : Vector3d.Cross (from, Vector3d.up);
                 perp.Normalize ();
                 return new QuaternionD (perp.x, perp.y, perp.z, 0);
@@ -343,7 +343,7 @@ namespace KRPC.SpaceCenter.ExtensionMethods
 
         /// <summary>
         /// The signed angle, in degrees, to rotate <paramref name="from"/> onto <paramref name="to"/>
-        /// about <paramref name="axis"/> (right-handed: positive when <c>from × to</c> points along
+        /// about <paramref name="axis"/> (right-handed: positive when <c>from x to</c> points along
         /// <paramref name="axis"/>). Both vectors are projected onto the plane perpendicular to the
         /// axis first; returns 0 if either projection vanishes.
         /// </summary>
@@ -379,8 +379,8 @@ namespace KRPC.SpaceCenter.ExtensionMethods
         }
 
         /// <summary>
-        /// Canonicalize a rotation quaternion's sign so that <c>q</c> and <c>-q</c> — which are the
-        /// same rotation — decompose identically. <see cref="ToAngleAxis"/> maps them to opposite
+        /// Canonicalize a rotation quaternion's sign so that <c>q</c> and <c>-q</c>, which are the
+        /// same rotation, decompose identically. <see cref="ToAngleAxis"/> maps them to opposite
         /// axes at exactly 180 degrees (where w is zero), which flips the sign of the decomposed
         /// axis*angle vector. Choose w &gt;= 0, and at w == 0 make the largest-magnitude component
         /// positive, so the axis is deterministic and does not flip under noise in a minor component.

--- a/service/SpaceCenter/src/ExtensionMethods/ITorqueProviderExtensions.cs
+++ b/service/SpaceCenter/src/ExtensionMethods/ITorqueProviderExtensions.cs
@@ -37,7 +37,7 @@ namespace KRPC.SpaceCenter
             var pos = Vector3d.zero;
             var neg = Vector3d.zero;
             foreach (var torque in torques) {
-                // Use abs() to normalise sign conventions: KSP's ITorqueProvider implementations
+                // Use abs() to normalize sign conventions: KSP's ITorqueProvider implementations
                 // are inconsistent (e.g. ModuleControlSurface negates the roll axis, while
                 // ModuleReactionWheel returns the same positive value in both pos and neg).
                 // This matches how KSP's own VesselSAS.GetTotalVesselTorque uses Max(pos,neg).

--- a/service/SpaceCenter/src/ExtensionMethods/PartExtensions.cs
+++ b/service/SpaceCenter/src/ExtensionMethods/PartExtensions.cs
@@ -236,14 +236,14 @@ namespace KRPC.SpaceCenter.ExtensionMethods
         public static Bounds GetBounds (this Part part, ReferenceFrame referenceFrame)
         {
             var bounds = new Bounds (referenceFrame.PositionFromWorldSpace (part.WCoM), Vector3.zero);
-            // Only the parts own model, the same subtree KSP measures a part against. Searching
-            // the whole part transform instead would pick up the models of physicsless child
-            // parts, which hang off it, along with any object a mod parents to the part.
+            // Only the part's own model, the same subtree KSP measures a part against. The
+            // whole part transform also holds the models of physicsless child parts, which
+            // hang off it, and any object a mod parents to the part
             var meshes = part.FindModelComponents<MeshFilter> ();
             for (int i = 0; i < meshes.Count; i++) {
                 var mesh = meshes [i];
                 // The model subtree is walked in full, so meshes that are currently switched
-                // off - a hidden part variant, a stowed animation state - have to be skipped.
+                // off, such as a hidden part variant or a stowed animation state, are skipped
                 if (!mesh.gameObject.activeInHierarchy)
                     continue;
                 // sharedMesh, not mesh: the latter instantiates a private copy of the mesh

--- a/service/SpaceCenter/src/ExtensionMethods/VesselControlStateExtensions.cs
+++ b/service/SpaceCenter/src/ExtensionMethods/VesselControlStateExtensions.cs
@@ -30,7 +30,7 @@ namespace KRPC.SpaceCenter.ExtensionMethods
         /// What is controlling a vessel, from its control level and, where the level does not
         /// say, its parts. KSP records whether partial control comes from a kerbal or a probe,
         /// but not for full control, so that case is decided by whether any part that is a
-        /// control source has crew aboard — a kerbal takes precedence over a probe core, as it
+        /// control source has crew aboard. A kerbal takes precedence over a probe core, as it
         /// does in KSP's own control state.
         /// </summary>
         public static ControlSource ToControlSource (

--- a/service/SpaceCenter/src/ExtensionMethods/VesselExtensions.cs
+++ b/service/SpaceCenter/src/ExtensionMethods/VesselExtensions.cs
@@ -8,7 +8,7 @@ namespace KRPC.SpaceCenter.ExtensionMethods
     {
         /// <summary>
         /// The angular velocity of the vessel in world space, in radians per second.
-        /// The vessel behaviour is attached to the root part's game object, so the
+        /// The vessel behavior is attached to the root part's game object, so the
         /// vessel's rigidbody is the root part's, available from its cached rb field
         /// without a GetComponent lookup.
         /// </summary>

--- a/service/SpaceCenter/src/Lifetime/ModuleRef.cs
+++ b/service/SpaceCenter/src/Lifetime/ModuleRef.cs
@@ -33,8 +33,7 @@ namespace KRPC.SpaceCenter
         readonly string name;
         readonly int occurrence;
         // The game's own name for the module, and where the module was in the part's module
-        // list, or 0 and -1 while it has not been found. Both are ways of finding it, neither
-        // is what the reference stands for.
+        // list, or 0 and -1 while it has not been found. Both are ways of finding the module
         uint id;
         int index;
 
@@ -102,12 +101,12 @@ namespace KRPC.SpaceCenter
             var modules = part.Modules;
             if (index >= 0 && index < modules.Count) {
                 var module = modules [index];
-                // The id is unique among the modules of a part from the moment the game hands
-                // it out, so what carries it and is of the reference's class is the module.
-                // Where it sits is only where it was, and says nothing on its own: a change to
-                // the list that leaves its length alone moves modules under it. The class is
-                // what an id loaded from a game state, which no uniqueness was enforced on,
-                // has to agree with before it can be believed.
+                // The id is unique among the modules of a part from the moment the game
+                // hands it out, so the module is the one carrying it that is of the
+                // reference's class. The index is only where the module was: a change that
+                // leaves the list length alone moves the modules under it. An id loaded from
+                // a game state had no uniqueness enforced on it, so the class has to agree
+                // as well
                 if (module != null && module.PersistentId == id && module.moduleName == name)
                     return module;
             }
@@ -159,8 +158,8 @@ namespace KRPC.SpaceCenter
                 for (var i = 0; i < moduleCount; i++) {
                     var module = modules [i];
                     // An id is unique among the modules of a part only from the moment the
-                    // game hands it out, so what carries one loaded from a game state has to
-                    // be of the reference's class before it can be its module.
+                    // game hands it out, so one loaded from a game state has to be of the
+                    // reference's class as well
                     if (module == null || module.PersistentId != id || module.moduleName != name)
                         continue;
                     index = i;

--- a/service/SpaceCenter/src/Lifetime/ModuleRef.cs
+++ b/service/SpaceCenter/src/Lifetime/ModuleRef.cs
@@ -127,7 +127,7 @@ namespace KRPC.SpaceCenter
         }
 
         /// <summary>
-        /// What the game holds for the module, for an object that stands for one.
+        /// The state of the module, for an object that identifies one.
         /// </summary>
         /// <remarks>
         /// A module belongs to its part's game object, so it is exactly as live, dormant or

--- a/service/SpaceCenter/src/PartId.cs
+++ b/service/SpaceCenter/src/PartId.cs
@@ -85,11 +85,11 @@ namespace KRPC.SpaceCenter
         }
 
         /// <summary>
-        /// What the game holds for the part. A part in flight is live while the vessel
-        /// carrying it is loaded, dormant while that vessel is unloaded, as the game then
-        /// keeps only a snapshot of each of its parts, and destroyed once the game holds
-        /// neither. A part in the editor is only ever in the vessel the editor has open,
-        /// so once it is not there it is gone, and leaving the editor takes it with it.
+        /// The state of the part. A part in flight is live while the vessel carrying it is
+        /// loaded, dormant while that vessel is unloaded and the game keeps only a snapshot
+        /// of its parts, and destroyed once the game holds neither. A part in the editor is
+        /// live while it is in the vessel the editor has open, and destroyed once it leaves
+        /// that vessel or the game leaves the editor.
         /// </summary>
         /// <remarks>
         /// Only reached once looking the part up has already failed, so it may take as

--- a/service/SpaceCenter/src/PartId.cs
+++ b/service/SpaceCenter/src/PartId.cs
@@ -100,9 +100,8 @@ namespace KRPC.SpaceCenter
             get {
                 if (Find () != null)
                     return GameObjectState.Live;
-                // The editor holds nothing that is not in the vessel it has open, so a
-                // part it does not have is gone as soon as it is known to have one, and a
-                // part of a vessel it has loaded over is gone whatever it has open now.
+                // The editor holds nothing outside the vessel it has open, so a part it
+                // does not have is gone, and so is a part of a vessel it has loaded over
                 if (inEditor) {
                     if (!OfLoadedShip)
                         return GameObjectState.Destroyed;

--- a/service/SpaceCenter/src/PilotAddon.cs
+++ b/service/SpaceCenter/src/PilotAddon.cs
@@ -195,10 +195,9 @@ namespace KRPC.SpaceCenter
                 if (other.ThrottleUpdated)
                     state.mainThrottle = other.state.mainThrottle;
                 ThrottleUpdated |= other.ThrottleUpdated;
-                // Custom axes are absolute axis positions, so they override (like the
-                // throttle) rather than accumulate. The flight control state is not
-                // reset each frame for non-active vessels, so accumulating them across
-                // frames would run away.
+                // Custom axes are absolute axis positions, so they override like the
+                // throttle. The flight control state is not reset each frame for non-active
+                // vessels, so accumulating them across frames would run away
                 for (int i = 0; i < 4; i++) {
                     if (other.customAxisUpdated[i])
                         state.custom_axes[i] = other.state.custom_axes[i];
@@ -269,7 +268,7 @@ namespace KRPC.SpaceCenter
         static HashSet<Vessel> remoteTechSanctionedDelegates = new HashSet<Vessel> ();
         /// <summary>
         /// The attitude controller for each vessel. Owned here rather than by the AutoPilot
-        /// service objects — those are transient API surface objects, so controller state (the
+        /// service objects, which are transient API surface objects, so controller state (the
         /// autotuner, the oscillation detector's persistent structural level, ...) must not be
         /// tied to their lifetime. Held per vessel for the duration of the flight session,
         /// however many AutoPilot objects come and go.
@@ -304,9 +303,9 @@ namespace KRPC.SpaceCenter
         }
 
         // The physics tick the server last ran an update on, and whether the order of that
-        // update and the game's control input has been reported yet. Which of the two comes
-        // first decides whether a value written by a call in a tick is acted on in that tick.
-        // The server addon fixes that order, so the log says once what the game actually did.
+        // update and the game's control input has been reported yet. The order decides
+        // whether a value written by a call in a tick is acted on in that tick, and the
+        // server addon fixes it, so the log reports it once
         static float lastUpdateFixedTime = float.NaN;
         static bool reportedUpdateOrder;
 
@@ -479,9 +478,9 @@ namespace KRPC.SpaceCenter
             HandleThrottle (vessel, manualInputs [vessel]);
             inputs.Add (manualInputs [vessel]);
 
-            // Auto-pilot inputs. The control loop itself runs at the point in the server's
-            // update that the vessel's update mode selects; this applies whatever it last
-            // produced. With no server running nothing else drives it, so it runs here.
+            // Auto-pilot inputs. The control loop runs at the point in the server's update
+            // that the vessel's update mode selects, and this applies whatever it last
+            // produced. With no server running nothing else drives it, so it runs here
             var attitudeController = FindAttitudeController (vessel.id);
             if (attitudeController != null) {
                 if (!Core.Instance.AnyRunning)
@@ -545,9 +544,8 @@ namespace KRPC.SpaceCenter
             if (FlightGlobals.ActiveVessel != vessel)
                 return;
             // If RemoteTech is controlling the vessel and there is no control connection,
-            // drop the input rather than applying it. Note this must consume the input
-            // (rather than just returning) so that it is not subsequently re-applied via
-            // the per-frame FlightCtrlState in ControlInputs.Add.
+            // drop the input. Note: the input has to be consumed, or the per-frame
+            // FlightCtrlState in ControlInputs.Add re-applies it
             if (!HasControlConnection (vessel)) {
                 inputs.Throttle = 0f;
                 inputs.ThrottleUpdated = false;

--- a/service/SpaceCenter/src/Services/Alarm.cs
+++ b/service/SpaceCenter/src/Services/Alarm.cs
@@ -41,10 +41,9 @@ namespace KRPC.SpaceCenter.Services
         }
 
         /// <summary>
-        /// What the game holds for the alarm. It is live while an alarm with the id is in
-        /// the game's alarm clock, and destroyed once the alarm clock is there to ask and
-        /// has none, as an alarm that is removed is gone for good. A game that has no alarm
-        /// clock running has no alarms to look through, which says nothing about this one.
+        /// The state of the alarm. It is live while an alarm with the id is in the game's
+        /// alarm clock, and destroyed once a running alarm clock has none. A game with no
+        /// alarm clock running leaves the alarm dormant.
         /// </summary>
         public GameObjectState GameObjectState
         {

--- a/service/SpaceCenter/src/Services/Alarm.cs
+++ b/service/SpaceCenter/src/Services/Alarm.cs
@@ -398,8 +398,8 @@ namespace KRPC.SpaceCenter.Services
         [KRPCMethod]
         public void Remove()
         {
-            // Resolve first, so that removing an alarm the game does not have reports that
-            // rather than passing an id the alarm clock knows nothing about.
+            // Resolve first, so that removing an alarm the game does not have is reported
+            // here, and not as an unknown id from the alarm clock
             var alarm = InternalAlarm;
             AlarmClockScenario.DeleteAlarm(alarm.Id);
         }

--- a/service/SpaceCenter/src/Services/AutoPilot.cs
+++ b/service/SpaceCenter/src/Services/AutoPilot.cs
@@ -31,7 +31,7 @@ namespace KRPC.SpaceCenter.Services
         }
 
         /// <summary>
-        /// What the game holds for the vessel this belongs to.
+        /// The state of the vessel this belongs to.
         /// </summary>
         public GameObjectState GameObjectState {
             get { return FlightGlobalsExtensions.VesselState (vesselId); }
@@ -250,7 +250,7 @@ namespace KRPC.SpaceCenter.Services
         /// <summary>
         /// Disengages the auto-pilot and resets all configuration parameters to their defaults.
         /// Also resets the target pitch, heading and roll, and clears all internal controller
-        /// state, including the oscillation detector's structural level — which otherwise
+        /// state, including the oscillation detector's structural level, which otherwise
         /// persists across engagements so that a craft known to be flexible re-latches quickly.
         /// </summary>
         [KRPCMethod]
@@ -302,7 +302,7 @@ namespace KRPC.SpaceCenter.Services
         /// </summary>
         /// <remarks>
         /// A convenience for aiming the nose by angle. Heading (and hence roll) is ill-defined when
-        /// the nose is near vertical (pitch → ±90°); near the vertical prefer
+        /// the nose is near vertical (a pitch near -90° or +90°). Near the vertical prefer
         /// <see cref="TargetDirection"/> or <see cref="SetDirectionAndUp"/>. The setter preserves the
         /// current roll relative to <see cref="UpReference"/>.
         /// </remarks>
@@ -317,7 +317,8 @@ namespace KRPC.SpaceCenter.Services
         /// </summary>
         /// <remarks>
         /// A convenience for aiming the nose by angle, ill-defined when the nose is near vertical
-        /// (pitch → ±90°) — see <see cref="TargetPitch"/>. The setter preserves the current roll
+        /// (a pitch near -90° or +90°). See <see cref="TargetPitch"/>. The setter preserves the
+        /// current roll
         /// relative to <see cref="UpReference"/>.
         /// </remarks>
         [KRPCProperty]
@@ -332,13 +333,13 @@ namespace KRPC.SpaceCenter.Services
         /// positive roll banks right). <c>NaN</c> if no target roll is set.
         /// </summary>
         /// <remarks>
-        /// When left unset (<c>NaN</c>) the auto-pilot suppresses roll rotation — it drives the roll
-        /// rate to zero rather than holding a specific roll angle. Setting a value re-rolls the
+        /// When left unset (<c>NaN</c>) the auto-pilot suppresses roll rotation, driving the roll
+        /// rate to zero instead of holding a specific roll angle. Setting a value re-rolls the
         /// current target to that angle relative to the up reference while keeping the nose direction.
-        /// With the default reference (the frame's up) this reproduces the historical roll away from
-        /// the vertical, and is ill-defined only when the nose points along the reference (near
-        /// straight up or down). To hold a well-defined roll through the vertical — for example a
-        /// gravity turn — set the up reference off the flight path (see
+        /// With the default reference (the frame's up) this is the roll away from the vertical, and
+        /// is ill-defined only when the nose points along the reference (near straight up or down).
+        /// To hold a well-defined roll through the vertical, such as through a gravity turn, set
+        /// the up reference off the flight path (see
         /// <see cref="SetDirectionAndUp"/> / <see cref="UpReference"/>).
         /// </remarks>
         [KRPCProperty]
@@ -379,7 +380,8 @@ namespace KRPC.SpaceCenter.Services
         /// <param name="heading">Target heading angle, in degrees between 0° and 360°.</param>
         /// <remarks>
         /// A convenience for aiming the nose by angle; heading is ill-defined when the nose is near
-        /// vertical (pitch → ±90°), so near the vertical prefer <see cref="TargetDirection"/> or
+        /// vertical (a pitch near -90° or +90°), so near the vertical prefer
+        /// <see cref="TargetDirection"/> or
         /// <see cref="SetDirectionAndUp"/>. Preserves the current roll relative to
         /// <see cref="UpReference"/>.
         /// </remarks>
@@ -399,12 +401,12 @@ namespace KRPC.SpaceCenter.Services
         /// </summary>
         /// <param name="direction">The direction to point the nose in.</param>
         /// <param name="up">The reference direction the roof is rolled towards. Need not be
-        /// normalized or perpendicular to <paramref name="direction"/> — its component perpendicular
-        /// to the nose is used. Stored as the <see cref="UpReference"/>.</param>
+        /// normalized or perpendicular to <paramref name="direction"/>, as its component
+        /// perpendicular to the nose is used. Stored as the <see cref="UpReference"/>.</param>
         /// <param name="roll">An additional roll about the nose, in degrees (positive banks right).
         /// Defaults to 0.</param>
         /// <remarks>
-        /// This is the way to hold a well-defined orientation through a maneuver — for example a
+        /// This is the way to hold a well-defined orientation through a maneuver such as a
         /// gravity turn: pass a fixed <paramref name="up"/> (say north) and the roll stays defined the
         /// whole way, with no singularity at the vertical. It is well-defined for every nose direction
         /// except <paramref name="up"/> parallel to <paramref name="direction"/> (asking the roof to
@@ -449,7 +451,7 @@ namespace KRPC.SpaceCenter.Services
         /// The current target pitch the auto-pilot is tracking, in degrees. When
         /// <see cref="TargetSmoothingTime"/> is non-zero this lags the commanded
         /// <see cref="TargetPitch"/> while a change is slewed in; otherwise the two are equal.
-        /// A convenience scalar, ill-defined near the vertical — see <see cref="TargetPitch"/>.
+        /// A convenience scalar, ill-defined near the vertical. See <see cref="TargetPitch"/>.
         /// </summary>
         [KRPCProperty]
         public float CurrentTargetPitch {
@@ -460,7 +462,7 @@ namespace KRPC.SpaceCenter.Services
         /// The current target heading the auto-pilot is tracking, in degrees. When
         /// <see cref="TargetSmoothingTime"/> is non-zero this lags the commanded
         /// <see cref="TargetHeading"/> while a change is slewed in; otherwise the two are equal.
-        /// A convenience scalar, ill-defined near the vertical — see <see cref="TargetHeading"/>.
+        /// A convenience scalar, ill-defined near the vertical. See <see cref="TargetHeading"/>.
         /// </summary>
         [KRPCProperty]
         public float CurrentTargetHeading {
@@ -620,8 +622,8 @@ namespace KRPC.SpaceCenter.Services
         /// Throws an exception if the auto-pilot has not been engaged.
         /// </summary>
         /// <remarks>
-        /// The pitch component of <see cref="AttitudeError"/> — the pitch part of the direction error
-        /// resolved in the roll-invariant frame, well-defined near the vertical.
+        /// The pitch component of <see cref="AttitudeError"/>, the pitch part of the direction
+        /// error resolved in the roll-invariant frame, well-defined near the vertical.
         /// </remarks>
         [KRPCProperty]
         public float PitchError {
@@ -633,9 +635,9 @@ namespace KRPC.SpaceCenter.Services
         /// Throws an exception if the auto-pilot has not been engaged.
         /// </summary>
         /// <remarks>
-        /// The yaw component of <see cref="AttitudeError"/> — the yaw part of the direction error
-        /// resolved in the roll-invariant frame, well-defined near the vertical (unlike the absolute
-        /// heading, which is undefined at the pole).
+        /// The yaw component of <see cref="AttitudeError"/>, the yaw part of the direction error
+        /// resolved in the roll-invariant frame, well-defined near the vertical, where the absolute
+        /// heading is undefined at the pole.
         /// </remarks>
         [KRPCProperty]
         public float HeadingError {
@@ -648,7 +650,7 @@ namespace KRPC.SpaceCenter.Services
         /// </summary>
         /// <remarks>
         /// Measured about the vessel's nose axis, so it stays well-defined near the vertical
-        /// singularity — unlike a subtraction of pitch/heading/roll angles, whose roll term is
+        /// singularity. A subtraction of pitch, heading and roll angles has a roll term that is
         /// ill-conditioned when the vessel points close to straight up or down.
         /// </remarks>
         [KRPCProperty]
@@ -682,7 +684,7 @@ namespace KRPC.SpaceCenter.Services
 
         /// <summary>
         /// The per-axis attitude error (pitch, yaw, roll), in degrees, between the vessel's current
-        /// attitude and the target the auto-pilot is currently tracking (the slewed target — see
+        /// attitude and the target the auto-pilot is currently tracking (the slewed target, see
         /// <see cref="CurrentTargetRotation"/>). Like <see cref="AttitudeError"/> but relative to the
         /// current target, so it stays small while a smoothed change (see
         /// <see cref="TargetSmoothingTime"/>) is fed in; equal to <see cref="AttitudeError"/> when
@@ -732,7 +734,7 @@ namespace KRPC.SpaceCenter.Services
         /// </summary>
         /// <remarks>
         /// Measured about the vessel's nose axis, so it stays well-defined near the vertical
-        /// singularity — see <see cref="RollError"/>.
+        /// singularity. See <see cref="RollError"/>.
         /// </remarks>
         [KRPCProperty]
         public float CurrentRollError {
@@ -931,8 +933,8 @@ namespace KRPC.SpaceCenter.Services
         /// <see cref="RateFilterMode.Automatic"/> (the default) the auto-pilot detects the
         /// oscillation at runtime, estimates its frequency and routes it to the appropriate tool
         /// (a notch filter for a low-frequency mode near the control band, a low-pass for a
-        /// high-frequency mode). <see cref="RateFilterMode.Off"/> disables rate filtering only —
-        /// the other oscillation mitigations are unaffected. <see cref="RateFilterMode.Notch"/>
+        /// high-frequency mode). <see cref="RateFilterMode.Off"/> disables rate filtering only,
+        /// leaving the other oscillation mitigations unaffected. <see cref="RateFilterMode.Notch"/>
         /// and <see cref="RateFilterMode.LowPass"/> force the respective tool unconditionally at
         /// <see cref="PitchYawOscillationFrequency"/>, for a vessel known in advance to be
         /// flexible.
@@ -991,7 +993,7 @@ namespace KRPC.SpaceCenter.Services
 
         /// <summary>
         /// Controls the bandwidth-floor mitigation: the reduction of the inner control loop
-        /// bandwidth on a structurally flexible axis — the primary oscillation stabilizer. When
+        /// bandwidth on a structurally flexible axis, the primary oscillation stabilizer. When
         /// <see cref="MitigationMode.Automatic"/> (the default) it engages on a latched axis
         /// while holding (and during a detected limit cycle). <see cref="MitigationMode.Off"/>
         /// never reduces the bandwidth; <see cref="MitigationMode.Forced"/> keeps it fully

--- a/service/SpaceCenter/src/Services/AutoPilot.cs
+++ b/service/SpaceCenter/src/Services/AutoPilot.cs
@@ -562,8 +562,8 @@ namespace KRPC.SpaceCenter.Services
             get { return (float)CurrentPitchHeadingRoll ().x; }
         }
 
-        // Total pointing error (degrees) between the vessel and a target. rollControlled selects the
-        // full-rotation error (honouring roll) versus the direction-only error.
+        // Total pointing error (degrees) between the vessel and a target. rollControlled
+        // selects the full-rotation error, which includes roll, over the direction-only error.
         float TotalError (QuaternionD targetRotation, Vector3d targetDirection, bool rollControlled)
         {
             if (rollControlled) {

--- a/service/SpaceCenter/src/Services/CelestialBody.cs
+++ b/service/SpaceCenter/src/Services/CelestialBody.cs
@@ -122,7 +122,7 @@ namespace KRPC.SpaceCenter.Services
 
         /// <summary>
         /// The current rotation angle of the body, in radians.
-        /// A value between 0 and 2·pi
+        /// A value between 0 and 2 pi.
         /// </summary>
         [KRPCProperty]
         public double RotationAngle {
@@ -131,7 +131,7 @@ namespace KRPC.SpaceCenter.Services
 
         /// <summary>
         /// The initial rotation angle of the body (at UT 0), in radians.
-        /// A value between 0 and 2·pi
+        /// A value between 0 and 2 pi.
         /// </summary>
         [KRPCProperty]
         public double InitialRotation {

--- a/service/SpaceCenter/src/Services/CelestialBody.cs
+++ b/service/SpaceCenter/src/Services/CelestialBody.cs
@@ -20,7 +20,7 @@ namespace KRPC.SpaceCenter.Services
         Orbit orbit;
 
         // The body's name. A body keeps its name for as long as it exists, and the game
-        // builds a new string every time it is asked for one, so it is taken once.
+        // builds a new string on every read, so it is taken once
         readonly string bodyName;
 
         /// <summary>
@@ -341,7 +341,7 @@ namespace KRPC.SpaceCenter.Services
         /// </summary>
         Vector3d TerrainNormal (double latitude, double longitude, Func<double, double, double> height)
         {
-            // How far apart to take the samples. Far enough that the height difference between
+            // The distance between samples. Far enough that the height difference between
             // them survives rounding, close enough to follow the local shape of the terrain.
             const double sampleDistance = 10;
             var up = InternalBody.GetSurfaceNVector (latitude, longitude);

--- a/service/SpaceCenter/src/Services/ClosestApproach.cs
+++ b/service/SpaceCenter/src/Services/ClosestApproach.cs
@@ -77,9 +77,8 @@ namespace KRPC.SpaceCenter.Services
         }
 
         /// <summary>
-        /// What the game holds for the approach. Every member reads both of the orbits,
-        /// so it needs both: it is as live, dormant or destroyed as the less alive of
-        /// the two.
+        /// The state of the approach. Every member reads both orbits, so it takes the less
+        /// alive of their two states.
         /// </summary>
         public GameObjectState GameObjectState {
             get { return orbit.GameObjectState.LeastAlive (target.GameObjectState); }

--- a/service/SpaceCenter/src/Services/ClosestApproach.cs
+++ b/service/SpaceCenter/src/Services/ClosestApproach.cs
@@ -30,8 +30,8 @@ namespace KRPC.SpaceCenter.Services
     {
         readonly Orbit orbit;
         readonly Orbit target;
-        // Which of the successive approaches this is: the search covers one orbital
-        // period, starting this many periods from now.
+        // The index of this approach among the successive ones: the search covers one
+        // orbital period, starting this many periods from now
         readonly int orbitsAhead;
         // The approach as it was last solved, with the physics tick and the game state it
         // was solved in.
@@ -84,10 +84,9 @@ namespace KRPC.SpaceCenter.Services
             get { return orbit.GameObjectState.LeastAlive (target.GameObjectState); }
         }
 
-        // The time the search for this approach starts from, which it covers one
-        // orbital period of the approaching object from. The next approach is searched
-        // for from now, and needs no period to step by; a hyperbolic orbit, which has
-        // none, therefore still has a next approach.
+        // The time the search for this approach starts from, covering one orbital period
+        // of the approaching object. The next approach is searched for from now and needs
+        // no period to step by, so a hyperbolic orbit still has one
         double BeginTime {
             get {
                 if (orbitsAhead == 0)
@@ -97,11 +96,9 @@ namespace KRPC.SpaceCenter.Services
         }
 
         // The universal time of the closest approach, and the distance there, estimated
-        // from where the two orbits are now. The estimate is a search over an orbital
-        // period, sampling both orbits at some seventy points, so it costs far more than
-        // any member that reads it. Nothing it reads moves within a physics tick, so it
-        // is solved once per tick: the members read in a tick share that one search, and
-        // all describe the same moment.
+        // from where the two orbits are now. The estimate searches an orbital period,
+        // sampling both orbits at some seventy points, so it is solved once per physics
+        // tick and shared by the members read in that tick
         double Solve (out double approachDistance)
         {
             if (solvedFixedTime != Time.fixedTime || solvedGeneration != GameState.Generation) {
@@ -125,13 +122,12 @@ namespace KRPC.SpaceCenter.Services
             return o.InternalOrbit.getPositionAtUT (ut);
         }
 
-        // The world-space velocity of the given orbit at the closest approach: the
-        // motion around its reference body then, plus the motion of that body now. The
-        // body is taken as it is now to match WorldPosition above, which places the
-        // orbit against the body's current position, and to match the velocity a
-        // reference frame moves at, which is also the body's current one. Both objects
-        // are treated the same way, so the relative quantities remain the difference of
-        // the absolute ones.
+        // The world-space velocity of the given orbit at the closest approach: the motion
+        // around its reference body then, plus the motion of that body now. The body is
+        // taken as it is now to match WorldPosition, which places the orbit against the
+        // body's current position, and the velocity a reference frame moves at. Both
+        // objects are treated the same way, so the relative quantities stay the difference
+        // of the absolute ones
         Vector3d WorldVelocity (Orbit o, double ut)
         {
             var internalOrbit = o.InternalOrbit;

--- a/service/SpaceCenter/src/Services/CommLink.cs
+++ b/service/SpaceCenter/src/Services/CommLink.cs
@@ -46,11 +46,10 @@ namespace KRPC.SpaceCenter.Services
         }
 
         /// <summary>
-        /// What the game holds for the link. It is live while the vessel's control path
-        /// still runs through the two nodes, and destroyed once the vessel is gone. A path
-        /// that no longer takes the hop has lost contact rather than destroyed anything,
-        /// and takes it again when the two are in range of each other, so the link is
-        /// dormant.
+        /// The state of the link. It is live while the vessel's control path runs through
+        /// the two nodes, and destroyed once the vessel is destroyed. A path that drops the
+        /// hop leaves the link dormant, and takes it again once the two nodes are in range
+        /// of each other.
         /// </summary>
         public GameObjectState GameObjectState {
             get {

--- a/service/SpaceCenter/src/Services/CommLink.cs
+++ b/service/SpaceCenter/src/Services/CommLink.cs
@@ -12,10 +12,10 @@ namespace KRPC.SpaceCenter.Services
     [KRPCClass (Service = "SpaceCenter")]
     public class CommLink : Equatable<CommLink>, IGameObjectState
     {
-        // A link is a hop in one vessel's control path, and the two nodes it joins are what
-        // identify it: the game builds the path again, out of new link objects, every time
-        // it works out the vessel's connection, so a link object stands for the state of
-        // one hop at one moment rather than for the hop itself.
+        // A link is a hop in one vessel's control path, identified by the two nodes it
+        // joins. The game builds the path again, out of new link objects, every time it
+        // works out the vessel's connection, so a link object stands for one hop at one
+        // moment
         readonly Guid vesselId;
         readonly CommNode start;
         readonly CommNode end;

--- a/service/SpaceCenter/src/Services/CommNode.cs
+++ b/service/SpaceCenter/src/Services/CommNode.cs
@@ -27,11 +27,10 @@ namespace KRPC.SpaceCenter.Services
         public CommNet.CommNode InternalNode { get; private set; }
 
         /// <summary>
-        /// What the game holds for the thing the node hangs off. The game gives nothing to
-        /// identify a node by, so the node itself is held; what can be checked is the
-        /// transform it was built with, which the game tears down with the vessel. A node
-        /// that never had one, such as a ground station, says nothing either way and is
-        /// therefore kept.
+        /// The state of the object the node hangs off. The game offers no identifier for a
+        /// node, so the node itself is held and the transform it was built with is what can
+        /// be read. The game tears that transform down with the vessel, and a node built
+        /// without one, such as a ground station, stays live.
         /// </summary>
         public GameObjectState GameObjectState {
             get {

--- a/service/SpaceCenter/src/Services/CommNode.cs
+++ b/service/SpaceCenter/src/Services/CommNode.cs
@@ -54,8 +54,8 @@ namespace KRPC.SpaceCenter.Services
         /// </summary>
         public override int GetHashCode ()
         {
-            // The node's identity hash rather than its own, so that nothing the game does to
-            // the node can change it while a client holds this object.
+            // The node's identity hash, so that nothing the game does to the node changes
+            // it while a client holds this object
             return RuntimeHelpers.GetHashCode (InternalNode);
         }
 

--- a/service/SpaceCenter/src/Services/Comms.cs
+++ b/service/SpaceCenter/src/Services/Comms.cs
@@ -33,7 +33,7 @@ namespace KRPC.SpaceCenter.Services
         }
 
         /// <summary>
-        /// What the game holds for the vessel this belongs to.
+        /// The state of the vessel this belongs to.
         /// </summary>
         public GameObjectState GameObjectState {
             get { return FlightGlobalsExtensions.VesselState (VesselId); }

--- a/service/SpaceCenter/src/Services/Contract.cs
+++ b/service/SpaceCenter/src/Services/Contract.cs
@@ -45,10 +45,9 @@ namespace KRPC.SpaceCenter.Services
         }
 
         /// <summary>
-        /// What the game holds for the contract. It is live while the contract system
-        /// lists it, running or finished, and destroyed once the system is there to ask and
-        /// does not. A game with no contract system has no contracts to look through, which
-        /// says nothing about this one.
+        /// The state of the contract. It is live while the contract system lists it,
+        /// running or finished, and destroyed once a running system stops listing it. A
+        /// game with no contract system leaves the contract dormant.
         /// </summary>
         public GameObjectState GameObjectState
         {

--- a/service/SpaceCenter/src/Services/Contract.cs
+++ b/service/SpaceCenter/src/Services/Contract.cs
@@ -16,8 +16,7 @@ namespace KRPC.SpaceCenter.Services
     {
         // The guid the game gives a contract, which it writes into the save and reads back,
         // so it names the contract across a load. The contract system builds new contract
-        // objects for a game it loads, so holding one would leave this reading a contract
-        // out of a game state that is no longer loaded.
+        // objects for a game it loads, so the contract object itself is not held
         readonly Guid contractGuid;
 
         /// <summary>

--- a/service/SpaceCenter/src/Services/ContractParameter.cs
+++ b/service/SpaceCenter/src/Services/ContractParameter.cs
@@ -57,9 +57,8 @@ namespace KRPC.SpaceCenter.Services
         }
 
         /// <summary>
-        /// What the game holds for the parameter. It belongs to its contract, so it is
-        /// exactly as live, dormant or destroyed as the contract is, and destroyed when a
-        /// contract that is there to look in no longer has it.
+        /// The state of the parameter. It takes the state of its contract, and is destroyed
+        /// once a live contract stops holding it.
         /// </summary>
         public GameObjectState GameObjectState
         {

--- a/service/SpaceCenter/src/Services/ContractParameter.cs
+++ b/service/SpaceCenter/src/Services/ContractParameter.cs
@@ -12,11 +12,11 @@ namespace KRPC.SpaceCenter.Services
     [KRPCClass(Service = "SpaceCenter")]
     public class ContractParameter : Equatable<ContractParameter>, IGameObjectState
     {
-        // The contract the parameter belongs to, and the indices that lead to it: a
-        // contract's parameters are an ordered list and so are each parameter's own, so the
-        // path names the parameter for as long as the contract exists. The game gives a
-        // parameter nothing else to be named by, and builds new parameter objects whenever
-        // it builds the contract.
+        // The contract the parameter belongs to, and the indices that lead to it. A
+        // contract's parameters are an ordered list, and so are each parameter's own, so
+        // the path names the parameter for as long as the contract exists. The game gives a
+        // parameter no other name, and builds new parameter objects whenever it builds the
+        // contract
         readonly Contract contract;
         readonly int[] path;
 

--- a/service/SpaceCenter/src/Services/Control.cs
+++ b/service/SpaceCenter/src/Services/Control.cs
@@ -50,7 +50,7 @@ namespace KRPC.SpaceCenter.Services
         }
 
         /// <summary>
-        /// What the game holds for the vessel this belongs to.
+        /// The state of the vessel this belongs to.
         /// </summary>
         public GameObjectState GameObjectState {
             get { return FlightGlobalsExtensions.VesselState (vesselId); }

--- a/service/SpaceCenter/src/Services/Control.cs
+++ b/service/SpaceCenter/src/Services/Control.cs
@@ -755,9 +755,9 @@ namespace KRPC.SpaceCenter.Services
                     InputLockManager.SetControlLock(ControlTypes.STAGING, "manualStageLock");
                 else
                     InputLockManager.RemoveControlLock("manualStageLock");
-                // Alt+L toggles this flag alongside the input lock, and decides from it whether the
-                // next press locks or unlocks. Setting it keeps the keybinding in step, so the next
-                // press does the opposite of what was set here rather than repeating it.
+                // Alt+L toggles this flag alongside the input lock, and decides from it
+                // whether the next press locks or unlocks. Setting it keeps the keybinding
+                // in step, so the next press does the opposite of what was set here
                 if (FlightInputHandler.fetch != null)
                     FlightInputHandler.fetch.stageLock = value;
             }
@@ -1009,7 +1009,7 @@ namespace KRPC.SpaceCenter.Services
             if (eva == null || eva.vessel == null || !eva.OnALadder)
                 return;
             // A kerbal that has just taken hold of a ladder is still swinging onto it, and
-            // cannot let go again until it is on, so wait for it rather than refuse.
+            // cannot let go again until it is on, so wait for it
             if (!eva.fsm.Started || !eva.fsm.CurrentState.IsValid (eva.On_ladderLetGo)) {
                 if (tick > 200)
                     throw new InvalidOperationException (

--- a/service/SpaceCenter/src/Services/CrewMember.cs
+++ b/service/SpaceCenter/src/Services/CrewMember.cs
@@ -23,9 +23,9 @@ namespace KRPC.SpaceCenter.Services
         }
 
         /// <summary>
-        /// What the game holds for the crew member, who is live while the game still
-        /// has them on its roster. A game that has not been loaded has no roster to look
-        /// in, which says nothing about anyone.
+        /// The state of the crew member, who is live while the game holds them on its
+        /// roster. A game that has yet to be loaded has no roster, and leaves the crew
+        /// member dormant.
         /// </summary>
         public GameObjectState GameObjectState {
             get {

--- a/service/SpaceCenter/src/Services/CrewMember.cs
+++ b/service/SpaceCenter/src/Services/CrewMember.cs
@@ -233,8 +233,7 @@ namespace KRPC.SpaceCenter.Services
         static Vessel WaitForEVA (KerbalEVA eva, int tick)
         {
             // The game brings the kerbal into being over the following frames and then
-            // switches to it, so wait for it to be flyable rather than hand back a vessel
-            // that cannot yet be controlled.
+            // switches to it, so wait for the vessel to be flyable
             if (eva == null || eva.vessel == null)
                 throw new InvalidOperationException ("The kerbal was destroyed while leaving the vessel");
             if (FlightGlobals.ActiveVessel == eva.vessel && eva.vessel.loaded && !eva.vessel.packed)

--- a/service/SpaceCenter/src/Services/Editor.cs
+++ b/service/SpaceCenter/src/Services/Editor.cs
@@ -231,10 +231,10 @@ namespace KRPC.SpaceCenter.Services
             if (settled < SettleFrames)
                 throw new YieldException<Action> (() => StartVesselLoad (path, settled + 1));
             EditorLogic.LoadShipFromFile (path);
-            // The game leaves itself set to read this file again the next time the
-            // editor starts up, which would spring the vessel on a later entry into the
-            // editor that did not ask for it. Point it back at the vessel the editor is
-            // holding, as it is when a vessel is edited in place.
+            // The game leaves itself set to read this file again the next time the editor
+            // starts up, which would load the vessel on a later entry into the editor.
+            // Point it back at the vessel the editor is holding, as it is when a vessel is
+            // edited in place
             EditorDriver.StartupBehaviour = EditorDriver.StartupBehaviours.LOAD_FROM_CACHE;
         }
     }

--- a/service/SpaceCenter/src/Services/Flight.cs
+++ b/service/SpaceCenter/src/Services/Flight.cs
@@ -34,10 +34,8 @@ namespace KRPC.SpaceCenter.Services
         }
 
         /// <summary>
-        /// What the game holds for the vessel this belongs to and the frame it is
-        /// measured in. Every member reads both, so it is as alive as the less alive of
-        /// them: a flight measured in a frame the client has removed has nothing left to
-        /// be expressed against.
+        /// The state of the vessel this belongs to and of the frame it is measured in.
+        /// Every member reads both, so it takes the less alive of their two states.
         /// </summary>
         public GameObjectState GameObjectState {
             get {
@@ -495,8 +493,9 @@ namespace KRPC.SpaceCenter.Services
         /// A value between -90° and +90°.
         /// </summary>
         /// <remarks>
-        /// An absolute Euler angle, ill-conditioned when the vessel points near vertical (pitch →
-        /// ±90°), where heading and roll become ambiguous. For an always-defined attitude use
+        /// An absolute Euler angle, ill-conditioned when the vessel points near vertical (a pitch
+        /// near -90° or +90°), where heading and roll become ambiguous. For an always-defined
+        /// attitude use
         /// <see cref="Rotation"/> or <see cref="Direction"/>.
         /// </remarks>
         [KRPCProperty]
@@ -509,8 +508,9 @@ namespace KRPC.SpaceCenter.Services
         /// A value between 0° and 360°.
         /// </summary>
         /// <remarks>
-        /// An absolute Euler angle, undefined when the vessel points near vertical (pitch → ±90°).
-        /// For an always-defined attitude use <see cref="Rotation"/> or <see cref="Direction"/>.
+        /// An absolute Euler angle, undefined when the vessel points near vertical (a pitch near
+        /// -90° or +90°). For an always-defined attitude use <see cref="Rotation"/> or
+        /// <see cref="Direction"/>.
         /// </remarks>
         [KRPCProperty]
         public float Heading {
@@ -522,8 +522,9 @@ namespace KRPC.SpaceCenter.Services
         /// A value between -180° and +180°.
         /// </summary>
         /// <remarks>
-        /// An absolute Euler angle, ill-conditioned when the vessel points near vertical (pitch →
-        /// ±90°), where the vertical-plane reference vanishes. For an always-defined attitude use
+        /// An absolute Euler angle, ill-conditioned when the vessel points near vertical (a pitch
+        /// near -90° or +90°), where the vertical-plane reference vanishes. For an always-defined
+        /// attitude use
         /// <see cref="Rotation"/>; for a well-defined roll use the auto-pilot's
         /// <c>TargetRoll</c> / <c>RollError</c> against a chosen up reference.
         /// </remarks>
@@ -633,7 +634,7 @@ namespace KRPC.SpaceCenter.Services
         /// <summary>
         /// The dynamic pressure acting on the vessel, in Pascals. This is a measure of the
         /// strength of the aerodynamic forces. It is equal to
-        /// ½ · air density · velocity².
+        /// <math>\frac{1}{2} . \mbox{air density} . \mbox{velocity}^2</math>.
         /// It is commonly denoted <math>Q</math>.
         /// </summary>
         [KRPCProperty]

--- a/service/SpaceCenter/src/Services/Flight.cs
+++ b/service/SpaceCenter/src/Services/Flight.cs
@@ -221,14 +221,14 @@ namespace KRPC.SpaceCenter.Services
                     // rb.angularDrag = part.angularDrag * dynamicPressure(atm) *
                     // PhysicsGlobals.AngularDragMultiplier every frame, and the engine
                     // damps the rigidbody's rotation by it. It is a real attitude torque
-                    // the game applies that never appears as a per-part force, so add its
-                    // first-order equivalent (-angularDrag * I_part * omega) to keep this
-                    // live sum consistent with the vessel's measured net torque and with
-                    // SimulateAerodynamicTorqueAt. Gate on the part's OWN rigidbody
-                    // (physicsless parts share the parent's and get no angular drag).
-                    // KSP runs Unity physics in tonne/kilonewton units, so rb.inertiaTensor
+                    // that never appears as a per-part force, so add its first-order
+                    // equivalent (-angularDrag * I_part * omega) to keep this sum
+                    // consistent with the vessel's measured net torque and with
+                    // SimulateAerodynamicTorqueAt. Gate on the part's own rigidbody, as
+                    // physicsless parts share the parent's and get no angular drag. KSP
+                    // runs Unity physics in tonne and kilonewton units, so rb.inertiaTensor
                     // is in tonne*m^2 and angularDrag * I * omega is already in
-                    // kilonewton-meters -- the same scale as this accumulator.
+                    // kilonewton-meters, the same scale as this accumulator
                     var rb = part.rb;
                     if (rb != null && rb.angularDrag > 0f)
                         torque -= (Vector3d)(rb.angularDrag *
@@ -452,10 +452,9 @@ namespace KRPC.SpaceCenter.Services
         /// acceleration, and its magnitude is the acceleration of the vessel in <math>m/s^2</math>.</returns>
         [KRPCProperty]
         public Tuple3 Acceleration {
-            // Use acceleration_immediate (the raw per-frame change in orbital velocity) rather than
-            // the acceleration field, which KSP boxcar-averages over several frames for the G-force
-            // gauge. The immediate value is the true time derivative of Velocity and responds
-            // without the averaging lag.
+            // Use acceleration_immediate, the raw per-frame change in orbital velocity. The
+            // acceleration field is boxcar-averaged over several frames for the G-force
+            // gauge, and lags behind the true time derivative of Velocity
             get { return referenceFrame.DirectionFromWorldSpace (InternalVessel.acceleration_immediate).ToTuple (); }
         }
 
@@ -1114,8 +1113,7 @@ namespace KRPC.SpaceCenter.Services
                 CheckFAR ();
                 // FAR averages how far each of the vessel's lifting surfaces is stalled,
                 // weighted by their area, which is zero over zero for a vessel that has
-                // none. Nothing on such a vessel can stall, so report no stall rather than
-                // passing the NaN on.
+                // none. Nothing on such a vessel can stall, so report no stall
                 var stall = FAR.VesselStallFrac (InternalVessel);
                 return double.IsNaN (stall) ? 0f : (float)stall;
             }

--- a/service/SpaceCenter/src/Services/Node.cs
+++ b/service/SpaceCenter/src/Services/Node.cs
@@ -22,9 +22,9 @@ namespace KRPC.SpaceCenter.Services
         /// The x-component is the radial component.
 
         readonly Guid vesselId;
-        // The game's own maneuver node. It offers nothing to identify a node by, so this is
-        // held rather than found again; a node the game no longer has in the vessel's flight
-        // plan, which includes every node after a game is loaded, is reclaimed instead.
+        // The game's own maneuver node. The game offers no way to identify a node, so the
+        // node is held. A node the game does not have in the vessel's flight plan, which
+        // includes every node after a game is loaded, is reclaimed
         readonly ManeuverNode node;
 
         internal Node (global::Vessel vessel, double ut, double prograde, double normal, double radial)
@@ -74,8 +74,8 @@ namespace KRPC.SpaceCenter.Services
         /// </summary>
         public override int GetHashCode ()
         {
-            // The node's identity hash rather than its own: it is what the game holds, and
-            // nothing about it may change while a client has this object.
+            // The node's identity hash: the game holds the node itself, and nothing about
+            // it may change while a client has this object
             return Hash.Of (vesselId).And (RuntimeHelpers.GetHashCode (node));
         }
 

--- a/service/SpaceCenter/src/Services/Node.cs
+++ b/service/SpaceCenter/src/Services/Node.cs
@@ -119,11 +119,9 @@ namespace KRPC.SpaceCenter.Services
         }
 
         /// <summary>
-        /// What the game holds for the node. It is live while the vessel still has it in
-        /// its flight plan, and destroyed once the vessel is there to ask and does not,
-        /// as a node that leaves the plan is gone for good. A vessel the game is not
-        /// solving conics for has no flight plan to look in, which says nothing about the
-        /// node either way.
+        /// The state of the node. It is live while the vessel holds it in its flight plan,
+        /// and destroyed once a live vessel stops holding it. A vessel the game solves no
+        /// conics for has no flight plan, and leaves the node dormant.
         /// </summary>
         public GameObjectState GameObjectState {
             get {

--- a/service/SpaceCenter/src/Services/Orbit.cs
+++ b/service/SpaceCenter/src/Services/Orbit.cs
@@ -80,9 +80,9 @@ namespace KRPC.SpaceCenter.Services
         }
 
         /// <summary>
-        /// What the game holds for the thing the orbit belongs to. An orbit built from a KSP
-        /// orbit alone has no owner to ask, so it is kept, and an orbit constructed for a
-        /// client is kept until it is removed or that client goes.
+        /// The state of the object the orbit belongs to. An orbit built from a KSP orbit
+        /// alone has no owner, and stays live. An orbit constructed for a client stays live
+        /// until it is removed or that client disconnects.
         /// </summary>
         public GameObjectState GameObjectState {
             get {
@@ -110,14 +110,12 @@ namespace KRPC.SpaceCenter.Services
         /// </summary>
         /// <remarks>
         /// Only an orbit created by <see cref="CreateFromPositionAndVelocity"/> or
-        /// <see cref="CreateFromOrbitalElements"/> can be removed. Every other orbit is
-        /// the orbit of something in the game, which is what says when it is finished
-        /// with, and the server holds one of each however often it is asked for.
+        /// <see cref="CreateFromOrbitalElements"/> can be removed. Every other orbit
+        /// belongs to something in the game, and the server holds one of each.
         ///
         /// Any further use of this object throws an exception, as does use of a
-        /// reference frame defined against it. An orbit is removed for the client that
-        /// created it and is not shared with any other, and one whose client disconnects
-        /// is removed with it.
+        /// reference frame defined against it. An orbit belongs to the client that
+        /// created it, and is removed when that client disconnects.
         /// </remarks>
         [KRPCMethod]
         public void Remove ()
@@ -499,25 +497,22 @@ namespace KRPC.SpaceCenter.Services
         /// <see cref="CelestialBody.NonRotatingReferenceFrame"/> of
         /// <paramref name="body"/>.</param>
         /// <remarks>
-        /// The orbit is a single conic around <paramref name="body"/>. Nothing else acts on
-        /// it: it never changes sphere of influence, so <see cref="NextOrbit"/> is
-        /// <c>null</c> however far it travels from the body, and it is not slowed by an
-        /// atmosphere. A vessel held on rails follows its own orbit exactly, while one
-        /// inside the physics bubble is simulated and drifts from it a little.
+        /// The orbit is a single conic around <paramref name="body"/>. It never changes
+        /// sphere of influence, so <see cref="NextOrbit"/> is <c>null</c>, and no
+        /// atmosphere slows it. A vessel held on rails follows its own orbit exactly,
+        /// while one inside the physics bubble is simulated and drifts from it a little.
         ///
-        /// The members that describe where the orbit has got to -- <see cref="Radius"/>,
-        /// <see cref="Speed"/>, <see cref="TrueAnomaly"/>, <see cref="TimeToApoapsis"/>
-        /// and the like -- describe it at <paramref name="ut"/> and stay there, as
-        /// nothing is moving along it. Use <see cref="RadiusAt"/>,
+        /// <see cref="Radius"/>, <see cref="Speed"/>, <see cref="TrueAnomaly"/>,
+        /// <see cref="TimeToApoapsis"/> and the like describe the orbit at
+        /// <paramref name="ut"/> and stay there. Use <see cref="RadiusAt"/>,
         /// <see cref="PositionAt"/>, <see cref="VelocityAt"/> and
-        /// <see cref="TrueAnomalyAtUT"/> to ask where it is at another time.
-        /// <see cref="ReferenceFrame"/> and <see cref="OrbitalReferenceFrame"/> follow
+        /// <see cref="TrueAnomalyAtUT"/> for another time, and
+        /// <see cref="ReferenceFrame"/> and <see cref="OrbitalReferenceFrame"/> to follow
         /// the orbit as time passes.
         ///
-        /// The orbit that is returned is kept until <see cref="Remove"/> is called on
-        /// it or the client that created it disconnects, so a script that creates one
-        /// repeatedly, for example once per update, should remove each one when it is
-        /// finished with it.
+        /// The orbit is held until <see cref="Remove"/> is called on it or the client
+        /// that created it disconnects. Remove each one created by a script that creates
+        /// them repeatedly, for example once per update.
         /// </remarks>
         [KRPCMethod]
         public static Orbit CreateFromPositionAndVelocity (
@@ -584,30 +579,27 @@ namespace KRPC.SpaceCenter.Services
         /// <param name="epoch">The universal time, in seconds, that
         /// <paramref name="meanAnomalyAtEpoch"/> is measured at.</param>
         /// <remarks>
-        /// The orbit is a single conic around <paramref name="body"/>. Nothing else acts
-        /// on it: it never changes sphere of influence, so <see cref="NextOrbit"/> is
-        /// <c>null</c> however far it travels from the body, and it is not slowed by an
-        /// atmosphere.
+        /// The orbit is a single conic around <paramref name="body"/>. It never changes
+        /// sphere of influence, so <see cref="NextOrbit"/> is <c>null</c>, and no
+        /// atmosphere slows it.
         ///
-        /// The angles are measured against the same reference plane and direction that
+        /// The angles are measured against the reference plane and direction that
         /// <see cref="Inclination"/>, <see cref="LongitudeOfAscendingNode"/> and
-        /// <see cref="ArgumentOfPeriapsis"/> report them against, which
+        /// <see cref="ArgumentOfPeriapsis"/> report them against.
         /// <see cref="ReferencePlaneNormal"/> and <see cref="ReferencePlaneDirection"/>
-        /// give as vectors in a reference frame.
+        /// give these as vectors in a reference frame.
         ///
-        /// The members that describe where the orbit has got to -- <see cref="Radius"/>,
-        /// <see cref="Speed"/>, <see cref="TrueAnomaly"/>, <see cref="TimeToApoapsis"/>
-        /// and the like -- describe it at <paramref name="epoch"/> and stay there, as
-        /// nothing is moving along it. Use <see cref="RadiusAt"/>,
+        /// <see cref="Radius"/>, <see cref="Speed"/>, <see cref="TrueAnomaly"/>,
+        /// <see cref="TimeToApoapsis"/> and the like describe the orbit at
+        /// <paramref name="epoch"/> and stay there. Use <see cref="RadiusAt"/>,
         /// <see cref="PositionAt"/>, <see cref="VelocityAt"/> and
-        /// <see cref="TrueAnomalyAtUT"/> to ask where it is at another time.
-        /// <see cref="ReferenceFrame"/> and <see cref="OrbitalReferenceFrame"/> follow
+        /// <see cref="TrueAnomalyAtUT"/> for another time, and
+        /// <see cref="ReferenceFrame"/> and <see cref="OrbitalReferenceFrame"/> to follow
         /// the orbit as time passes.
         ///
-        /// The orbit that is returned is kept until <see cref="Remove"/> is called on
-        /// it or the client that created it disconnects, so a script that creates one
-        /// repeatedly, for example once per update, should remove each one when it is
-        /// finished with it.
+        /// The orbit is held until <see cref="Remove"/> is called on it or the client
+        /// that created it disconnects. Remove each one created by a script that creates
+        /// them repeatedly, for example once per update.
         /// </remarks>
         [KRPCMethod]
         public static Orbit CreateFromOrbitalElements (

--- a/service/SpaceCenter/src/Services/Orbit.cs
+++ b/service/SpaceCenter/src/Services/Orbit.cs
@@ -20,19 +20,16 @@ namespace KRPC.SpaceCenter.Services
         readonly Vessel ownerVessel;
         readonly CelestialBody ownerBody;
         readonly Node ownerNode;
-        // The KSP orbit, held only where it is not the orbit of the thing the object
-        // belongs to and so cannot be asked for again: a patch, or an orbit a caller
-        // handed in. An orbit that has an owner is looked up on it instead, because the
-        // game builds a new one whenever it builds the owner, and the object has to read
-        // the loaded game rather than the state it was made in.
+        // The KSP orbit, held only for an orbit that cannot be looked up again: a patch, or
+        // an orbit a caller handed in. An orbit that has an owner is looked up on the
+        // owner, because the game builds a new one whenever it builds the owner, and the
+        // object has to read the loaded game
         readonly global::Orbit patch;
-        // Whether a client asked for the orbit to be built, rather than it being the
-        // orbit of something in the game or a patch of one.
+        // Whether a client asked for the orbit to be built
         bool constructed;
-        // Whether the orbit has been let go of. A constructed orbit is as valid on the
-        // last frame of the session as on the first, so it stands for nothing the game
-        // can destroy, and the client removing it or going is the only thing that can
-        // say the object is finished with.
+        // Whether the orbit has been let go of. A constructed orbit is as valid on the last
+        // frame of the session as on the first, so only the client removing it or going
+        // marks the object as finished with
         bool released;
 
         internal Orbit (Vessel vessel)
@@ -125,9 +122,9 @@ namespace KRPC.SpaceCenter.Services
                 throw new InvalidOperationException (
                     "Only an orbit created by CreateFromPositionAndVelocity or " +
                     "CreateFromOrbitalElements can be removed");
-            // The addon holds the orbit on its client's behalf and has nothing left to
-            // do for one the client has finished with. Taking it out is also what asks
-            // for the sweep that drops it from the object store.
+            // The addon holds the orbit on its client's behalf and has nothing left to do
+            // for one the client has finished with. Taking it out also requests the sweep
+            // that drops it from the object store
             ConstructedOrbitsAddon.Remove (this);
             released = true;
         }
@@ -271,9 +268,9 @@ namespace KRPC.SpaceCenter.Services
             get { return ownerVessel; }
         }
 
-        // The celestial body this orbit belongs to (the orbiting body, not the parent
-        // it orbits — that is Body), or null if it belongs to something else or the
-        // owner is unknown.
+        // The celestial body this orbit belongs to (the orbiting body, not the parent it
+        // orbits, which is Body), or null if it belongs to something else or the owner is
+        // unknown.
         internal CelestialBody OwnerBody {
             get { return ownerBody; }
         }
@@ -542,9 +539,8 @@ namespace KRPC.SpaceCenter.Services
             orbit.UpdateFromStateVectors (
                 relativePosition.SwapYZ (), relativeVelocity.SwapYZ (), internalBody, ut);
             // Init derives the mean motion, period and anomalies that the orbit is
-            // propagated from; without it the orbit only carries its shape. Stepping it
-            // to the epoch then fills in where along the orbit it has got to, which
-            // nothing else will do for an orbit that no object is following.
+            // propagated from, and without it the orbit only carries its shape. Stepping it
+            // to the epoch then fills in where along the orbit it has got to
             orbit.Init ();
             orbit.UpdateFromUT (ut);
             if (!IsFinite (orbit.semiMajorAxis) || !IsFinite (orbit.eccentricity))
@@ -632,17 +628,16 @@ namespace KRPC.SpaceCenter.Services
                 throw new ArgumentException (
                     "An eccentricity above one is a hyperbola, which needs a negative " +
                     "semi-major axis, got " + semiMajorAxis);
-            // The game states the three orientation angles in degrees, and the mean
-            // anomaly in radians, which is what this reports them in.
+            // The game states the three orientation angles in degrees, and the mean anomaly
+            // in radians, and they are reported the same way
             var orbit = new global::Orbit (
                 GeometryExtensions.ToDegrees (inclination), eccentricity, semiMajorAxis,
                 GeometryExtensions.ToDegrees (longitudeOfAscendingNode),
                 GeometryExtensions.ToDegrees (argumentOfPeriapsis), meanAnomalyAtEpoch,
                 epoch, body.InternalBody);
-            // The constructor derives the mean motion, period and anomalies that the
-            // orbit is propagated from. Stepping it to the epoch then fills in where
-            // along the orbit it has got to, which nothing else will do for an orbit
-            // that no object is following.
+            // The constructor derives the mean motion, period and anomalies that the orbit
+            // is propagated from. Stepping it to the epoch then fills in where along the
+            // orbit it has got to
             orbit.UpdateFromUT (epoch);
             // Nothing solved a following patch for this orbit, and a sphere-of-influence
             // change is reported as one in the past. Zero, the value an orbit is built
@@ -653,9 +648,8 @@ namespace KRPC.SpaceCenter.Services
 
         // The object for an orbit a client asked to be built, recorded as the client's so
         // that it is let go of when the client is. An orbit read off a vessel, a body or a
-        // maneuver node is not recorded: it is named by the thing whose orbit it is, so
-        // the object store gives back one object for it however often it is asked for,
-        // and dropping it when one client goes would take it away from the others.
+        // maneuver node is not recorded: it is named by the thing whose orbit it is, so the
+        // object store gives back one object for it, shared by every client
         static Orbit Constructed (global::Orbit orbit)
         {
             var result = new Orbit (orbit);

--- a/service/SpaceCenter/src/Services/Parts/ActionGroupAction.cs
+++ b/service/SpaceCenter/src/Services/Parts/ActionGroupAction.cs
@@ -24,8 +24,8 @@ namespace KRPC.SpaceCenter.Services.Parts
         }
 
         /// <summary>
-        /// What the game holds for the module the action belongs to, or for its part
-        /// where the action has no module.
+        /// The state of the module the action belongs to, or of its part where the action
+        /// has no module.
         /// </summary>
         public GameObjectState GameObjectState {
             get { return module != null ? module.GameObjectState : part.GameObjectState; }

--- a/service/SpaceCenter/src/Services/Parts/Antenna.cs
+++ b/service/SpaceCenter/src/Services/Parts/Antenna.cs
@@ -39,8 +39,8 @@ namespace KRPC.SpaceCenter.Services.Parts
         }
 
         /// <summary>
-        /// What the game holds for the antenna: the state of the part
-        /// carrying it, or destroyed once that part no longer has the module.
+        /// The state of the part carrying the antenna, or destroyed once that part loses
+        /// the module.
         /// </summary>
         public GameObjectState GameObjectState {
             get { return transmitterRef.StateOn (Part); }

--- a/service/SpaceCenter/src/Services/Parts/CargoBay.cs
+++ b/service/SpaceCenter/src/Services/Parts/CargoBay.cs
@@ -43,8 +43,8 @@ namespace KRPC.SpaceCenter.Services.Parts
         }
 
         /// <summary>
-        /// What the game holds for the cargo bay: the state of the part
-        /// carrying it, or destroyed once that part no longer has the module.
+        /// The state of the part carrying the cargo bay, or destroyed once that part loses
+        /// the module.
         /// </summary>
         public GameObjectState GameObjectState {
             get { return bayRef.StateOn (Part); }

--- a/service/SpaceCenter/src/Services/Parts/ConfigNode.cs
+++ b/service/SpaceCenter/src/Services/Parts/ConfigNode.cs
@@ -37,8 +37,8 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         public override int GetHashCode ()
         {
-            // The node's identity hash rather than its own: a config node's contents are
-            // not what this object stands for, and a hash must not move under the store.
+            // The node's identity hash: this object stands for the node and not for its
+            // contents, and a hash must not move under the store
             return RuntimeHelpers.GetHashCode (node);
         }
 

--- a/service/SpaceCenter/src/Services/Parts/ControlSurface.cs
+++ b/service/SpaceCenter/src/Services/Parts/ControlSurface.cs
@@ -173,7 +173,7 @@ namespace KRPC.SpaceCenter.Services.Parts
                 var torque = InternalControlSurface.GetPotentialTorque ();
                 // ModuleControlSurface.GetPotentialTorque negates the roll (y) axis of both the
                 // positive and negative torque vectors, unlike other ITorqueProvider
-                // implementations. Normalise to the kRPC convention (positive torque >= 0,
+                // implementations. Normalize to the kRPC convention (positive torque >= 0,
                 // negative torque <= 0) with Math.Abs, matching ITorqueProviderExtensions.Sum.
                 return new TupleV3 (
                     new Vector3d (Math.Abs (torque.Item1.x), Math.Abs (torque.Item1.y), Math.Abs (torque.Item1.z)),

--- a/service/SpaceCenter/src/Services/Parts/ControlSurface.cs
+++ b/service/SpaceCenter/src/Services/Parts/ControlSurface.cs
@@ -40,8 +40,8 @@ namespace KRPC.SpaceCenter.Services.Parts
         }
 
         /// <summary>
-        /// What the game holds for the control surface: the state of the part
-        /// carrying it, or destroyed once that part no longer has the module.
+        /// The state of the part carrying the control surface, or destroyed once that part
+        /// loses the module.
         /// </summary>
         public GameObjectState GameObjectState {
             get { return controlSurfaceRef.StateOn (Part); }

--- a/service/SpaceCenter/src/Services/Parts/Decoupler.cs
+++ b/service/SpaceCenter/src/Services/Parts/Decoupler.cs
@@ -40,8 +40,8 @@ namespace KRPC.SpaceCenter.Services.Parts
         }
 
         /// <summary>
-        /// What the game holds for the decoupler: the state of the part carrying it, or
-        /// destroyed once that part no longer has the module.
+        /// The state of the part carrying the decoupler, or destroyed once that part loses
+        /// the module.
         /// </summary>
         public GameObjectState GameObjectState {
             get { return decouplerRef.StateOn (Part); }

--- a/service/SpaceCenter/src/Services/Parts/DockingPort.cs
+++ b/service/SpaceCenter/src/Services/Parts/DockingPort.cs
@@ -39,8 +39,8 @@ namespace KRPC.SpaceCenter.Services.Parts
         }
 
         /// <summary>
-        /// What the game holds for the docking port: the state of the part
-        /// carrying it, or destroyed once that part no longer has the module.
+        /// The state of the part carrying the docking port, or destroyed once that part
+        /// loses the module.
         /// </summary>
         public GameObjectState GameObjectState {
             get { return portRef.StateOn (Part); }

--- a/service/SpaceCenter/src/Services/Parts/DockingPort.cs
+++ b/service/SpaceCenter/src/Services/Parts/DockingPort.cs
@@ -188,9 +188,9 @@ namespace KRPC.SpaceCenter.Services.Parts
                 // Don't do anything if we are aren't in a state where the shield can be opened or closed
                 if (state != DockingPortState.Shielded && state != DockingPortState.Ready)
                     return;
-                // A single event toggles the shield open or closed. It is looked up by id -- the
-                // name of the method implementing it -- which the game does not translate, unlike
-                // the display name shown on the button.
+                // A single event toggles the shield open or closed. It is looked up by id,
+                // the name of the method implementing it, which the game does not translate,
+                // unlike the display name shown on the button
                 if (value != Shielded)
                     InternalShield.Events ["Toggle"].Invoke ();
             }

--- a/service/SpaceCenter/src/Services/Parts/Engine.cs
+++ b/service/SpaceCenter/src/Services/Parts/Engine.cs
@@ -79,8 +79,8 @@ namespace KRPC.SpaceCenter.Services.Parts
         }
 
         /// <summary>
-        /// What the game holds for the engine: the state of the part
-        /// carrying it, or destroyed once that part no longer has the module.
+        /// The state of the part carrying the engine, or destroyed once that part loses the
+        /// module.
         /// </summary>
         public GameObjectState GameObjectState {
             get { return primaryRef.StateOn (Part); }
@@ -695,7 +695,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// direction of thrust. While the reverser is still moving, this reports
         /// the state it is moving to, so a read immediately after a set returns
         /// the value that was set and setting the same value again has no effect.
-        /// Raises an exception if the engine does not have a thrust reverser
+        /// Throws an exception if the engine does not have a thrust reverser
         /// (see <see cref="CanReverseThrust"/>).
         /// </summary>
         [KRPCProperty]
@@ -711,7 +711,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         }
 
         /// <summary>
-        /// Toggle the engine's thrust reverser. Raises an exception if the engine
+        /// Toggle the engine's thrust reverser. Throws an exception if the engine
         /// does not have a thrust reverser (see <see cref="CanReverseThrust"/>).
         /// </summary>
         [KRPCMethod]
@@ -747,7 +747,7 @@ namespace KRPC.SpaceCenter.Services.Parts
 
         /// <summary>
         /// The number of times the engine can still be ignited, or -1 if it can be ignited an
-        /// unlimited number of times. Raises an exception if the engine is not managed by
+        /// unlimited number of times. Throws an exception if the engine is not managed by
         /// RealFuels (see <see cref="HasRealFuels"/>).
         /// </summary>
         [KRPCProperty (GameScene = GameScene.Flight | GameScene.Editor)]
@@ -758,7 +758,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// <summary>
         /// The resources the engine consumes each time it ignites, keyed by resource name, with
         /// the amount of each that is required. The engine uses up an ignition and fails to
-        /// light if they are not available. Raises an exception if the engine is not managed by
+        /// light if they are not available. Throws an exception if the engine is not managed by
         /// RealFuels (see <see cref="HasRealFuels"/>).
         /// </summary>
         [KRPCProperty (GameScene = GameScene.Flight | GameScene.Editor)]
@@ -768,7 +768,7 @@ namespace KRPC.SpaceCenter.Services.Parts
 
         /// <summary>
         /// Whether the engine's propellant is subject to ullage, so that it must be settled
-        /// before the engine will run reliably. Raises an exception if the engine is not
+        /// before the engine will run reliably. Throws an exception if the engine is not
         /// managed by RealFuels (see <see cref="HasRealFuels"/>).
         /// </summary>
         [KRPCProperty (GameScene = GameScene.Flight | GameScene.Editor)]
@@ -779,7 +779,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// <summary>
         /// How settled the propellant feeding the engine is, from 0 (fully unsettled) to 1
         /// (fully settled). Acceleration along the engine's thrust axis settles it, and
-        /// coasting and rotation unsettle it. Raises an exception if the engine is not managed
+        /// coasting and rotation unsettle it. Throws an exception if the engine is not managed
         /// by RealFuels (see <see cref="HasRealFuels"/>).
         /// </summary>
         [KRPCProperty]
@@ -791,7 +791,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// The probability that the propellant feeding the engine behaves normally, from 0 to 1.
         /// This is <see cref="PropellantStability"/> scaled by the game's ullage difficulty
         /// setting, and is the value RealFuels itself tests against when deciding whether the
-        /// engine runs. Raises an exception if the engine is not managed by RealFuels
+        /// engine runs. Throws an exception if the engine is not managed by RealFuels
         /// (see <see cref="HasRealFuels"/>).
         /// </summary>
         [KRPCProperty]
@@ -801,7 +801,7 @@ namespace KRPC.SpaceCenter.Services.Parts
 
         /// <summary>
         /// Whether the engine is fed by tank pressure rather than by a pump, and so needs to
-        /// draw from a highly pressurized tank. Raises an exception if the engine is not
+        /// draw from a highly pressurized tank. Throws an exception if the engine is not
         /// managed by RealFuels (see <see cref="HasRealFuels"/>).
         /// </summary>
         [KRPCProperty (GameScene = GameScene.Flight | GameScene.Editor)]
@@ -811,7 +811,7 @@ namespace KRPC.SpaceCenter.Services.Parts
 
         /// <summary>
         /// Whether the tanks feeding the engine supply the pressure it needs. Always
-        /// <c>true</c> for an engine that is not pressure fed. Raises an exception if the
+        /// <c>true</c> for an engine that is not pressure fed. Throws an exception if the
         /// engine is not managed by RealFuels (see <see cref="HasRealFuels"/>).
         /// </summary>
         [KRPCProperty]

--- a/service/SpaceCenter/src/Services/Parts/Engine.cs
+++ b/service/SpaceCenter/src/Services/Parts/Engine.cs
@@ -181,9 +181,9 @@ namespace KRPC.SpaceCenter.Services.Parts
                 flowMultiplier *= engine.velCurve.Evaluate ((float)engine.vessel.mach);
 
             // Apply KSP's soft cap on the flow multiplier. Above flowMultCap the excess is
-            // compressed (so extra ram flow gives diminishing returns rather than growing
-            // without bound), then a lower bound is enforced. Without this the reported
-            // thrust of air-breathing engines is overstated at high Mach.
+            // compressed, so extra ram flow gives diminishing returns, and then a lower
+            // bound is enforced. Without this the reported thrust of air-breathing engines
+            // is overstated at high Mach
             if (flowMultiplier > engine.flowMultCap) {
                 float excess = flowMultiplier - engine.flowMultCap;
                 flowMultiplier = engine.flowMultCap +

--- a/service/SpaceCenter/src/Services/Parts/Experiment.cs
+++ b/service/SpaceCenter/src/Services/Parts/Experiment.cs
@@ -38,8 +38,8 @@ namespace KRPC.SpaceCenter.Services.Parts
         }
 
         /// <summary>
-        /// What the game holds for the experiment: the state of the part
-        /// carrying it, or destroyed once that part no longer has the module.
+        /// The state of the part carrying the experiment, or destroyed once that part loses
+        /// the module.
         /// </summary>
         public GameObjectState GameObjectState {
             get { return experimentRef.StateOn (Part); }

--- a/service/SpaceCenter/src/Services/Parts/Fairing.cs
+++ b/service/SpaceCenter/src/Services/Parts/Fairing.cs
@@ -36,8 +36,8 @@ namespace KRPC.SpaceCenter.Services.Parts
         }
 
         /// <summary>
-        /// What the game holds for the fairing. The module objects it is built from
-        /// find their part modules again on each access, so this follows them.
+        /// The state of the fairing. The module objects it is built from look their part
+        /// modules up on each access, and this follows them.
         /// </summary>
         public GameObjectState GameObjectState {
             get { return (fairing ?? proceduralFairing).GameObjectState; }

--- a/service/SpaceCenter/src/Services/Parts/Fairing.cs
+++ b/service/SpaceCenter/src/Services/Parts/Fairing.cs
@@ -77,9 +77,9 @@ namespace KRPC.SpaceCenter.Services.Parts
                     fairing.TriggerVisibleEventById("DeployFairing");
                 } else {
                     // Older versions of ProceduralFairings have the "Jettison" event, newer
-                    // versions have the "Jettison Fairing" event. These match the display name
-                    // rather than the event id, as the mod's method names are not known here;
-                    // the mod does not appear to translate them.
+                    // versions have the "Jettison Fairing" event. These match the display
+                    // name, as the mod's method names are not known here, and the mod does
+                    // not appear to translate them
                     foreach (var e in proceduralFairing.VisibleEventNames) {
                         if (e == "Jettison")
                             proceduralFairing.TriggerVisibleEvent("Jettison");
@@ -101,9 +101,9 @@ namespace KRPC.SpaceCenter.Services.Parts
                     return !fairing.HasVisibleEventById("DeployFairing");
                 } else {
                     // Older versions of ProceduralFairings have the "Jettison" event, newer
-                    // versions have the "Jettison Fairing" event. These match the display name
-                    // rather than the event id, as the mod's method names are not known here;
-                    // the mod does not appear to translate them.
+                    // versions have the "Jettison Fairing" event. These match the display
+                    // name, as the mod's method names are not known here, and the mod does
+                    // not appear to translate them
                     return !(proceduralFairing.HasVisibleEvent("Jettison") ||
                              proceduralFairing.HasVisibleEvent("Jettison Fairing"));
                 }

--- a/service/SpaceCenter/src/Services/Parts/Force.cs
+++ b/service/SpaceCenter/src/Services/Parts/Force.cs
@@ -37,11 +37,10 @@ namespace KRPC.SpaceCenter.Services.Parts
         public Part Part { get; private set; }
 
         /// <summary>
-        /// What the game holds for the force. A force is applied to a part, so it is
-        /// exactly as live, dormant or destroyed as that part: a part the game has
-        /// destroyed can never be pushed again, and one it has merely unloaded has no
-        /// rigidbody to push until it is loaded. A force the client has taken off its
-        /// part is gone whatever the part is doing, as nothing applies it again.
+        /// The state of the force. A force is applied to a part and takes that part's
+        /// state: a destroyed part can never be pushed again, and an unloaded part has no
+        /// rigidbody to push until it is loaded. A force the client has removed is
+        /// destroyed whatever its part's state.
         /// </summary>
         public GameObjectState GameObjectState {
             get { return removed ? GameObjectState.Destroyed : Part.GameObjectState; }

--- a/service/SpaceCenter/src/Services/Parts/Force.cs
+++ b/service/SpaceCenter/src/Services/Parts/Force.cs
@@ -17,9 +17,8 @@ namespace KRPC.SpaceCenter.Services.Parts
         Vector3 force;
         Vector3 position;
         ReferenceFrame frame;
-        // Whether the force has been taken off the part. The object goes on standing for
-        // an instruction the game is no longer given, so it says it is gone rather than
-        // reporting a force that is not being applied.
+        // Whether the force has been taken off the part. The object outlives the force it
+        // stands for, so this marks it as gone
         bool removed;
 
         internal Force (Part part, Tuple3 forceVector, Tuple3 forcePosition, ReferenceFrame referenceFrame)

--- a/service/SpaceCenter/src/Services/Parts/Intake.cs
+++ b/service/SpaceCenter/src/Services/Parts/Intake.cs
@@ -32,8 +32,8 @@ namespace KRPC.SpaceCenter.Services.Parts
         }
 
         /// <summary>
-        /// What the game holds for the intake: the state of the part
-        /// carrying it, or destroyed once that part no longer has the module.
+        /// The state of the part carrying the intake, or destroyed once that part loses the
+        /// module.
         /// </summary>
         public GameObjectState GameObjectState {
             get { return intakeRef.StateOn (Part); }

--- a/service/SpaceCenter/src/Services/Parts/LaunchClamp.cs
+++ b/service/SpaceCenter/src/Services/Parts/LaunchClamp.cs
@@ -32,8 +32,8 @@ namespace KRPC.SpaceCenter.Services.Parts
         }
 
         /// <summary>
-        /// What the game holds for the launch clamp: the state of the part
-        /// carrying it, or destroyed once that part no longer has the module.
+        /// The state of the part carrying the launch clamp, or destroyed once that part
+        /// loses the module.
         /// </summary>
         public GameObjectState GameObjectState {
             get { return launchClampRef.StateOn (Part); }

--- a/service/SpaceCenter/src/Services/Parts/Leg.cs
+++ b/service/SpaceCenter/src/Services/Parts/Leg.cs
@@ -48,8 +48,8 @@ namespace KRPC.SpaceCenter.Services.Parts
         }
 
         /// <summary>
-        /// What the game holds for the landing leg: the state of the part
-        /// carrying it, or destroyed once that part no longer has the module.
+        /// The state of the part carrying the landing leg, or destroyed once that part
+        /// loses the module.
         /// </summary>
         public GameObjectState GameObjectState {
             get { return wheelRef.StateOn (Part); }

--- a/service/SpaceCenter/src/Services/Parts/Light.cs
+++ b/service/SpaceCenter/src/Services/Parts/Light.cs
@@ -34,8 +34,8 @@ namespace KRPC.SpaceCenter.Services.Parts
         }
 
         /// <summary>
-        /// What the game holds for the light: the state of the part
-        /// carrying it, or destroyed once that part no longer has the module.
+        /// The state of the part carrying the light, or destroyed once that part loses the
+        /// module.
         /// </summary>
         public GameObjectState GameObjectState {
             get { return lightRef.StateOn (Part); }

--- a/service/SpaceCenter/src/Services/Parts/Module.cs
+++ b/service/SpaceCenter/src/Services/Parts/Module.cs
@@ -138,8 +138,8 @@ namespace KRPC.SpaceCenter.Services.Parts
         }
 
         // The following three helpers match on the display name, which the game translates.
-        // They exist to serve the guiName-keyed public API and must not be used to identify a
-        // known event from within kRPC -- use the ById helpers below for that.
+        // They serve the guiName-keyed public API. To identify a known event from within
+        // kRPC, use the ById helpers below
 
         internal IEnumerable<string> VisibleEventNames {
             get { return AllEvents.Select (x => x.guiName); }
@@ -155,8 +155,8 @@ namespace KRPC.SpaceCenter.Services.Parts
             AllEvents.First (x => x.guiName == name).Invoke ();
         }
 
-        // Events are identified by their id -- the name of the method implementing them -- which
-        // the game does not translate, unlike the display name.
+        // Events are identified by their id, the name of the method implementing them, which
+        // the game does not translate, unlike the display name
 
         internal bool HasVisibleEventById (string id)
         {

--- a/service/SpaceCenter/src/Services/Parts/Module.cs
+++ b/service/SpaceCenter/src/Services/Parts/Module.cs
@@ -37,8 +37,8 @@ namespace KRPC.SpaceCenter.Services.Parts
         }
 
         /// <summary>
-        /// What the game holds for the module. A module belongs to its part's game object,
-        /// so a module of a part that is not loaded is no more gone than the part is.
+        /// The state of the module. A module belongs to its part's game object, and takes
+        /// the part's state.
         /// </summary>
         public GameObjectState GameObjectState {
             get { return reference.StateOn (Part); }

--- a/service/SpaceCenter/src/Services/Parts/Parachute.cs
+++ b/service/SpaceCenter/src/Services/Parts/Parachute.cs
@@ -53,9 +53,9 @@ namespace KRPC.SpaceCenter.Services.Parts
         }
 
         /// <summary>
-        /// What the game holds for the parachute. A part carries a stock parachute
-        /// module, a RealChutes one, or both, and either is enough for the parachute,
-        /// so it is as alive as the more alive of them.
+        /// The state of the parachute. A part carries a stock parachute module, a
+        /// RealChutes one, or both, and either is enough, so the parachute takes the more
+        /// alive of their states.
         /// </summary>
         public GameObjectState GameObjectState {
             get {

--- a/service/SpaceCenter/src/Services/Parts/Part.cs
+++ b/service/SpaceCenter/src/Services/Parts/Part.cs
@@ -75,7 +75,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         }
 
         /// <summary>
-        /// What the game holds for the part.
+        /// The state of the part.
         /// </summary>
         /// <remarks>
         /// A part looked up in this game state and still there is the part, so there is
@@ -1118,7 +1118,7 @@ namespace KRPC.SpaceCenter.Services.Parts
 
         /// <summary>
         /// Whether the tank is highly pressurized, which is what a pressure-fed engine needs to
-        /// draw from (see <see cref="Engine.PressureFed"/>). Raises an exception if the part is
+        /// draw from (see <see cref="Engine.PressureFed"/>). Throws an exception if the part is
         /// not a RealFuels fuel tank (see <see cref="HasRealFuelsTank"/>).
         /// </summary>
         [KRPCProperty]
@@ -1132,7 +1132,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// The contents keep boiling off under time warp, where that update covers a much
         /// longer span of in-game time than a physics frame does. The rate is zero for a
         /// tank holding nothing cryogenic, for one still being fed by a launch clamp, whose
-        /// temperature RealFuels holds down instead, and in the editor. Raises an exception
+        /// temperature RealFuels holds down instead, and in the editor. Throws an exception
         /// if the part is not a RealFuels fuel tank (see <see cref="HasRealFuelsTank"/>).
         /// </summary>
         [KRPCProperty]

--- a/service/SpaceCenter/src/Services/Parts/PartAction.cs
+++ b/service/SpaceCenter/src/Services/Parts/PartAction.cs
@@ -34,7 +34,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         }
 
         /// <summary>
-        /// What the game holds for the module this belongs to.
+        /// The state of the module this belongs to.
         /// </summary>
         public GameObjectState GameObjectState {
             get { return Module.GameObjectState; }

--- a/service/SpaceCenter/src/Services/Parts/PartEvent.cs
+++ b/service/SpaceCenter/src/Services/Parts/PartEvent.cs
@@ -34,7 +34,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         }
 
         /// <summary>
-        /// What the game holds for the module this belongs to.
+        /// The state of the module this belongs to.
         /// </summary>
         public GameObjectState GameObjectState {
             get { return Module.GameObjectState; }

--- a/service/SpaceCenter/src/Services/Parts/PartField.cs
+++ b/service/SpaceCenter/src/Services/Parts/PartField.cs
@@ -34,7 +34,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         }
 
         /// <summary>
-        /// What the game holds for the module this belongs to.
+        /// The state of the module this belongs to.
         /// </summary>
         public GameObjectState GameObjectState {
             get { return Module.GameObjectState; }

--- a/service/SpaceCenter/src/Services/Parts/PartSeparation.cs
+++ b/service/SpaceCenter/src/Services/Parts/PartSeparation.cs
@@ -6,7 +6,7 @@ using KRPC.Service;
 namespace KRPC.SpaceCenter.Services.Parts
 {
     /// <summary>
-    /// Shared logic for the RPCs that split a vessel in two — decoupling and undocking — each of
+    /// Shared logic for the RPCs that split a vessel in two, decoupling and undocking, each of
     /// which returns the newly created vessel.
     /// </summary>
     static class PartSeparation
@@ -23,13 +23,13 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// <summary>
         /// Yields until the separation has completed (<paramref name="separated"/> returns true) and
         /// the settle margin has elapsed, then returns the vessel that <c>FlightGlobals.Vessels</c>
-        /// gained relative to <paramref name="preVesselIds"/> — the snapshot of vessel ids taken
+        /// gained relative to <paramref name="preVesselIds"/>, the snapshot of vessel ids taken
         /// before the separation was triggered.
         ///
         /// A separation usually produces one new vessel, but an omni-decoupler detaches at every
         /// node at once: it separates the vessel beyond it and is itself left on a vessel of its
         /// own, so two appear. The one to return is the vessel that was separated, which is the one
-        /// <paramref name="part"/> — the decoupler or docking port that was fired — did not end up
+        /// <paramref name="part"/>, the decoupler or docking port that was fired, did not end up
         /// on. It is looked up once the wait is over, and by identifier, so that it resolves to
         /// the right object however the separation rearranged the parts in the meantime.
         /// </summary>

--- a/service/SpaceCenter/src/Services/Parts/Parts.cs
+++ b/service/SpaceCenter/src/Services/Parts/Parts.cs
@@ -38,7 +38,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         }
 
         /// <summary>
-        /// What the game holds for the vessel this belongs to.
+        /// The state of the vessel this belongs to.
         /// </summary>
         public GameObjectState GameObjectState {
             get {

--- a/service/SpaceCenter/src/Services/Parts/Parts.cs
+++ b/service/SpaceCenter/src/Services/Parts/Parts.cs
@@ -102,8 +102,8 @@ namespace KRPC.SpaceCenter.Services.Parts
         [KRPCProperty]
         public Part Root {
             get {
-                // Walk up the parent links rather than reading the vessel's root part, as
-                // a vessel in the editor has no equivalent of it.
+                // Walk up the parent links, as a vessel in the editor has no equivalent of
+                // the vessel's root part
                 var parts = InternalShipConstruct.Parts;
                 if (parts.Count == 0)
                     throw new InvalidOperationException ("The vessel has no parts.");

--- a/service/SpaceCenter/src/Services/Parts/Propellant.cs
+++ b/service/SpaceCenter/src/Services/Parts/Propellant.cs
@@ -22,7 +22,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         }
 
         /// <summary>
-        /// What the game holds for the part this belongs to.
+        /// The state of the part this belongs to.
         /// </summary>
         public GameObjectState GameObjectState {
             get { return new Part (partId).GameObjectState; }

--- a/service/SpaceCenter/src/Services/Parts/RCS.cs
+++ b/service/SpaceCenter/src/Services/Parts/RCS.cs
@@ -42,8 +42,8 @@ namespace KRPC.SpaceCenter.Services.Parts
         }
 
         /// <summary>
-        /// What the game holds for the RCS thrusters: the state of the part
-        /// carrying it, or destroyed once that part no longer has the module.
+        /// The state of the part carrying the RCS thrusters, or destroyed once that part
+        /// loses the module.
         /// </summary>
         public GameObjectState GameObjectState {
             get { return rcsRef.StateOn (Part); }

--- a/service/SpaceCenter/src/Services/Parts/Radiator.cs
+++ b/service/SpaceCenter/src/Services/Parts/Radiator.cs
@@ -43,9 +43,9 @@ namespace KRPC.SpaceCenter.Services.Parts
         }
 
         /// <summary>
-        /// What the game holds for the radiator. A part carries an active radiator
-        /// module, a deployable one, or both, and either is enough for the radiator, so
-        /// it is as alive as the more alive of them.
+        /// The state of the radiator. A part carries an active radiator module, a
+        /// deployable one, or both, and either is enough, so the radiator takes the more
+        /// alive of their states.
         /// </summary>
         public GameObjectState GameObjectState {
             get { return activeRadiatorRef.StateOn (Part).MostAlive (deployableRadiatorRef.StateOn (Part)); }

--- a/service/SpaceCenter/src/Services/Parts/ReactionWheel.cs
+++ b/service/SpaceCenter/src/Services/Parts/ReactionWheel.cs
@@ -40,8 +40,8 @@ namespace KRPC.SpaceCenter.Services.Parts
         }
 
         /// <summary>
-        /// What the game holds for the reaction wheel: the state of the part
-        /// carrying it, or destroyed once that part no longer has the module.
+        /// The state of the part carrying the reaction wheel, or destroyed once that part
+        /// loses the module.
         /// </summary>
         public GameObjectState GameObjectState {
             get { return reactionWheelRef.StateOn (Part); }

--- a/service/SpaceCenter/src/Services/Parts/ReactionWheel.cs
+++ b/service/SpaceCenter/src/Services/Parts/ReactionWheel.cs
@@ -123,11 +123,11 @@ namespace KRPC.SpaceCenter.Services.Parts
 
         internal TupleV3 AvailableTorqueVectors {
             get {
-                // Computed from the wheel's torque fields rather than ModuleReactionWheel's
-                // ITorqueProvider implementation, whose handling of the authority limiter
-                // varies between the stock module and modded replacements of it. The
-                // conditions under which the wheel produces no torque match the stock ones:
-                // the module must be enabled and active, and actuator mode 2 disables it.
+                // Computed from the wheel's torque fields. ModuleReactionWheel's
+                // ITorqueProvider implementation handles the authority limiter differently
+                // between the stock module and modded replacements of it. The conditions
+                // under which the wheel produces no torque match the stock ones: the module
+                // must be enabled and active, and actuator mode 2 disables it
                 var reactionWheel = InternalReactionWheel;
                 if (!reactionWheel.moduleIsEnabled || !Active || reactionWheel.actuatorModeCycle == 2)
                     return ITorqueProviderExtensions.zero;

--- a/service/SpaceCenter/src/Services/Parts/RealFuelsTank.cs
+++ b/service/SpaceCenter/src/Services/Parts/RealFuelsTank.cs
@@ -67,13 +67,12 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// </summary>
         internal double BoiloffRate {
             get {
-                // RealFuels accumulates the mass boiled off during an update, in tonnes,
-                // rather than a rate, so divide by the length of that update to get one. It
-                // runs off the flight integrator's thermal step, which is shorter than the
-                // fixed update only when the game is stepping faster than the minimum the
-                // integrator honors - never in practice, as the minimum is well below one
-                // frame. Under time warp both scale together, so this stays a rate per second
-                // of in-game time.
+                // RealFuels accumulates the mass boiled off during an update, in tonnes, so
+                // divide by the length of that update to get a rate. It runs off the flight
+                // integrator's thermal step, which is shorter than the fixed update only
+                // when the game steps faster than the minimum the integrator honors, well
+                // below one frame. Under time warp both scale together, so this stays a rate
+                // per second of in-game time
                 var delta = TimeWarp.fixedDeltaTime;
                 if (delta <= 0)
                     return 0;

--- a/service/SpaceCenter/src/Services/Parts/ResourceConverter.cs
+++ b/service/SpaceCenter/src/Services/Parts/ResourceConverter.cs
@@ -142,11 +142,10 @@ namespace KRPC.SpaceCenter.Services.Parts
         {
             CheckConverterExists (index);
             var converter = Converter (index);
-            // Use IsActivated for the active/idle distinction rather than matching
-            // the localized "Inactive" status string. A running converter reports
-            // either "<x>% load" (while thermally throttled) or "Operational" (at
-            // full capacity), so anything active that isn't reporting a problem is
-            // treated as running.
+            // Use IsActivated for the active/idle distinction. The localized "Inactive"
+            // status string is not matched: a running converter reports either "<x>% load"
+            // while thermally throttled or "Operational" at full capacity, so anything
+            // active that is not reporting a problem is treated as running
             if (!converter.IsActivated)
                 return ResourceConverterState.Idle;
             var status = converter.status;
@@ -162,8 +161,8 @@ namespace KRPC.SpaceCenter.Services.Parts
         }
 
         // The messages the game builds a converter's status out of. It reports the status
-        // already translated, so these are the tags for the same messages rather than the
-        // English text, which only matches when the game is running in English.
+        // already translated, so these are the tags for the same messages, as the English
+        // text only matches a game running in English
         static readonly string[] MissingResourceMessages = {
             "#autoLOC_261263", "#autoLOC_261304", // missing <resource>
             "#autoLOC_258451", "#autoLOC_259933"  // insufficient power

--- a/service/SpaceCenter/src/Services/Parts/ResourceConverter.cs
+++ b/service/SpaceCenter/src/Services/Parts/ResourceConverter.cs
@@ -42,8 +42,8 @@ namespace KRPC.SpaceCenter.Services.Parts
         }
 
         /// <summary>
-        /// What the game holds for the converters: the state of the part carrying
-        /// them, or destroyed once that part no longer has them.
+        /// The state of the part carrying the converters, or destroyed once that part loses
+        /// them.
         /// </summary>
         public GameObjectState GameObjectState {
             get { return converterRefs [0].StateOn (Part); }

--- a/service/SpaceCenter/src/Services/Parts/ResourceDrain.cs
+++ b/service/SpaceCenter/src/Services/Parts/ResourceDrain.cs
@@ -39,8 +39,8 @@ namespace KRPC.SpaceCenter.Services.Parts
         }
 
         /// <summary>
-        /// What the game holds for the resource drain: the state of the part
-        /// carrying it, or destroyed once that part no longer has the module.
+        /// The state of the part carrying the resource drain, or destroyed once that part
+        /// loses the module.
         /// </summary>
         public GameObjectState GameObjectState {
             get { return drainRef.StateOn (Part); }

--- a/service/SpaceCenter/src/Services/Parts/ResourceHarvester.cs
+++ b/service/SpaceCenter/src/Services/Parts/ResourceHarvester.cs
@@ -43,8 +43,8 @@ namespace KRPC.SpaceCenter.Services.Parts
         }
 
         /// <summary>
-        /// What the game holds for the resource harvester: the state of the part
-        /// carrying it, or destroyed once that part no longer has the module.
+        /// The state of the part carrying the resource harvester, or destroyed once that
+        /// part loses the module.
         /// </summary>
         public GameObjectState GameObjectState {
             get { return harvesterRef.StateOn (Part); }

--- a/service/SpaceCenter/src/Services/Parts/ResourceHarvester.cs
+++ b/service/SpaceCenter/src/Services/Parts/ResourceHarvester.cs
@@ -129,9 +129,8 @@ namespace KRPC.SpaceCenter.Services.Parts
             get { return InternalHarvester.IsActivated; }
             set {
                 if (!Deployed) {
-                    // The converter cannot start until the deploy animation has
-                    // finished; defer the requested state until then rather than
-                    // silently dropping it.
+                    // The converter cannot start until the deploy animation has finished,
+                    // so defer the requested state until then
                     if (State == DeployableState.Deploying)
                         ResourceHarvesterAddon.Request (InternalHarvester, InternalAnimator, value);
                     return;

--- a/service/SpaceCenter/src/Services/Parts/RoboticController.cs
+++ b/service/SpaceCenter/src/Services/Parts/RoboticController.cs
@@ -35,8 +35,8 @@ namespace KRPC.SpaceCenter.Services.Parts
         }
 
         /// <summary>
-        /// What the game holds for the robotic controller: the state of the part
-        /// carrying it, or destroyed once that part no longer has the module.
+        /// The state of the part carrying the robotic controller, or destroyed once that
+        /// part loses the module.
         /// </summary>
         public GameObjectState GameObjectState {
             get { return controllerRef.StateOn (Part); }

--- a/service/SpaceCenter/src/Services/Parts/RoboticHinge.cs
+++ b/service/SpaceCenter/src/Services/Parts/RoboticHinge.cs
@@ -36,8 +36,8 @@ namespace KRPC.SpaceCenter.Services.Parts
         }
 
         /// <summary>
-        /// What the game holds for the hinge servo: the state of the part
-        /// carrying it, or destroyed once that part no longer has the module.
+        /// The state of the part carrying the hinge servo, or destroyed once that part
+        /// loses the module.
         /// </summary>
         public GameObjectState GameObjectState {
             get { return servoRef.StateOn (Part); }

--- a/service/SpaceCenter/src/Services/Parts/RoboticPiston.cs
+++ b/service/SpaceCenter/src/Services/Parts/RoboticPiston.cs
@@ -36,8 +36,8 @@ namespace KRPC.SpaceCenter.Services.Parts
         }
 
         /// <summary>
-        /// What the game holds for the piston servo: the state of the part
-        /// carrying it, or destroyed once that part no longer has the module.
+        /// The state of the part carrying the piston servo, or destroyed once that part
+        /// loses the module.
         /// </summary>
         public GameObjectState GameObjectState {
             get { return servoRef.StateOn (Part); }

--- a/service/SpaceCenter/src/Services/Parts/RoboticRotation.cs
+++ b/service/SpaceCenter/src/Services/Parts/RoboticRotation.cs
@@ -36,8 +36,8 @@ namespace KRPC.SpaceCenter.Services.Parts
         }
 
         /// <summary>
-        /// What the game holds for the rotation servo: the state of the part
-        /// carrying it, or destroyed once that part no longer has the module.
+        /// The state of the part carrying the rotation servo, or destroyed once that part
+        /// loses the module.
         /// </summary>
         public GameObjectState GameObjectState {
             get { return servoRef.StateOn (Part); }

--- a/service/SpaceCenter/src/Services/Parts/RoboticRotor.cs
+++ b/service/SpaceCenter/src/Services/Parts/RoboticRotor.cs
@@ -36,8 +36,8 @@ namespace KRPC.SpaceCenter.Services.Parts
         }
 
         /// <summary>
-        /// What the game holds for the rotor servo: the state of the part
-        /// carrying it, or destroyed once that part no longer has the module.
+        /// The state of the part carrying the rotor servo, or destroyed once that part
+        /// loses the module.
         /// </summary>
         public GameObjectState GameObjectState {
             get { return servoRef.StateOn (Part); }

--- a/service/SpaceCenter/src/Services/Parts/ScienceData.cs
+++ b/service/SpaceCenter/src/Services/Parts/ScienceData.cs
@@ -31,9 +31,8 @@ namespace KRPC.SpaceCenter.Services.Parts
         }
 
         /// <summary>
-        /// What the game holds for the record. It is as live, dormant or destroyed as the
-        /// experiment holding it until that experiment is there to look in, and destroyed
-        /// once the experiment no longer holds this record.
+        /// The state of the record. It takes the state of the experiment holding it, and is
+        /// destroyed once a live experiment stops holding it.
         /// </summary>
         public GameObjectState GameObjectState {
             get {

--- a/service/SpaceCenter/src/Services/Parts/ScienceData.cs
+++ b/service/SpaceCenter/src/Services/Parts/ScienceData.cs
@@ -13,10 +13,9 @@ namespace KRPC.SpaceCenter.Services.Parts
     {
         readonly Part part;
         ModuleRef experimentRef;
-        // The game's own record of the data. It is a plain object rather than something in
-        // the scene, and the game offers nothing to identify it by, so it is the one thing
-        // here that is held on to rather than found again. When the game replaces it, which
-        // it does whenever it rebuilds the experiment, this object is reclaimed instead.
+        // The game's own record of the data. It is a plain object with nothing to identify
+        // it by, so it is held rather than found again. The game replaces it whenever it
+        // rebuilds the experiment, and this object is then reclaimed
         readonly global::ScienceData data;
 
         internal ScienceData (Part dataPart, ModuleScienceExperiment experimentModule, global::ScienceData scienceData)

--- a/service/SpaceCenter/src/Services/Parts/ScienceSubject.cs
+++ b/service/SpaceCenter/src/Services/Parts/ScienceSubject.cs
@@ -52,9 +52,8 @@ namespace KRPC.SpaceCenter.Services.Parts
         }
 
         /// <summary>
-        /// What the game holds for the subject. It belongs to the game state it was taken
-        /// from, so it is destroyed once another state is loaded, with no dormant state to
-        /// return to.
+        /// The state of the subject. It belongs to the game state it was taken from, and is
+        /// destroyed once another state is loaded. It has no dormant state.
         /// </summary>
         public GameObjectState GameObjectState {
             get {

--- a/service/SpaceCenter/src/Services/Parts/Sensor.cs
+++ b/service/SpaceCenter/src/Services/Parts/Sensor.cs
@@ -33,8 +33,8 @@ namespace KRPC.SpaceCenter.Services.Parts
         }
 
         /// <summary>
-        /// What the game holds for the sensor: the state of the part
-        /// carrying it, or destroyed once that part no longer has the module.
+        /// The state of the part carrying the sensor, or destroyed once that part loses the
+        /// module.
         /// </summary>
         public GameObjectState GameObjectState {
             get { return sensorRef.StateOn (Part); }

--- a/service/SpaceCenter/src/Services/Parts/SolarPanel.cs
+++ b/service/SpaceCenter/src/Services/Parts/SolarPanel.cs
@@ -32,8 +32,8 @@ namespace KRPC.SpaceCenter.Services.Parts
         }
 
         /// <summary>
-        /// What the game holds for the solar panel: the state of the part
-        /// carrying it, or destroyed once that part no longer has the module.
+        /// The state of the part carrying the solar panel, or destroyed once that part
+        /// loses the module.
         /// </summary>
         public GameObjectState GameObjectState {
             get { return panelRef.StateOn (Part); }

--- a/service/SpaceCenter/src/Services/Parts/ThrustReverser.cs
+++ b/service/SpaceCenter/src/Services/Parts/ThrustReverser.cs
@@ -134,10 +134,10 @@ namespace KRPC.SpaceCenter.Services.Parts
 
         public bool Reversed {
             // animSwitch is false when the animation is at, or playing towards, its
-            // deployed end, so this reads the commanded target state rather than the
-            // animation's progress. Reading progress would make the setter
-            // non-idempotent: a set re-issued while the animation is still short of
-            // its midpoint would toggle a second time and cancel the first.
+            // deployed end, so this reads the commanded target state. Reading the
+            // animation's progress would make the setter non-idempotent: a set re-issued
+            // before the animation passes its midpoint would toggle a second time and
+            // cancel the first
             get { return !Animation.animSwitch == reversedWhenDeployed; }
             set { if (value != Reversed) Animation.Toggle (); }
         }

--- a/service/SpaceCenter/src/Services/Parts/Thruster.cs
+++ b/service/SpaceCenter/src/Services/Parts/Thruster.cs
@@ -22,7 +22,7 @@ namespace KRPC.SpaceCenter.Services.Parts
     {
         readonly Part part;
         // A thruster belongs either to an engine or to a set of RCS thrusters, so one of
-        // these two references stands for nothing.
+        // these two references is unset
         ModuleRef engineRef;
         ModuleRef rcsRef;
         ModuleRef gimbalRef;

--- a/service/SpaceCenter/src/Services/Parts/Thruster.cs
+++ b/service/SpaceCenter/src/Services/Parts/Thruster.cs
@@ -62,9 +62,8 @@ namespace KRPC.SpaceCenter.Services.Parts
         }
 
         /// <summary>
-        /// What the game holds for the engine or RCS module the thruster is part of.
-        /// Either is enough for the thruster, so it is as alive as the more alive of
-        /// them.
+        /// The state of the engine or RCS module the thruster is part of. Either is enough,
+        /// so the thruster takes the more alive of their states.
         /// </summary>
         public GameObjectState GameObjectState {
             get { return engineRef.StateOn (part).MostAlive (rcsRef.StateOn (part)); }

--- a/service/SpaceCenter/src/Services/Parts/Wheel.cs
+++ b/service/SpaceCenter/src/Services/Parts/Wheel.cs
@@ -74,8 +74,8 @@ namespace KRPC.SpaceCenter.Services.Parts
         }
 
         /// <summary>
-        /// What the game holds for the wheel: the state of the part
-        /// carrying it, or destroyed once that part no longer has the module.
+        /// The state of the part carrying the wheel, or destroyed once that part loses the
+        /// module.
         /// </summary>
         public GameObjectState GameObjectState {
             get { return wheelRef.StateOn (Part); }

--- a/service/SpaceCenter/src/Services/RateFilterMode.cs
+++ b/service/SpaceCenter/src/Services/RateFilterMode.cs
@@ -4,7 +4,7 @@ using KRPC.Service.Attributes;
 namespace KRPC.SpaceCenter.Services
 {
     /// <summary>
-    /// Controls the auto-pilot's rate-feedback filtering for an axis group — the mitigation that
+    /// Controls the auto-pilot's rate-feedback filtering for an axis group, the mitigation that
     /// removes a structural oscillation (wobble) from the measured angular velocity before the
     /// control loops consume it.
     /// See <see cref="AutoPilot.PitchYawRateFilterMode"/> and <see cref="AutoPilot.RollRateFilterMode"/>.

--- a/service/SpaceCenter/src/Services/ReferenceFrame.cs
+++ b/service/SpaceCenter/src/Services/ReferenceFrame.cs
@@ -30,15 +30,14 @@ namespace KRPC.SpaceCenter.Services
     {
         readonly ReferenceFrameType type;
         readonly global::CelestialBody body;
-        // The body's name, which is what the frame is hashed by. A body keeps its name for
-        // as long as it exists, and the game builds a new string every time it is asked for
-        // one, so it is taken once rather than on every hash.
+        // The body's name, which the frame is hashed by. A body keeps its name for as long
+        // as it exists, and the game builds a new string on every read, so it is taken once
         readonly string bodyName;
         readonly Guid vesselId;
         readonly ManeuverNode node;
-        // The part object finds the KSP part again, says whether it is still
-        // there, and is what the frame is identified by. A part is named by
-        // flight id in flight and by craft id in the editor.
+        // The part object finds the KSP part again, says whether it is still there, and
+        // identifies the frame. A part is named by flight id in flight and by craft id in
+        // the editor
         readonly Parts.Part servicePart;
         ModuleRef dockingPortRef;
         readonly Thruster thruster;
@@ -52,9 +51,8 @@ namespace KRPC.SpaceCenter.Services
         readonly ReferenceFrame hybridRotation;
         readonly ReferenceFrame hybridVelocity;
         readonly ReferenceFrame hybridAngularVelocity;
-        // Whether the client has let go of the frame. A frame a client creates stands
-        // for nothing in the game, so nothing the game destroys ever retires one and the
-        // client removing it or disconnecting is the only thing that can.
+        // Whether the client has let go of the frame. A frame a client creates stands for
+        // nothing in the game, so only the client removing it or disconnecting retires one
         bool removed;
 
         ReferenceFrame (
@@ -87,8 +85,8 @@ namespace KRPC.SpaceCenter.Services
 
         ReferenceFrame (ReferenceFrame parent, Vector3d relativePosition, QuaternionD relativeRotation, Vector3d relativeVelocity, Vector3d relativeAngularVelocity)
         {
-            // The frame is defined against its parent and has no meaning without one,
-            // so this is caught here rather than left to the first member that reads it.
+            // The frame is defined against its parent and has no meaning without one, so
+            // this is caught here
             if (ReferenceEquals (parent, null))
                 throw new ArgumentNullException (nameof (parent));
             type = ReferenceFrameType.Relative;
@@ -138,12 +136,10 @@ namespace KRPC.SpaceCenter.Services
                 .And (parent);
         }
 
-        // Whether a client asked for the frame to be built, rather than it being named by
-        // something in the game. Such a frame is a distinct thing each time it is created,
-        // so it keeps the identity of the object itself: it is the client's to remove, and
-        // removing it must neither take away a frame another client built from the same
-        // values nor leave the next creation from those values handing back the one that
-        // has gone.
+        // Whether a client asked for the frame to be built. Such a frame is a distinct
+        // thing each time it is created, so it keeps the identity of the object itself: it
+        // is the client's to remove, removing it leaves a frame another client built from
+        // the same values alone, and the next creation from those values gives a new frame
         bool Created {
             get {
                 return type == ReferenceFrameType.Relative || type == ReferenceFrameType.Hybrid;
@@ -333,8 +329,8 @@ namespace KRPC.SpaceCenter.Services
         }
 
         // The navball speed mode frames take their orientation from the velocity they
-        // measure, so they are singular when it is zero -- as is the navball's prograde
-        // marker, which the game stops drawing at zero speed.
+        // measure, so they are singular when it is zero, as is the navball's prograde
+        // marker, which the game stops drawing at zero speed
         static void CheckSpeedNotSingular (Vector3d velocity, string name, string description)
         {
             if (velocity.sqrMagnitude < 0.01d)
@@ -563,8 +559,8 @@ namespace KRPC.SpaceCenter.Services
                     "Only a reference frame created by CreateRelative or CreateHybrid " +
                     "can be removed");
             // The addon holds the frame on its client's behalf and has nothing left to do
-            // for one the client has finished with. Taking it out is also what asks for
-            // the sweep that drops it from the object store.
+            // for one the client has finished with. Taking it out also requests the sweep
+            // that drops it from the object store
             CreatedReferenceFramesAddon.Remove (this);
             removed = true;
         }
@@ -621,9 +617,9 @@ namespace KRPC.SpaceCenter.Services
                     }
                 case ReferenceFrameType.OrbitNonRotating:
                 case ReferenceFrameType.OrbitOrbital:
-                    // An orbit is not attached to anything in the scene, so it has no
-                    // transform position to correct this towards the way a maneuver node,
-                    // which belongs to a vessel, does. The orbit is the whole of it.
+                    // An orbit is not attached to anything in the scene, so there is no
+                    // transform position to correct towards, as there is for a maneuver
+                    // node that belongs to a vessel
                     return orbit.InternalOrbit.getPositionAtUT (Planetarium.GetUniversalTime ());
                 case ReferenceFrameType.Part:
                     return InternalPart.transform.position;
@@ -953,11 +949,11 @@ namespace KRPC.SpaceCenter.Services
                 }
                 case ReferenceFrameType.VesselSurface: {
                     // The surface frame's orientation tracks the vessel's inertial
-                    // position (zenith points from the body centre to the vessel) and
-                    // the body's spin axis (north), so its angular velocity is the rate
-                    // at which that basis rotates -- not the body's rotation rate. It is
+                    // position (zenith points from the body center to the vessel) and the
+                    // body's spin axis (north), so its angular velocity is the rate at
+                    // which that basis rotates, and not the body's rotation rate. It is
                     // the orbital sweep of the zenith axis plus the twist of the north
-                    // direction about the zenith as the vessel's latitude changes.
+                    // direction about the zenith as the vessel's latitude changes
                     var vessel = InternalVessel;
                     var mainBody = vessel.mainBody;
                     var r = vessel.CoM - mainBody.position;
@@ -980,7 +976,7 @@ namespace KRPC.SpaceCenter.Services
                     var srf_vel = vessel.srf_velocity;
                     if (srf_vel.sqrMagnitude < 0.01d)
                         return vessel.mainBody.angularVelocity;
-                    // d(srf_vel)/dt ≈ grav − body.ω × v_orbital
+                    // d(srf_vel)/dt is approximately grav - body.omega x v_orbital
                     var grav = (Vector3d)FlightGlobals.getGeeForceAtPosition (vessel.CoM);
                     var v_orb = vessel.GetOrbit ().GetVel ();
                     var a_srf = grav - Vector3d.Cross (vessel.mainBody.angularVelocity, v_orb);
@@ -990,7 +986,7 @@ namespace KRPC.SpaceCenter.Services
                     var vessel = InternalVessel;
                     var srfVelocity = vessel.srf_velocity;
                     CheckSpeedNotSingular (srfVelocity, "VesselSurfaceSpeed", "surface velocity");
-                    // d(srf_vel)/dt ≈ grav − body.ω × v_orbital
+                    // d(srf_vel)/dt is approximately grav - body.omega x v_orbital
                     var grav = (Vector3d)FlightGlobals.getGeeForceAtPosition (vessel.CoM);
                     var acceleration = grav - Vector3d.Cross (
                         vessel.mainBody.angularVelocity, vessel.GetOrbit ().GetVel ());
@@ -1004,9 +1000,9 @@ namespace KRPC.SpaceCenter.Services
                     // Vessel and target are both in free fall, so their relative velocity
                     // turns with the difference in gravity between the two positions. Each
                     // is taken against the body that object orbits, as the gravity of a
-                    // body at its own center -- where a targeted body sits -- is undefined.
+                    // body at its own center, where a targeted body sits, is undefined.
                     // Whatever pulls on both of them cancels in the difference. Thrust and
-                    // drag on either of them are not accounted for.
+                    // drag on either of them are not accounted for
                     var target = InternalTarget;
                     var targetOrbit = target.GetOrbit ();
                     var acceleration =
@@ -1017,9 +1013,10 @@ namespace KRPC.SpaceCenter.Services
                     return SpeedModeAngularVelocity (vessel, relativeVelocity, acceleration);
                 }
                 case ReferenceFrameType.Maneuver: {
-                    // The burn vector is stored in prograde/normal/radial components, so it rotates
-                    // with the orbital frame. The z-axis (arbitrary inertial projection) introduces
-                    // a small spin correction about ŷ that is neglected here.
+                    // The burn vector is stored in prograde/normal/radial components, so it
+                    // rotates with the orbital frame. The z-axis (arbitrary inertial
+                    // projection) introduces a small spin correction about the y-axis that
+                    // is neglected here
                     var r = node.patch.getRelativePositionAtUT (node.UT).SwapYZ ();
                     var v = node.patch.getOrbitalVelocityAtUT (node.UT).SwapYZ ();
                     return Vector3d.Cross (r, v) / r.sqrMagnitude;
@@ -1059,10 +1056,10 @@ namespace KRPC.SpaceCenter.Services
         /// the given velocity, which is changing at the given acceleration.
         /// </summary>
         /// <remarks>
-        /// The basis is ŷ along the velocity, ẑ along the velocity crossed with the zenith
-        /// and x̂ the remaining axis. For a basis whose axes obey ė = ω × e, the angular
-        /// velocity is ω = (ŷ × dŷ/dt) + ŷ (x̂ · dẑ/dt): the swing of the velocity direction,
-        /// plus the roll about it as the plane through the velocity and the zenith turns.
+        /// The basis is y along the velocity, z along the velocity crossed with the zenith and x
+        /// the remaining axis. For a basis whose axes obey de/dt = omega x e, the angular velocity
+        /// is omega = (y x dy/dt) + y (x * dz/dt): the swing of the velocity direction, plus the
+        /// roll about it as the plane through the velocity and the zenith turns.
         /// </remarks>
         static Vector3d SpeedModeAngularVelocity (
             global::Vessel vessel, Vector3d velocity, Vector3d acceleration)

--- a/service/SpaceCenter/src/Services/ReferenceFrame.cs
+++ b/service/SpaceCenter/src/Services/ReferenceFrame.cs
@@ -279,11 +279,11 @@ namespace KRPC.SpaceCenter.Services
         }
 
         /// <summary>
-        /// What the game holds for everything the frame is built from. A frame needs each
-        /// of the vessel, part, maneuver node, thruster, orbit and other frames it is
-        /// defined against, so it is as alive as the least alive of them; one defined
-        /// against a celestial body alone never dies. A frame the client has removed is
-        /// gone whatever it was built from, and so is anything built on it.
+        /// The state of everything the frame is built from. A frame needs each of the
+        /// vessel, part, maneuver node, thruster, orbit and other frames it is defined
+        /// against, so it takes the least alive of their states. A frame defined against a
+        /// celestial body alone stays live, and a frame the client has removed is destroyed
+        /// along with anything built on it.
         /// </summary>
         public GameObjectState GameObjectState {
             get {
@@ -547,14 +547,12 @@ namespace KRPC.SpaceCenter.Services
         /// </summary>
         /// <remarks>
         /// Only a frame created by <see cref="CreateRelative"/> or
-        /// <see cref="CreateHybrid"/> can be removed. Every other frame is named by
-        /// something in the game, which is what says when it is finished with, and the
-        /// server holds one of each however often it is asked for.
+        /// <see cref="CreateHybrid"/> can be removed. Every other frame belongs to
+        /// something in the game, and the server holds one of each.
         ///
         /// Any further use of this object throws an exception, as does use of a frame
-        /// built on it, which cannot be evaluated without it. A frame is removed for the
-        /// client that created it and is not shared with any other, and one whose client
-        /// disconnects is removed with it.
+        /// built on it, which cannot be evaluated without it. A frame belongs to the
+        /// client that created it, and is removed when that client disconnects.
         /// </remarks>
         [KRPCMethod]
         public void Remove ()

--- a/service/SpaceCenter/src/Services/Resource.cs
+++ b/service/SpaceCenter/src/Services/Resource.cs
@@ -21,7 +21,7 @@ namespace KRPC.SpaceCenter.Services
         }
 
         /// <summary>
-        /// What the game holds for the part this belongs to.
+        /// The state of the part this belongs to.
         /// </summary>
         public GameObjectState GameObjectState {
             get { return partId.GameObjectState; }

--- a/service/SpaceCenter/src/Services/ResourceTransfer.cs
+++ b/service/SpaceCenter/src/Services/ResourceTransfer.cs
@@ -12,18 +12,17 @@ namespace KRPC.SpaceCenter.Services
     [KRPCClass (Service = "SpaceCenter")]
     public class ResourceTransfer : IGameObjectState
     {
-        // The resource's definition comes from the game's part database rather than from any
-        // craft, so unlike the parts it is not something the game tears down.
+        // The resource's definition comes from the game's part database and not from any
+        // craft, so the game does not tear it down with the parts
         readonly PartResourceDefinition internalResource;
         readonly float transferRate;
         // The game state the transfer was started in. A transfer is let go of when the
-        // flight it runs in is left as much as when its client removes it, and the two
-        // look the same to the object, so the state having moved on is what tells them
-        // apart when there is a client left to say it to.
+        // flight it runs in is left as much as when its client removes it, and the
+        // generation moving on tells the two apart
         readonly uint generation = GameState.Generation;
         // Whether the client has removed the transfer. A finished transfer moves nothing
-        // and goes on standing for a pair of parts the game may keep for hours, so the
-        // client saying it is done with it is the only thing that can retire the object.
+        // and stands for a pair of parts the game may keep for hours, so only the client
+        // retires the object
         bool removed;
         bool complete;
         float amount;
@@ -165,9 +164,9 @@ namespace KRPC.SpaceCenter.Services
         public void Remove ()
         {
             CheckExists ();
-            // The addon runs the transfer and has nothing left to do for one the client
-            // is finished with. Taking it out is also what asks for the sweep that drops
-            // it from the object store.
+            // The addon runs the transfer and has nothing left to do for one the client is
+            // finished with. Taking it out also requests the sweep that drops it from the
+            // object store
             ResourceTransferAddon.Remove (this);
             Release ();
         }
@@ -202,11 +201,11 @@ namespace KRPC.SpaceCenter.Services
         {
             if (complete)
                 return;
-            // A transfer runs from the game's fixed update, so it has to decide for itself
-            // what to do about a part it can no longer reach rather than raise the error a
-            // call would get. A destroyed part ends the transfer, as nothing can move into
-            // or out of it again. A part whose vessel the game has unloaded is not gone and
-            // is not being simulated either, so the transfer waits for it to come back.
+            // A transfer runs from the game's fixed update, so it handles a part it can no
+            // longer reach itself, without the error a call would raise. A destroyed part
+            // ends the transfer, as nothing can move into or out of it again. A part whose
+            // vessel the game has unloaded is still there and is not being simulated, so
+            // the transfer waits for it
             var fromState = FromPart.GameObjectState;
             var toState = ToPart.GameObjectState;
             if (fromState == GameObjectState.Destroyed || toState == GameObjectState.Destroyed) {

--- a/service/SpaceCenter/src/Services/ResourceTransfer.cs
+++ b/service/SpaceCenter/src/Services/ResourceTransfer.cs
@@ -42,9 +42,9 @@ namespace KRPC.SpaceCenter.Services
         }
 
         /// <summary>
-        /// What the game holds for the transfer, which needs both of the parts it runs
-        /// between and so is as alive as the less alive of them. A transfer the client
-        /// has removed is gone whatever the parts are doing.
+        /// The state of the transfer. It needs both of the parts it runs between, and takes
+        /// the less alive of their two states. A transfer the client has removed is
+        /// destroyed whatever the parts' states.
         /// </summary>
         public GameObjectState GameObjectState {
             get {

--- a/service/SpaceCenter/src/Services/Resources.cs
+++ b/service/SpaceCenter/src/Services/Resources.cs
@@ -65,7 +65,7 @@ namespace KRPC.SpaceCenter.Services
         }
 
         /// <summary>
-        /// What the game holds for the vessel or part these are the resources of.
+        /// The state of the vessel or part these are the resources of.
         /// </summary>
         public GameObjectState GameObjectState {
             get {

--- a/service/SpaceCenter/src/Services/SpaceCenter.cs
+++ b/service/SpaceCenter/src/Services/SpaceCenter.cs
@@ -39,9 +39,9 @@ namespace KRPC.SpaceCenter.Services
         public static IList<string> Expansions {
             get {
                 // KSP ships exactly two expansions, tracked by these fixed names in
-                // ExpansionsLoader's installed set. The public supportedExpansions array is only
-                // populated from expansion master-config files and is empty at runtime, so query
-                // each known name directly — this is how KSP's own code checks for them.
+                // ExpansionsLoader's installed set. The public supportedExpansions array is
+                // only populated from expansion master-config files and is empty at runtime,
+                // so query each known name directly, as KSP's own code does
                 var result = new List<string>();
                 foreach (var name in new[] { "MakingHistory", "Serenity" }) {
                     if (global::Expansions.ExpansionsLoader.IsExpansionInstalled(name))

--- a/service/SpaceCenter/src/Services/SpaceCenter.cs
+++ b/service/SpaceCenter/src/Services/SpaceCenter.cs
@@ -417,7 +417,7 @@ namespace KRPC.SpaceCenter.Services
         /// <item><description>Otherwise, the named Kerbals are placed in the craft in the order
         /// given: the first name takes the first seat, the second name the next seat, and so on,
         /// scanning the craft's parts in order. No other Kerbals are hired to fill remaining seats.
-        /// An exception is thrown, without launching, if a name does not match an available Kerbal
+        /// Throws an exception, without launching, if a name does not match an available Kerbal
         /// or the craft has too few seats for the requested crew.</description></item>
         /// </list>
         /// Throws an exception if any of the games pre-flight checks fail.

--- a/service/SpaceCenter/src/Services/Stage.cs
+++ b/service/SpaceCenter/src/Services/Stage.cs
@@ -70,7 +70,7 @@ namespace KRPC.SpaceCenter.Services
         }
 
         /// <summary>
-        /// What the game holds for the vessel the stage belongs to.
+        /// The state of the vessel the stage belongs to.
         /// </summary>
         public GameObjectState GameObjectState {
             get {

--- a/service/SpaceCenter/src/Services/Vessel.cs
+++ b/service/SpaceCenter/src/Services/Vessel.cs
@@ -78,9 +78,8 @@ namespace KRPC.SpaceCenter.Services
         }
 
         /// <summary>
-        /// What the game holds for the vessel. A vessel is either there to be
-        /// found, loaded or not, or it is gone for good; it has no unloaded form that
-        /// the game can bring back.
+        /// The state of the vessel. A vessel is live whether it is loaded or not, and
+        /// destroyed once the game holds no vessel with its id.
         /// </summary>
         public GameObjectState GameObjectState {
             get { return FlightGlobalsExtensions.VesselState (Id); }
@@ -134,14 +133,14 @@ namespace KRPC.SpaceCenter.Services
 
         /// <summary>
         /// The distance from the active vessel, in meters, out to which this vessel keeps running
-        /// its physics simulation — and so stays controllable, able to burn its engines and
+        /// its physics simulation, and so stays controllable, able to burn its engines and
         /// respond to its autopilot. Setting this raises the vessel out of the stock physics
         /// bubble, so that it keeps flying while the active vessel is far away. Set to zero to
         /// restore the game's default range.
         /// </summary>
         /// <remarks>
         /// This always reports the vessel's live range, so reading it when no range has been set
-        /// gives the game's default for the vessel's current <see cref="Situation" /> — which is
+        /// gives the game's default for the vessel's current <see cref="Situation" />, which is
         /// much shorter than the distance at which the vessel unloads. In orbit a vessel is put
         /// on rails just 350m away, long before it unloads at 2.5km, and a vessel on rails
         /// produces no thrust and ignores control input even though it is still loaded.
@@ -152,7 +151,7 @@ namespace KRPC.SpaceCenter.Services
         /// between it keeps whichever state it is already in.
         ///
         /// The requested range applies in every situation. The game's own defaults are not
-        /// uniform — a vessel flying in atmosphere stays loaded out to 22.5km — so setting a
+        /// uniform, and a vessel flying in atmosphere stays loaded out to 22.5km, so setting a
         /// small range can shorten the range such a vessel would otherwise have had.
         ///
         /// A range lasts until it is set back to zero or the game is exited. Unlike most state a

--- a/service/SpaceCenter/src/Services/Vessel.cs
+++ b/service/SpaceCenter/src/Services/Vessel.cs
@@ -218,21 +218,20 @@ namespace KRPC.SpaceCenter.Services
             } else {
                 var flightState = HighLogic.CurrentGame.flightState;
                 // A vessel's protovessel object is replaced every time it is backed up or
-                // unloaded, so the one the flight state holds is not necessarily the one the
-                // vessel points at now, and the game drops only the object it is handed. Drop
-                // every entry for this vessel by id instead: one left behind still records the
-                // vessel as standing where it was, and the next thing to read the list, such as
-                // the launch site check, recovers it a second time.
+                // unloaded, so the one the flight state holds may not be the one the vessel
+                // points at now, and the game drops only the object it is handed. Drop every
+                // entry for this vessel by id: one left behind still records the vessel as
+                // standing where it was, and the next read of the list, such as the launch
+                // site check, recovers it a second time
                 flightState.protoVessels.RemoveAll (x => x.vesselID == vessel.id);
                 // Recovery is computed from the protovessel, which for a loaded vessel still
                 // describes it as it was when the scene was entered or the game last saved.
                 // Back it up so that the crew, parts and resources recovered are the ones the
                 // vessel actually has.
                 vessel.BackupVessel ();
-                // Recovering quickly awards the same crew, funds and science, and differs only
-                // in showing no mission summary. That dialog belongs to a player who pressed
-                // recover and is waiting to read it; here it would sit over the flight with
-                // nobody to dismiss it.
+                // Recovering quickly awards the same crew, funds and science, and differs
+                // only in showing no mission summary. That dialog would sit over the flight
+                // with nobody to dismiss it
                 ShipConstruction.RecoverVesselFromFlight (vessel.protoVessel, flightState, true);
             }
         }
@@ -269,8 +268,8 @@ namespace KRPC.SpaceCenter.Services
         static IEnumerator TerminateVesselCoroutine (global::Vessel vessel)
         {
             yield return new WaitUntil (() => true);
-            // What the tracking station's terminate button fires, so that contracts and mods
-            // watching for a vessel to be terminated see this the same way.
+            // The event the tracking station's terminate button fires, so that contracts and
+            // mods watching for a vessel to be terminated see this the same way
             GameEvents.onVesselTerminated.Fire (vessel.protoVessel);
             // The crew go missing rather than being killed, which is how the game treats the
             // crew of a vessel terminated from the tracking station. The list an unloaded
@@ -279,11 +278,11 @@ namespace KRPC.SpaceCenter.Services
             var crew = vessel.GetVesselCrew ().ToList ();
             foreach (var member in crew)
                 member.StartRespawnPeriod ();
-            // Destroying an unloaded vessel kills its crew outright, which would override the
-            // respawn period just started, report the deaths to contracts watching for them,
-            // and drop any tourists aboard from the roster entirely. That reads the crew off
-            // the protovessel, which is going with the vessel, so emptying it leaves nobody
-            // to kill.
+            // Destroying an unloaded vessel kills its crew outright, which would override
+            // the respawn period just started, report the deaths to contracts watching for
+            // them, and drop any tourists aboard from the roster entirely. It reads the crew
+            // off the protovessel, which is going with the vessel, so emptying it leaves the
+            // crew alone
             if (!vessel.loaded)
                 foreach (var member in crew)
                     vessel.protoVessel.RemoveCrew (member);

--- a/service/SpaceCenter/src/Services/Waypoint.cs
+++ b/service/SpaceCenter/src/Services/Waypoint.cs
@@ -67,10 +67,9 @@ namespace KRPC.SpaceCenter.Services
         }
 
         /// <summary>
-        /// What the game holds for the waypoint. It is live while the game's waypoint
-        /// manager lists it, and destroyed once the manager is there to ask and does not, as
-        /// a waypoint that leaves the list is gone for good. A game with no waypoint manager
-        /// has no waypoints to look through, which says nothing about this one.
+        /// The state of the waypoint. It is live while the game's waypoint manager lists
+        /// it, and destroyed once a running manager stops listing it. A game with no
+        /// waypoint manager leaves the waypoint dormant.
         /// </summary>
         public GameObjectState GameObjectState {
             get {

--- a/service/SpaceCenter/src/Services/Waypoint.cs
+++ b/service/SpaceCenter/src/Services/Waypoint.cs
@@ -12,9 +12,9 @@ namespace KRPC.SpaceCenter.Services
     [KRPCClass (Service = "SpaceCenter", GameScene = GameScene.Flight)]
     public class Waypoint : Equatable<Waypoint>, IGameObjectState
     {
-        // The identifier the game gives a waypoint when it builds one. Nothing else names
-        // a waypoint: its name is neither unique nor fixed, and its seed and index only
-        // pick out the waypoints of a contract.
+        // The identifier the game gives a waypoint when it builds one. It is the only name
+        // a waypoint has: its name is neither unique nor fixed, and its seed and index only
+        // pick out the waypoints of a contract
         readonly Guid navigationId;
 
         /// <summary>
@@ -26,7 +26,7 @@ namespace KRPC.SpaceCenter.Services
                 throw new ArgumentNullException (nameof (body));
             // The waypoint is set up before the game is given it, so this works on it
             // directly: until the game has it, there is nothing for this object to find.
-            // What each line does is what the property of the same name does.
+            // Each line does what the property of the same name does
             var waypoint = new FinePrint.Waypoint ();
             waypoint.name = name;
             waypoint.celestialName = body.Name;

--- a/service/SpaceCenter/src/VesselPhysicsRangeAddon.cs
+++ b/service/SpaceCenter/src/VesselPhysicsRangeAddon.cs
@@ -11,7 +11,7 @@ namespace KRPC.SpaceCenter
     /// <remarks>
     /// KSP assigns <c>Vessel.vesselRanges</c> only in <c>Vessel.Awake</c>, copying
     /// <c>PhysicsGlobals.VesselRangesDefault</c>, and never saves it. A vessel rebuilt from its
-    /// protovessel — after a scene change, or when it comes back into loading range — therefore
+    /// protovessel, after a scene change or when it comes back into loading range, therefore
     /// starts again at the stock ranges. The requested range is held here, keyed by vessel id so
     /// that it outlives the vessel object, and re-applied so it survives those rebuilds.
     ///
@@ -81,7 +81,7 @@ namespace KRPC.SpaceCenter
 
         /// <summary>
         /// Re-apply the requested ranges, so that they survive a vessel being rebuilt from its
-        /// protovessel — on entering the scene, or on coming back into loading range.
+        /// protovessel, on entering the scene or on coming back into loading range.
         /// </summary>
         public void FixedUpdate ()
         {

--- a/service/SpaceCenter/test/test_autopilot.py
+++ b/service/SpaceCenter/test/test_autopilot.py
@@ -366,9 +366,9 @@ def _make_autopilot_test_class(
             # roll angles reports spurious large values. roll_error is measured about
             # the nose axis instead, which stays well-defined as long as the vessel and
             # target share a nose direction. The direction is ~1 degree off straight up
-            # (surface +x is the zenith) with a fixed heading, so the vertical plane —
-            # and hence the roll angle — is still defined (exactly vertical is
-            # inherently degenerate between heading and roll; see AutoPilot.TargetRoll).
+            # (surface +x is the zenith) with a fixed heading, so the vertical plane, and
+            # with it the roll angle, is still defined. Exactly vertical is inherently
+            # degenerate between heading and roll, see AutoPilot.TargetRoll.
             set_roll = 40
             offset = math.radians(1)
             direction = normalize((math.cos(offset), math.sin(offset), 0))
@@ -507,10 +507,10 @@ def _make_autopilot_test_class(
             self.assertAlmostEqual(self.ap.target_direction, direction, delta=1e-3)
 
         def test_roll_defined_through_vertical(self):
-            # The #564 fix at the API level: with an up reference off the flight path,
-            # roll stays well-defined as the nose sweeps through the exact vertical —
-            # where the default (zenith) reference is singular. Command roll 0 at each
-            # step and confirm it reads back 0 continuously, including at the pole.
+            # The #564 fix at the API level: with an up reference off the flight path, roll
+            # stays well-defined as the nose sweeps through the exact vertical, where the
+            # default zenith reference is singular. Command roll 0 at each step and confirm
+            # it reads back 0 continuously, including at the pole.
             self.ap.reset()
             self.ap.reference_frame = self.vessel.surface_reference_frame
             north = (0, 1, 0)  # perpendicular to the zenith-east sweep plane
@@ -583,8 +583,8 @@ def _make_autopilot_test_class(
         def test_hold_through_vertical_with_fixed_up(self):
             # Physics companion to test_roll_defined_through_vertical: hold an orientation
             # whose nose sits at the vertical using an up reference off the path, and
-            # confirm the tracked roll error stays bounded — where the old vertical-plane
-            # roll returned spurious values up to ~180 deg (#564).
+            # confirm the tracked roll error stays bounded, where the vertical-plane roll is
+            # singular and returns spurious values up to 180 degrees (#564).
             self.cheat_orientation_to(88, 90, 0)
             self.ap.reference_frame = self.vessel.surface_reference_frame
             north = (0, 1, 0)  # perpendicular to the zenith-east sweep plane
@@ -1065,7 +1065,7 @@ def _make_autopilot_test_class(
         def test_target_smoothing_ramp(self):
             # With target_smoothing_time set, a step change to the target must not reach
             # the *effective* control target until ~smoothing seconds (of game time)
-            # have elapsed -- the slew ramps the setpoint there rather than stepping
+            # have elapsed, as the slew ramps the setpoint there instead of stepping
             # instantly. Asserts on the logged effective target (eff_tgt), so it is
             # craft-independent (it measures the setpoint, not how the vessel tracks
             # it). The assertion is on elapsed game time rather than ramp shape so it is
@@ -1348,8 +1348,8 @@ def _make_autopilot_test_class(
         def test_oscillation_force_on(self):
             # Forcing a rate-filter tool (Notch on pitch/yaw, LowPass on roll) applies
             # that filtering unconditionally at the group's manual frequency, bypassing
-            # the detector -- it does not depend on (or require) a latch (contrast the
-            # Automatic path in test_oscillation_auto_detection). Forcing the other
+            # the detector, so it needs no latch. Contrast the Automatic path in
+            # test_oscillation_auto_detection. Forcing the other
             # mitigations engages them fully regardless of the detector. This checks the
             # forced modes are accepted, persist across an engage, and the autopilot
             # still drives to and holds the target. Craft-independent.
@@ -1369,11 +1369,10 @@ def _make_autopilot_test_class(
         def test_oscillation_force_off(self):
             # Forcing every mitigation Off disables all oscillation handling, even on a
             # structurally flexible craft: the craft is controlled with full authority
-            # (and may wobble). The detector keeps observing -- the latch and level
-            # observables are unaffected by the modes -- so unlike the pre-redesign
-            # semantics no assertion is made on them here. Uses capture_recovery (which
-            # does not raise on a non-settle) rather than wait_for_autopilot, since
-            # forcing Off means accepting the wobble; only that the modes persist is
+            # (and may wobble). The detector keeps observing, and the latch and level
+            # observables are unaffected by the modes, so no assertion is made on them
+            # here. Uses capture_recovery, which does not raise on a non-settle, since
+            # forcing Off means accepting the wobble. Only that the modes persist is
             # required.
             rfm = self.rate_filter_mode
             mm = self.mitigation_mode
@@ -2024,9 +2023,9 @@ TestAutoPilotFlightGull = _make_autopilot_flight_test_class(
 # Re-entry attitude-hold tests for stock spaceplanes: place the craft descending through the
 # upper atmosphere at supersonic speed, nose held slightly above the flight path (a small
 # positive angle of attack), and confirm the autopilot holds that attitude steadily against the
-# high dynamic-pressure aero moments -- keeping the angle of attack small and positive -- without
-# tumbling or breaking up. Unpowered (engines flame out in the thin air anyway); RCS is enabled as
-# a re-entry vehicle would use it, though the aero surfaces carry most of the authority.
+# high dynamic-pressure aero moments, keeping the angle of attack small and positive, without
+# tumbling or breaking up. Unpowered, as engines flame out in the thin air anyway. RCS is enabled
+# as a re-entry vehicle would use it, though the aero surfaces carry most of the authority.
 # pylint: disable=too-many-statements,too-many-arguments,too-many-positional-arguments,too-many-locals
 def _make_autopilot_reentry_test_class(
     test_name,
@@ -2239,12 +2238,11 @@ class TestAutoPilotOtherVessel(krpctest.TestCase):
 
 
 class TestAutoPilotRevertToLaunch(krpctest.TestCase):
-    # Regression for the auto-pilot no longer engaging after a Revert to Launch. A client
-    # that keeps its auto-pilot handle across the revert (a persistent connection, or a
-    # script re-run without reconnecting) must be able to re-engage and actually control
-    # the vessel — previously the handle pointed at an orphaned controller that the
-    # per-tick pilot loop never drove, so the vessel was left uncontrolled until a game
-    # restart.
+    # Regression for the auto-pilot failing to engage after a Revert to Launch. A client
+    # that keeps its auto-pilot handle across the revert, over a persistent connection or a
+    # script re-run without reconnecting, must be able to re-engage and control the vessel.
+    # A handle pointing at an orphaned controller that the per-tick pilot loop never drives
+    # leaves the vessel uncontrolled until a game restart.
 
     @classmethod
     def setUpClass(cls):
@@ -2271,8 +2269,8 @@ class TestAutoPilotRevertToLaunch(krpctest.TestCase):
         # An engaged auto-pilot that the per-tick pilot loop is actually driving forces the
         # stock SAS action group off every physics tick. Enabling SAS and watching it clear
         # is a ground-independent signal that the engaged handle is wired to the vessel's
-        # live controller — a revert leaves the craft on the launch pad, where it cannot be
-        # slewed to a target, so this checks the drive path rather than actual rotation.
+        # live controller. A revert leaves the craft on the launch pad, where it cannot be
+        # slewed to a target, so this checks the drive path and not actual rotation.
         #
         # SAS can only be enabled while the auto-pilot is disengaged, so the sequence is
         # disengage, arm SAS, then engage and watch the pilot loop clear it.

--- a/service/SpaceCenter/test/test_parts_control_surface.py
+++ b/service/SpaceCenter/test/test_parts_control_surface.py
@@ -157,7 +157,7 @@ class TestPartsControlSurface(krpctest.TestCase):
     def test_available_torque(self):
         # Not verified here: that authority_limiter scales available_torque proportionally
         # (mirrors test_authority_limiter in test_parts_reaction_wheel.py). This
-        # requires the vessel to be in motion — GetPotentialTorque() returns zero
+        # requires the vessel to be in motion, as GetPotentialTorque() returns zero
         # at rest with no airspeed, so the scaling cannot be exercised here.
         self.assertAlmostEqual((0, 0, 0), self.ctrlsrf.available_torque[0], places=3)
         self.assertAlmostEqual((0, 0, 0), self.winglet.available_torque[1], places=3)

--- a/service/SpaceCenter/test/test_referenceframe.py
+++ b/service/SpaceCenter/test/test_referenceframe.py
@@ -4,7 +4,7 @@
 # so even a single-frame gap (~20 ms) introduces tens of metres of error.
 # Affected tests use delta=200 (metres) rather than the default 7-place tolerance.
 # Tests that check a single value from one RPC (e.g. direction in own frame) are
-# not affected by the race, but are limited to places=6 by float→double precision
+# not affected by the race, but are limited to places=6 by float to double precision
 # loss when Unity float Vector3 values are promoted for double-precision arithmetic.
 
 import math
@@ -643,8 +643,8 @@ class TestReferenceFrame(krpctest.TestCase):
         which is only valid at the equator.  Off the equator it produced a
         surface velocity error of ~52 m/s.
         """
-        # Inclination 45°, observed a quarter orbit past the ascending node
-        # (mean anomaly π/2) so the vessel sits near its peak latitude.
+        # Inclination 45 degrees, observed a quarter orbit past the ascending node
+        # (mean anomaly pi/2) so the vessel sits near its peak latitude.
         self.addCleanup(self.set_circular_orbit, "Kerbin", 100000)
         self.set_orbit("Kerbin", 700000, 0, 45, 0, 0, math.pi / 2, 0)
         expected = self._expected_surface_speed()
@@ -668,8 +668,8 @@ class TestReferenceFrame(krpctest.TestCase):
         Before the #454 fix the buggy ω×r correction was rotation-frame
         dependent, so the two speeds diverged away from the equator.
         """
-        # Inclination 45°, observed a quarter orbit past the ascending node
-        # (mean anomaly π/2) so the vessel sits near its peak latitude.
+        # Inclination 45 degrees, observed a quarter orbit past the ascending node
+        # (mean anomaly pi/2) so the vessel sits near its peak latitude.
         self.addCleanup(self.set_circular_orbit, "Kerbin", 100000)
         self.set_orbit("Kerbin", 700000, 0, 45, 0, 0, math.pi / 2, 0)
         hybrid = self.space_center.ReferenceFrame.create_hybrid(
@@ -865,8 +865,8 @@ class TestReferenceFrame(krpctest.TestCase):
         surface speed frame is correct away from the equator too. Checked at ~45°
         latitude in an inclined orbit, where the co-rotation velocity is neither
         aligned with nor perpendicular to the orbital velocity."""
-        # Inclination 45°, observed a quarter orbit past the ascending node
-        # (mean anomaly π/2) so the vessel sits near its peak latitude.
+        # Inclination 45 degrees, observed a quarter orbit past the ascending node
+        # (mean anomaly pi/2) so the vessel sits near its peak latitude.
         self.addCleanup(self.set_circular_orbit, "Kerbin", 100000)
         self.set_orbit("Kerbin", 700000, 0, 45, 0, 0, math.pi / 2, 0)
         expected = self._expected_surface_speed()
@@ -1099,7 +1099,7 @@ class TestReferenceFrame(krpctest.TestCase):
         ang_vel = self.vessel.angular_velocity(self.vessel.surface_reference_frame)
         orbital_angular_speed = 2 * math.pi / self.vessel.orbit.period
         self.assertAlmostEqual(orbital_angular_speed, norm(ang_vel), delta=1e-4)
-        # Locks out the old body.angularVelocity behaviour (~1x rotational speed).
+        # Locks out the body.angularVelocity reading, at one times rotational speed.
         self.assertGreater(norm(ang_vel), 5 * self.kerbin.rotational_speed)
         # No twist about the zenith (x-axis) on an equatorial orbit.
         self.assertAlmostEqual(0.0, ang_vel[0], delta=5e-5)
@@ -1110,9 +1110,9 @@ class TestReferenceFrame(krpctest.TestCase):
         vessel's angular velocity has a large zenith (x-axis) component. A sweep-only
         model (Cross(r, v) / r^2) would miss this term and report ~zero there.
         """
-        # 60 deg inclination, argument of periapsis 90 deg, and epoch = now so the
-        # vessel is teleported to periapsis -- its highest latitude (= inclination),
-        # independent of orbital phase.
+        # 60 deg inclination, argument of periapsis 90 deg, and an epoch of now, so the
+        # vessel is teleported to periapsis, its highest latitude, independent of orbital
+        # phase.
         self.addCleanup(self.set_circular_orbit, "Kerbin", 100000)
         self.set_orbit(
             "Kerbin", 700000, 0.0, 60.0, 0.0, 90.0, 0.0, self.space_center.ut

--- a/service/UI/CHANGELOG.md
+++ b/service/UI/CHANGELOG.md
@@ -1,78 +1,57 @@
 ## [v0.7.0] - unreleased
 
-- **Breaking:** Removing a user interface element another client created, or one the
-  server no longer holds, reports that it is not among those this client created, rather
-  than a bad argument. Every other object a client asks the server to build already
-  refused it that way (#1072)
+- **Breaking:** Removing a user interface element another client created, or one the server no
+  longer holds, reports that it is not among those this client created (#1072)
 - **Breaking:** Colors are given as `(red, green, blue, alpha)` rather than
-  `(red, green, blue)`, so that an element can be drawn translucent. Affects `Text.Color`
-  and the color of a `UI.Message` (#1040)
-- **Breaking:** `InputField.Changed` is only set when the user types in the field, and no
-  longer when a client sets `InputField.Value`. `Changed` on the controls added in this
-  release behaves the same way (#1040)
-- **Breaking:** User interface elements are drawn using the skin that the game draws its
-  own interface in, so the size and color that `Text` starts out with are no longer fixed
-  values (#1040)
-- **Breaking:** `Visible` is the element's own setting, rather than whether it and
-  everything it is inside are visible. An element is only drawn when everything it is
-  inside is visible as well, so an interface can be built with its parts visible, inside a
-  panel that is not, and shown all at once (#1040)
-- User interface elements can be created in every game scene, not just flight (#1040)
+  `(red, green, blue)`, so an element can be drawn translucent. Affects `Text.Color` and the
+  color of a `UI.Message` (#1040)
+- **Breaking:** `InputField.Changed` is only set when the user types in the field (#1040)
+- **Breaking:** User interface elements are drawn using the skin the game draws its own
+  interface in, so the size and color that `Text` starts out with are not fixed values (#1040)
+- **Breaking:** `Visible` is the element's own setting. An element is drawn when everything it
+  is inside is visible as well, so an interface can be built inside a hidden panel and shown
+  all at once (#1040)
+- User interface elements can be created in every game scene (#1040)
 - User interface elements are removed when the game scene changes (#1040)
 - Add `Interactable` to every control, to gray one out and stop it responding to the user
-  without hiding it (#1040)
-- Add `Toggle`, a check box, and `ToggleGroup`, which makes a set of toggles behave as
-  radio buttons. A group refers to its toggles rather than containing them, so they can be
-  grouped independently of how they are laid out (#1040)
-- Add `Layout` to arrange the contents of a `Panel` in a row, a column or a grid, rather
-  than positioning every element by hand. `Panel.AddHorizontalLayout`,
-  `Panel.AddVerticalLayout` and `Panel.AddGridLayout` create one (#1040)
-- Add `Slider`, `Dropdown` and `Image`. An image shows the contents of a PNG or JPEG file,
-  or a plain colored rectangle (#1040)
-- Add `Panel.Style`, to draw a panel as a box rather than a window, and `Panel.Color`.
-  A box with a `Text` caption makes a group box (#1040)
+  (#1040)
+- Add `Toggle`, a check box, and `ToggleGroup`, which makes a set of toggles behave as radio
+  buttons. A group refers to its toggles rather than containing them (#1040)
+- Add `Layout` to arrange the contents of a `Panel` in a row, a column or a grid.
+  `Panel.AddHorizontalLayout`, `Panel.AddVerticalLayout` and `Panel.AddGridLayout` create
+  one (#1040)
+- Add `Slider`, `Dropdown` and `Image`. An image shows the contents of a PNG or JPEG file, or
+  a plain colored rectangle (#1040)
+- Add `Panel.Style`, to draw a panel as a box rather than a window, and `Panel.Color` (#1040)
 - Add `Panel.Draggable`, so a panel can be moved by the user and used as a window (#1040)
-- Add `ScrollView`, a view onto a panel larger than the space available for it, with
-  scroll bars to move around it (#1040)
-- Add `LayoutElement`, on every user interface object, for how much space it asks a layout
-  for, and `Panel.SizeFitter`, for sizing a panel to fit what it contains (#1040)
+- Add `ScrollView`, a view onto a panel larger than the space available for it (#1040)
+- Add `LayoutElement`, for how much space a user interface object asks a layout for, and
+  `Panel.SizeFitter`, for sizing a panel to fit what it contains (#1040)
 - Add `InputField.Placeholder`, the hint drawn in an input field while it is empty (#1040)
-- Add `InputField.ContentType`, filtering what the user can type into a field as they type
-  it, so a numeric field never shows text a client has to reject, along with
-  `InputField.CharacterLimit` and `InputField.ReadOnly` (#1040)
-- Add `Color` to every control, tinting the sprite it is drawn with so a script can show a
-  state of its own, an engaged autopilot for instance, by color (#1040)
+- Add `InputField.ContentType`, filtering what the user can type into a field as they type it,
+  along with `InputField.CharacterLimit` and `InputField.ReadOnly` (#1040)
+- Add `Color` to every control, tinting the sprite it is drawn with (#1040)
 - Add `Tooltip` to every control, a short piece of text shown beside the pointer while it
   rests on the control (#1040)
-- Add `Panel.BringToFront`, to draw a panel in front of the elements beside it. A
-  draggable panel also brings itself to the front when the user presses it, the way a
-  window comes to the front when clicked (#1040)
+- Add `Panel.BringToFront`, to draw a panel in front of the elements beside it. A draggable
+  panel also brings itself to the front when the user presses it (#1040)
 - `AddSlider` can create a vertical slider, running from bottom to top (#1040)
-- Add `Button.Pressed`, true while the user is holding the button down, so a script can
-  repeat an action for as long as it is held (#1040)
-- Add `Text.WordWrap`, so a value label can be kept to one line rather than wrapping and
-  reflowing its layout as the value changes (#1040)
-- Add `Image.SetPixels`, drawing a picture from raw pixels rather than a file, so a script
-  can draw a graph, or anything else, and redraw it as often as it likes.
-  `Image.UpdatePixels` redraws a block of the picture and leaves the rest, so a picture
-  that changes a little at a time only sends what changed (#1040)
-- Two user interface objects that refer to the same element now compare equal, so a
-  client can tell whether it already has an element without keeping track of it (#1040)
-- A canvas added with `UI.AddCanvas` follows the interface scale the player has set, as
-  the stock canvas does, so the same interface is the same size on either (#1040)
+- Add `Button.Pressed`, true while the user is holding the button down (#1040)
+- Add `Text.WordWrap`, so a value label can be kept to one line (#1040)
+- Add `Image.SetPixels`, drawing a picture from raw pixels rather than a file.
+  `Image.UpdatePixels` redraws a block of the picture and leaves the rest (#1040)
+- Two user interface objects that refer to the same element compare equal (#1040)
+- A canvas added with `UI.AddCanvas` follows the interface scale the player has set, as the
+  stock canvas does (#1040)
 - Fix `Text.Font` making a font of its own every time it is set, and leaving it behind when
-  the label went. A font of a given name is made once and shared by the labels using it
-  (#1040)
-- A user interface object raises `KRPC.ObjectDestroyedException` once the element it
-  stands for is gone, which removing it, `UI.Clear`, the client that made it disconnecting
-  and changing scene all do. They previously failed on a destroyed game object, and were
-  kept for the rest of the session (#1051)
+  the label went. A font of a given name is made once and shared (#1040)
+- A user interface object raises `KRPC.ObjectDestroyedException` once its element is gone,
+  which removing it, `UI.Clear`, the client that made it disconnecting and changing scene all
+  do (#1051)
 - `RectTransform`, `Layout`, `LayoutElement` and `SizeFitter` do the same once the element
-  they were taken from is gone, and are dropped with it rather than being kept for the rest
-  of the session (#1051)
-- Fix `RectTransform` objects accumulating for the rest of the session, one for every read
-  of any object's `RectTransform`. Reading the same one twice now gives the same object
-  (#1051)
+  they were taken from is gone, and are dropped with it (#1051)
+- Fix `RectTransform` objects accumulating for the rest of the session. Reading the same one
+  twice gives the same object (#1051)
 
 ## [v0.6.0]
 - Fix locale issues with `UI.Message` (#993)

--- a/service/UI/src/Canvas.cs
+++ b/service/UI/src/Canvas.cs
@@ -37,9 +37,8 @@ namespace KRPC.UI
             GameObject.AddComponent<KSPGraphicRaycaster> ();
             GameObject.GetComponent<UnityEngine.Canvas> ().renderMode = RenderMode.ScreenSpaceOverlay;
             GameObject.GetComponent<UnityEngine.RectTransform> ().sizeDelta = new Vector2 (Screen.width, Screen.height);
-            // Without this the canvas would ignore the interface scale the player has set,
-            // and the same interface would come out a different size on it than on the
-            // stock canvas.
+            // Apply the interface scale the player has set, so that the same interface comes
+            // out the same size here as on the stock canvas
             GameObject.AddComponent<CanvasScale> ();
         }
     }

--- a/service/UI/src/DragHandler.cs
+++ b/service/UI/src/DragHandler.cs
@@ -31,10 +31,9 @@ namespace KRPC.UI
             var rect = GetComponent<UnityEngine.RectTransform> ();
             if (rect == null)
                 return;
-            // The pointer moves in screen pixels, while the panel is positioned in the
-            // canvas's own units, so the movement is divided by however much the canvas is
-            // scaled by. Without this the panel runs away from the pointer on a scaled
-            // interface.
+            // The pointer moves in screen pixels and the panel is positioned in the canvas's own
+            // units, so the movement is divided by the canvas scale. Otherwise the panel runs
+            // away from the pointer on a scaled interface
             var canvas = GetComponentInParent<UnityEngine.Canvas> ();
             var scale = canvas == null || canvas.scaleFactor <= 0 ? 1 : canvas.scaleFactor;
             rect.anchoredPosition += eventData.delta / scale;

--- a/service/UI/src/Dropdown.cs
+++ b/service/UI/src/Dropdown.cs
@@ -148,9 +148,8 @@ namespace KRPC.UI
         public int SelectedIndex {
             get { return Internal.value; }
             set {
-                // Unity moves a position outside the list to the nearest one that is in
-                // it, so a client that asked for the wrong one would be left reading back
-                // a value it did not set and no way to tell that it had happened.
+                // Unity moves a position outside the list to the nearest one inside it, so
+                // check the range here and report it
                 if (value < 0 || value >= Internal.options.Count)
                     throw new ArgumentOutOfRangeException (
                         nameof (value), "The dropdown does not have that option");

--- a/service/UI/src/Image.cs
+++ b/service/UI/src/Image.cs
@@ -159,9 +159,8 @@ namespace KRPC.UI
             if (data.LongLength != (long)width * height * 4)
                 throw new ArgumentException (
                     "The block needs width * height * 4 bytes, 4 bytes per pixel");
-            // The block is drawn into the texture rather than through the image component,
-            // so the check that the other members get from Internal is made here, before
-            // anything is concluded from what an image the game no longer has is holding.
+            // The block is drawn into the texture and not through the image component, so the
+            // check that the other members get from Internal is made here
             CheckExists ();
             if (!rawPixels || texture == null)
                 throw new InvalidOperationException (
@@ -169,9 +168,9 @@ namespace KRPC.UI
             if (x < 0 || y < 0 ||
                 (long)x + width > texture.width || (long)y + height > texture.height)
                 throw new ArgumentException ("The block does not fit inside the picture");
-            // The block arrives top row first while Unity takes rows bottom first, so
-            // the rows are turned over as they are converted, and the y offset is
-            // measured down from the top while Unity measures up from the bottom.
+            // The block arrives top row first and Unity takes rows bottom first, so the rows are
+            // turned over as they are converted, and the y offset is measured down from the top
+            // where Unity measures up from the bottom
             var pixels = new Color32[width * height];
             for (var row = 0; row < height; row++) {
                 var source = row * width * 4;

--- a/service/UI/src/InputField.cs
+++ b/service/UI/src/InputField.cs
@@ -95,13 +95,12 @@ namespace KRPC.UI
         }
 
         /// <summary>
-        /// What the field lets the user type into it. Keystrokes that do not fit are
-        /// ignored as they are typed, so a numeric field never shows text a client would
-        /// have to reject.
+        /// The content the field accepts from the user. Keystrokes that do not fit are
+        /// ignored as they are typed, so a numeric field only ever shows a number.
         /// </summary>
         /// <remarks>
-        /// Only what the user types is filtered. A value set by a client is shown as it
-        /// is given.
+        /// The filter applies to typing alone. A value set by a client is shown as it is
+        /// given.
         /// </remarks>
         [KRPCProperty]
         public InputContentType ContentType {

--- a/service/UI/src/Layout.cs
+++ b/service/UI/src/Layout.cs
@@ -49,9 +49,8 @@ namespace KRPC.UI
         }
 
         /// <summary>
-        /// What the game holds for the layout. It belongs to the interface element it was
-        /// taken from, and the game destroys it with that element, which nothing builds
-        /// again.
+        /// The state of the layout. It belongs to the interface element it was taken from,
+        /// and the game destroys it with that element. The layout is never built again.
         /// </summary>
         public GameObjectState GameObjectState {
             get {

--- a/service/UI/src/Layout.cs
+++ b/service/UI/src/Layout.cs
@@ -19,9 +19,8 @@ namespace KRPC.UI
     [KRPCClass (Service = "UI")]
     public class Layout : Equatable<Layout>, IGameObjectState
     {
-        // The game's layout group, which is what this stands for: it belongs to the
-        // interface element it was taken from and lives exactly as long as that
-        // element, and the game gives it nothing else to be named by.
+        // The game's layout group. It belongs to the interface element it was taken from and
+        // lives exactly as long as that element, and the game gives it no other name
         readonly UnityEngine.UI.LayoutGroup layout;
 
         internal Layout (UnityEngine.UI.LayoutGroup innerLayout)
@@ -43,8 +42,8 @@ namespace KRPC.UI
         /// </summary>
         public override int GetHashCode ()
         {
-            // The layout's identity hash rather than its own, so that nothing the game
-            // does to it can change it while a client holds this object.
+            // The layout's identity hash, so that nothing the game does to it changes it
+            // while a client holds this object
             return RuntimeHelpers.GetHashCode (layout);
         }
 
@@ -172,9 +171,7 @@ namespace KRPC.UI
         public int ConstraintCount {
             get { return Grid.constraintCount; }
             set {
-                // Unity moves a count below one up to one, so a client that asked for
-                // fewer would be left reading back a count it did not set and no way to
-                // tell that it had happened.
+                // Unity moves a count below one up to one, so check the range here and report it
                 if (value < 1)
                     throw new ArgumentOutOfRangeException (
                         nameof (value), "A grid must have at least one column or row");

--- a/service/UI/src/LayoutElement.cs
+++ b/service/UI/src/LayoutElement.cs
@@ -19,9 +19,8 @@ namespace KRPC.UI
     [KRPCClass (Service = "UI")]
     public class LayoutElement : Equatable<LayoutElement>, IGameObjectState
     {
-        // The game's layout element, which is what this stands for: it belongs to the
-        // interface element it was taken from and lives exactly as long as that element,
-        // and the game gives it nothing else to be named by.
+        // The game's layout element. It belongs to the interface element it was taken from and
+        // lives exactly as long as that element, and the game gives it no other name
         readonly UnityEngine.UI.LayoutElement element;
 
         internal LayoutElement (UnityEngine.UI.LayoutElement innerElement)
@@ -43,8 +42,8 @@ namespace KRPC.UI
         /// </summary>
         public override int GetHashCode ()
         {
-            // The element's identity hash rather than its own, so that nothing the game
-            // does to it can change it while a client holds this object.
+            // The element's identity hash, so that nothing the game does to it changes it
+            // while a client holds this object
             return RuntimeHelpers.GetHashCode (element);
         }
 

--- a/service/UI/src/LayoutElement.cs
+++ b/service/UI/src/LayoutElement.cs
@@ -49,9 +49,9 @@ namespace KRPC.UI
         }
 
         /// <summary>
-        /// What the game holds for the layout element. It belongs to the interface element
-        /// it was taken from, and the game destroys it with that element, which nothing
-        /// builds again.
+        /// The state of the layout element. It belongs to the interface element it was
+        /// taken from, and the game destroys it with that element. The layout element is
+        /// never built again.
         /// </summary>
         public GameObjectState GameObjectState {
             get {

--- a/service/UI/src/Object.cs
+++ b/service/UI/src/Object.cs
@@ -18,9 +18,9 @@ namespace KRPC.UI
         /// with what they belong to.
         /// </summary>
         readonly bool removable;
-        // Whether the element has been taken out of the interface. The game tears a game
-        // object down at the end of the frame, so this records that it is on its way out,
-        // and an element removed and read again in the same frame reports it gone.
+        // Whether the element has been taken out of the interface. The game tears a game object
+        // down at the end of the frame, so this records that it is going, and an element removed
+        // and read again in the same frame reports it gone
         bool removed;
 
         /// <summary>
@@ -109,8 +109,8 @@ namespace KRPC.UI
         /// </summary>
         public override int GetHashCode ()
         {
-            // The game object's identity hash rather than its own, so that nothing the
-            // game does to it can change it while a client holds this object.
+            // The game object's identity hash, so that nothing the game does to it changes it
+            // while a client holds this object
             return RuntimeHelpers.GetHashCode (GameObject);
         }
 
@@ -151,10 +151,9 @@ namespace KRPC.UI
         [KRPCProperty]
         public LayoutElement LayoutElement {
             get {
-                // The component is added the first time it is asked for, so asking must be
-                // refused for an object that would keep it for good. The stock canvas is
-                // the game's own, and kRPC never destroys it, so a component added to it
-                // would be left there for the rest of the session.
+                // The component is added the first time it is read, so an object that would keep
+                // it for good is refused. The stock canvas is the game's own and kRPC never
+                // destroys it, so a component added to it stays for the rest of the session
                 if (!CanHaveLayoutElement)
                     throw new InvalidOperationException (
                         "A canvas is not inside a layout, so it has no layout element");

--- a/service/UI/src/Object.cs
+++ b/service/UI/src/Object.cs
@@ -29,11 +29,10 @@ namespace KRPC.UI
         protected GameObject GameObject { get; private set; }
 
         /// <summary>
-        /// What the game holds for the element. The element is the game object it was made
-        /// with, so it is live while the game still has that object, and destroyed once it
-        /// does not, which is what removing it, clearing the interface elements,
-        /// disconnecting the client that made it and leaving the scene all do. Nothing
-        /// builds a client's element again, so there is no dormant state.
+        /// The state of the element, which is the game object it was made with. Removing
+        /// it, clearing the interface elements, disconnecting the client that made it and
+        /// leaving the scene each destroy that object. A client's element is never built
+        /// again, so it has no dormant state.
         /// </summary>
         public GameObjectState GameObjectState {
             get {

--- a/service/UI/src/Panel.cs
+++ b/service/UI/src/Panel.cs
@@ -40,9 +40,8 @@ namespace KRPC.UI
                 var image = CheckedGameObject.GetComponent<UnityEngine.UI.Image> ();
                 if (image == null) {
                     image = Widgets.AddImage (GameObject, null);
-                    // It has no sprite yet, and Unity draws an image that has no sprite
-                    // as a rectangle filled with its color, so it is left undrawn until
-                    // a style gives it one.
+                    // Unity draws an image with no sprite as a rectangle filled with its color,
+                    // so the image is left undrawn until a style gives it one
                     image.enabled = false;
                 }
                 return image;
@@ -66,11 +65,9 @@ namespace KRPC.UI
                 background.sprite = sprite;
                 if (sprite != null)
                     background.type = UnityEngine.UI.Image.Type.Sliced;
-                // Unity draws an image that has no sprite as a rectangle filled with its
-                // color, so a panel is stopped from being drawn rather than left to fill
-                // itself in: one with no style, and one whose style the game gave no
-                // sprite for, which falls back to not being drawn rather than to a solid
-                // block hiding whatever is behind it.
+                // Unity draws an image with no sprite as a rectangle filled with its color, so a
+                // panel with no style, or whose style the game gave no sprite for, is left
+                // undrawn instead of filling itself with a solid block
                 background.enabled = sprite != null;
                 style = value;
             }

--- a/service/UI/src/RectTransform.cs
+++ b/service/UI/src/RectTransform.cs
@@ -49,9 +49,9 @@ namespace KRPC.UI
         }
 
         /// <summary>
-        /// What the game holds for the rect transform. It belongs to the interface element
-        /// it was taken from, and the game destroys it with that element, which nothing
-        /// builds again.
+        /// The state of the rect transform. It belongs to the interface element it was
+        /// taken from, and the game destroys it with that element. The rect transform is
+        /// never built again.
         /// </summary>
         public GameObjectState GameObjectState {
             get {

--- a/service/UI/src/RectTransform.cs
+++ b/service/UI/src/RectTransform.cs
@@ -17,9 +17,8 @@ namespace KRPC.UI
     [KRPCClass (Service = "UI")]
     public class RectTransform : Equatable<RectTransform>, IGameObjectState
     {
-        // The game's rect transform, which is what this stands for: it belongs to the
-        // interface element it was taken from and lives exactly as long as that element,
-        // and the game gives it nothing else to be named by.
+        // The game's rect transform. It belongs to the interface element it was taken from and
+        // lives exactly as long as that element, and the game gives it no other name
         readonly UnityEngine.RectTransform rectTransform;
 
         internal RectTransform (UnityEngine.RectTransform innerRectTransform)
@@ -43,8 +42,8 @@ namespace KRPC.UI
         /// </summary>
         public override int GetHashCode ()
         {
-            // The transform's identity hash rather than its own, so that nothing the game
-            // does to it can change it while a client holds this object.
+            // The transform's identity hash, so that nothing the game does to it changes it
+            // while a client holds this object
             return RuntimeHelpers.GetHashCode (rectTransform);
         }
 

--- a/service/UI/src/ScrollView.cs
+++ b/service/UI/src/ScrollView.cs
@@ -30,8 +30,8 @@ namespace KRPC.UI
             Widgets.AddImage (GameObject, Widgets.Style (skin => skin.scrollView));
 
             var viewport = Widgets.CreateFilling (GameObject, "krpc.scrollView.viewport", 0);
-            // Anything outside the viewport is cut off rather than drawn over the rest of
-            // the interface.
+            // Cut off anything outside the viewport, so it is not drawn over the rest of the
+            // interface
             viewport.AddComponent<UnityEngine.UI.RectMask2D> ();
 
             var contentObject = Widgets.CreateTopLeft (

--- a/service/UI/src/SizeFitter.cs
+++ b/service/UI/src/SizeFitter.cs
@@ -14,9 +14,8 @@ namespace KRPC.UI
     [KRPCClass (Service = "UI")]
     public class SizeFitter : Equatable<SizeFitter>, IGameObjectState
     {
-        // The game's size fitter, which is what this stands for: it belongs to the
-        // interface element it was taken from and lives exactly as long as that
-        // element, and the game gives it nothing else to be named by.
+        // The game's size fitter. It belongs to the interface element it was taken from and
+        // lives exactly as long as that element, and the game gives it no other name
         readonly UnityEngine.UI.ContentSizeFitter fitter;
 
         internal SizeFitter (UnityEngine.UI.ContentSizeFitter innerFitter)
@@ -38,8 +37,8 @@ namespace KRPC.UI
         /// </summary>
         public override int GetHashCode ()
         {
-            // The size fitter's identity hash rather than its own, so that nothing the game
-            // does to it can change it while a client holds this object.
+            // The size fitter's identity hash, so that nothing the game does to it changes it
+            // while a client holds this object
             return RuntimeHelpers.GetHashCode (fitter);
         }
 

--- a/service/UI/src/SizeFitter.cs
+++ b/service/UI/src/SizeFitter.cs
@@ -44,8 +44,8 @@ namespace KRPC.UI
         }
 
         /// <summary>
-        /// What the game holds for the size fitter. It belongs to the interface element it was
-        /// taken from, and the game destroys it with that element, which nothing builds
+        /// The state of the size fitter. It belongs to the interface element it was taken
+        /// from, and the game destroys it with that element. The size fitter is never built
         /// again.
         /// </summary>
         public GameObjectState GameObjectState {

--- a/service/UI/src/Slider.cs
+++ b/service/UI/src/Slider.cs
@@ -92,9 +92,8 @@ namespace KRPC.UI
         public float Value {
             get { return Internal.value; }
             set {
-                // Unity moves a value outside the range to the nearest end of it, so a
-                // client that set the wrong value would be left reading back one it did
-                // not set and no way to tell that it had happened.
+                // Unity moves a value outside the range to the nearest end of it, so check
+                // the range here and report it
                 if (value < Internal.minValue || value > Internal.maxValue)
                     throw new ArgumentOutOfRangeException (
                         nameof (value), "The value is outside the range of the slider");
@@ -130,9 +129,8 @@ namespace KRPC.UI
         /// </summary>
         void SetRange (float min, float max)
         {
-            // A range with its ends crossed refuses every value, including the one the
-            // slider is showing, so it is refused rather than handed to Unity to make
-            // something of.
+            // A range with its ends crossed accepts no value, including the one the slider is
+            // showing, so it is refused here
             if (min > max)
                 throw new ArgumentException (
                     "The minimum of the range must not be greater than the maximum");

--- a/service/UI/src/Text.cs
+++ b/service/UI/src/Text.cs
@@ -114,9 +114,8 @@ namespace KRPC.UI
 
         /// <summary>
         /// Whether the text wraps onto further lines when it is wider than the space it
-        /// has. When wrapping is off, the text carries on past the edge instead, and a
-        /// label asked for its preferred size asks for a single line, so a value that
-        /// changes does not reflow a layout.
+        /// has. Text that does not wrap carries on past the edge, and its preferred size
+        /// is that of a single line, so a changing value leaves a layout in place.
         /// </summary>
         [KRPCProperty]
         public bool WordWrap {

--- a/service/UI/src/Toggle.cs
+++ b/service/UI/src/Toggle.cs
@@ -113,18 +113,17 @@ namespace KRPC.UI
         [KRPCProperty (Nullable = true)]
         public ToggleGroup Group {
             get {
-                // A group that has been removed is dropped as it is found, so that the
-                // toggle does not hand out a group that is no longer there.
+                // Drop a group that has been removed as it is found, so that the toggle does
+                // not hand out a torn down group
                 if (group != null && !group.Exists)
                     group = null;
                 return group;
             }
             set {
-                // Unity tells the listeners of a group's toggles when a checked toggle
-                // joins it, which is not a change the user made. So the toggle leaves the
-                // group it is in and joins the new one unchecked, and is checked again
-                // once it is a member: that unchecks the rest of the new group, as it
-                // would had the toggle been checked while already a member of it.
+                // Unity notifies the listeners of a group's toggles when a checked toggle
+                // joins it, which the user did not do. The toggle therefore leaves the group it
+                // is in and joins the new one unchecked, then is checked again once it is a
+                // member, which unchecks the rest of the new group
                 var wasChecked = Checked;
                 Checked = false;
                 var current = Group;

--- a/service/UI/src/ToggleGroup.cs
+++ b/service/UI/src/ToggleGroup.cs
@@ -31,8 +31,7 @@ namespace KRPC.UI
         }
 
         internal UnityEngine.UI.ToggleGroup InnerGroup {
-            // Checked, so that a toggle joining a group the game no longer has says so
-            // rather than being tied to a torn down one.
+            // Checked, so that a toggle joining a group the game has dropped raises here
             get { return Internal; }
         }
 
@@ -84,9 +83,9 @@ namespace KRPC.UI
         /// </remarks>
         internal void Check (Toggle toggle, bool value)
         {
-            // Unity refuses to uncheck the last checked toggle of a group that does not
-            // allow being switched off. That rule is for the user, who can only check a
-            // different toggle; a client saying what a toggle is set to is obeyed.
+            // Unity keeps the last checked toggle of a group that does not allow being
+            // switched off. That rule is for the user, who can only check a different toggle,
+            // and a client setting a toggle directly is not bound by it
             var switchOff = Internal.allowSwitchOff;
             Internal.allowSwitchOff = true;
             try {

--- a/service/UI/src/TooltipHandler.cs
+++ b/service/UI/src/TooltipHandler.cs
@@ -29,9 +29,8 @@ namespace KRPC.UI
             Hide ();
             if (string.IsNullOrEmpty (Text))
                 return;
-            // The tooltip is parented to the canvas rather than the control, so that it
-            // is drawn over the control's neighbors and is not cut off by the viewport
-            // of a scroll view.
+            // The tooltip is parented to the canvas, so that it is drawn over the control's
+            // neighbors and is not cut off by the viewport of a scroll view
             var canvas = GetComponentInParent<UnityEngine.Canvas> ();
             if (canvas == null)
                 return;

--- a/service/UI/src/Widgets.cs
+++ b/service/UI/src/Widgets.cs
@@ -215,8 +215,8 @@ namespace KRPC.UI
 
         static GameObject NewObject (GameObject parent, string name)
         {
-            // Creating the object with a rect transform, rather than adding one afterwards,
-            // avoids it being given the plain transform that a bare game object gets.
+            // Create the object with a rect transform, so that it does not get the plain
+            // transform a bare game object gets
             var obj = new GameObject (name, typeof(UnityEngine.RectTransform));
             obj.transform.SetParent (parent.transform, false);
             return obj;
@@ -244,8 +244,8 @@ namespace KRPC.UI
             var sprite = Background (style, style == null ? null : select (style));
             if (sprite != null) {
                 image.sprite = sprite;
-                // The skin's sprites carry borders, so they are stretched by their edges
-                // rather than as a whole and controls can be resized without distortion.
+                // The skin's sprites carry borders, so they are stretched by their edges and
+                // controls can be resized without distortion
                 image.type = UnityEngine.UI.Image.Type.Sliced;
             }
             return image;

--- a/service/UI/test/test_panel.py
+++ b/service/UI/test/test_panel.py
@@ -81,8 +81,8 @@ class TestPanel(krpctest.TestCase):
         panel.remove()
 
     def test_bring_to_front(self):
-        # Which panel is drawn on top cannot be read back, so this covers that the
-        # call is accepted, including on a panel that is already at the front.
+        # The panel drawn on top cannot be read back, so this covers only that the call
+        # is accepted, including on a panel that is already at the front.
         older = self.canvas.add_panel()
         newer = self.canvas.add_panel()
         older.bring_to_front()

--- a/tools/TestServer/src/Program.cs
+++ b/tools/TestServer/src/Program.cs
@@ -134,7 +134,7 @@ namespace TestServer
             // Services are found by scanning the assemblies that are loaded, and the runtime
             // does not load one until something in it is used. Nothing in this program calls
             // into the benchmark service, so name a type from it to get it loaded before the
-            // scan; the game has no such problem, since KSP loads every assembly it installs.
+            // scan. KSP loads every assembly it installs, so the game has no such problem.
             Logger.WriteLine (
                 "Loaded " + typeof (KRPC.Benchmarks.Benchmark).Assembly.GetName ().Name);
 
@@ -239,11 +239,10 @@ namespace TestServer
                         Console.WriteLine ("Fast by " + diffTime + " ms (" + diffTicks + " ticks)");
                 }
 
-                // Wait, to force 60 FPS — sleep most of the remaining time rather than
-                // spinning, so the process doesn't burn a core during profiling/benchmarks.
-                // Unpaced, the next update follows immediately instead, which costs a core
-                // and is what makes a round trip measure the client rather than the update
-                // it landed in.
+                // Wait, to force 60 FPS. Sleep most of the remaining time, so the process
+                // does not burn a core during profiling and benchmarks. Unpaced, the next
+                // update follows immediately, which costs a core and makes a round trip
+                // measure the client and not the update it landed in.
                 if (framePacing) {
                     var remainingTicks = ticksPerUpdate - timer.ElapsedTicks;
                     if (remainingTicks > Stopwatch.Frequency / 1000) {

--- a/tools/TestServer/src/TestService.cs
+++ b/tools/TestServer/src/TestService.cs
@@ -785,9 +785,9 @@ namespace TestServer
         }
 
         // The special values of the numeric types as default arguments. Each is a compile-time
-        // constant, so they are plain optional parameters rather than KRPCDefaultValue
-        // factories. Every generated client has to spell them in a way its language accepts,
-        // which the client builds check by compiling the generated stubs.
+        // constant, so they are plain optional parameters and not KRPCDefaultValue factories.
+        // Every generated client has to spell them in a way its language accepts, which the
+        // client builds check by compiling the generated stubs.
 
         /// <summary>
         /// Procedure whose defaults are the special values of double.

--- a/tools/TestingTools/src/AutoLoadGame.cs
+++ b/tools/TestingTools/src/AutoLoadGame.cs
@@ -77,11 +77,10 @@ namespace TestingTools
             GameEvents.onLevelWasLoadedGUIReady.Remove(OnGUIReady);
         }
 
-        // Named OnGUIReady rather than OnLevelWasLoaded to avoid colliding with
-        // Unity's deprecated OnLevelWasLoaded(int) magic message. The collision is
-        // harmless (the handler is invoked via the GameEvents delegate, not Unity's
-        // message dispatch) but logs a spurious "message parameter has to be of
-        // type: int" error on every run.
+        // Named OnGUIReady, to avoid colliding with Unity's deprecated
+        // OnLevelWasLoaded(int) magic message. The collision is harmless, as the handler
+        // is invoked through the GameEvents delegate, but it logs a spurious "message
+        // parameter has to be of type: int" error on every run.
         void OnGUIReady(GameScenes scene)
         {
             // Only auto-load when an auto-load argument was actually supplied.
@@ -118,10 +117,10 @@ namespace TestingTools
                 throw Fatal.Error(
                     "Failed to load game configuration for save \"" + Save + "\" in folder saves/" + Game);
             // Ensure the loaded save has every scenario module the current install
-            // expects. Loading a clean save into a modded install commonly adds
-            // modules and makes this return true; that is normal, not a failure, so
-            // the return value is ignored, matching KSP's own MainMenu load flow.
-            // (Treating true as an error here left the game stuck at the main menu.)
+            // expects. Loading a clean save into a modded install commonly adds modules
+            // and makes this return true, which is normal, so the return value is
+            // ignored, matching KSP's own MainMenu load flow. Treating true as an error
+            // here leaves the game stuck at the main menu.
             GamePersistence.UpdateScenarioModules(HighLogic.CurrentGame);
 
             // Load the game
@@ -129,9 +128,9 @@ namespace TestingTools
             HighLogic.SaveFolder = Game;
 
             if (Options.HasCraft) {
-                // A failure here quits KSP (via Fatal.Error) rather than loading into the
-                // Space Center without the requested craft, so the launch fails fast instead
-                // of leaving the user or the test framework to guess why the craft is missing.
+                // A failure here quits KSP through Fatal.Error, so the launch fails fast and
+                // does not load into the Space Center without the requested craft, leaving the
+                // user or the test framework to guess why the craft is missing.
                 PrepareCraftLaunch(Options);
                 AutoSwitchVessel.SetCraftLaunch(
                     Options.Craft, Options.CraftDirectory, Options.LaunchSite);

--- a/tools/TestingTools/src/AutoSwitchVessel.cs
+++ b/tools/TestingTools/src/AutoSwitchVessel.cs
@@ -77,9 +77,9 @@ namespace TestingTools
             GameEvents.onLevelWasLoadedGUIReady.Remove(OnGUIReady);
         }
 
-        // Named OnGUIReady rather than OnLevelWasLoaded to avoid colliding with
-        // Unity's deprecated OnLevelWasLoaded(int) magic message, which would
-        // otherwise log a spurious type error on every run.
+        // Named OnGUIReady, to avoid colliding with Unity's deprecated
+        // OnLevelWasLoaded(int) magic message, which logs a spurious type error on
+        // every run.
         void OnGUIReady(GameScenes scene)
         {
             if (scene != GameScenes.SPACECENTER)

--- a/tools/TestingTools/src/Benchmark.cs
+++ b/tools/TestingTools/src/Benchmark.cs
@@ -140,11 +140,11 @@ namespace TestingTools
             new Dictionary<string, Func<ServiceVessel, Action>> {
                 { "empty", vessel => () => { Timer.IntSink = 0; } },
 
-                // What returning a proxy costs once it has been constructed: the object store
+                // The cost of returning a proxy once it has been constructed: the object store
                 // hashes it and compares it against what it already holds, so this is the dedup
                 // path, over a store holding one entry per part of the vessel. The store is a
-                // private one rather than the server's, so the benchmark does not grow the store
-                // the rest of the session is measured against.
+                // private one, so the benchmark does not grow the store the rest of the session
+                // is measured against.
                 { "store.dedup", vessel => {
                     var store = new ObjectStore ();
                     var parts = vessel.Parts.All;

--- a/tools/TestingTools/src/Fatal.cs
+++ b/tools/TestingTools/src/Fatal.cs
@@ -5,7 +5,7 @@ namespace TestingTools
 {
     /// <summary>
     /// Thrown when a TestingTools --krpctest-load-* option cannot be honoured. The launch is
-    /// aborted rather than silently continuing with different behaviour than was requested.
+    /// aborted, and does not silently continue with different behavior than was requested.
     /// </summary>
     sealed class TestingToolsException : Exception
     {

--- a/tools/TestingTools/src/TestingTools.cs
+++ b/tools/TestingTools/src/TestingTools.cs
@@ -220,7 +220,7 @@ namespace TestingTools
         /// Reassign every crew member of the given vessel (default: the active vessel) to the Pilot
         /// profession at full experience level. The save's auto-crew fills the pod with whichever
         /// kerbal is next in the roster (often an engineer/scientist), which leaves the vessel on
-        /// "partial control" — no in-game SAS and, after a rails warp, an unreliable control source.
+        /// "partial control": no in-game SAS and, after a rails warp, an unreliable control source.
         /// Overwriting the trait to Pilot gives deterministic full control for every test run without
         /// changing the craft (a kerbal's mass is the same for any profession, so the calibrated MOI
         /// and torque are unaffected).

--- a/tools/TestingTools/src/TestingToolsOptions.cs
+++ b/tools/TestingTools/src/TestingToolsOptions.cs
@@ -88,8 +88,7 @@ namespace TestingTools
                 } else
                     // A "--krpctest-" argument matching no known option: a typo, an empty
                     // value like "--krpctest-load-game=", or a flag we do not handle. Fail
-                    // loudly rather than silently ignoring it and doing something other than
-                    // what was asked.
+                    // loudly, so nothing other than what was asked for happens.
                     throw Fatal.Error(
                         "Unrecognized or empty TestingTools argument \"" + arg + "\". Valid arguments: " +
                         GameArgument + "<folder>, " + SaveArgument + "<name>, " +

--- a/tools/benchmarks/chunking.py
+++ b/tools/benchmarks/chunking.py
@@ -14,8 +14,8 @@ from tools.benchmarks.report import Result
 # One chunk is one call to a benchmark RPC, sized to run for about this long.
 CHUNK_SECONDS = 0.2
 
-# How many chunks to take. The fastest is the estimate and the spread across them says how
-# much the machine got in the way, so a handful is enough for both.
+# The number of chunks to take. The fastest is the estimate and the spread across them shows
+# how much the machine got in the way, so a handful is enough for both.
 REPEATS = 5
 
 # The chunk that sizes the rest. Small, because nothing is known yet about how expensive one

--- a/tools/benchmarks/report.py
+++ b/tools/benchmarks/report.py
@@ -16,26 +16,23 @@ import statistics
 # block, since a number that unsteady is not one to draw a conclusion from.
 NOISY_SPREAD = 0.25
 
-# What a figure has to be measured in for its reciprocal to be a rate a second, and how many of
-# that unit go into a second. A case measured in anything else reports no rate.
+# The units whose reciprocal is a rate per second, and how many of each go into a second. A
+# case measured in anything else reports no rate.
 PER_SECOND = {"s": 1.0, "ms": 1e3, "us": 1e6, "ns": 1e9, "ns/op": 1e9}
 
 # Every figure in a table of one suite per column is printed to the same number of places, so
-# that a column of them reads down as a column. The significant digits of a client's round trip
-# in milliseconds are the last of these; a table of one suite still prints as many as its
-# figures are worth and no more.
+# that a column of them reads down as a column. The last of these places are the significant
+# digits of a client's round trip in milliseconds. A table of one suite still prints as many
+# as its figures are worth.
 FIGURE = "%.5f"
 
-# A case whose samples moved this much between the start of the measurement and the end, on top
-# of however far they scattered, is called out under its block. Drift and noise both widen the
-# spread but mean opposite things: noise says the estimate is uncertain, drift says the case was
-# still going somewhere while it was measured and the number is wherever it had got to. The
-# second is worth another run.
-#
-# The spread is part of the threshold because the two ends being compared are each the middle of
-# a few samples, and samples that scatter widely give middles that differ by about as much on
-# their own. A case has only gone somewhere when it went further than its own scatter would have
-# carried it; below that it is a noisy case, which is what the spread column already says.
+# A case whose samples moved this much between the start of the measurement and the end, on
+# top of however far they scattered, is called out under its block. Drift and noise both widen
+# the spread but mean opposite things: noise makes the estimate uncertain, where drift means
+# the case was still moving while it was measured and the number is wherever it had got to.
+# The spread is part of the threshold because the two ends being compared are each the middle
+# of a few samples, and samples that scatter widely give middles that differ by about as much
+# on their own.
 DRIFT = 0.10
 
 
@@ -79,18 +76,17 @@ class Result:
         self.exact_allocations = exact_allocations
         self.iterations = iterations
         self.note = note
-        # A row that is there to explain the others rather than to be concluded from - the
-        # cost of the empty loop, say, which is subtracted from every case beside it. Still
-        # worth comparing between runs, but not worth warning that it wobbled.
+        # A row that explains the others, such as the cost of the empty loop, which is
+        # subtracted from every case beside it. Still worth comparing between runs, and not
+        # worth warning that it wobbled.
         self.context = context
         # Whether the case had stopped getting faster before it was measured. Where it had
-        # not, the figure is where it had reached rather than what the case costs, which is
-        # said beside it rather than left for the reader to notice.
+        # not, the figure is where it had reached and not the cost of the case, and the report
+        # says so beside it.
         self.settled = settled
-        # What one of whatever this case does is called, for a figure worth reading as a rate
-        # as well as a cost: a round trip measured in milliseconds is also so many calls a
-        # second. Naming the thing counted is the measurement's to do; working the rate out
-        # and phrasing it is not.
+        # The name of one operation, for a figure worth reading as a rate as well as a cost: a
+        # round trip measured in milliseconds is also so many calls a second. The measurement
+        # names the thing counted, and the report works the rate out.
         self.rate = rate
 
     @property
@@ -313,7 +309,7 @@ def _columns(scenario, suites, results):
         lines.append("")
         lines.extend(block(_rate, heading=_counted(results)))
 
-    # What each suite costs against the one that measured the case fastest, which is the
+    # The cost of each suite against the one that measured the case fastest, which is the
     # comparison a table of several of them is read for: the figures above it hold for the
     # machine and the session that took them, and these hold wherever they were taken.
     if len(suites) > 1:
@@ -386,7 +382,7 @@ def _scenarios(results):
 
 
 def _block(scenario, results):
-    # Only show the allocation columns for a suite that measured allocations; a client
+    # Only show the allocation columns for a suite that measured allocations. A client
     # benchmark, which times a round trip from outside the server, has nothing to put there.
     allocations = any(x.bytes_per_op is not None for x in results)
     case_width = max([len("case")] + [len(x.case) for x in results])

--- a/tools/benchmarks/run_client.py
+++ b/tools/benchmarks/run_client.py
@@ -64,8 +64,8 @@ def measure(server, suite, client, client_localsocket=None):
         cases, version, settings = run(server, program, transport)
         results += [record(suite, scenario(transport), case) for case in cases]
         environment.setdefault("server", version)
-        # What the server was told is the same whichever transport it serves, so the first one
-        # measured says it for the run.
+        # The server settings are the same whichever transport it serves, so the first one
+        # measured records them for the run.
         environment.setdefault("measured against", settings)
     return results, environment
 
@@ -96,8 +96,8 @@ def run(server, client, transport=testserver.TCP):
     with testserver.running(
         server, frame_pacing=False, transport=transport
     ) as endpoint:
-        # On a connection of our own, closed again before the program runs, so that what is
-        # measured is one client talking to the server, as it was before the warmup.
+        # On a connection of our own, closed again before the program runs, so that the
+        # measurement is one client talking to the server, as it was before the warmup.
         with testserver.connect("benchmark_warmup", endpoint) as conn:
             testserver.warm_up(conn)
         cases = parse(execute(client, endpoint))["results"]

--- a/tools/benchmarks/run_clients.py
+++ b/tools/benchmarks/run_clients.py
@@ -33,9 +33,9 @@ def main():
     for name, client in [(PYTHON, None)] + args.client:
         measured, version, settings = measure(args, name, client)
         results += measured
-        # One line for the lot rather than one per client: they are measured against servers
-        # started the same way, and a table whose columns ran under different settings would
-        # be reporting two things at once.
+        # One line for the lot, not one per client: they are measured against servers started
+        # the same way, and a table whose columns ran under different settings would be
+        # reporting two things at once.
         environment.setdefault("server", version)
         environment.setdefault("measured against", settings)
     runner.report(results, SUITE, environment, args.json, render=report.by_suite)

--- a/tools/benchmarks/run_python.py
+++ b/tools/benchmarks/run_python.py
@@ -23,33 +23,33 @@ from tools.benchmarks.report import Result
 SUITE = "client, python"
 SCENARIO = "round trips"
 
-# What a round trip's figure counts, for the report to work its reciprocal out from.
+# The unit a round trip's figure counts, for the report to work its reciprocal out from.
 RATE = "calls/s"
 
-# How long one timed loop should run for. Long enough that the clock and a stray scheduling
+# Duration of one timed loop. Long enough that the clock and a stray scheduling
 # delay do not decide the answer, short enough that a whole run stays in seconds.
 TARGET_SECONDS = 0.2
 
-# How many timed loops to take. More than the server-side suites take, because a round trip
+# The number of timed loops to take. More than the server-side suites take, as a round trip
 # crosses a socket and a scheduler as well as the server, and every one of those can only make
 # a sample slower.
 SAMPLES = 9
 
-# How long one discarded chunk of calls runs for while a case is being settled, and how many
+# The duration of one discarded chunk of calls while a case is being settled, and how many
 # of them at a time are asked whether it has stopped getting faster.
 SETTLE_CHUNK_SECONDS = 0.1
 SETTLE_CHUNKS = 3
 
-# How much better the last few chunks have to be than everything before them for a case to
-# count as still improving. Below this it has stopped going anywhere and can be measured.
+# The margin the last few chunks have to beat for a case to count as still improving. Below
+# this it has stopped moving and can be measured.
 SETTLE_TOLERANCE = 0.02
 
-# How long to keep settling one case before measuring it anyway. Reaching this means the
-# figure is whatever the case had reached rather than what it costs, so it is reported.
+# The time to keep settling one case before measuring it anyway. Reaching this means the
+# figure is where the case had reached and not its cost, so the report says so.
 SETTLE_TIMEOUT_SECONDS = 10.0
 
-# How many values the collection case sends and gets back. A call carries a value at a time, so
-# what one costs to encode and decode is lost in the round trip it arrives in; a list makes that
+# The number of values the collection case sends and gets back. A call carries one value at a
+# time, so the cost of encoding and decoding it is lost in the round trip. A list makes that
 # per-value cost most of what the case measures. The same count for every client, so that the
 # figures can be read against each other.
 LIST_VALUES = 100
@@ -77,8 +77,8 @@ def measure(server):
             testserver.warm_up(conn)
             results += measure_calls(conn, transport)
             environment.setdefault("server", conn.krpc.get_status().version)
-            # What the server was told is the same whichever transport it serves, so the first
-            # one measured says it for the run.
+            # The server settings are the same whichever transport it serves, so the first one
+            # measured records them for the run.
             environment.setdefault(
                 "measured against", testserver.settings(conn, pacing)
             )

--- a/tools/benchmarks/run_server.py
+++ b/tools/benchmarks/run_server.py
@@ -30,7 +30,7 @@ def main():
     # Under `bazel run` the process starts in the runfiles tree. Work in the directory bazel
     # was invoked from instead, so that a path given on the command line means what it would
     # for a bare pytest, and so that the framework's nested bazel calls and the scripts' craft
-    # fixtures resolve against the repository rather than a tree of symlinks.
+    # fixtures resolve against the repository and not a tree of symlinks.
     workspace = os.environ.get("BUILD_WORKSPACE_DIRECTORY")
     if not workspace:
         sys.exit("This tool must be run via `bazel run //tools/benchmarks:server`.")
@@ -39,7 +39,7 @@ def main():
 
     options, forwarded = arguments()
     # -s so the table reaches the terminal: pytest captures output by default, and the report
-    # is the point of the run rather than a detail of a failure.
+    # is the point of the run and not a detail of a failure.
     args = ["-p", "krpctest.pytest_plugin", "-s"]
     if options.json:
         args += ["--json", options.json]

--- a/tools/benchmarks/server/harness.py
+++ b/tools/benchmarks/server/harness.py
@@ -94,8 +94,8 @@ class BenchmarkTestCase(krpctest.TestCase):
         RESULTS.append(result)
         return result
 
-    # How long to let the stream update reading settle before sampling it, how many samples
-    # to take, and how long to leave between them. time_per_stream_update is an exponential
+    # The settling time for the stream update reading before it is sampled, the number of
+    # samples to take, and the gap between them. time_per_stream_update is an exponential
     # moving average, so it takes a few updates to reach the value for the streams that were
     # just added.
     stream_settle_seconds = 2
@@ -118,9 +118,9 @@ class BenchmarkTestCase(krpctest.TestCase):
                 stream.start(wait=False)
             self.wait(self.stream_settle_seconds)
             status = conn.krpc.get_status()
-            # Scene sanity rather than a measurement: each stream is evaluated every fixed
-            # update, so the rate is a large multiple of the number of streams. Anything less
-            # means they are not all running, and the timing below is an empty loop.
+            # A scene check, not a measurement: each stream is evaluated every fixed update,
+            # so the rate is a large multiple of the number of streams. Anything less means
+            # they are not all running, and the timing below is an empty loop.
             self.assertEqual(len(streams), status.stream_rpcs)
             self.assertGreater(status.stream_rpc_rate, len(streams))
             samples = []

--- a/tools/benchmarks/server/test_reference_craft.py
+++ b/tools/benchmarks/server/test_reference_craft.py
@@ -75,7 +75,7 @@ class TestEndToEnd(ReferenceCraft):
         self.measure_getter("module.part", self.module, "part")
 
     def test_concrete_module_proxies(self):
-        # Reading through a concrete proxy that already exists, which is what a stream over
+        # Reading through a concrete proxy that already exists, as a stream over
         # engine.thrust or parachute.state does.
         self.measure_getter("engine.thrust", self.engine_part.engine, "thrust")
         self.measure_getter("parachute.state", self.parachute_part.parachute, "state")
@@ -83,8 +83,8 @@ class TestEndToEnd(ReferenceCraft):
         self.measure_getter("part.engine", self.engine_part, "engine")
 
     def test_bulk(self):
-        # Work proportional to the size of the vessel rather than to one access: one Part
-        # proxy per part, constructed, deduplicated against the object store and encoded.
+        # Work proportional to the size of the vessel, not to one access: one Part proxy per
+        # part, constructed, deduplicated against the object store and encoded.
         self.measure_getter("vessel.parts.all", self.parts, "all")
 
 
@@ -115,12 +115,11 @@ class TestObjectAccess(ReferenceCraft):
 
     def test_of_type_to_list(self):
         # The pattern a concrete module proxy can use to collect the modules it wraps. It
-        # allocates an enumerator and a list every time, which is why it is measured rather
-        # than assumed cheap.
+        # allocates an enumerator and a list every time, so it is measured.
         self.measure_part(self.part, "module.of_type_to_list")
 
     def test_store_dedup(self):
-        # What returning an already-known proxy costs: the object store hashes it and
+        # The cost of returning an already-known proxy: the object store hashes it and
         # compares it against what it holds. Every proxy a call returns pays this.
         self.measure_vessel(self.vessel, "store.dedup")
 

--- a/tools/benchmarks/src/Timer.cs
+++ b/tools/benchmarks/src/Timer.cs
@@ -90,11 +90,11 @@ namespace KRPC.Benchmarks
         }
 
         // Bytes allocated so far, for the allocation figures. GC.GetAllocatedBytesForCurrentThread
-        // is exact and unaffected by collections, but is not guaranteed to exist on the runtime KSP
-        // ships, so fall back to the size of the heap: coarse per operation, and meaningless if a
-        // collection happens inside the window (memory was freed as well as allocated), but over a
-        // large enough loop it still answers the question these numbers are for, which is whether a
-        // path allocates at all. Which one was used is reported alongside the figure.
+        // is exact and unaffected by collections, but is not guaranteed to exist on the runtime
+        // KSP ships, so fall back to the size of the heap. That is coarse per operation, and
+        // meaningless if a collection happens inside the window, but over a large enough loop it
+        // still shows whether a path allocates at all. The one used is reported alongside the
+        // figure.
         static long AllocatedBytes ()
         {
             return allocatedBytes != null ? allocatedBytes () : GC.GetTotalMemory (false);

--- a/tools/benchmarks/testserver.py
+++ b/tools/benchmarks/testserver.py
@@ -27,9 +27,9 @@ import time
 
 import krpc
 
-# What TestServer writes to standard output as it comes up, behind the log line's timestamp
-# and severity. Where it is listening comes first, then the ready line, so a reader that has
-# seen the ready line has already seen the rest.
+# The lines TestServer writes to standard output as it comes up, behind the log line's
+# timestamp and severity. Where it is listening comes first, then the ready line, so a reader
+# that has seen the ready line has already seen the rest.
 ADDRESSES = {
     "rpc_port": re.compile(r"rpc_port = (\d+)"),
     "stream_port": re.compile(r"stream_port = (\d+)"),
@@ -48,15 +48,15 @@ LABELS = {TCP: "TCP/IP", LOCAL_SOCKET: "a local socket"}
 SERVER_TYPES = {TCP: "protobuf", LOCAL_SOCKET: "localsocket"}
 
 # Every variable a benchmark program reads to find the server. A program looks for the socket
-# paths first and falls back to the ports, so naming only the pair the transport being measured
-# uses is also what picks that transport inside the program - as long as the other pair is
-# cleared rather than inherited from whatever started the run.
+# paths first and falls back to the ports, so setting only the pair the transport being
+# measured uses also picks that transport inside the program. The other pair has to be
+# cleared, not inherited from whatever started the run.
 VARIABLES = ("RPC_PORT", "STREAM_PORT", "RPC_PATH", "STREAM_PATH")
 
-# How long to wait for those lines before giving up and showing what the server did say.
+# The time to wait for those lines before giving up and showing what the server printed.
 STARTUP_TIMEOUT_SECONDS = 60
 
-# How long to exercise a freshly started server before anything is measured against it. A
+# The time to exercise a freshly started server before anything is measured against it. A
 # server that has just started spends its first calls having the paths they run through
 # compiled, and whichever case is measured first otherwise pays for that and reports itself as
 # a case that was still getting faster.

--- a/tools/build/run_client_test.py
+++ b/tools/build/run_client_test.py
@@ -166,8 +166,8 @@ def run(config):
     serial = config["server_type"] == "serialio"
     local_socket = config["server_type"] == "localsocket"
 
-    # The executables locate their own runfiles -- the .NET runtime and
-    # assemblies, the python interpreter and its packages -- through RUNFILES_DIR
+    # The executables locate their own runfiles, the .NET runtime and assemblies,
+    # the python interpreter and its packages, through RUNFILES_DIR
     # when they cannot find a runfiles tree of their own beside them. They share
     # this test's tree, which holds everything they need.
     environment = dict(os.environ)

--- a/tools/build/run_sphinx_test.py
+++ b/tools/build/run_sphinx_test.py
@@ -24,7 +24,7 @@ import sys
 # regular file, and Bazel stages a source as a read-only symlink.
 DICTIONARY = "dictionary.txt"
 
-# Where the link checker lists the links it could not follow.
+# The file the link checker lists the links it could not follow in.
 LINKCHECK_REPORT = "output.txt"
 
 

--- a/tools/krpctest/CHANGELOG.md
+++ b/tools/krpctest/CHANGELOG.md
@@ -1,11 +1,9 @@
 ## [v0.7.0] - unreleased
 - Add Ferram Aerospace Research to the managed third-party mods, requested with
-  `mods = ["FAR"]` or `krpc-install --mods=FAR`, so the tests can exercise the aerodynamic
-  readouts against it (#1032)
+  `mods = ["FAR"]` or `krpc-install --mods=FAR` (#1032)
 - Add `--skip-mod-install` to `krpc-install` and `krpc-run-ksp`, and the
-  `KRPC_SKIP_MOD_INSTALL` environment variable honored when the tests auto-launch KSP,
-  to leave the managed third-party mods in GameData untouched so a locally built mod
-  assembly is preserved across a launch (#1016)
+  `KRPC_SKIP_MOD_INSTALL` environment variable, to leave the managed third-party mods in
+  GameData untouched (#1016)
 
 ## [v0.6.0]
 - Add the `TestCase.expansions` attribute, to declare KSP expansions a test class

--- a/tools/krpctest/krpctest/diagnostics.py
+++ b/tools/krpctest/krpctest/diagnostics.py
@@ -177,7 +177,7 @@ def overshoot(samples):
 
 def path_deviation(samples):
     # Max perpendicular distance of the (pitch_error, yaw_error) trajectory from the straight
-    # line between its start and the origin, normalised by the initial error magnitude. Zero
+    # line between its start and the origin, normalized by the initial error magnitude. Zero
     # for a perfect great-circle slew; grows as the path curves.
     if not samples:
         return 0.0
@@ -205,10 +205,10 @@ def feedforward_spikes(samples, threshold=0.5):
 
 
 def control_spikes(samples, threshold=0.5):
-    # Number of ticks where any *actual control* axis (post-clamp, in [-1, 1]) jumps by more than
-    # threshold in one step. Unlike feedforward_spikes -- which looks at the pre-clamp acceleration
-    # feedforward, where a setpoint discontinuity legitimately produces a large impulse that the
-    # [-1, 1] clamp then absorbs -- this measures the jerk actually commanded to the actuators.
+    # Number of ticks where a post-clamp control axis, in [-1, 1], jumps by more than threshold
+    # in one step. This measures the jerk commanded to the actuators, where feedforward_spikes
+    # looks at the pre-clamp acceleration feedforward, in which a setpoint discontinuity
+    # legitimately produces a large impulse that the clamp absorbs.
     count = 0
     for cur, nxt in zip(samples, samples[1:]):
         if cur.ctrl is None or nxt.ctrl is None:
@@ -220,10 +220,10 @@ def control_spikes(samples, threshold=0.5):
 
 def control_reversal_rate(samples, floor=0.3):
     # Fraction of adjacent ticks on which a large-magnitude control axis (pitch or yaw) flips sign.
-    # This is the signature of a structural / bending-mode limit cycle (test plan §11.9): the
-    # actuators slam ±full deflection every tick or two, so the net torque averages to ~0. Only
-    # pairs where at least one side exceeds `floor` are counted, so the small, slowly-varying
-    # corrections of a settled rigid craft (which never approach full deflection) do not register.
+    # This is the signature of a structural or bending-mode limit cycle: the actuators slam
+    # full deflection either way every tick or two, so the net torque averages to zero. Only
+    # pairs where at least one side exceeds `floor` are counted, so the small, slowly varying
+    # corrections of a settled rigid craft do not register.
     # Returns the worst of the pitch and yaw axes; roll is handled separately and rarely flexes.
     worst = 0.0
     for axis in (0, 2):

--- a/tools/krpctest/krpctest/env.py
+++ b/tools/krpctest/krpctest/env.py
@@ -10,7 +10,7 @@ import os
 import subprocess
 import sys
 
-# What the game's executable is called here. An install is built for one platform, and the
+# The name of the game's executable here. An install is built for one platform, and the
 # name it gives the executable is what says which.
 _KSP_EXECUTABLE = "KSP_x64.exe" if sys.platform == "win32" else "KSP.x86_64"
 

--- a/tools/krpctest/krpctest/game.py
+++ b/tools/krpctest/krpctest/game.py
@@ -71,7 +71,7 @@ _MOD_FLAGS = {
 _owned_ksp = None  # pylint: disable=invalid-name
 
 # Mod sets (as frozensets) that were installed and launched but did not become available
-# in-game — recorded so ensure_game fails fast instead of relaunching KSP forever.
+# in-game, recorded so that ensure_game fails fast instead of relaunching KSP forever.
 _unsatisfiable = set()
 
 

--- a/tools/krpctest/krpctest/pytest_plugin.py
+++ b/tools/krpctest/krpctest/pytest_plugin.py
@@ -68,7 +68,7 @@ def _mods_key(item):
 
 def pytest_collection_modifyitems(items):
     # Stable sort keeps definition order within each mod group, so tests are reordered only
-    # as much as needed to keep each mod set contiguous (minimising KSP restarts).
+    # as much as needed to keep each mod set contiguous, minimizing KSP restarts.
     items.sort(key=_mods_key)
 
 

--- a/tools/krpctest/krpctest/test/test_install.py
+++ b/tools/krpctest/krpctest/test/test_install.py
@@ -58,7 +58,7 @@ class TestValidateGamedata(krpctest.TestCase):
 
     def test_requested_mod_missing_from_set_raises(self):
         # A managed mod present in GameData but not among the requested subdirs is still
-        # unexpected — reconcile should have removed it.
+        # unexpected, as reconcile should have removed it.
         self._populate(_CLEAN + ["RealChute"])
         with self.assertRaises(RuntimeError) as cm:
             _validate_gamedata(self.gamedata, set())

--- a/tools/krpctest/run_tests.py
+++ b/tools/krpctest/run_tests.py
@@ -33,7 +33,7 @@ def main():
     # krpctest is a library here rather than an installed distribution, so it has no
     # pytest11 entry point for pytest to discover the plugin through; name it explicitly.
     # This belongs here and not in pytest.ini, which is also read when krpctest is
-    # installed -- pytest would then register the plugin twice and fail.
+    # installed, as pytest would then register the plugin twice and fail.
     return pytest.main(["-p", "krpctest.pytest_plugin", *sys.argv[1:]])
 
 

--- a/tools/krpctools/CHANGELOG.md
+++ b/tools/krpctools/CHANGELOG.md
@@ -1,31 +1,24 @@
 ## [v0.7.0] - unreleased
 - Generate and document the structure types a service defines, for every client (#1066)
-- **Breaking:** A generator module given to `krpc-clientgen` by path is constructed with
-  the definitions of every service that was loaded, rather than with those of the single
-  service it generates (#1044)
+- **Breaking:** A generator module given to `krpc-clientgen` by path is constructed with the
+  definitions of every service that was loaded, rather than those of the single service it
+  generates (#1044)
 - Support for nullable values across all types (#1017)
 - Generate an enumeration default value as the member it names, instead of a cast of its
   integer value (#1044)
-- Fix generating a default value whose type contains an enumeration, such as a list of
-  them, failing (#1044)
-- Fix Lua documentation writing default values in Python's syntax rather than Lua's
-  (#1044)
-- Fix C++ documentation writing a collection default value as a constructor call rather
-  than a braced initializer list, so `std::vector<int32_t>(1, 2, 3)` named a constructor
-  that builds something else entirely (#1044)
-- A default value naming an undeclared enumeration value, or one whose enumeration no
-  supplied service defines, is now reported naming the service, procedure and parameter
-  it came from (#1044)
+- Fix generating a default value whose type contains an enumeration, such as a list of them,
+  failing (#1044)
+- Fix Lua documentation writing default values in Python's syntax rather than Lua's (#1044)
+- Fix C++ documentation writing a collection default value as a constructor call rather than a
+  braced initializer list (#1044)
+- A default value naming an undeclared enumeration value is reported naming the service,
+  procedure and parameter it came from (#1044)
 - The special values of the numeric types - NaN, the infinities and the extremes of the
-  integer and floating point ranges - can now be used as parameter default values.
-  Generated code and documentation name them as the target language does, such as
-  `double.NaN` in C# and `(std::numeric_limits<int32_t>::max)()` in C++, rather than
-  writing a decimal literal that does not compile. Neither Python nor Lua has a name of its
-  own for the finite extremes, so both name the new `krpc.limits` constants (#1045)
-- Fix a 32-bit float default value being written as the full decimal expansion of the
-  double it widens to, so `0.1f` read as `0.10000000149011612`, in Python, C# and C++
-  code and in the Python, C#, C++ and Lua documentation. C++ also writes it as a float
-  literal now, rather than a double one (#1045)
+  integer and floating point ranges - can be used as parameter default values. Generated code
+  and documentation name them as the target language does, such as `double.NaN` in C#. Python
+  and Lua name the new `krpc.limits` constants (#1045)
+- Fix a 32-bit float default value being written as the full decimal expansion of the double
+  it widens to, so `0.1f` read as `0.10000000149011612` (#1045)
 
 ## [v0.6.0]
 - **Breaking:** Requires Python 3.10+

--- a/tools/release/68-release-ckan.py
+++ b/tools/release/68-release-ckan.py
@@ -26,13 +26,13 @@ import lib
 # draft is exactly the state that leaves the bot with nothing to pull.
 RELEASE_API = 'https://api.github.com/repos/krpc/krpc/releases/tags/{tag}'
 
-# Where the NetKAN bot writes kRPC's generated metadata, one file per version.
+# The directory the NetKAN bot writes kRPC's generated metadata to, one file per version.
 # The CKAN version comes from the KSP-AVC file, whose 3-part MAJOR.MINOR.PATCH
 # matches the release version, so the file is named for the tag: kRPC-v0.6.0.ckan.
 CKAN_META = ('https://raw.githubusercontent.com/KSP-CKAN/CKAN-meta/master/'
              'kRPC/kRPC-{tag}.ckan')
 
-# How long to wait for the metadata, and how often to look. Inflation is usually
+# The time to wait for the metadata, and how often to look. Inflation is usually
 # minutes but can lag; override the wait with CKAN_POLL_MINUTES for a longer sit.
 POLL_SECONDS = 30
 DEFAULT_POLL_MINUTES = 20

--- a/tools/release/publish-docs.py
+++ b/tools/release/publish-docs.py
@@ -157,18 +157,16 @@ GAMESCENE_SHIM = '''namespace KRPC.Service.KRPC
 }
 '''
 
-# Before 0.5.4 the KRPC service lived in server/ and its Paused and
-# CurrentGameScene properties were implemented against server and KSP symbols --
-# the server Addon and the KSP PauseMenu, EditorDriver and EditorFacility -- that
-# the KSP-free core/ assembly, where the service is now grafted, cannot see.
-# These compile-only shims, placed in the KRPC service's own namespace so the
-# grafted code resolves them unqualified and carrying no [KRPC*] attribute so the
-# scanner ignores them, let those properties build; their bodies never run during
-# doc generation. The service's namespace (not KRPC) keeps the shim Addon from
-# colliding with the server's own KRPC.Addon, which core is imported into. The
-# shim is written only when the grafted service still references these symbols,
-# so 0.5.4 onwards (which moved the properties out of the service) needs it not at
-# all.
+# A release before 0.5.4 has the KRPC service in server/, with its Paused and
+# CurrentGameScene properties implemented against server and KSP symbols: the
+# server Addon and the KSP PauseMenu, EditorDriver and EditorFacility. The
+# KSP-free core/ assembly the service is grafted into cannot see them. These
+# compile-only shims let those properties build, and their bodies never run
+# during doc generation. They sit in the KRPC service's own namespace, so the
+# grafted code resolves them unqualified and the shim Addon does not collide
+# with the server's own KRPC.Addon, and they carry no [KRPC*] attribute, so the
+# scanner ignores them. The shim is written only when the grafted service still
+# references these symbols.
 KRPC_COMPAT_SHIM_PATH = 'core/src/Service/KRPC/DocsCompat.cs'
 KRPC_COMPAT_SHIM = '''namespace KRPC.Service.KRPC
 {
@@ -319,9 +317,9 @@ def graft_krpc_service(worktree, ref):
         lib.run('git', '-C', worktree, 'checkout', ref, '--', KRPC_SERVICE_DEST)
         return
     # Relocate: materialize the ref's tree at its old path, then move it into the
-    # current core/ location. The stale index entry the checkout leaves at the
-    # old path is harmless -- the build reads the worktree, and the move leaves
-    # the sources there only at the core/ location.
+    # current core/ location. The stale index entry the checkout leaves at the old
+    # path is harmless, as the build reads the worktree and the move leaves the
+    # sources only at the core/ location.
     lib.run('git', '-C', worktree, 'checkout', ref, '--', source)
     dest = worktree / KRPC_SERVICE_DEST
     dest.parent.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
**Style guide.** `CLAUDE.md` gains sections for sentences, documentation, XML documentation comments and code comments, and a rule for the shape of a changelog entry. The faults it names are the long comma-chained sentence, saying what a thing is not, anthropomorphizing the game and the server, and a comment sized for a mechanism sitting over one statement.

**Documentation.** The pages added since v0.6.0 are rewritten to it: the object lifetime and control loops tutorials, and the additions to the protocol, extending, internals and client guides.

**Comments.** The XML documentation comments settle on one exception formula and lose the emdashes and the symbols that appear nowhere in the source. The code comments added since v0.5.4 return to the register used before it, and paragraphs cloned across sibling files collapse into one.

**Changelog.** The unreleased 0.7.0 entries lose their rationale and implementation detail, leaving what a user needs and the issue link for the rest. The median entry drops from 42 words to 19, and entries carrying two changes are split.

Comments and prose only, with no code changes.
