### PR TITLE
Ask the game to calculate delta-v in flight

### DIFF
--- a/doc/order.txt
+++ b/doc/order.txt
@@ -199,6 +199,8 @@ SpaceCenter.Vessel.Stages
 SpaceCenter.Vessel.StageAt
 SpaceCenter.Vessel.DecoupleStages
 SpaceCenter.Vessel.DecoupleStageAt
+SpaceCenter.Vessel.DeltaVReady
+SpaceCenter.Vessel.RecalculateDeltaV
 SpaceCenter.Vessel.DeltaV
 SpaceCenter.Vessel.VacuumDeltaV
 SpaceCenter.Vessel.SeaLevelDeltaV

--- a/service/SpaceCenter/CHANGELOG.md
+++ b/service/SpaceCenter/CHANGELOG.md
@@ -69,6 +69,10 @@
 - Staging
   - Fix stages from `Vessel.Stages`, `Vessel.StageAt`, `Vessel.DecoupleStages` and
     `Vessel.DecoupleStageAt` breaking after a Revert to Launch (#1023)
+  - The delta-v figures on `Vessel` and `Stage` ask the game to calculate them, so they are
+    available in flight without opening the game's own delta-v app first (#1076)
+  - Add `Vessel.RecalculateDeltaV`, which recalculates the figures and waits for them, and
+    `Vessel.DeltaVReady`, which reports whether they are current (#1076)
 
 - Autopilot
   - Setting `AutoPilot.TargetDirection` keeps the target roll, rather than clearing it (#1054)

--- a/service/SpaceCenter/src/KRPC.SpaceCenter.csproj
+++ b/service/SpaceCenter/src/KRPC.SpaceCenter.csproj
@@ -142,6 +142,7 @@
     <Compile Include="Services\EditorFacility.cs" />
     <Compile Include="Services\EditorVessel.cs" />
     <Compile Include="Services\Flight.cs" />
+    <Compile Include="Services\FlightDeltaV.cs" />
     <Compile Include="Services\GameMode.cs" />
     <Compile Include="Services\MapFilterType.cs" />
     <Compile Include="Services\MitigationMode.cs" />

--- a/service/SpaceCenter/src/Services/FlightDeltaV.cs
+++ b/service/SpaceCenter/src/Services/FlightDeltaV.cs
@@ -1,0 +1,175 @@
+using System;
+using System.Linq;
+using KRPC.Service;
+using KRPC.SpaceCenter.ExtensionMethods;
+using UnityEngine;
+
+namespace KRPC.SpaceCenter.Services
+{
+    /// <summary>
+    /// The stock delta-v simulation for a vessel in flight, and the means to ask the game
+    /// to run it.
+    /// </summary>
+    /// <remarks>
+    /// The game runs the simulation for the active vessel alone, and only on a tick that
+    /// finds the vessel's figures marked out of date. It clears that mark before it
+    /// decides it has no engines to work from, and marks them again only when the vessel
+    /// changes.
+    /// A first run that lands before the vessel's staging is built is therefore dropped,
+    /// and the vessel is left without figures for as long as it is flown. Asking for
+    /// another run is what recovers it.
+    /// </remarks>
+    static class FlightDeltaV
+    {
+        /// <summary>
+        /// Ticks to wait for a run before giving up. The game holds a run asked for by a
+        /// vessel event back by <c>DELTAV_VESSEL_EVENT_DELAY_SECS</c>, one second in the
+        /// stock settings, and then spends a rendered frame per stage on it.
+        /// </summary>
+        const int WaitTicks = 500;
+
+        /// <summary>
+        /// Ticks to leave the game to run the simulation by itself before asking for one.
+        /// It holds a run back until the vessel has settled after an event, and figures
+        /// taken from a vessel still settling differ from the ones it comes to rest with.
+        /// Asking straight away would report those instead of the game's own.
+        /// </summary>
+        const int GraceTicks = 150;
+
+        /// <summary>
+        /// The vessel a run was last asked for, and the fixed time it was asked at. The
+        /// game does not act on the request, or drop its own ready flag, until the next
+        /// fixed update, so until the clock has moved past this the flag still describes
+        /// the figures from before the request. One record covers every vessel, as only
+        /// the active vessel is ever run.
+        /// </summary>
+        static Guid requestedFor;
+        static double requestedAt = double.NegativeInfinity;
+
+        /// <summary>
+        /// Whether the vessel carries an engine the simulation counts. The game leaves the
+        /// ready flag down for a vessel without one, however many runs it is given, and
+        /// the zeros it computed are all there is to report.
+        /// </summary>
+        static bool HasEngines (global::Vessel vessel)
+        {
+            return vessel.parts.Any (
+                part => part.Modules.OfType<ModuleEngines> ()
+                    .Any (engine => engine.includeinDVCalcs && !engine.nonThrustMotor));
+        }
+
+        /// <summary>
+        /// Ask the game to run the simulation, and record when, so that the figures are
+        /// reported as out of date until it has.
+        /// </summary>
+        internal static void Recalculate (Guid id)
+        {
+            RequireSimulation (FlightGlobalsExtensions.GetVesselById (id)).SetCalcsDirty (true);
+            requestedFor = id;
+            requestedAt = Time.fixedTime;
+        }
+
+        /// <summary>
+        /// Whether the figures are current: the game is not mid-run, any run asked for
+        /// here has been picked up, and the game either says the figures are ready or the
+        /// vessel has no engines for it to work from.
+        /// </summary>
+        internal static bool Ready (Guid id)
+        {
+            return Ready (FlightGlobalsExtensions.GetVesselById (id));
+        }
+
+        /// <summary>
+        /// Whether the vessel is far enough through a scene load to be worth calculating.
+        /// A run against one the game is still unpacking latches figures taken from a part
+        /// of it.
+        /// </summary>
+        static bool Settled (global::Vessel vessel)
+        {
+            return FlightGlobals.ready && vessel.loaded && !vessel.packed;
+        }
+
+        static bool Ready (global::Vessel vessel)
+        {
+            var simulation = vessel.VesselDeltaV;
+            if (simulation == null || simulation.SimulationRunning)
+                return false;
+            if (vessel.id == requestedFor && Time.fixedTime <= requestedAt)
+                return false;
+            // A vessel between scenes holds no parts yet, and reads as engine-less until
+            // the game has rebuilt it.
+            return simulation.IsReady || (vessel.parts.Count > 0 && !HasEngines (vessel));
+        }
+
+        /// <summary>
+        /// The simulation for the vessel, or an error naming the reason the game will
+        /// never produce figures for it.
+        /// </summary>
+        static VesselDeltaV RequireSimulation (global::Vessel vessel)
+        {
+            var simulation = vessel.VesselDeltaV;
+            if (simulation == null)
+                throw new InvalidOperationException (
+                    "The game does not calculate delta-v for this kind of vessel.");
+            if (!simulation.DoStockSimulation)
+                throw new InvalidOperationException (
+                    "The game's delta-v calculations are turned off.");
+            var active = FlightGlobals.ActiveVessel;
+            if (ReferenceEquals (active, null) || active.id != vessel.id)
+                throw new InvalidOperationException (
+                    "The game only calculates delta-v for the active vessel.");
+            return simulation;
+        }
+
+        /// <summary>
+        /// Read a figure off the simulation, asking the game for a run when the figures
+        /// are out of date and yielding until it has finished. Callers pass no tick; the
+        /// continuations count it up.
+        /// </summary>
+        internal static T Read<T> (Guid id, Func<VesselDeltaV, T> figure, int tick = 0)
+        {
+            var vessel = FlightGlobalsExtensions.GetVesselById (id);
+            if (Ready (vessel))
+                return figure (vessel.VesselDeltaV);
+            if (tick > WaitTicks)
+                throw TimedOut ();
+            Request (vessel, tick);
+            throw new YieldException<Func<T>> (() => Read (id, figure, tick + 1));
+        }
+
+        /// <summary>
+        /// Yield until the figures are current.
+        /// </summary>
+        internal static void Wait (Guid id, int tick = 0)
+        {
+            var vessel = FlightGlobalsExtensions.GetVesselById (id);
+            if (Ready (vessel))
+                return;
+            if (tick > WaitTicks)
+                throw TimedOut ();
+            Request (vessel, tick);
+            throw new YieldException<Action> (() => Wait (id, tick + 1));
+        }
+
+        /// <summary>
+        /// Ask for a run on a tick spent waiting for one, once the grace period the game
+        /// has to run it itself is up. The game drops a run that found nothing to work
+        /// from and never repeats it, so a wait that only sat out the first run would wait
+        /// out the whole budget. Asking only while the game is idle leaves a run it has
+        /// started to finish.
+        /// </summary>
+        static void Request (global::Vessel vessel, int tick)
+        {
+            var simulation = RequireSimulation (vessel);
+            if (tick < GraceTicks || !Settled (vessel) || simulation.SimulationRunning)
+                return;
+            Recalculate (vessel.id);
+        }
+
+        static TimeoutException TimedOut ()
+        {
+            return new TimeoutException (
+                "Timed out waiting for the game to calculate delta-v for this vessel.");
+        }
+    }
+}

--- a/service/SpaceCenter/src/Services/Stage.cs
+++ b/service/SpaceCenter/src/Services/Stage.cs
@@ -114,15 +114,12 @@ namespace KRPC.SpaceCenter.Services
         }
 
         /// <summary>
-        /// The stock delta-v simulation the stage's figures come from, for either the
-        /// vessel in flight or the vessel in the editor.
+        /// The stock delta-v simulation the figures of a stage of the vessel under
+        /// construction come from. A stage in flight goes through
+        /// <see cref="FlightDeltaV" />, which also asks the game to run the simulation.
         /// </summary>
-        VesselDeltaV InternalDeltaV {
-            get {
-                return editorVessel
-                    ? EditorExtensions.GetShip ().vesselDeltaV
-                    : InternalVessel.VesselDeltaV;
-            }
+        VesselDeltaV EditorInternalDeltaV {
+            get { return EditorExtensions.GetShip ().vesselDeltaV; }
         }
 
         /// <summary>
@@ -169,119 +166,130 @@ namespace KRPC.SpaceCenter.Services
         /// Delta-v for this stage in the current situation, in m/s.
         /// </summary>
         [KRPCProperty]
-        public float DeltaV => RequireBurnStage ().deltaVActual;
+        public float DeltaV => Figure (stage => stage.deltaVActual);
 
         /// <summary>
         /// Vacuum delta-v for this stage, in m/s.
         /// </summary>
         [KRPCProperty]
-        public float VacuumDeltaV => RequireBurnStage ().deltaVinVac;
+        public float VacuumDeltaV => Figure (stage => stage.deltaVinVac);
 
         /// <summary>
         /// Sea-level delta-v for this stage, in m/s.
         /// </summary>
         [KRPCProperty]
-        public float SeaLevelDeltaV => RequireBurnStage ().deltaVatASL;
+        public float SeaLevelDeltaV => Figure (stage => stage.deltaVatASL);
 
         /// <summary>
         /// Thrust in the current situation, in newtons.
         /// </summary>
         [KRPCProperty]
-        public float Thrust => RequireBurnStage ().thrustActual * 1000f;
+        public float Thrust => Figure (stage => stage.thrustActual * 1000f);
 
         /// <summary>
         /// Vacuum thrust, in newtons.
         /// </summary>
         [KRPCProperty]
-        public float VacuumThrust => RequireBurnStage ().thrustVac * 1000f;
+        public float VacuumThrust => Figure (stage => stage.thrustVac * 1000f);
 
         /// <summary>
         /// Sea-level thrust, in newtons.
         /// </summary>
         [KRPCProperty]
-        public float SeaLevelThrust => RequireBurnStage ().thrustASL * 1000f;
+        public float SeaLevelThrust => Figure (stage => stage.thrustASL * 1000f);
 
         /// <summary>
         /// Thrust-to-weight ratio in the current situation.
         /// </summary>
         [KRPCProperty]
-        public float TWR => RequireBurnStage ().TWRActual;
+        public float TWR => Figure (stage => stage.TWRActual);
 
         /// <summary>
         /// Vacuum thrust-to-weight ratio.
         /// </summary>
         [KRPCProperty]
-        public float VacuumTWR => RequireBurnStage ().TWRVac;
+        public float VacuumTWR => Figure (stage => stage.TWRVac);
 
         /// <summary>
         /// Sea-level thrust-to-weight ratio.
         /// </summary>
         [KRPCProperty]
-        public float SeaLevelTWR => RequireBurnStage ().TWRASL;
+        public float SeaLevelTWR => Figure (stage => stage.TWRASL);
 
         /// <summary>
         /// Specific impulse in the current situation, in seconds.
         /// </summary>
         [KRPCProperty]
-        public float SpecificImpulse => (float)RequireBurnStage ().ispActual;
+        public float SpecificImpulse => Figure (stage => (float)stage.ispActual);
 
         /// <summary>
         /// Vacuum specific impulse, in seconds.
         /// </summary>
         [KRPCProperty]
-        public float VacuumSpecificImpulse => (float)RequireBurnStage ().ispVac;
+        public float VacuumSpecificImpulse => Figure (stage => (float)stage.ispVac);
 
         /// <summary>
         /// Sea-level specific impulse, in seconds.
         /// </summary>
         [KRPCProperty]
-        public float SeaLevelSpecificImpulse => (float)RequireBurnStage ().ispASL;
+        public float SeaLevelSpecificImpulse => Figure (stage => (float)stage.ispASL);
 
         /// <summary>
         /// Burn time for this stage, in seconds.
         /// </summary>
         [KRPCProperty]
-        public float BurnTime => (float)RequireBurnStage ().stageBurnTime;
+        public float BurnTime => Figure (stage => (float)stage.stageBurnTime);
 
         /// <summary>
         /// Start mass for this stage, in kg.
         /// </summary>
         [KRPCProperty]
-        public float StartMass => RequireBurnStage ().startMass * 1000f;
+        public float StartMass => Figure (stage => stage.startMass * 1000f);
 
         /// <summary>
         /// End mass for this stage, in kg.
         /// </summary>
         [KRPCProperty]
-        public float EndMass => RequireBurnStage ().endMass * 1000f;
+        public float EndMass => Figure (stage => stage.endMass * 1000f);
 
         /// <summary>
         /// Dry mass for this stage, in kg.
         /// </summary>
         [KRPCProperty]
-        public float DryMass => RequireBurnStage ().dryMass * 1000f;
+        public float DryMass => Figure (stage => stage.dryMass * 1000f);
 
         /// <summary>
         /// Fuel mass for this stage, in kg.
         /// </summary>
         [KRPCProperty]
-        public float FuelMass => RequireBurnStage ().fuelMass * 1000f;
+        public float FuelMass => Figure (stage => stage.fuelMass * 1000f);
 
         /// <summary>
-        /// Validates that a stage can provide burn-related delta-v data 
-        /// before returning it. It throws an exception for decouple stages, 
-        /// for vessels whose delta-v calculations are not ready, or when 
-        /// the requested activation stage has no available delta-v 
-        /// information.
+        /// Read a figure off the stage's entry in the stock delta-v simulation. In flight
+        /// the game is asked for a run when the figures are out of date, and the read
+        /// yields until it has finished.
         /// </summary>
-        DeltaVStageInfo RequireBurnStage ()
+        T Figure<T> (Func<DeltaVStageInfo, T> read)
         {
             if (decoupleStage)
-                throw new InvalidOperationException ("Delta-v information is not available for a decouple stage.");
-            var dv = InternalDeltaV;
-            if (dv == null || !dv.IsReady || (editorVessel && !EditorDeltaV.Ready))
-                throw new InvalidOperationException ("Delta-v has not been calculated for this vessel yet.");
-            var stageInfo = dv.GetStage (stageNumber);
+                throw new InvalidOperationException (
+                    "Delta-v information is not available for a decouple stage.");
+            if (!editorVessel)
+                return FlightDeltaV.Read (vesselId, deltaV => read (BurnStage (deltaV)));
+            var ship = EditorInternalDeltaV;
+            if (ship == null || !ship.IsReady || !EditorDeltaV.Ready)
+                throw new InvalidOperationException (
+                    "Delta-v has not been calculated for this vessel yet.");
+            return read (BurnStage (ship));
+        }
+
+        /// <summary>
+        /// The stage's entry in the simulation, or an error when the simulation holds none
+        /// for its number.
+        /// </summary>
+        DeltaVStageInfo BurnStage (VesselDeltaV deltaV)
+        {
+            var stageInfo = deltaV.GetStage (stageNumber);
             if (stageInfo == null)
                 throw new InvalidOperationException (
                     string.Format (

--- a/service/SpaceCenter/src/Services/Vessel.cs
+++ b/service/SpaceCenter/src/Services/Vessel.cs
@@ -440,12 +440,6 @@ namespace KRPC.SpaceCenter.Services
                 .ToList ();
         }
 
-        void RequireVesselDeltaVReady ()
-        {
-            if (InternalVessel.VesselDeltaV == null || !InternalVessel.VesselDeltaV.IsReady)
-                throw new InvalidOperationException ("Delta-v has not been calculated for this vessel yet.");
-        }
-
         /// <summary>
         /// Activation (burn) stages for this vessel, in ascending stage order. This does
         /// not include the -1 stage (parts with no staging icon), as it carries no
@@ -501,11 +495,35 @@ namespace KRPC.SpaceCenter.Services
         }
 
         /// <summary>
+        /// Whether the vessel's delta-v figures are current.
+        /// </summary>
+        /// <remarks>
+        /// The game calculates delta-v for the active vessel alone, over the several ticks
+        /// after the vessel changes. Reading a delta-v member waits for the figures, so poll
+        /// this instead when a call must not block.
+        /// </remarks>
+        [KRPCProperty (GameScene = GameScene.Flight)]
+        public bool DeltaVReady {
+            get { return FlightDeltaV.Ready (Id); }
+        }
+
+        /// <summary>
+        /// Recalculates the vessel's delta-v figures, and waits until they are current.
+        /// Throws an exception if the vessel is not the active vessel.
+        /// </summary>
+        [KRPCMethod (GameScene = GameScene.Flight)]
+        public void RecalculateDeltaV ()
+        {
+            FlightDeltaV.Recalculate (Id);
+            FlightDeltaV.Wait (Id);
+        }
+
+        /// <summary>
         /// Total delta-v for the vessel in the current situation, in m/s.
         /// </summary>
         [KRPCProperty (GameScene = GameScene.Flight)]
         public float DeltaV {
-            get { RequireVesselDeltaVReady (); return (float)InternalVessel.VesselDeltaV.TotalDeltaVActual; }
+            get { return FlightDeltaV.Read (Id, dv => (float)dv.TotalDeltaVActual); }
         }
 
         /// <summary>
@@ -513,7 +531,7 @@ namespace KRPC.SpaceCenter.Services
         /// </summary>
         [KRPCProperty (GameScene = GameScene.Flight)]
         public float VacuumDeltaV {
-            get { RequireVesselDeltaVReady (); return (float)InternalVessel.VesselDeltaV.TotalDeltaVVac; }
+            get { return FlightDeltaV.Read (Id, dv => (float)dv.TotalDeltaVVac); }
         }
 
         /// <summary>
@@ -521,7 +539,7 @@ namespace KRPC.SpaceCenter.Services
         /// </summary>
         [KRPCProperty (GameScene = GameScene.Flight)]
         public float SeaLevelDeltaV {
-            get { RequireVesselDeltaVReady (); return (float)InternalVessel.VesselDeltaV.TotalDeltaVASL; }
+            get { return FlightDeltaV.Read (Id, dv => (float)dv.TotalDeltaVASL); }
         }
 
         /// <summary>
@@ -529,7 +547,7 @@ namespace KRPC.SpaceCenter.Services
         /// </summary>
         [KRPCProperty (GameScene = GameScene.Flight)]
         public float BurnTime {
-            get { RequireVesselDeltaVReady (); return (float)InternalVessel.VesselDeltaV.TotalBurnTime; }
+            get { return FlightDeltaV.Read (Id, dv => (float)dv.TotalBurnTime); }
         }
 
         /// <summary>

--- a/service/SpaceCenter/test/test_stage.py
+++ b/service/SpaceCenter/test/test_stage.py
@@ -55,6 +55,19 @@ class TestStage(krpctest.TestCase):
         self.assertGreaterEqual(self.vessel.sea_level_delta_v, 0)
         self.assertGreaterEqual(self.vessel.burn_time, 0)
 
+    def test_delta_v_ready(self):
+        # The game drops the first calculation of a vessel whose staging is not built yet,
+        # and never repeats it. Reading a figure asks for another calculation, so a figure
+        # read at any point in the flight is a figure the game has produced.
+        self.assertGreater(self.vessel.vacuum_delta_v, 0)
+        self.assertTrue(self.vessel.delta_v_ready)
+
+    def test_recalculate_delta_v(self):
+        before = self.vessel.vacuum_delta_v
+        self.vessel.recalculate_delta_v()
+        self.assertTrue(self.vessel.delta_v_ready)
+        self.assertAlmostEqual(before, self.vessel.vacuum_delta_v, delta=1)
+
     def test_stage_at_and_decouple_stage_at(self):
         stage = self.vessel.stage_at(0)
         self.assertIsNotNone(stage)
@@ -104,16 +117,21 @@ class TestStageRevertToLaunch(krpctest.TestCase):
 
     def wait_for_delta_v(self, vessel):
         # The recreated vessel builds its delta-v simulation over the first few frames of
-        # the reloaded scene, so wait for it before reading any stage. This uses the
-        # vessel-level figure, which resolves the vessel by id and so is unaffected by
-        # what this test is checking.
-        def ready():
+        # the reloaded scene, and the game revises its first figures once the vessel has
+        # come to rest, so wait for one that stops changing before reading any stage. This
+        # uses the vessel-level figure, which resolves the vessel by id and so is
+        # unaffected by what this test is checking.
+        def settled():
             try:
-                return vessel.vacuum_delta_v > 0
+                first = vessel.vacuum_delta_v
             except RuntimeError:
                 return False
+            if first <= 0:
+                return False
+            self.wait(0.5)
+            return vessel.vacuum_delta_v == first
 
-        self.wait_until(ready, timeout=30, message="delta-v after revert")
+        self.wait_until(settled, timeout=30, message="delta-v after revert")
 
     def stage_state(self, stage, decouple_stage):
         # Everything a stage exposes that has to survive the reload: the delta-v figures
@@ -160,3 +178,61 @@ class TestStageRevertToLaunch(krpctest.TestCase):
                 vessel.decouple_stage_at(decouple_stage_number),
             ),
         )
+
+
+class TestStageDeltaVJettisoned(krpctest.TestCase):
+    """The game calculates delta-v for the active vessel alone, so a vessel left behind by
+    staging can never report figures and says so."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.new_save()
+        cls.launch_vessel_from_vab("Staging")
+        cls.remove_other_vessels()
+        cls.space_center = cls.connect().space_center
+        cls.vessel = cls.space_center.active_vessel
+        cls.set_circular_orbit("Kerbin", 250000)
+        # The first few stages ignite engines without separating anything, so keep going
+        # until one leaves a vessel behind.
+        cls.jettisoned = None
+        for _ in range(6):
+            jettisoned = cls.vessel.control.activate_next_stage()
+            cls.wait(1)
+            if jettisoned:
+                cls.jettisoned = jettisoned[0]
+                break
+        assert cls.jettisoned is not None, "no stage of the craft left a vessel behind"
+
+    def test_jettisoned_vessel_reports_no_figures(self):
+        self.assertFalse(self.jettisoned.delta_v_ready)
+        with self.assertRaises(RuntimeError) as cm:
+            _ = self.jettisoned.vacuum_delta_v
+        self.assertIn("delta-v", str(cm.exception).lower())
+
+    def test_active_vessel_still_reports_figures(self):
+        self.assertTrue(self.vessel.delta_v_ready)
+
+
+class TestStageDeltaVWithoutEngines(krpctest.TestCase):
+    """CrewlessCommandPod carries no engine. The game runs its simulation but leaves the
+    ready flag down, and the zeros it computed are what there is to report."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.new_save()
+        cls.space_center = cls.connect().space_center
+        if cls.space_center.get_kerbal("Solo Kerman") is None:
+            cls.space_center.create_kerbal("Solo Kerman", "Pilot", True)
+        cls._stage_craft("CrewlessCommandPod", "VAB", None)
+        cls.space_center.launch_vessel(
+            "VAB", "CrewlessCommandPod", "LaunchPad", ["Solo Kerman"]
+        )
+        cls.remove_other_vessels()
+        cls.vessel = cls.space_center.active_vessel
+
+    def test_figures_are_zero(self):
+        self.assertTrue(self.vessel.delta_v_ready)
+        self.assertEqual(0, self.vessel.vacuum_delta_v)
+        self.assertEqual(0, self.vessel.sea_level_delta_v)
+        self.assertEqual(0, self.vessel.delta_v)
+        self.assertEqual(0, self.vessel.burn_time)


### PR DESCRIPTION
**Root cause.** KSP runs its delta-v simulation for the active vessel alone, and only on a tick where `VesselDeltaV.calcsDirty` is set. `RunCalculations` clears that flag before it decides it found no engines to work from, and the stock `DELTAV_USE_TIMED_VESSELCALCS = False` means nothing retries. A first run that lands before the vessel's staging is built is therefore dropped and never repeated, leaving the vessel without figures for the rest of the flight. Opening the stock delta-v app reaches `SetCalcsDirty`, which is the recovery the issue reports.

**Fix.** `FlightDeltaV` is the flight counterpart of the existing `EditorDeltaV`: it asks the game for a run, stamps `Time.fixedTime`, and yields until the figures land. The delta-v members of `Vessel` and the figures of a `Stage` go through it. `Vessel.DeltaVReady` reports whether the figures are current, for a call that must not block, and `Vessel.RecalculateDeltaV` asks for a run and waits for it. The game is left 150 ticks to run the simulation at its own moment before kRPC asks, so the figures a settled vessel comes to rest with are the ones reported.

The cases the game will never satisfy raise rather than waiting out the budget: a vessel that is not the active one, a vessel type given no simulation, and calculations turned off in the game's settings. A vessel with no engines reports the zeros the game computed. The editor keeps reporting that its figures are not ready, as `EditorVessel.DeltaVReady` describes.

**Testing.** `test_stage.py` covers the figures being available without the stock app, an explicit recalculation, a vessel left behind by staging, and a vessel with no engines. `TestStageRevertToLaunch` now waits for a figure that stops changing: the game revises its first answer once the reloaded vessel has come to rest, and a getter that returns the moment the game says ready catches the first one where polling every 100 ms used to skip past it.

Fixes #1075