### PR TITLE
Extension members

### DIFF
--- a/client/lua/krpc/test/test_client.lua
+++ b/client/lua/krpc/test/test_client.lua
@@ -76,6 +76,23 @@ function TestClient:test_properties()
   luaunit.assertEquals(obj, self.conn.test_service.object_property)
 end
 
+function TestClient:test_extension_members()
+  local obj = self.conn.test_service.create_test_object('jeb')
+  luaunit.assertEquals('value=jeb42', obj:extension_method(42))
+  luaunit.assertEquals('value=jeb', obj.extension_property)
+  obj.extension_read_write_property = 42
+  luaunit.assertEquals(42, obj.extension_read_write_property)
+  -- The extension property writes through to the class's own int_property
+  luaunit.assertEquals(42, obj.int_property)
+end
+
+function TestClient:test_extension_member_returning_class_from_other_service()
+  local obj = self.conn.test_service.create_test_object('jeb')
+  local obj2 = obj:extension_method_returning_class_from_other_service()
+  luaunit.assertTrue(obj2:is_a(self.conn.test_service2.TestClass2))
+  luaunit.assertEquals('value=jeb', obj2.value)
+end
+
 function TestClient:test_class_as_return_value()
   local obj = self.conn.test_service.create_test_object('jeb')
   luaunit.assertTrue(obj:is_a(self.conn.test_service.TestClass))
@@ -197,8 +214,9 @@ end
 
 function TestClient:test_client_members()
   -- benchmark is the server-side benchmarks the test server exposes
+  -- test_service2 owns the class that an extension member of test_service returns
   luaunit.assertEquals(
-    Set{'krpc', 'test_service', 'benchmark'},
+    Set{'krpc', 'test_service', 'test_service2', 'benchmark'},
     Set(filter_private(tablex.keys(self.conn)))
   )
 end
@@ -512,13 +530,18 @@ function TestClient:test_test_service_test_class_members()
   luaunit.assertEquals(
     members,
     {'echo_nullable_object',
+     'extension_method',
+     'extension_method_returning_class_from_other_service',
      'float_to_string',
+     'get_extension_property',
+     'get_extension_read_write_property',
      'get_int_property',
      'get_object_property',
      'get_string_property_private_set',
      'get_value',
      'object_to_string',
      'optional_arguments',
+     'set_extension_read_write_property',
      'set_int_property',
      'set_object_property',
      'set_string_property_private_get',

--- a/client/python/CHANGELOG.md
+++ b/client/python/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## [v0.7.0] - unreleased
+- A service with pre-generated stubs also gains the class members that only the server
+  declares (#1077)
 - Support structure types. A value is a named tuple, and a tuple or list with one element per
   field is accepted where one is expected (#1066)
 - A service definition naming an unknown type skips the member that names it with a warning,

--- a/client/python/krpc/client.py
+++ b/client/python/krpc/client.py
@@ -10,7 +10,12 @@ from krpc.definitions import CLASS, ENUMERATION, STRUCT, Definition, register_al
 from krpc.error import StreamError
 from krpc.event import Event
 from krpc.types import Types, TypeBase, DefaultArgument, EXCEPTION_TYPES
-from krpc.service import create_service, service_definitions
+from krpc.service import (
+    create_service,
+    extended_stub_classes,
+    merge_service,
+    service_definitions,
+)
 from krpc.streammanager import StreamManager
 from krpc.stream import Stream
 from krpc.encoder import Encoder
@@ -20,6 +25,24 @@ from krpc.error import RPCError
 import krpc.streammanager
 import krpc.schema.KRPC_pb2 as KRPC
 import krpc.services
+
+
+def _client_class(service_name: str, class_name: str, python_type: type) -> type:
+    """One client's subclass of a pre-generated class, for the members it adds to it.
+
+    The subclass names the class it stands for, which is what coerces an object between two
+    connections that each have a subclass of their own."""
+    return type(
+        python_type.__name__,
+        (python_type,),
+        {
+            "_service_name": service_name,
+            "_class_name": class_name,
+            "__doc__": python_type.__doc__,
+            "__module__": python_type.__module__,
+            "__qualname__": python_type.__qualname__,
+        },
+    )
 
 
 def _stub_definitions(
@@ -70,8 +93,14 @@ def _stub_definitions(
 
         return register
 
+    # A pre-generated class is shared by every client in the process, so a member built for
+    # one client cannot go on it. The client's own subclass is what carries the members that
+    # only the server's definition declares
+    extended = extended_stub_classes(service_info, service)
     classes = service._classes  # type: ignore[attr-defined]
     for class_name, python_type in classes.items():
+        if class_name in extended:
+            python_type = _client_class(name, class_name, python_type)
         yield Definition(
             CLASS, name, class_name, [], register_class(class_name, python_type)
         )
@@ -130,12 +159,14 @@ class Client(krpc.services.Client):
         # Load services
         definitions = []
         dynamic_services = []
+        stub_services = []
         for service_info in services:
             service = None
             if use_pregenerated_stubs:
                 service = self._services.get(service_info.name)
             if service is not None:
                 definitions.extend(_stub_definitions(service_info, service))
+                stub_services.append((service_info, service))
             else:
                 dynamic_services.append(service_info)
                 definitions.extend(service_definitions(service_info))
@@ -149,6 +180,9 @@ class Client(krpc.services.Client):
             setattr(
                 self, snake_case(service_info.name), create_service(self, service_info)
             )
+        # Add the class members that only the server's definition declares
+        for service_info, service in stub_services:
+            merge_service(self, service_info, service)
 
         # Set up stream update thread
         if stream_connection is not None:

--- a/client/python/krpc/client.py
+++ b/client/python/krpc/client.py
@@ -27,15 +27,19 @@ import krpc.schema.KRPC_pb2 as KRPC
 import krpc.services
 
 
-def _client_class(service_name: str, class_name: str, python_type: type) -> type:
+def _client_class(
+    client: Client, service_name: str, class_name: str, python_type: type
+) -> type:
     """One client's subclass of a pre-generated class, for the members it adds to it.
 
     The subclass names the class it stands for, which is what coerces an object between two
-    connections that each have a subclass of their own."""
+    connections that each have a subclass of their own. It also carries the client, so a
+    static method reached through an object's class uses that object's connection."""
     return type(
         python_type.__name__,
         (python_type,),
         {
+            "_client": client,
             "_service_name": service_name,
             "_class_name": class_name,
             "__doc__": python_type.__doc__,
@@ -46,7 +50,7 @@ def _client_class(service_name: str, class_name: str, python_type: type) -> type
 
 
 def _stub_definitions(
-    service_info: KRPC.Service, service: object
+    client: Client, service_info: KRPC.Service, service: object
 ) -> Iterator[Definition]:
     """The types of a service whose stubs were generated ahead of time, as records that can be
     registered in a type registry. The stubs already provide the python types, so registering
@@ -100,7 +104,7 @@ def _stub_definitions(
     classes = service._classes  # type: ignore[attr-defined]
     for class_name, python_type in classes.items():
         if class_name in extended:
-            python_type = _client_class(name, class_name, python_type)
+            python_type = _client_class(client, name, class_name, python_type)
         yield Definition(
             CLASS, name, class_name, [], register_class(class_name, python_type)
         )
@@ -165,7 +169,7 @@ class Client(krpc.services.Client):
             if use_pregenerated_stubs:
                 service = self._services.get(service_info.name)
             if service is not None:
-                definitions.extend(_stub_definitions(service_info, service))
+                definitions.extend(_stub_definitions(self, service_info, service))
                 stub_services.append((service_info, service))
             else:
                 dynamic_services.append(service_info)

--- a/client/python/krpc/service.py
+++ b/client/python/krpc/service.py
@@ -4,10 +4,12 @@ from typing import (
     Any,
     Callable,
     DefaultDict,
+    Dict,
     Iterable,
     Iterator,
     List,
     Optional,
+    Set,
     Tuple,
     TYPE_CHECKING,
 )
@@ -30,6 +32,7 @@ from krpc.types import (
     DynamicClassBase,
     DefaultArgument,
     UnknownTypeError,
+    WrappedClass,
     check_type_is_known,
     is_a_known_type,
 )
@@ -426,29 +429,54 @@ def create_service(client: Client, service: KRPC.Service) -> object:
             procedures[1],
         )
 
+    _add_class_members(cls, service)
+
+    return cls()  # type: ignore[operator]
+
+
+def _add_class_members(
+    cls: ServiceBase,
+    service: KRPC.Service,
+    skip: Optional[Callable[[str, str], bool]] = None,
+) -> None:
+    """Attach the members that a service declares for its classes to the class types.
+
+    skip takes a class and member name, and returns whether the member is already
+    present."""
+
+    def attach(
+        class_name: str,
+        member_name: str,
+        add: Callable[..., None],
+        *args: object,
+    ) -> None:
+        if skip is not None and skip(class_name, member_name):
+            return
+        _skipping_unknown_types(
+            "%s.%s.%s" % (service.name, class_name, member_name),
+            add,
+            class_name,
+            member_name,
+            *args,
+        )
+
     # Add class methods
     for procedure in service.procedures:
         if Attributes.is_a_class_method(procedure.name):
-            class_name = Attributes.get_class_name(procedure.name)
-            method_name = Attributes.get_class_member_name(procedure.name)
-            _skipping_unknown_types(
-                "%s.%s.%s" % (service.name, class_name, method_name),
+            attach(
+                Attributes.get_class_name(procedure.name),
+                Attributes.get_class_member_name(procedure.name),
                 cls._add_service_class_method,
-                class_name,
-                method_name,
                 procedure,
             )
 
     # Add static class methods
     for procedure in service.procedures:
         if Attributes.is_a_class_static_method(procedure.name):
-            class_name = Attributes.get_class_name(procedure.name)
-            method_name = Attributes.get_class_member_name(procedure.name)
-            _skipping_unknown_types(
-                "%s.%s.%s" % (service.name, class_name, method_name),
+            attach(
+                Attributes.get_class_name(procedure.name),
+                Attributes.get_class_member_name(procedure.name),
                 cls._add_service_class_static_method,
-                class_name,
-                method_name,
                 procedure,
             )
 
@@ -458,24 +486,80 @@ def create_service(client: Client, service: KRPC.Service) -> object:
     )
     for procedure in service.procedures:
         if Attributes.is_a_class_property_accessor(procedure.name):
-            class_name = Attributes.get_class_name(procedure.name)
-            property_name = Attributes.get_class_member_name(procedure.name)
-            key = (class_name, property_name)
+            key = (
+                Attributes.get_class_name(procedure.name),
+                Attributes.get_class_member_name(procedure.name),
+            )
             if Attributes.is_a_class_property_getter(procedure.name):
                 class_properties[key][0] = procedure
             else:
                 class_properties[key][1] = procedure
     for (class_name, property_name), procedures in class_properties.items():
-        _skipping_unknown_types(
-            "%s.%s.%s" % (service.name, class_name, property_name),
-            cls._add_service_class_property,
+        attach(
             class_name,
             property_name,
+            cls._add_service_class_property,
             procedures[0],
             procedures[1],
         )
 
-    return cls()  # type: ignore[operator]
+
+def _stub_is_missing(
+    classes: Dict[str, type], class_name: str, member_name: str
+) -> bool:
+    """Whether the stubs lack a member that a service declares for one of its classes.
+
+    A class the stubs omit lacks nothing, as there is nothing to add a member to."""
+    python_type = classes.get(class_name)
+    return python_type is not None and not hasattr(
+        python_type, _member_name(member_name)
+    )
+
+
+def extended_stub_classes(service: KRPC.Service, stub: object) -> Set[str]:
+    """The classes of a service whose members the stubs do not all have.
+
+    The stubs are generated from one version of a service. The server may declare more
+    members for its classes, either because another mod adds them or because the server
+    is newer."""
+    classes = stub._classes  # type: ignore[attr-defined]
+    names: Set[str] = set()
+    for procedure in service.procedures:
+        if not Attributes.is_a_class_member(procedure.name):
+            continue
+        class_name = Attributes.get_class_name(procedure.name)
+        member_name = Attributes.get_class_member_name(procedure.name)
+        if _stub_is_missing(classes, class_name, member_name):
+            names.add(class_name)
+    return names
+
+
+def merge_service(client: Client, service: KRPC.Service, stub: object) -> None:
+    """Attach the class members that only a service's definition declares.
+
+    The members go on this client's subclass of each pre-generated class, which the type
+    registry already holds (see extended_stub_classes). Members the stubs already have are
+    left alone, as are classes the stubs omit."""
+    classes = stub._classes  # type: ignore[attr-defined]
+    cls = cast(
+        ServiceBase,
+        type(
+            str(service.name),
+            (ServiceBase,),
+            {"_client": client, "_name": service.name},
+        ),
+    )
+
+    def already_present(class_name: str, member_name: str) -> bool:
+        return not _stub_is_missing(classes, class_name, member_name)
+
+    _add_class_members(cls, service, already_present)
+
+    # The class reached through the service is the pre-generated one, so point it at the
+    # subclass the members went on
+    for class_name in extended_stub_classes(service, stub):
+        python_type = client._types.class_type(service.name, class_name).python_type
+        stub.__dict__[class_name] = WrappedClass(client, python_type)
 
 
 class ServiceBase(DynamicType):

--- a/client/python/krpc/test/test_client.py
+++ b/client/python/krpc/test/test_client.py
@@ -619,6 +619,8 @@ class TestClient(ServerTestCase, unittest.TestCase):
                 [
                     "krpc",
                     "test_service",
+                    # Owns the class that an extension member of TestService returns
+                    "test_service2",
                     # The server-side benchmarks the test server exposes. It has no
                     # pre-generated stubs, so this is also the client building a service
                     # from the definitions the server hands over.

--- a/client/python/krpc/test/test_client.py
+++ b/client/python/krpc/test/test_client.py
@@ -150,6 +150,39 @@ class TestClient(ServerTestCase, unittest.TestCase):
         finally:
             conn.close()
 
+    def test_extension_members(self) -> None:
+        obj = self.conn.test_service.create_test_object("jeb")
+        self.assertEqual("value=jeb42", obj.extension_method(42))
+        self.assertEqual("value=jeb", obj.extension_property)
+        obj.extension_read_write_property = 42
+        self.assertEqual(42, obj.extension_read_write_property)
+        # The extension property writes through to the class's own int_property
+        self.assertEqual(42, obj.int_property)
+
+    def test_extension_member_returning_class_from_other_service(self) -> None:
+        obj = self.conn.test_service.create_test_object("jeb")
+        obj2 = obj.extension_method_returning_class_from_other_service()
+        self.assertEqual("TestClass2", type(obj2).__name__)
+        self.assertEqual("value=jeb", obj2.value)
+
+    def test_extension_members_are_per_connection(self) -> None:
+        # A pre-generated class is shared by every client in the process, so the members
+        # merged onto it go through the connection the object was reached through
+        other = self.connect()
+        try:
+            obj = other.test_service.create_test_object("jeb")
+            self.assertEqual("value=jeb", obj.extension_property)
+            obj2 = obj.extension_method_returning_class_from_other_service()
+            self.assertIs(other, obj2._client)
+            self.assertIn("extension_method", dir(other.test_service.TestClass))
+        finally:
+            other.close()
+
+    def test_extension_member_stream(self) -> None:
+        obj = self.conn.test_service.create_test_object("jeb")
+        with self.conn.stream(getattr, obj, "extension_property") as stream:
+            self.assertEqual("value=jeb", stream())
+
     def test_class_as_return_value(self) -> None:
         obj = self.conn.test_service.create_test_object("jeb")
         self.assertEqual("TestClass", type(obj).__name__)
@@ -777,6 +810,12 @@ class TestClient(ServerTestCase, unittest.TestCase):
                     "optional_arguments",
                     "static_method",
                     "static_nullable_object",
+                    # Added by extension members, which the client picks up from the
+                    # server's definitions
+                    "extension_method",
+                    "extension_method_returning_class_from_other_service",
+                    "extension_property",
+                    "extension_read_write_property",
                 ]
             ),
             set(

--- a/client/python/krpc/test/test_service_definitions.py
+++ b/client/python/krpc/test/test_service_definitions.py
@@ -205,7 +205,9 @@ class TestServiceDefinitions(unittest.TestCase):
         service = struct_service("ServiceB", Types().sint32_type.protobuf_type)
         with warnings.catch_warnings(record=True) as caught:
             warnings.simplefilter("always")
-            register_all(client._types, _stub_definitions(service, StubService()))
+            register_all(
+                client._types, _stub_definitions(client, service, StubService())
+            )
         self.assertTrue(
             any("ServiceB.Thing" in str(warning.message) for warning in caught)
         )

--- a/client/python/krpc/types.py
+++ b/client/python/krpc/types.py
@@ -647,7 +647,7 @@ class DynamicType:
         return getattr(cls, name)
 
 
-class ClassBase:
+class ClassBase(DynamicType):
     """Base class for service-defined class types"""
 
     def __init__(self, client: Client, object_id: int) -> None:
@@ -684,7 +684,7 @@ class ClassBase:
         return hash(self._object_id)
 
 
-class DynamicClassBase(ClassBase, DynamicType):
+class DynamicClassBase(ClassBase):
     def __repr__(self) -> str:
         return "<%s.%s remote object #%d>" % (
             self._service_name,

--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -1,4 +1,7 @@
 ## [v0.7.0] - unreleased
+- Add extension members: a service can add methods and properties to a class belonging to
+  another service, declared as C# extension methods annotated with `KRPCMethod` or
+  `KRPCProperty` (#1077)
 - Add structure types: a compound value with named fields, declared with `KRPCStruct` on a C#
   `struct` and sent to the client in full (#1066)
 - Add a communication protocol carrying protocol buffer messages over a unix domain socket,

--- a/core/src/Service/Attributes/KRPCPropertyAttribute.cs
+++ b/core/src/Service/Attributes/KRPCPropertyAttribute.cs
@@ -3,9 +3,10 @@ using System;
 namespace KRPC.Service.Attributes
 {
     /// <summary>
-    /// A kRPC property.
+    /// A kRPC property. Applied to a property, or to a GetX or SetX extension method that
+    /// adds a property to another service's class.
     /// </summary>
-    [AttributeUsage (AttributeTargets.Property)]
+    [AttributeUsage (AttributeTargets.Property | AttributeTargets.Method)]
     public sealed class KRPCPropertyAttribute : Attribute
     {
         /// <summary>

--- a/core/src/Service/ClassStaticMethodHandler.cs
+++ b/core/src/Service/ClassStaticMethodHandler.cs
@@ -7,17 +7,22 @@ using System.Reflection;
 namespace KRPC.Service
 {
     /// <summary>
-    /// Used to invoke a static method with the KRPCMethod attribute.
+    /// Used to invoke a static method with the KRPCMethod attribute, and to invoke an
+    /// extension member of a class. An extension member is a static call taking the
+    /// instance as its first argument.
     /// </summary>
     sealed class ClassStaticMethodHandler : IProcedureHandler
     {
         readonly Func<object, object[], object> invoker;
         readonly ProcedureParameter[] parameters;
 
-        public ClassStaticMethodHandler (MethodInfo methodInfo, bool returnIsNullable)
+        public ClassStaticMethodHandler (MethodInfo methodInfo, bool returnIsNullable, bool isExtension = false)
         {
             invoker = BuildInvoker (methodInfo);
             parameters = methodInfo.GetParameters ().Select (x => new ProcedureParameter (x)).ToArray ();
+            // Clients expect the instance parameter of a class member to be named "this"
+            if (isExtension)
+                parameters [0] = new ProcedureParameter (parameters [0].Type, "this");
             ReturnType = methodInfo.ReturnType;
             ReturnIsNullable = returnIsNullable;
         }

--- a/core/src/Service/Scanner/Scanner.cs
+++ b/core/src/Service/Scanner/Scanner.cs
@@ -56,10 +56,11 @@ namespace KRPC.Service.Scanner
                             HandleError(errors, "service " + service.Name, exn);
                         }
                     }
-                    // Check for methods
+                    // Check for class members declared in the service
                     var invalidMethod = Reflection.GetMethodsWith<KRPCMethodAttribute> (serviceType).FirstOrDefault ();
                     if (invalidMethod != null)
                         HandleError(errors, "service " + service.Name, "Service contains a class method " + invalidMethod.Name);
+                    CheckForPropertyMethod (errors, "service " + service.Name, serviceType);
                 } catch (ServiceException exn) {
                     HandleError(errors, string.Empty, exn);
                 }
@@ -91,6 +92,7 @@ namespace KRPC.Service.Scanner
                             HandleError(errors, "service " + serviceName + ", class " + cls, exn);
                         }
                     }
+                    CheckForPropertyMethod (errors, "service " + serviceName + ", class " + cls, classType);
                 } catch (ServiceException exn) {
                     HandleError(errors, string.Empty, exn);
                 }
@@ -142,6 +144,14 @@ namespace KRPC.Service.Scanner
                 }
             }
 
+            // Extension members are methods in public static classes that add a member to
+            // another service's class. They are scanned last, once every class is registered
+            var unreachable = new HashSet<Type> ();
+            foreach (var method in Reflection.GetStaticClassMethodsWith<KRPCMethodAttribute> ())
+                AddExtensionMember (signatures, errors, unreachable, method, false);
+            foreach (var method in Reflection.GetStaticClassMethodsWith<KRPCPropertyAttribute> ())
+                AddExtensionMember (signatures, errors, unreachable, method, true);
+
             CurrentAssembly = null;
 
             // Check that the main KRPC service was found
@@ -149,6 +159,57 @@ namespace KRPC.Service.Scanner
                 HandleError(errors, string.Empty, "KRPC service could not be found");
 
             return signatures;
+        }
+
+        /// <summary>
+        /// Report a KRPCProperty applied to a method of the given type. Only an extension method
+        /// declares a property that way, and the extension pass skips services and classes.
+        /// </summary>
+        static void CheckForPropertyMethod (IList<string> errors, string context, Type type)
+        {
+            var method = Reflection.GetMethodsWith<KRPCPropertyAttribute> (type).FirstOrDefault ();
+            if (method != null)
+                HandleError (errors, context, "KRPCProperty is applied to the method " + method.Name +
+                             "; a method declares a property only as an extension member, in a public static class outside a service");
+        }
+
+        static void AddExtensionMember (IDictionary<string, ServiceSignature> signatures, IList<string> errors,
+                                        ISet<Type> unreachable, MethodInfo method, bool isProperty)
+        {
+            var declaringType = method.DeclaringType;
+            // Members declared in a service are handled when scanning the service itself
+            if (Reflection.HasAttribute<KRPCServiceAttribute> (declaringType))
+                return;
+            // A class that is not public is out of reach of the assembly the server runs from,
+            // so its members are named in a warning
+            if (!(declaringType.IsPublic || declaringType.IsNestedPublic)) {
+                if (unreachable.Add (declaringType))
+                    Logger.WriteLine (
+                        "Ignoring the extension members of " + declaringType + ", as the class is not public",
+                        Logger.Severity.Warning);
+                return;
+            }
+            try {
+                CurrentAssembly = declaringType.Assembly;
+                var classType = TypeUtils.GetExtensionTargetClass (method);
+                var serviceName = TypeUtils.GetClassServiceName (classType);
+                if (!signatures.ContainsKey (serviceName)) {
+                    HandleError (errors, "service " + serviceName, "Service does not exist, when loading extension member");
+                    return;
+                }
+                var service = signatures [serviceName];
+                var cls = classType.Name;
+                try {
+                    if (isProperty)
+                        service.AddClassExtensionProperty (cls, classType, method);
+                    else
+                        service.AddClassExtensionMethod (cls, classType, method);
+                } catch (ServiceException exn) {
+                    HandleError (errors, "service " + serviceName + ", class " + cls, exn);
+                }
+            } catch (ServiceException exn) {
+                HandleError (errors, string.Empty, exn);
+            }
         }
 
         static void HandleError(IList<string> errors, string context, string msg) {

--- a/core/src/Service/Scanner/ServiceSignature.cs
+++ b/core/src/Service/Scanner/ServiceSignature.cs
@@ -68,6 +68,12 @@ namespace KRPC.Service.Scanner
         GameScene gameScene;
 
         /// <summary>
+        /// The type declaring each extension member added to this service, by procedure
+        /// name, used when reporting a clash.
+        /// </summary>
+        readonly Dictionary<string,Type> extensionMembers = new Dictionary<string, Type> ();
+
+        /// <summary>
         /// Create a service signature from a C# type annotated with the KRPCService attribute
         /// </summary>
         public ServiceSignature (Type type, uint id)
@@ -308,6 +314,89 @@ namespace KRPC.Service.Scanner
                 Name, cls + '_' + method.Name, NextProcedureId, property.GetDocumentation (), handler,
                 TypeUtils.GetClassPropertyGameScene(classType, property, classGameScene),
                 deprecated, deprecatedReason));
+        }
+
+        /// <summary>
+        /// Add an extension method to the given class in the given service for the given
+        /// method annotated with the KRPCMethod attribute.
+        /// </summary>
+        public void AddClassExtensionMethod (string cls, Type classType, MethodInfo method)
+        {
+            TypeUtils.ValidateIdentifier (cls);
+            TypeUtils.ValidateKRPCExtensionMethod (method);
+            CheckClassExists (cls);
+            var classGameScene = TypeUtils.GetClassGameScene (classType, gameScene);
+            string deprecatedReason;
+            var deprecated = TypeUtils.GetDeprecated (method, out deprecatedReason);
+            AddExtensionProcedure (
+                cls + '_' + method.Name, method, method.GetDocumentation (),
+                new ClassStaticMethodHandler (method, TypeUtils.GetNullable (method), true),
+                TypeUtils.GetExtensionMethodGameScene (method, classGameScene),
+                deprecated, deprecatedReason);
+        }
+
+        /// <summary>
+        /// Add one accessor of an extension property to the given class in the given service
+        /// for the given method annotated with the KRPCProperty attribute.
+        /// </summary>
+        public void AddClassExtensionProperty (string cls, Type classType, MethodInfo method)
+        {
+            TypeUtils.ValidateIdentifier (cls);
+            TypeUtils.ValidateKRPCExtensionProperty (method);
+            CheckClassExists (cls);
+            var isSetter = TypeUtils.IsAnExtensionPropertySetter (method);
+            var property = TypeUtils.GetExtensionPropertyName (method);
+            CheckOtherAccessor (cls + (isSetter ? "_get_" : "_set_") + property, method);
+            var classGameScene = TypeUtils.GetClassGameScene (classType, gameScene);
+            string deprecatedReason;
+            var deprecated = TypeUtils.GetDeprecated (method, out deprecatedReason);
+            AddExtensionProcedure (
+                cls + (isSetter ? "_set_" : "_get_") + property,
+                method, method.GetDocumentation (),
+                new ClassStaticMethodHandler (method, TypeUtils.GetNullable (method), true),
+                TypeUtils.GetExtensionPropertyGameScene (method, classGameScene),
+                deprecated, deprecatedReason);
+        }
+
+        void CheckClassExists (string cls)
+        {
+            if (!Classes.ContainsKey (cls))
+                throw new ServiceException ("Class " + cls + " does not exist");
+        }
+
+        /// <summary>
+        /// Check that the other accessor of an extension property, if the class has one, comes
+        /// from the same extension. An accessor cannot be added to a property declared elsewhere.
+        /// </summary>
+        void CheckOtherAccessor (string procedureName, MethodInfo method)
+        {
+            if (!Procedures.ContainsKey (procedureName))
+                return;
+            Type owner;
+            if (extensionMembers.TryGetValue (procedureName, out owner) && owner == method.DeclaringType)
+                return;
+            throw Clash (procedureName, method);
+        }
+
+        ServiceException Clash (string procedureName, MethodInfo method)
+        {
+            Type owner;
+            var declaredBy = extensionMembers.TryGetValue (procedureName, out owner) ? owner.ToString () : "the class itself";
+            return new ServiceException (
+                "Extension member " + method.DeclaringType + "." + method.Name + " clashes with " +
+                Name + "." + procedureName + ", which is declared by " + declaredBy);
+        }
+
+        void AddExtensionProcedure (string procedureName, MethodInfo method, string documentation,
+                                    IProcedureHandler handler, GameScene procedureGameScene,
+                                    bool deprecated, string deprecatedReason)
+        {
+            if (Procedures.ContainsKey (procedureName))
+                throw Clash (procedureName, method);
+            AddProcedure (new ProcedureSignature (
+                Name, procedureName, NextProcedureId, documentation, handler,
+                procedureGameScene, deprecated, deprecatedReason));
+            extensionMembers [procedureName] = method.DeclaringType;
         }
 
         /// <summary>

--- a/core/src/Service/TypeUtils.cs
+++ b/core/src/Service/TypeUtils.cs
@@ -327,6 +327,30 @@ namespace KRPC.Service
         }
 
         /// <summary>
+        /// Get the game scene(s) that an extension method should be available during
+        /// </summary>
+        public static GameScene GetExtensionMethodGameScene (MethodInfo method, GameScene classGameScene)
+        {
+            ValidateKRPCExtensionMethod (method);
+            var attribute = Reflection.GetAttribute<KRPCMethodAttribute> (method);
+            if (attribute.GameScene == GameScene.Inherit)
+                return classGameScene;
+            return attribute.GameScene;
+        }
+
+        /// <summary>
+        /// Get the game scene(s) that an extension property should be available during
+        /// </summary>
+        public static GameScene GetExtensionPropertyGameScene (MethodInfo method, GameScene classGameScene)
+        {
+            ValidateKRPCExtensionProperty (method);
+            var attribute = Reflection.GetAttribute<KRPCPropertyAttribute> (method);
+            if (attribute.GameScene == GameScene.Inherit)
+                return classGameScene;
+            return attribute.GameScene;
+        }
+
+        /// <summary>
         /// Get the name of the service for the given KRPCEnum annotated type
         /// </summary>
         public static string GetEnumServiceName (Type type)
@@ -662,6 +686,97 @@ namespace KRPC.Service
             var declaringType = property.DeclaringType;
             if (declaringType == null || !declaringType.IsAssignableFrom (cls))
                 throw new ServiceException ("KRPCProperty " + property + " is not declared inside a KRPCClass");
+        }
+
+        /// <summary>
+        /// Returns true if the given method is a C# extension method.
+        /// </summary>
+        public static bool IsAnExtensionMethod (MethodBase method)
+        {
+            return Reflection.HasAttribute<ExtensionAttribute> (method);
+        }
+
+        /// <summary>
+        /// Returns true if the given extension property accessor is a setter.
+        /// </summary>
+        public static bool IsAnExtensionPropertySetter (MethodInfo method)
+        {
+            return method.Name.StartsWith ("Set", StringComparison.Ordinal);
+        }
+
+        /// <summary>
+        /// Get the name of the property that the given accessor implements, i.e. its name
+        /// without the Get or Set prefix.
+        /// </summary>
+        public static string GetExtensionPropertyName (MethodInfo method)
+        {
+            return method.Name.Substring (3);
+        }
+
+        /// <summary>
+        /// Get the kRPC class that the given extension member adds a member to, which is the
+        /// type of its instance parameter.
+        /// </summary>
+        public static Type GetExtensionTargetClass (MethodInfo method)
+        {
+            ValidateExtensionTarget (method);
+            return method.GetParameters () [0].ParameterType;
+        }
+
+        /// <summary>
+        /// Check the given method can add a member to a kRPC class
+        /// 1. Must be a public static extension method
+        /// 2. The type it extends must be a kRPC class
+        /// </summary>
+        static void ValidateExtensionTarget (MethodInfo method)
+        {
+            var parameters = method.GetParameters ();
+            if (!(method.IsPublic && method.IsStatic && IsAnExtensionMethod (method) && parameters.Length > 0))
+                throw new ServiceException ("Extension member " + method + " is not a public static extension method");
+            var target = parameters [0].ParameterType;
+            if (IsAStructType (target))
+                throw new ServiceException ("Extension member " + method + " extends the KRPCStruct " + target + "; only kRPC classes can be extended");
+            if (!IsAClassType (target))
+                throw new ServiceException ("Extension member " + method + " does not extend a KRPCClass");
+            ValidateKRPCClass (target);
+        }
+
+        /// <summary>
+        /// Check the given method is a valid kRPC extension method
+        /// 1. Must have KRPCMethod attribute
+        /// 2. Must have a valid identifier
+        /// 3. Must be a public static extension method of a kRPC class
+        /// </summary>
+        public static void ValidateKRPCExtensionMethod (MethodInfo method)
+        {
+            if (!Reflection.HasAttribute<KRPCMethodAttribute> (method))
+                throw new ArgumentException (method + " does not have KRPCMethod attribute");
+            ValidateIdentifier (method.Name);
+            ValidateExtensionTarget (method);
+        }
+
+        /// <summary>
+        /// Check the given method is a valid kRPC extension property accessor
+        /// 1. Must have KRPCProperty attribute
+        /// 2. Must be named GetX or SetX, where X is a valid identifier
+        /// 3. Must be a public static extension method of a kRPC class
+        /// 4. A getter must take only the instance and return a value
+        /// 5. A setter must take the instance and the value to set, and return nothing
+        /// </summary>
+        public static void ValidateKRPCExtensionProperty (MethodInfo method)
+        {
+            if (!Reflection.HasAttribute<KRPCPropertyAttribute> (method))
+                throw new ArgumentException (method + " does not have KRPCProperty attribute");
+            var isSetter = IsAnExtensionPropertySetter (method);
+            if (!isSetter && !method.Name.StartsWith ("Get", StringComparison.Ordinal))
+                throw new ServiceException ("KRPCProperty " + method + " is not named GetX or SetX");
+            ValidateIdentifier (GetExtensionPropertyName (method));
+            ValidateExtensionTarget (method);
+            var numParameters = method.GetParameters ().Length;
+            if (isSetter && !(numParameters == 2 && method.ReturnType == typeof(void)))
+                throw new ServiceException ("KRPCProperty " + method + " is not a property setter; it must take the value to set and return nothing");
+            if (!isSetter && !(numParameters == 1 && method.ReturnType != typeof(void)))
+                throw new ServiceException ("KRPCProperty " + method + " is not a property getter; it must take no arguments and return a value");
         }
 
         /// <summary>

--- a/core/src/Utils/Reflection.cs
+++ b/core/src/Utils/Reflection.cs
@@ -7,12 +7,14 @@ namespace KRPC.Utils
 {
     static class Reflection
     {
-        static IEnumerable<Type> AllTypes ()
+        static IEnumerable<Type> AllTypes (Func<Assembly, bool> include = null)
         {
             foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies()) {
                 // Get all types that can be loaded from the assembly
                 // Note: We skip Assembly-CSharp as it causes a crash when running nunit tests.
                 if (assembly.FullName.Contains ("Assembly-CSharp"))
+                    continue;
+                if (include != null && !include (assembly))
                     continue;
                 Type[] types;
                 try {
@@ -60,6 +62,40 @@ namespace KRPC.Utils
                 if (method.IsDefined (typeof(TAttribute), inherit)) {
                     yield return method;
                 }
+            }
+        }
+
+        /// <summary>
+        /// Whether the given assembly can declare the given attribute, which it can only do by
+        /// being, or by referencing, the assembly the attribute comes from.
+        /// </summary>
+        static bool CanDeclare (Assembly assembly, Assembly attributeAssembly)
+        {
+            if (assembly == attributeAssembly)
+                return true;
+            var name = attributeAssembly.GetName ().Name;
+            foreach (var reference in assembly.GetReferencedAssemblies ()) {
+                if (reference.Name == name)
+                    return true;
+            }
+            return false;
+        }
+
+        /// <summary>
+        /// Returns all methods in static classes with the specified attribute. Only the
+        /// assemblies that can declare the attribute are searched, which leaves the rest of a
+        /// modded game untouched. A class that is not public is searched along with the rest, so
+        /// that the caller can report the members it puts out of reach.
+        /// </summary>
+        public static IEnumerable<MethodInfo> GetStaticClassMethodsWith<TAttribute> (bool inherit = false)
+            where TAttribute : Attribute
+        {
+            var attributeAssembly = typeof(TAttribute).Assembly;
+            foreach (var type in AllTypes (x => CanDeclare (x, attributeAssembly))) {
+                if (!type.IsStatic ())
+                    continue;
+                foreach (var method in GetMethodsWith<TAttribute> (type, inherit))
+                    yield return method;
             }
         }
 

--- a/core/test/KRPC.Core.Test.csproj
+++ b/core/test/KRPC.Core.Test.csproj
@@ -77,10 +77,12 @@
     <Compile Include="Server\WebSockets\StreamServerTest.cs" />
     <Compile Include="Server\WebSockets\StreamStreamTest.cs" />
     <Compile Include="Service\ClassMethodHandlerTest.cs" />
+    <Compile Include="Service\ClassStaticMethodHandlerTest.cs" />
     <Compile Include="Service\DocumentationUtilsTest.cs" />
     <Compile Include="Service\GameSceneTest.cs" />
     <Compile Include="Service\GameStateTest.cs" />
     <Compile Include="Service\ITestService.cs" />
+    <Compile Include="Service\InvalidExtensions.cs" />
     <Compile Include="Service\KRPC\ExpressionTest.cs" />
     <Compile Include="Service\KRPC\KRPCTest.cs" />
     <Compile Include="Service\MessageAssert.cs" />
@@ -89,11 +91,13 @@
     <Compile Include="Service\ProcedureHandlerTest.cs" />
     <Compile Include="Service\ProcedureParameterTest.cs" />
     <Compile Include="Service\ScannerTest.cs" />
+    <Compile Include="Service\ServiceSignatureTest.cs" />
     <Compile Include="Service\ServicesTest.cs" />
     <Compile Include="Service\TestService.cs" />
     <Compile Include="Service\TestService2.cs" />
     <Compile Include="Service\TestService3.cs" />
     <Compile Include="Service\TestServiceDeprecated.cs" />
+    <Compile Include="Service\TestServiceExtensions.cs" />
     <Compile Include="Service\TestTopLevelClass.cs" />
     <Compile Include="Service\TypeUtilsTest.cs" />
     <Compile Include="Service\ValueUtilsTest.cs" />

--- a/core/test/Service/ClassStaticMethodHandlerTest.cs
+++ b/core/test/Service/ClassStaticMethodHandlerTest.cs
@@ -1,0 +1,46 @@
+using System.Linq;
+using KRPC.Service;
+using NUnit.Framework;
+
+namespace KRPC.Test.Service
+{
+    [TestFixture]
+    public class ClassStaticMethodHandlerTest
+    {
+        [Test]
+        public void StaticMethod ()
+        {
+            var classType = typeof(TestService.TestClass);
+            var handler = new ClassStaticMethodHandler (classType.GetMethod ("StaticMethod"), false);
+            Assert.IsFalse (handler.HasInstance);
+            Assert.AreEqual ("jebfoo", handler.Invoke (null, new object [] { "foo" }));
+        }
+
+        [Test]
+        public void ExtensionMethod ()
+        {
+            var instance = new TestService.TestClass ("foo");
+            var method = typeof(TestServiceExtensions).GetMethod ("ExtensionMethod");
+            var handler = new ClassStaticMethodHandler (method, false, true);
+            // The instance is passed as argument 0, as it is the first argument of the static call
+            Assert.IsFalse (handler.HasInstance);
+            Assert.AreEqual ("foo42", handler.Invoke (null, new object [] { instance, 42 }));
+        }
+
+        [Test]
+        public void ExtensionMethodProperties ()
+        {
+            var method = typeof(TestServiceExtensions).GetMethod ("ExtensionMethod");
+            var handler = new ClassStaticMethodHandler (method, false, true);
+            var parameters = handler.Parameters.ToList ();
+            Assert.AreEqual (2, parameters.Count);
+            Assert.AreEqual ("this", parameters [0].Name);
+            Assert.AreEqual ("x", parameters [1].Name);
+            Assert.AreEqual (typeof(TestService.TestClass), parameters [0].Type);
+            Assert.AreEqual (typeof(int), parameters [1].Type);
+            Assert.IsFalse (parameters [0].HasDefaultValue);
+            Assert.IsFalse (parameters [0].Nullable);
+            Assert.AreEqual (typeof(string), handler.ReturnType);
+        }
+    }
+}

--- a/core/test/Service/InvalidExtensions.cs
+++ b/core/test/Service/InvalidExtensions.cs
@@ -1,0 +1,81 @@
+using KRPC.Service.Attributes;
+
+namespace KRPC.Test.Service
+{
+    /// <summary>
+    /// Extension members that are not valid. The class is internal, so the scanner skips
+    /// it. Each member is validated on its own.
+    /// </summary>
+    internal static class InvalidExtensions
+    {
+        [KRPCMethod]
+        public static string MethodWithoutThis (TestService.TestClass obj)
+        {
+            return obj.Value;
+        }
+
+        [KRPCMethod]
+        public static string MethodExtendingAValueType (this string value)
+        {
+            return value;
+        }
+
+        [KRPCMethod]
+        public static string MethodExtendingAStruct (this TestService.TestStruct value)
+        {
+            return value.StringField;
+        }
+
+        [KRPCMethod]
+        public static string lowerCaseMethod (this TestService.TestClass obj)
+        {
+            return obj.Value;
+        }
+
+        /// <summary>
+        /// Clashes with the TestClass method of the same name.
+        /// </summary>
+        [KRPCMethod]
+        public static string FloatToString (this TestService.TestClass obj, float x)
+        {
+            return obj.Value + x;
+        }
+
+        [KRPCProperty]
+        public static string PropertyWithoutAnAccessorPrefix (this TestService.TestClass obj)
+        {
+            return obj.Value;
+        }
+
+        [KRPCProperty]
+        public static string GetPropertyWithTooManyParameters (this TestService.TestClass obj, int x)
+        {
+            return obj.Value + x;
+        }
+
+        [KRPCProperty]
+        public static void GetPropertyWithNoReturnValue (this TestService.TestClass obj)
+        {
+        }
+
+        [KRPCProperty]
+        public static string SetPropertyWithAReturnValue (this TestService.TestClass obj, string value)
+        {
+            return obj.Value + value;
+        }
+
+        [KRPCProperty]
+        public static void SetPropertyWithNoValue (this TestService.TestClass obj)
+        {
+        }
+
+        /// <summary>
+        /// Adds a setter to a property that TestClass declares read-only.
+        /// </summary>
+        [KRPCProperty]
+        public static void SetClassPropertyAvailableInInheritedGameScene (
+            this TestService.TestClass obj, string value)
+        {
+        }
+    }
+}

--- a/core/test/Service/ScannerTest.cs
+++ b/core/test/Service/ScannerTest.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using KRPC.Service.Messages;
+using KRPC.Utils;
 using NUnit.Framework;
 
 namespace KRPC.Test.Service
@@ -31,7 +32,7 @@ namespace KRPC.Test.Service
         public void TestService ()
         {
             var service = services.ServicesList.First (x => x.Name == "TestService");
-            Assert.AreEqual (65, service.Procedures.Count);
+            Assert.AreEqual (75, service.Procedures.Count);
             Assert.AreEqual (3, service.Classes.Count);
             Assert.AreEqual (2, service.Enumerations.Count);
             Assert.AreEqual (2, service.Structs.Count);
@@ -53,11 +54,41 @@ namespace KRPC.Test.Service
         public void TestService3Name ()
         {
             var service = services.ServicesList.First (x => x.Name == "TestService3Name");
-            Assert.AreEqual (1, service.Procedures.Count);
+            Assert.AreEqual (2, service.Procedures.Count);
             Assert.AreEqual (1, service.Classes.Count);
             Assert.AreEqual (0, service.Enumerations.Count);
             Assert.AreEqual (string.Empty, service.Documentation);
             MessageAssert.IsNotDeprecated (service);
+        }
+
+        [Test]
+        public void TestService3NameExtensionMember ()
+        {
+            var service = services.ServicesList.First (x => x.Name == "TestService3Name");
+            var proc = service.Procedures.First (x => x.Name == "TestClass3_ExtensionMethodOnOtherServicesClass");
+            MessageAssert.HasParameters (proc, 1);
+            MessageAssert.HasParameter (proc, 0, typeof(TestClass3), "this");
+            MessageAssert.HasReturnType (proc, typeof(string));
+            MessageAssert.HasGameScene (proc, global::KRPC.Service.GameScene.Editor);
+            MessageAssert.HasNoDocumentation (proc);
+        }
+
+        [Test]
+        public void ExtensionMembersInAClassThatIsNotPublic ()
+        {
+            var warnings = new List<string> ();
+            var writer = Logger.Writer;
+            var level = Logger.Level;
+            try {
+                Logger.Level = Logger.Severity.Warning;
+                Logger.Writer = (message, severity) => warnings.Add (message);
+                global::KRPC.Service.Scanner.Scanner.GetServices (new List<string> ());
+            } finally {
+                Logger.Writer = writer;
+                Logger.Level = level;
+            }
+            // InvalidExtensions is internal, so its members are named in a warning and skipped
+            Assert.AreEqual (1, warnings.Count (x => x.Contains ("InvalidExtensions")));
         }
 
         [Test]
@@ -473,13 +504,77 @@ namespace KRPC.Test.Service
                     MessageAssert.HasReturnType (proc, typeof(string));
                     MessageAssert.HasGameScene (proc, global::KRPC.Service.GameScene.EditorVAB);
                     MessageAssert.HasNoDocumentation (proc);
+                } else if (proc.Name == "TestClass_ExtensionMethod") {
+                    MessageAssert.HasParameters (proc, 2);
+                    MessageAssert.HasParameter (proc, 0, typeof(TestService.TestClass), "this");
+                    MessageAssert.HasParameter (proc, 1, typeof(int), "x");
+                    MessageAssert.HasReturnType (proc, typeof(string));
+                    MessageAssert.HasGameScene (proc, global::KRPC.Service.GameScene.Flight | global::KRPC.Service.GameScene.SpaceCenter);
+                    MessageAssert.HasDocumentation (proc, "<doc>\n<summary>\nExtension method documentation string.\n</summary>\n</doc>");
+                } else if (proc.Name == "TestClass_ExtensionNullableMethod") {
+                    MessageAssert.HasParameters (proc, 2);
+                    MessageAssert.HasParameter (proc, 0, typeof(TestService.TestClass), "this");
+                    MessageAssert.HasNullableParameter (proc, 1, typeof(TestService.TestClass), "other");
+                    MessageAssert.HasReturnType (proc, typeof(TestService.TestClass), true);
+                    MessageAssert.HasGameScene (proc, global::KRPC.Service.GameScene.Flight | global::KRPC.Service.GameScene.SpaceCenter);
+                    MessageAssert.HasNoDocumentation (proc);
+                } else if (proc.Name == "TestClass_ExtensionMethodAvailableInSpecifiedGameScene") {
+                    MessageAssert.HasParameters (proc, 1);
+                    MessageAssert.HasParameter (proc, 0, typeof(TestService.TestClass), "this");
+                    MessageAssert.HasReturnType (proc, typeof(string));
+                    MessageAssert.HasGameScene (proc, global::KRPC.Service.GameScene.EditorVAB);
+                    MessageAssert.HasNoDocumentation (proc);
+                } else if (proc.Name == "TestClass_DeprecatedExtensionMethod") {
+                    MessageAssert.HasParameters (proc, 1);
+                    MessageAssert.HasParameter (proc, 0, typeof(TestService.TestClass), "this");
+                    MessageAssert.HasReturnType (proc, typeof(string));
+                    MessageAssert.HasGameScene (proc, global::KRPC.Service.GameScene.Flight | global::KRPC.Service.GameScene.SpaceCenter);
+                    MessageAssert.IsDeprecated (proc, "Use ExtensionMethod instead.");
+                } else if (proc.Name == "TestClass_ExtensionMethodReturningClassFromOtherService") {
+                    MessageAssert.HasParameters (proc, 1);
+                    MessageAssert.HasParameter (proc, 0, typeof(TestService.TestClass), "this");
+                    MessageAssert.HasReturnType (proc, typeof(TestClass3));
+                    MessageAssert.HasGameScene (proc, global::KRPC.Service.GameScene.Flight | global::KRPC.Service.GameScene.SpaceCenter);
+                    MessageAssert.HasNoDocumentation (proc);
+                } else if (proc.Name == "TestClass_get_ExtensionProperty") {
+                    MessageAssert.HasParameters (proc, 1);
+                    MessageAssert.HasParameter (proc, 0, typeof(TestService.TestClass), "this");
+                    MessageAssert.HasReturnType (proc, typeof(string));
+                    MessageAssert.HasGameScene (proc, global::KRPC.Service.GameScene.Flight | global::KRPC.Service.GameScene.SpaceCenter);
+                    MessageAssert.HasDocumentation (proc, "<doc>\n<summary>\nExtension property documentation string.\n</summary>\n</doc>");
+                } else if (proc.Name == "TestClass_get_ExtensionReadWriteProperty") {
+                    MessageAssert.HasParameters (proc, 1);
+                    MessageAssert.HasParameter (proc, 0, typeof(TestService.TestClass), "this");
+                    MessageAssert.HasReturnType (proc, typeof(int));
+                    MessageAssert.HasGameScene (proc, global::KRPC.Service.GameScene.Flight | global::KRPC.Service.GameScene.SpaceCenter);
+                    MessageAssert.HasNoDocumentation (proc);
+                } else if (proc.Name == "TestClass_set_ExtensionReadWriteProperty") {
+                    MessageAssert.HasParameters (proc, 2);
+                    MessageAssert.HasParameter (proc, 0, typeof(TestService.TestClass), "this");
+                    MessageAssert.HasParameter (proc, 1, typeof(int), "value");
+                    MessageAssert.HasNoReturnType (proc);
+                    MessageAssert.HasGameScene (proc, global::KRPC.Service.GameScene.Flight | global::KRPC.Service.GameScene.SpaceCenter);
+                    MessageAssert.HasNoDocumentation (proc);
+                } else if (proc.Name == "TestClass_get_ExtensionNullableProperty") {
+                    MessageAssert.HasParameters (proc, 1);
+                    MessageAssert.HasParameter (proc, 0, typeof(TestService.TestClass), "this");
+                    MessageAssert.HasReturnType (proc, typeof(TestService.TestClass), true);
+                    MessageAssert.HasGameScene (proc, global::KRPC.Service.GameScene.Flight | global::KRPC.Service.GameScene.SpaceCenter);
+                    MessageAssert.HasNoDocumentation (proc);
+                } else if (proc.Name == "TestClass_set_ExtensionNullableProperty") {
+                    MessageAssert.HasParameters (proc, 2);
+                    MessageAssert.HasParameter (proc, 0, typeof(TestService.TestClass), "this");
+                    MessageAssert.HasNullableParameter (proc, 1, typeof(TestService.TestClass), "value");
+                    MessageAssert.HasNoReturnType (proc);
+                    MessageAssert.HasGameScene (proc, global::KRPC.Service.GameScene.Flight | global::KRPC.Service.GameScene.SpaceCenter);
+                    MessageAssert.HasNoDocumentation (proc);
                 } else {
                     Assert.Fail ("Procedure not found");
                 }
                 foundProcedures++;
             }
-            Assert.AreEqual (65, foundProcedures);
-            Assert.AreEqual (65, service.Procedures.Count);
+            Assert.AreEqual (75, foundProcedures);
+            Assert.AreEqual (75, service.Procedures.Count);
         }
 
         [Test]

--- a/core/test/Service/ServiceSignatureTest.cs
+++ b/core/test/Service/ServiceSignatureTest.cs
@@ -1,0 +1,83 @@
+using KRPC.Service;
+using KRPC.Service.Scanner;
+using NUnit.Framework;
+
+namespace KRPC.Test.Service
+{
+    [TestFixture]
+    public class ServiceSignatureTest
+    {
+        static ServiceSignature ServiceWithTestClass (out string cls)
+        {
+            var service = new ServiceSignature (typeof(TestService), 1);
+            cls = service.AddClass (typeof(TestService.TestClass));
+            return service;
+        }
+
+        [Test]
+        public void ExtensionMemberClashingWithAClassMethod ()
+        {
+            string cls;
+            var service = ServiceWithTestClass (out cls);
+            var classType = typeof(TestService.TestClass);
+            service.AddClassMethod (cls, classType, classType.GetMethod ("FloatToString"));
+            var exn = Assert.Throws<ServiceException> (
+                () => service.AddClassExtensionMethod (
+                    cls, classType, typeof(InvalidExtensions).GetMethod ("FloatToString")));
+            StringAssert.Contains ("InvalidExtensions.FloatToString", exn.Message);
+            StringAssert.Contains ("TestService.TestClass_FloatToString", exn.Message);
+        }
+
+        [Test]
+        public void ExtensionMemberClashingWithAnotherExtensionMember ()
+        {
+            string cls;
+            var service = ServiceWithTestClass (out cls);
+            var classType = typeof(TestService.TestClass);
+            var method = typeof(TestServiceExtensions).GetMethod ("ExtensionMethod");
+            service.AddClassExtensionMethod (cls, classType, method);
+            var exn = Assert.Throws<ServiceException> (
+                () => service.AddClassExtensionMethod (cls, classType, method));
+            StringAssert.Contains ("TestServiceExtensions", exn.Message);
+        }
+
+        [Test]
+        public void ExtensionPropertyClashingWithAClassProperty ()
+        {
+            string cls;
+            var service = ServiceWithTestClass (out cls);
+            var classType = typeof(TestService.TestClass);
+            var property = classType.GetProperty ("ClassPropertyAvailableInInheritedGameScene");
+            service.AddClassProperty (cls, classType, property);
+            var exn = Assert.Throws<ServiceException> (
+                () => service.AddClassExtensionProperty (
+                    cls, classType,
+                    typeof(InvalidExtensions).GetMethod ("SetClassPropertyAvailableInInheritedGameScene")));
+            StringAssert.Contains ("TestService.TestClass_get_ClassPropertyAvailableInInheritedGameScene", exn.Message);
+            StringAssert.Contains ("the class itself", exn.Message);
+        }
+
+        [Test]
+        public void ExtensionPropertyAccessorPair ()
+        {
+            string cls;
+            var service = ServiceWithTestClass (out cls);
+            var classType = typeof(TestService.TestClass);
+            var extensions = typeof(TestServiceExtensions);
+            service.AddClassExtensionProperty (cls, classType, extensions.GetMethod ("GetExtensionReadWriteProperty"));
+            Assert.DoesNotThrow (
+                () => service.AddClassExtensionProperty (
+                    cls, classType, extensions.GetMethod ("SetExtensionReadWriteProperty")));
+        }
+
+        [Test]
+        public void ExtensionMemberOnAClassThatIsNotInTheService ()
+        {
+            var service = new ServiceSignature (typeof(TestService), 1);
+            Assert.Throws<ServiceException> (
+                () => service.AddClassExtensionMethod (
+                    "TestClass", typeof(TestService.TestClass),
+                    typeof(TestServiceExtensions).GetMethod ("ExtensionMethod")));
+        }
+    }
+}

--- a/core/test/Service/TestServiceExtensions.cs
+++ b/core/test/Service/TestServiceExtensions.cs
@@ -1,0 +1,87 @@
+using System;
+using KRPC.Service;
+using KRPC.Service.Attributes;
+
+namespace KRPC.Test.Service
+{
+    /// <summary>
+    /// Members added to classes belonging to other services.
+    /// </summary>
+    public static class TestServiceExtensions
+    {
+        /// <summary>
+        /// Extension method documentation string.
+        /// </summary>
+        [KRPCMethod]
+        public static string ExtensionMethod (this TestService.TestClass obj, int x)
+        {
+            return obj.Value + x;
+        }
+
+        [KRPCMethod (Nullable = true)]
+        public static TestService.TestClass ExtensionNullableMethod (
+            this TestService.TestClass obj, [KRPCNullable] TestService.TestClass other)
+        {
+            return other;
+        }
+
+        [KRPCMethod (GameScene = GameScene.EditorVAB)]
+        public static string ExtensionMethodAvailableInSpecifiedGameScene (this TestService.TestClass obj)
+        {
+            return obj.Value;
+        }
+
+        [Obsolete ("Use ExtensionMethod instead.")]
+        [KRPCMethod]
+        public static string DeprecatedExtensionMethod (this TestService.TestClass obj)
+        {
+            return obj.Value;
+        }
+
+        [KRPCMethod]
+        public static TestClass3 ExtensionMethodReturningClassFromOtherService (this TestService.TestClass obj)
+        {
+            return new TestClass3 ();
+        }
+
+        /// <summary>
+        /// Extension property documentation string.
+        /// </summary>
+        [KRPCProperty]
+        public static string GetExtensionProperty (this TestService.TestClass obj)
+        {
+            return obj.Value;
+        }
+
+        [KRPCProperty]
+        public static int GetExtensionReadWriteProperty (this TestService.TestClass obj)
+        {
+            return obj.IntProperty;
+        }
+
+        [KRPCProperty]
+        public static void SetExtensionReadWriteProperty (this TestService.TestClass obj, int value)
+        {
+            obj.IntProperty = value;
+        }
+
+        [KRPCProperty (Nullable = true)]
+        public static TestService.TestClass GetExtensionNullableProperty (this TestService.TestClass obj)
+        {
+            return obj.ObjectProperty;
+        }
+
+        [KRPCProperty]
+        public static void SetExtensionNullableProperty (
+            this TestService.TestClass obj, [KRPCNullable] TestService.TestClass value)
+        {
+            obj.ObjectProperty = value;
+        }
+
+        [KRPCMethod]
+        public static string ExtensionMethodOnOtherServicesClass (this TestClass3 obj)
+        {
+            return obj == null ? string.Empty : "jeb";
+        }
+    }
+}

--- a/core/test/Service/TypeUtilsTest.cs
+++ b/core/test/Service/TypeUtilsTest.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using KRPC.Service;
 using KRPC.Service.Attributes;
 using KRPC.Service.Messages;
@@ -451,6 +452,70 @@ namespace KRPC.Test.Service
         public void ValidStructFields (Type type)
         {
             Assert.DoesNotThrow (() => TypeUtils.ValidateStructFields (type));
+        }
+
+        static MethodInfo Extension (Type type, string name)
+        {
+            return type.GetMethod (name, BindingFlags.Public | BindingFlags.Static);
+        }
+
+        [TestCase ("ExtensionMethod")]
+        [TestCase ("ExtensionNullableMethod")]
+        [TestCase ("DeprecatedExtensionMethod")]
+        [TestCase ("ExtensionMethodOnOtherServicesClass")]
+        public void ValidExtensionMethod (string name)
+        {
+            Assert.DoesNotThrow (
+                () => TypeUtils.ValidateKRPCExtensionMethod (Extension (typeof(TestServiceExtensions), name)));
+        }
+
+        [TestCase ("MethodWithoutThis")]
+        [TestCase ("MethodExtendingAValueType")]
+        [TestCase ("MethodExtendingAStruct")]
+        [TestCase ("lowerCaseMethod")]
+        public void InvalidExtensionMethod (string name)
+        {
+            Assert.Throws<ServiceException> (
+                () => TypeUtils.ValidateKRPCExtensionMethod (Extension (typeof(InvalidExtensions), name)));
+        }
+
+        [TestCase ("GetExtensionProperty")]
+        [TestCase ("GetExtensionReadWriteProperty")]
+        [TestCase ("SetExtensionReadWriteProperty")]
+        [TestCase ("GetExtensionNullableProperty")]
+        [TestCase ("SetExtensionNullableProperty")]
+        public void ValidExtensionProperty (string name)
+        {
+            Assert.DoesNotThrow (
+                () => TypeUtils.ValidateKRPCExtensionProperty (Extension (typeof(TestServiceExtensions), name)));
+        }
+
+        [TestCase ("PropertyWithoutAnAccessorPrefix")]
+        [TestCase ("GetPropertyWithTooManyParameters")]
+        [TestCase ("GetPropertyWithNoReturnValue")]
+        [TestCase ("SetPropertyWithAReturnValue")]
+        [TestCase ("SetPropertyWithNoValue")]
+        public void InvalidExtensionProperty (string name)
+        {
+            Assert.Throws<ServiceException> (
+                () => TypeUtils.ValidateKRPCExtensionProperty (Extension (typeof(InvalidExtensions), name)));
+        }
+
+        [TestCase ("ExtensionMethod", typeof(TestService.TestClass))]
+        [TestCase ("GetExtensionProperty", typeof(TestService.TestClass))]
+        [TestCase ("ExtensionMethodOnOtherServicesClass", typeof(TestClass3))]
+        public void GetExtensionTargetClass (string name, Type target)
+        {
+            Assert.AreEqual (target, TypeUtils.GetExtensionTargetClass (Extension (typeof(TestServiceExtensions), name)));
+        }
+
+        [TestCase ("GetExtensionProperty", false, "ExtensionProperty")]
+        [TestCase ("SetExtensionReadWriteProperty", true, "ExtensionReadWriteProperty")]
+        public void ExtensionPropertyName (string name, bool isSetter, string propertyName)
+        {
+            var method = Extension (typeof(TestServiceExtensions), name);
+            Assert.AreEqual (isSetter, TypeUtils.IsAnExtensionPropertySetter (method));
+            Assert.AreEqual (propertyName, TypeUtils.GetExtensionPropertyName (method));
         }
 
         [TestCase ("IdentifierName")]

--- a/core/test/Utils/ReflectionTest.cs
+++ b/core/test/Utils/ReflectionTest.cs
@@ -38,6 +38,24 @@ namespace KRPC.Test.Utils
         }
 
         [Test]
+        public void GetStaticClassMethodsWithAttribute ()
+        {
+            var methods = Reflection.GetStaticClassMethodsWith<KRPCMethodAttribute> ().ToList ();
+            Assert.AreEqual (6, methods.Count (x => x.DeclaringType == typeof(TestServiceExtensions)));
+            Assert.AreEqual (
+                5,
+                Reflection.GetStaticClassMethodsWith<KRPCPropertyAttribute> ()
+                .Count (x => x.DeclaringType == typeof(TestServiceExtensions)));
+            // A class that is not public is searched too, so that the scanner can report the
+            // members it puts out of reach, valid or not
+            Assert.AreEqual (5, methods.Count (x => x.DeclaringType == typeof(InvalidExtensions)));
+            CollectionAssert.Contains (methods.Select (x => x.Name).ToList (), "MethodWithoutThis");
+            // Only the assemblies that can declare the attribute are searched
+            var assemblies = methods.Select (x => x.DeclaringType.Assembly).Distinct ().ToList ();
+            CollectionAssert.DoesNotContain (assemblies, typeof(string).Assembly);
+        }
+
+        [Test]
         public void GetPropertiesWithAttribute ()
         {
             Assert.AreEqual (7, Reflection.GetPropertiesWith<KRPCPropertyAttribute> (typeof(TestService)).Count ());

--- a/doc/src/extending.rst
+++ b/doc/src/extending.rst
@@ -248,7 +248,8 @@ to add functionality to the kRPC server.
 
    This `attribute <https://msdn.microsoft.com/en-us/library/aa287992.aspx>`_ is applied to methods
    inside a :csharp:attr:`KRPCClass`. This allows a client to call methods on an instance, or static
-   methods in the class.
+   methods in the class. It can also be applied to a C# extension method, adding a method to a
+   class belonging to another service; see :ref:`service-api-extension-members`.
 
    The method to which this attribute is applied must satisfy the following criteria:
 
@@ -256,7 +257,8 @@ to add functionality to the kRPC server.
 
    * The name of the method must be a valid :ref:`kRPC identifier <service-api-identifiers>`.
 
-   * The method must be declared in a :csharp:attr:`KRPCClass`.
+   * The method must be declared in a :csharp:attr:`KRPCClass`, or be a ``public static`` extension
+     method of one.
 
    * The parameter types and return type must be :ref:`types that kRPC can serialize
      <service-api-serializable-types>`.
@@ -293,7 +295,7 @@ to add functionality to the kRPC server.
       setting from the class the property is defined in.
 
    This `attribute <https://msdn.microsoft.com/en-us/library/aa287992.aspx>`_ is applied to class
-   properties, and comes in two flavors:
+   properties, and comes in three flavors:
 
    1. Applied to static properties in a :csharp:attr:`KRPCService`. In this case, the property must
       satisfy the following criteria:
@@ -313,6 +315,10 @@ to add functionality to the kRPC server.
       * The name of the property must be a valid :ref:`kRPC identifier <service-api-identifiers>`.
 
       * Must be declared inside a :csharp:attr:`KRPCClass`.
+
+   3. Applied to a ``public static`` extension method of a :csharp:attr:`KRPCClass`, adding a
+      property to a class belonging to another service. C# has no extension properties, so the
+      getter and setter are a pair of methods; see :ref:`service-api-extension-members`.
 
    If the property getter might return a null value, or the setter should accept ``null``, the
    ``Nullable`` parameter of the attribute must be set to true. A ``null`` write to a property that
@@ -941,6 +947,149 @@ mechanism: for example, the Python client emits a ``DeprecationWarning`` when a 
 is called, and the generated C#, C++, Java and C-nano client code marks deprecated members with
 ``[Obsolete]``, ``[[deprecated]]``, ``@Deprecated`` and ``KRPC_DEPRECATED`` respectively.
 
+.. _service-api-extension-members:
+
+Extending Other Services
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+A mod can add methods and properties to a class belonging to another service, as
+:csharp:attr:`KRPCClass` lets it add a class to one. A ``TestFlight`` mod can add
+``vessel.parts.with_failure(...)`` to ``SpaceCenter.Parts``. The member is written as a C# extension
+method, and joins the service that owns the type being extended:
+
+.. code-block:: csharp
+
+   public static class TestFlightExtensions {
+       /// <summary>The parts that have the named failure.</summary>
+       [KRPCMethod]
+       public static IList<Part> WithFailure (this Parts parts, string failure)
+       {
+           ...
+       }
+   }
+
+The containing class needs no kRPC attribute, only ``public static``. A dynamic client, such as
+Python or Lua, exposes the member as an ordinary member of the class it extends. A static client,
+such as C#, C++, Java or C-nano, reaches it once its code is regenerated from the mod's assembly
+and the assembly declaring the service being extended; see :ref:`service-api-clientgen`.
+
+C# has no extension properties, so a property is a pair of extension methods named ``GetX`` and
+``SetX``, each carrying :csharp:attr:`KRPCProperty`. The getter takes only the instance and returns
+a value. The setter takes the instance and the value to set, and returns nothing. Either one on its
+own gives a read-only or a write-only property.
+
+.. code-block:: csharp
+
+   [KRPCProperty]
+   public static bool GetFailed (this Parts parts)
+   {
+       ...
+   }
+
+   [KRPCProperty]
+   public static void SetFailed (this Parts parts, bool value)
+   {
+       ...
+   }
+
+An extension member must satisfy the following criteria:
+
+* The method must be a ``public static`` C# extension method, declared in a ``public static`` class
+  outside any :csharp:attr:`KRPCService`. A class that is not public puts its members out of reach,
+  and the server names it in a warning in the log.
+
+* The type it extends must be a :csharp:attr:`KRPCClass`. A :csharp:attr:`KRPCStruct` is a value
+  with a fixed set of fields, and cannot be extended.
+
+* The name of the member must be a valid :ref:`kRPC identifier <service-api-identifiers>`, and must
+  not clash with a member the class already has, or with another extension member. The getter and
+  the setter of an extension property must be declared in the same class.
+
+* The parameter types and return type must be :ref:`types that kRPC can serialize
+  <service-api-serializable-types>`, and may name types from any service.
+
+Deprecation and the ``Nullable`` parameter of the attribute work as they do for a member declared
+in the class. A setter's value is an ordinary parameter, so mark it nullable with
+:csharp:attr:`KRPCNullable`. The ``GameScene`` parameter defaults to the game scenes of the class
+being extended.
+
+Exposing a Part Module as a Class
+"""""""""""""""""""""""""""""""""
+
+A mod that adds a ``PartModule`` to a part can expose it as a class of its own, in place of the
+string-keyed ``SpaceCenter.Module`` API. Declare a :csharp:attr:`KRPCClass` wrapping the module, and
+add a nullable extension property on ``SpaceCenter.Part`` that returns it. The wrapper names the
+module with a ``KRPC.SpaceCenter.ModuleRef``, as ``SpaceCenter.Module`` does:
+
+.. code-block:: csharp
+
+   [KRPCClass (Service = "TestFlight")]
+   public class FailureModule : Equatable<FailureModule>, IGameObjectState {
+       // The part the module is on, and which of the part's modules it is
+       readonly Part part;
+       ModuleRef reference;
+
+       internal FailureModule (Part part, ModuleRef reference)
+       {
+           this.part = part;
+           this.reference = reference;
+       }
+
+       // The module, which every member reaches the game through
+       TestFlightFailure InternalModule {
+           get { return (TestFlightFailure)reference.Get (part.InternalPart); }
+       }
+
+       /// <summary>The state of the module, which is its part's until the part is there to look in.</summary>
+       public GameObjectState GameObjectState {
+           get { return reference.StateOn (part); }
+       }
+
+       /// <summary>Returns true if the objects are equal.</summary>
+       public override bool Equals (FailureModule other)
+       {
+           return !ReferenceEquals (other, null) && part == other.part && reference == other.reference;
+       }
+
+       /// <summary>Hash code for the object.</summary>
+       public override int GetHashCode ()
+       {
+           return Hash.Of (part).And (reference);
+       }
+
+       /// <summary>Whether the part has failed.</summary>
+       [KRPCProperty]
+       public bool Failed { get { return InternalModule.failed; } }
+   }
+
+   public static class TestFlightExtensions {
+       /// <summary>The failure module of the part, or <c>null</c> if it does not have one.</summary>
+       [KRPCProperty (Nullable = true)]
+       public static FailureModule GetFailureModule (this Part part)
+       {
+           var reference = ModuleRef.ForType<TestFlightFailure> (part.InternalPart);
+           return reference == ModuleRef.None ? null : new FailureModule (part, reference);
+       }
+   }
+
+The server keeps the object in a store keyed on the object itself, so the rules the ``SpaceCenter``
+classes follow apply here too. A ``ModuleRef`` names one of a part's modules by its class and its
+position among the part's modules of that class, which outlives any one of them. The wrapper holds
+the part and the reference, and finds the module again on each access.
+
+``Equals`` and ``GetHashCode`` read that identity alone, never a resolved game object, and build the
+hash with ``KRPC.Utils.Hash``. The extension property builds a wrapper on each call, so value
+identity is what keeps the store to one entry for the module.
+
+``ModuleRef.Get`` raises ``KRPC.Service.KRPC.ObjectDestroyedException`` once the part no longer has
+the module. ``ModuleRef.StateOn`` gives the module the state of its part, which is what lets the
+store drop the object once the game destroys the part.
+
+The reference records where it last found the module, so the field holding one is declared without
+``readonly``. A ``readonly`` field is copied on each access, and the record is written to the copy.
+
+Clients reach the module as ``part.failure_module.failed``.
+
 Documentation
 -------------
 
@@ -1006,6 +1155,12 @@ You can then run the script from the command line:
 Client code can be generated either directly from an assembly DLL containing the service, or from a
 JSON file that has previously been generated from an assembly DLL (using the ``--output-defs``
 flag).
+
+.. note::
+
+   Pass every assembly that declares part of the service. A mod adding an extension member to
+   another service's class is generated alongside that service's assembly; see
+   :ref:`service-api-extension-members`.
 
 Generating client code from an assembly DLL requires a copy of Kerbal Space Program and a C# runtime
 to be available on the machine. In contrast, generating client code from a JSON file does not have

--- a/service/SpaceCenter/CHANGELOG.md
+++ b/service/SpaceCenter/CHANGELOG.md
@@ -178,6 +178,8 @@
   - Fix `Experiment.ScienceSubject` adding a new object for every read (#771)
   - Fix `ScienceSubject.Science` and `ScienceSubject.ScienceCap` scaling by the science gain
     multiplier that was in force when the object was read (#1051)
+  - Make `ModuleRef` public, for a mod that exposes a part module as a class of its own
+    service (#1077)
 
 - Resources
   - Add `ResourceTransfer.Cancel` to stop a transfer before it finishes (#1028)

--- a/service/SpaceCenter/src/Lifetime/ModuleRef.cs
+++ b/service/SpaceCenter/src/Lifetime/ModuleRef.cs
@@ -1,3 +1,4 @@
+using System;
 using KRPC.Utils;
 using ObjectDestroyedException = KRPC.Service.KRPC.ObjectDestroyedException;
 
@@ -23,10 +24,18 @@ namespace KRPC.SpaceCenter
     /// nothing to look it up by. Counting the part's modules of the class is what answers
     /// then, and it settles the id and the position again for next time.
     ///
+    /// A reference names a module of a part, and the part is the holder's to supply. An access
+    /// given a different part finds that part's module of the same class and position.
+    ///
+    /// Finding a module records where it was, so a field holding a reference is declared
+    /// without <c>readonly</c>. A <c>readonly</c> field is copied on each access, and the
+    /// record is written to the copy. A property and a <c>List</c> indexer hand back a copy
+    /// in the same way.
+    ///
     /// Nothing here allocates, and nothing is generic on the module type, which in a shared
     /// generic costs more than the lookup itself.
     /// </remarks>
-    struct ModuleRef
+    public struct ModuleRef : IEquatable<ModuleRef>
     {
         // The module's class name, and which of the part's modules of that class this is.
         // A null name stands for no module at all.
@@ -87,10 +96,12 @@ namespace KRPC.SpaceCenter
         }
 
         /// <summary>
-        /// A reference to no module at all, for an object that has one only sometimes.
+        /// A reference to no module at all, for an object that has one only sometimes. It
+        /// compares equal to the default value of the type, which a field holds until one
+        /// is built for it.
         /// </summary>
         public static ModuleRef None {
-            get { return new ModuleRef (null, -1); }
+            get { return new ModuleRef (null, 0); }
         }
 
         /// <summary>

--- a/tools/TestServer/BUILD.bazel
+++ b/tools/TestServer/BUILD.bazel
@@ -28,7 +28,15 @@ lib_deps = [
     "//tools/build/ksp:KRPC.IO.Ports",
 ]
 
-exe_srcs = srcs + ["src/Program.cs"]
+# The extension members, and the service whose class one of them returns, are built into
+# the server but not into the assembly the service definitions are generated from. The
+# bundled stubs therefore lack them, and a client has to pick them up from the definitions
+# the server sends at connect
+exe_srcs = srcs + [
+    "src/Program.cs",
+    "src/TestService2.cs",
+    "src/TestServiceExtensions.cs",
+]
 
 exe_deps = [
     "//core:KRPC.Core.net8",

--- a/tools/TestServer/src/TestServer.csproj
+++ b/tools/TestServer/src/TestServer.csproj
@@ -46,5 +46,7 @@
     </Compile>
     <Compile Include="Program.cs" />
     <Compile Include="TestService.cs" />
+    <Compile Include="TestService2.cs" />
+    <Compile Include="TestServiceExtensions.cs" />
   </ItemGroup>
 </Project>

--- a/tools/TestServer/src/TestService2.cs
+++ b/tools/TestServer/src/TestService2.cs
@@ -1,0 +1,33 @@
+using KRPC.Service.Attributes;
+
+namespace TestServer
+{
+    /// <summary>
+    /// A second service. An extension member of TestService returns its class.
+    /// </summary>
+    [KRPCService (Id = 9997)]
+    public static class TestService2
+    {
+        /// <summary>
+        /// Class documentation string.
+        /// </summary>
+        [KRPCClass]
+        public sealed class TestClass2
+        {
+            readonly string value;
+
+            public TestClass2 (string value)
+            {
+                this.value = value;
+            }
+
+            /// <summary>
+            /// Property documentation string.
+            /// </summary>
+            [KRPCProperty]
+            public string Value {
+                get { return value; }
+            }
+        }
+    }
+}

--- a/tools/TestServer/src/TestServiceExtensions.cs
+++ b/tools/TestServer/src/TestServiceExtensions.cs
@@ -1,0 +1,47 @@
+using KRPC.Service.Attributes;
+
+namespace TestServer
+{
+    /// <summary>
+    /// Members added to TestService's classes from outside TestService.
+    /// </summary>
+    public static class TestServiceExtensions
+    {
+        /// <summary>
+        /// Extension method documentation string.
+        /// </summary>
+        [KRPCMethod]
+        public static string ExtensionMethod (this TestService.TestClass obj, int x)
+        {
+            return obj.GetValue () + x;
+        }
+
+        [KRPCMethod]
+        public static TestService2.TestClass2 ExtensionMethodReturningClassFromOtherService (
+            this TestService.TestClass obj)
+        {
+            return new TestService2.TestClass2 (obj.GetValue ());
+        }
+
+        /// <summary>
+        /// Extension property documentation string.
+        /// </summary>
+        [KRPCProperty]
+        public static string GetExtensionProperty (this TestService.TestClass obj)
+        {
+            return obj.GetValue ();
+        }
+
+        [KRPCProperty]
+        public static int GetExtensionReadWriteProperty (this TestService.TestClass obj)
+        {
+            return obj.IntProperty;
+        }
+
+        [KRPCProperty]
+        public static void SetExtensionReadWriteProperty (this TestService.TestClass obj, int value)
+        {
+            obj.IntProperty = value;
+        }
+    }
+}


### PR DESCRIPTION
**Extension members.** A service can add a method or property to a class belonging to another service. The member is a `public static` C# extension method annotated with `KRPCMethod`, or a `GetX`/`SetX` pair annotated with `KRPCProperty`. The scanner adds it to the extended class's own service definition as an ordinary class member, so a client needs nothing new to reach it.

**Dynamic clients.** A service with pre-generated stubs was built from the stubs alone, dropping any class member that only the server's definition declares. The Python client now merges the live definition into the stub classes at connect. This is what carries an extension member to the client, and it also exposes the members a newer server has gained.

**Part modules.** `KRPC.SpaceCenter.ModuleRef` is public, so a mod can expose its own `PartModule` as a class of its own service and find the module again on each access. The service API guide walks through one.

**Testing.** `TestService`'s classes in the test server gain extension members, and its bundled stubs are generated without them. The Python and Lua client tests reach the members through the definitions the server sends at connect.

Fixes #305

Fixes #900
