### PR TITLE
RCS force and torque

### DIFF
--- a/doc/order.txt
+++ b/doc/order.txt
@@ -1117,6 +1117,8 @@ SpaceCenter.RCS.AvailableTorque
 SpaceCenter.RCS.AvailableForce
 SpaceCenter.RCS.Force
 SpaceCenter.RCS.Torque
+SpaceCenter.RCS.OverrideForce
+SpaceCenter.RCS.OverrideTorque
 SpaceCenter.RCS.AvailableThrust
 SpaceCenter.RCS.MaxThrust
 SpaceCenter.RCS.MaxVacuumThrust

--- a/doc/order.txt
+++ b/doc/order.txt
@@ -1238,6 +1238,7 @@ SpaceCenter.SolarPanel.EnergyFlow
 SpaceCenter.SolarPanel.SunExposure
 SpaceCenter.Thruster
 SpaceCenter.Thruster.Part
+SpaceCenter.Thruster.Thrust
 SpaceCenter.Thruster.ThrustPosition
 SpaceCenter.Thruster.ThrustDirection
 SpaceCenter.Thruster.ThrustReferenceFrame

--- a/doc/order.txt
+++ b/doc/order.txt
@@ -1115,6 +1115,8 @@ SpaceCenter.RCS.RotationOverride
 SpaceCenter.RCS.TranslationOverride
 SpaceCenter.RCS.AvailableTorque
 SpaceCenter.RCS.AvailableForce
+SpaceCenter.RCS.Force
+SpaceCenter.RCS.Torque
 SpaceCenter.RCS.AvailableThrust
 SpaceCenter.RCS.MaxThrust
 SpaceCenter.RCS.MaxVacuumThrust

--- a/service/SpaceCenter/CHANGELOG.md
+++ b/service/SpaceCenter/CHANGELOG.md
@@ -143,6 +143,12 @@
   - Setting `Control.StageLock` leaves the in-game Alt+L shortcut in step with it (#1022)
 
 - Parts
+  - **Breaking:** `RCS.TranslationOverride` thrusts along the right, up and forward axes it
+    documents (#1080)
+  - Add `RCS.Force` and `RCS.Torque`, the force and torque a block is applying, and
+    `RCS.OverrideForce` and `RCS.OverrideTorque`, what a given demand would apply (#1080)
+  - Add `Thruster.Thrust`, the thrust a single nozzle of an engine or RCS block is producing
+    (#1080)
   - `RCS.Thrusters`, `RCS.AvailableForce` and `RCS.AvailableTorque` count only the nozzles of
     the part's selected variant (#1079)
   - `Decoupler.IsOmniDecoupler` reports what the part is configured as for every decoupler,

--- a/service/SpaceCenter/src/ActuatorControlAddon.cs
+++ b/service/SpaceCenter/src/ActuatorControlAddon.cs
@@ -71,12 +71,12 @@ namespace KRPC.SpaceCenter
 
             public override Vector3 ApplyInputRotationAdjustment (Vector3 inputRotation)
             {
-                return ToWorld () * Rotation;
+                return ToWorld () * RCSRotationInput (Rotation);
             }
 
             public override Vector3 ApplyInputLinearAdjustment (Vector3 inputLinear)
             {
-                return ToWorld () * Linear;
+                return ToWorld () * RCSTranslationInput (Linear);
             }
         }
 
@@ -234,6 +234,24 @@ namespace KRPC.SpaceCenter
         internal static void SetRCSOverride (ModuleRCS module, bool enabled)
         {
             rcs.Set (module, enabled);
+        }
+
+        /// <summary>
+        /// The rotation demand as the module's own rotation input. RCS.OverrideTorque predicts
+        /// through the same mapping, so the prediction follows the override.
+        /// </summary>
+        internal static Vector3 RCSRotationInput (Vector3 rotation)
+        {
+            return rotation;
+        }
+
+        /// <summary>
+        /// The translation demand as the module's own linear input. RCS.OverrideForce predicts
+        /// through the same mapping, so the prediction follows the override.
+        /// </summary>
+        internal static Vector3 RCSTranslationInput (Vector3 translation)
+        {
+            return translation;
         }
 
         internal static Vector3 GetRCSRotation (ModuleRCS module)

--- a/service/SpaceCenter/src/ActuatorControlAddon.cs
+++ b/service/SpaceCenter/src/ActuatorControlAddon.cs
@@ -246,12 +246,15 @@ namespace KRPC.SpaceCenter
         }
 
         /// <summary>
-        /// The translation demand as the module's own linear input. RCS.OverrideForce predicts
-        /// through the same mapping, so the prediction follows the override.
+        /// The translation demand as the module's own linear input. ModuleRCS takes
+        /// (-right, -forward, up) and thrusts along the negative of it, so the right, up and
+        /// forward demand is negated and reordered to match the cooked control input.
+        /// RCS.OverrideForce predicts through the same mapping, so the prediction follows the
+        /// override.
         /// </summary>
         internal static Vector3 RCSTranslationInput (Vector3 translation)
         {
-            return translation;
+            return new Vector3 (-translation.x, -translation.z, translation.y);
         }
 
         internal static Vector3 GetRCSRotation (ModuleRCS module)

--- a/service/SpaceCenter/src/Services/Parts/RCS.cs
+++ b/service/SpaceCenter/src/Services/Parts/RCS.cs
@@ -227,11 +227,53 @@ namespace KRPC.SpaceCenter.Services.Parts
         }
 
         /// <summary>
+        /// The force being applied by the RCS thrusters, in Newtons. The vector is in the
+        /// vessel's reference frame (<see cref="Vessel.ReferenceFrame"/>).
+        /// Returns zero if the RCS is inactive.
+        /// </summary>
+        [KRPCProperty]
+        public Tuple3 Force {
+            get { return AppliedForceAndTorque ().Item1.ToTuple (); }
+        }
+
+        /// <summary>
+        /// The torque being applied by the RCS thrusters about the vessel's center of mass,
+        /// in Newton meters. The vector is in the vessel's reference frame
+        /// (<see cref="Vessel.ReferenceFrame"/>). Returns zero if the RCS is inactive.
+        /// </summary>
+        [KRPCProperty]
+        public Tuple3 Torque {
+            get { return AppliedForceAndTorque ().Item2.ToTuple (); }
+        }
+
+        /// <summary>
         /// Whether the game has stopped allocating thrust to the nozzles. ModuleRCS returns
         /// early from its update in high warp, leaving the last allocation in place.
         /// </summary>
         internal static bool ThrustAllocationStale {
             get { return TimeWarp.CurrentRate > 1f && TimeWarp.WarpMode == TimeWarp.Modes.HIGH; }
+        }
+
+        /// <summary>
+        /// Sums the force and torque the game allocated to each nozzle in the last physics
+        /// frame, in the vessel's reference frame.
+        /// </summary>
+        TupleV3 AppliedForceAndTorque ()
+        {
+            if (!Active || ThrustAllocationStale)
+                return ITorqueProviderExtensions.zero;
+            var frame = Part.Vessel.ReferenceFrame;
+            var force = Vector3d.zero;
+            var torque = Vector3d.zero;
+            foreach (var thruster in Thrusters) {
+                var thrust = thruster.Thrust;
+                if (thrust <= 0f)
+                    continue;
+                var thrusterForce = thruster.ThrustDirection (frame).ToVector () * thrust;
+                force += thrusterForce;
+                torque += Vector3d.Cross (thruster.ThrustPosition (frame).ToVector (), thrusterForce);
+            }
+            return new TupleV3 (force, torque);
         }
 
         /// <summary>

--- a/service/SpaceCenter/src/Services/Parts/RCS.cs
+++ b/service/SpaceCenter/src/Services/Parts/RCS.cs
@@ -5,6 +5,7 @@ using KRPC.Service;
 using KRPC.Service.Attributes;
 using KRPC.SpaceCenter.ExtensionMethods;
 using KRPC.Utils;
+using UnityEngine;
 using Tuple3 = System.Tuple<double, double, double>;
 using TupleV3 = System.Tuple<Vector3d, Vector3d>;
 using TupleT3 = System.Tuple<System.Tuple<double, double, double>, System.Tuple<double, double, double>>;
@@ -247,6 +248,46 @@ namespace KRPC.SpaceCenter.Services.Parts
         }
 
         /// <summary>
+        /// The force the given demands would produce, in Newtons. The vector is in the
+        /// vessel's reference frame (<see cref="Vessel.ReferenceFrame"/>).
+        /// Returns zero if the RCS is inactive.
+        /// </summary>
+        /// <returns>The force as a vector.</returns>
+        /// <param name="rotation">A rotation demand, as set by
+        /// <see cref="RotationOverride"/>.</param>
+        /// <param name="translation">A translation demand, as set by
+        /// <see cref="TranslationOverride"/>.</param>
+        /// <remarks>
+        /// The demands do not have to be applied. The prediction leaves out precision mode,
+        /// full thrust and the lever divisor, which <see cref="Force"/> includes.
+        /// </remarks>
+        [KRPCMethod]
+        public Tuple3 OverrideForce (Tuple3 rotation, Tuple3 translation)
+        {
+            return DemandForceAndTorque (rotation, translation).Item1.ToTuple ();
+        }
+
+        /// <summary>
+        /// The torque the given demands would produce about the vessel's center of mass, in
+        /// Newton meters. The vector is in the vessel's reference frame
+        /// (<see cref="Vessel.ReferenceFrame"/>). Returns zero if the RCS is inactive.
+        /// </summary>
+        /// <returns>The torque as a vector.</returns>
+        /// <param name="rotation">A rotation demand, as set by
+        /// <see cref="RotationOverride"/>.</param>
+        /// <param name="translation">A translation demand, as set by
+        /// <see cref="TranslationOverride"/>.</param>
+        /// <remarks>
+        /// The demands do not have to be applied. The prediction leaves out precision mode,
+        /// full thrust and the lever divisor, which <see cref="Torque"/> includes.
+        /// </remarks>
+        [KRPCMethod]
+        public Tuple3 OverrideTorque (Tuple3 rotation, Tuple3 translation)
+        {
+            return DemandForceAndTorque (rotation, translation).Item2.ToTuple ();
+        }
+
+        /// <summary>
         /// Whether the game has stopped allocating thrust to the nozzles. ModuleRCS returns
         /// early from its update in high warp, leaving the last allocation in place.
         /// </summary>
@@ -272,6 +313,41 @@ namespace KRPC.SpaceCenter.Services.Parts
                 var thrusterForce = thruster.ThrustDirection (frame).ToVector () * thrust;
                 force += thrusterForce;
                 torque += Vector3d.Cross (thruster.ThrustPosition (frame).ToVector (), thrusterForce);
+            }
+            return new TupleV3 (force, torque);
+        }
+
+        /// <summary>
+        /// Runs the game's thrust allocation over the nozzles for the given demands, in the
+        /// vessel's reference frame. A nozzle fires when its exhaust aligns with the demand,
+        /// hence the sign of each dot product, and the two terms are summed before the clamp.
+        /// </summary>
+        TupleV3 DemandForceAndTorque (Tuple3 rotationDemand, Tuple3 translationDemand)
+        {
+            if (!Active)
+                return ITorqueProviderExtensions.zero;
+            // The demands go through the mapping the override applies, clamped as its setters
+            // clamp them
+            Vector3 rotationInput = rotationDemand.ToVector ();
+            Vector3 translationInput = translationDemand.ToVector ();
+            Vector3d rotation = ActuatorControlAddon.RCSRotationInput (rotationInput.Clamp (-1f, 1f));
+            Vector3d translation = ActuatorControlAddon.RCSTranslationInput (translationInput.Clamp (-1f, 1f));
+            var frame = Part.Vessel.ReferenceFrame;
+            var thrust = AvailableThrust;
+            var force = Vector3d.zero;
+            var torque = Vector3d.zero;
+            foreach (var thruster in Thrusters) {
+                var direction = thruster.ThrustDirection (frame).ToVector ();
+                var position = thruster.ThrustPosition (frame).ToVector ();
+                var demand = Math.Max (0, -Vector3d.Dot (direction, translation));
+                if (rotation != Vector3d.zero) {
+                    var lever = Vector3d.Exclude (rotation, position);
+                    if (lever.sqrMagnitude > 0)
+                        demand += Math.Max (0, -Vector3d.Dot (direction, Vector3d.Cross (rotation, lever.normalized)));
+                }
+                var thrusterForce = direction * Math.Min (demand, 1) * thrust;
+                force += thrusterForce;
+                torque += Vector3d.Cross (position, thrusterForce);
             }
             return new TupleV3 (force, torque);
         }

--- a/service/SpaceCenter/src/Services/Parts/RCS.cs
+++ b/service/SpaceCenter/src/Services/Parts/RCS.cs
@@ -227,6 +227,14 @@ namespace KRPC.SpaceCenter.Services.Parts
         }
 
         /// <summary>
+        /// Whether the game has stopped allocating thrust to the nozzles. ModuleRCS returns
+        /// early from its update in high warp, leaving the last allocation in place.
+        /// </summary>
+        internal static bool ThrustAllocationStale {
+            get { return TimeWarp.CurrentRate > 1f && TimeWarp.WarpMode == TimeWarp.Modes.HIGH; }
+        }
+
+        /// <summary>
         /// Calculates available torque vectors.
         /// We use this custom code rather than KSPs ITorqueProvider as it produces erroneous values.
         /// </summary>

--- a/service/SpaceCenter/src/Services/Parts/Thruster.cs
+++ b/service/SpaceCenter/src/Services/Parts/Thruster.cs
@@ -94,6 +94,28 @@ namespace KRPC.SpaceCenter.Services.Parts
         }
 
         /// <summary>
+        /// The thrust being produced by the thruster, in Newtons.
+        /// </summary>
+        [KRPCProperty]
+        public float Thrust {
+            get {
+                var engine = InternalEngine;
+                if (engine != null) {
+                    // The engine's thrust is split across its nozzles by these weights
+                    var multipliers = engine.thrustTransformMultipliers;
+                    if (multipliers == null || transformIndex >= multipliers.Count)
+                        return 0f;
+                    return engine.finalThrust * multipliers [transformIndex] * 1000f;
+                }
+                // ModuleRCS records the thrust it allocated to each nozzle, in kilonewtons
+                var forces = InternalRCS.thrustForces;
+                if (RCS.ThrustAllocationStale || forces == null || transformIndex >= forces.Length)
+                    return 0f;
+                return forces [transformIndex] * 1000f;
+            }
+        }
+
+        /// <summary>
         /// The position at which the thruster generates thrust, in the given reference frame.
         /// For gimballed engines, this takes into account the current rotation of the gimbal.
         /// </summary>

--- a/service/SpaceCenter/test/test_parts_engine.py
+++ b/service/SpaceCenter/test/test_parts_engine.py
@@ -282,6 +282,23 @@ class TestPartsEngine(krpctest.TestCase, EngineTestBase):
         self.vessel.control.throttle = 0
         engine.active = False
 
+    def test_thruster_thrust(self):
+        engine = self.get_engine("liquidEngine")  # LV-T30 "Reliant"
+        for thruster in engine.thrusters:
+            self.assertEqual(0, thruster.thrust)
+        engine.thrust_limit = 1
+        engine.active = True
+        self.vessel.control.throttle = 1
+        self.wait(0.5)
+        # The engine's thrust is split across its nozzles
+        self.assertGreater(engine.thrust, 0)
+        self.assertAlmostEqual(
+            engine.thrust, sum(t.thrust for t in engine.thrusters), delta=1
+        )
+        self.vessel.control.throttle = 0
+        engine.active = False
+        self.wait_until(lambda: all(t.thrust == 0 for t in engine.thrusters))
+
     def test_thrust_limit(self):
         engine = self.get_engine("liquidEngine")  # LV-T30 "Reliant"
         thrust = 205600

--- a/service/SpaceCenter/test/test_parts_rcs.py
+++ b/service/SpaceCenter/test/test_parts_rcs.py
@@ -1,6 +1,6 @@
 import unittest
 import krpctest
-from krpctest.geometry import distance, norm
+from krpctest.geometry import cross, distance, norm
 
 
 class RCSTestBase:
@@ -236,6 +236,40 @@ class TestPartsRCS(krpctest.TestCase, RCSTestBase):
         rcs.rotation_override = rotation
         rcs.translation_override = translation
         self.wait(0.5)
+
+    def test_force_and_torque(self):
+        rcs = self.get_rcs("RCSBlock.v2")
+        self.control.rcs = True
+        self.wait()
+        self.assertAlmostEqual((0, 0, 0), rcs.force)
+        self.assertAlmostEqual((0, 0, 0), rcs.torque)
+        try:
+            self.override(rcs, translation=(0, 0, 1))
+            self.assertGreater(norm(rcs.force), 0)
+        finally:
+            rcs.input_override = False
+        self.wait(0.5)
+        self.assertAlmostEqual((0, 0, 0), rcs.force)
+        self.assertAlmostEqual((0, 0, 0), rcs.torque)
+
+    def test_force_and_torque_match_the_thrusters(self):
+        rcs = self.get_rcs("RCSBlock.v2")
+        frame = self.vessel.reference_frame
+        try:
+            self.override(rcs, rotation=(1, 0, 0), translation=(0, 0, 1))
+            force = (0.0, 0.0, 0.0)
+            torque = (0.0, 0.0, 0.0)
+            for thruster in rcs.thrusters:
+                thrust = thruster.thrust
+                nozzle = tuple(x * thrust for x in thruster.thrust_direction(frame))
+                position = thruster.thrust_position(frame)
+                force = tuple(a + b for a, b in zip(force, nozzle))
+                torque = tuple(a + b for a, b in zip(torque, cross(position, nozzle)))
+            self.assertGreater(norm(force), 0)
+            self.assertAlmostEqual(force, rcs.force, delta=1)
+            self.assertAlmostEqual(torque, rcs.torque, delta=1)
+        finally:
+            rcs.input_override = False
 
     def test_thruster_thrust(self):
         rcs = self.get_rcs("RCSBlock.v2")

--- a/service/SpaceCenter/test/test_parts_rcs.py
+++ b/service/SpaceCenter/test/test_parts_rcs.py
@@ -228,6 +228,33 @@ class TestPartsRCS(krpctest.TestCase, RCSTestBase):
         self.assertFalse(rcs.input_override)
         self.assertAlmostEqual((0, 0, 0), rcs.rotation_override)
 
+    def override(self, rcs, rotation=(0, 0, 0), translation=(0, 0, 0)):
+        """Drive a block with the given demands, and wait for the game to
+        allocate thrust to its nozzles."""
+        self.control.rcs = True
+        rcs.input_override = True
+        rcs.rotation_override = rotation
+        rcs.translation_override = translation
+        self.wait(0.5)
+
+    def test_thruster_thrust(self):
+        rcs = self.get_rcs("RCSBlock.v2")
+        self.control.rcs = True
+        self.wait()
+        for thruster in rcs.thrusters:
+            self.assertEqual(0, thruster.thrust)
+        try:
+            self.override(rcs, translation=(0, 0, 1))
+            thrusts = [thruster.thrust for thruster in rcs.thrusters]
+            self.assertGreater(max(thrusts), 0)
+            for thrust in thrusts:
+                self.assertLessEqual(thrust, rcs.max_thrust + 1)
+        finally:
+            rcs.input_override = False
+        self.wait(0.5)
+        for thruster in rcs.thrusters:
+            self.assertEqual(0, thruster.thrust)
+
     def test_thrusters_match_the_part_variant(self):
         """The RV-105 mesh carries the nozzles of every variant, and the game
         fires only the ones the chosen variant leaves active."""

--- a/service/SpaceCenter/test/test_parts_rcs.py
+++ b/service/SpaceCenter/test/test_parts_rcs.py
@@ -237,6 +237,53 @@ class TestPartsRCS(krpctest.TestCase, RCSTestBase):
         rcs.translation_override = translation
         self.wait(0.5)
 
+    def check_override_matches_control(self, rcs, name, demand, rotation):
+        """Drive an axis with the cooked control, then with the equivalent
+        override demand, and compare what the block applies."""
+        setattr(self.control, name, 1)
+        self.wait(0.5)
+        cooked = rcs.torque if rotation else rcs.force
+        setattr(self.control, name, 0)
+        self.wait(0.5)
+        if rotation:
+            self.override(rcs, rotation=demand)
+        else:
+            self.override(rcs, translation=demand)
+        self.assertGreater(norm(cooked), 0)
+        self.assertAlmostEqual(cooked, rcs.torque if rotation else rcs.force, delta=2)
+        rcs.input_override = False
+        self.wait(0.5)
+
+    def test_translation_override_axes(self):
+        rcs = self.get_rcs("RCSBlock.v2")
+        self.control.rcs = True
+        try:
+            for name, demand in (
+                ("right", (1, 0, 0)),
+                ("up", (0, 1, 0)),
+                ("forward", (0, 0, 1)),
+            ):
+                self.check_override_matches_control(rcs, name, demand, False)
+        finally:
+            for name in ("right", "up", "forward"):
+                setattr(self.control, name, 0)
+            rcs.input_override = False
+
+    def test_rotation_override_axes(self):
+        rcs = self.get_rcs("RCSBlock.v2")
+        self.control.rcs = True
+        try:
+            for name, demand in (
+                ("pitch", (1, 0, 0)),
+                ("roll", (0, 1, 0)),
+                ("yaw", (0, 0, 1)),
+            ):
+                self.check_override_matches_control(rcs, name, demand, True)
+        finally:
+            for name in ("pitch", "roll", "yaw"):
+                setattr(self.control, name, 0)
+            rcs.input_override = False
+
     def test_force_and_torque(self):
         rcs = self.get_rcs("RCSBlock.v2")
         self.control.rcs = True

--- a/service/SpaceCenter/test/test_parts_rcs.py
+++ b/service/SpaceCenter/test/test_parts_rcs.py
@@ -271,6 +271,38 @@ class TestPartsRCS(krpctest.TestCase, RCSTestBase):
         finally:
             rcs.input_override = False
 
+    def test_override_force_and_torque_predict_what_is_applied(self):
+        rcs = self.get_rcs("RCSBlock.v2")
+        self.control.rcs = True
+        self.wait()
+        demands = (
+            ((0, 0, 0), (0, 0, 1)),
+            ((1, 0, 0), (0, 0, 0)),
+            ((0, 0.5, 0), (0.5, 0, 0)),
+        )
+        try:
+            for rotation, translation in demands:
+                force = rcs.override_force(rotation, translation)
+                torque = rcs.override_torque(rotation, translation)
+                self.override(rcs, rotation=rotation, translation=translation)
+                self.assertAlmostEqual(force, rcs.force, delta=1)
+                self.assertAlmostEqual(torque, rcs.torque, delta=1)
+        finally:
+            rcs.input_override = False
+
+    def test_override_force_lies_within_the_available_force(self):
+        rcs = self.get_rcs("RCSBlock.v2")
+        self.control.rcs = True
+        self.wait()
+        positive, negative = rcs.available_force
+        for axis in range(3):
+            for sign in (1, -1):
+                translation = tuple(sign if i == axis else 0 for i in range(3))
+                force = rcs.override_force((0, 0, 0), translation)
+                for i in range(3):
+                    self.assertLessEqual(force[i], positive[i] + 1)
+                    self.assertGreaterEqual(force[i], negative[i] - 1)
+
     def test_thruster_thrust(self):
         rcs = self.get_rcs("RCSBlock.v2")
         self.control.rcs = True


### PR DESCRIPTION
**What a block applies.** `RCS.Force` and `RCS.Torque` sum the thrust the game allocated to each nozzle, about the vessel's center of mass, in the vessel's reference frame. `Thruster.Thrust` reports one nozzle's share of it, for an RCS block and for an engine.

**What a demand would apply.** `RCS.OverrideForce` and `RCS.OverrideTorque` run the game's allocation for demands that are not applied, so a script can size a translation before committing to it. Six calls with a unit demand on each axis give a block's whole allocation, including the off-axis coupling of a block whose nozzles sit at different positions, such as the RCS built into a command pod. The prediction leaves out precision mode, full thrust and the lever divisor, which the measured `Force` and `Torque` carry.

**Breaking.** `RCS.TranslationOverride` wrote its demand into `ModuleRCS.inputLin` unchanged. The game reads that as (-right, -forward, up) and thrusts along the negative of it, so the documented right, up and forward axes moved the vessel left, aft and up. The override and the prediction now share one mapping, so the two cannot drift apart.

**Testing.** Verified in game against an RV-105. Each axis is driven by the cooked control and then by the equivalent override demand, comparing the force the block applies; the prediction is compared against the measurement a physics frame later; and the torque is compared against the geometry it came from.