### PR TITLE
Precision mode

### DIFF
--- a/doc/order.txt
+++ b/doc/order.txt
@@ -491,6 +491,7 @@ SpaceCenter.Control.Roll
 SpaceCenter.Control.PitchTrim
 SpaceCenter.Control.YawTrim
 SpaceCenter.Control.RollTrim
+SpaceCenter.Control.PrecisionMode
 SpaceCenter.Control.Forward
 SpaceCenter.Control.Up
 SpaceCenter.Control.Right

--- a/service/SpaceCenter/CHANGELOG.md
+++ b/service/SpaceCenter/CHANGELOG.md
@@ -141,6 +141,8 @@
     standing at, and `Control.GrabLadder`, `Control.ReleaseLadder` and `Control.Ladder` for
     the ladder it is alongside (#319)
   - Setting `Control.StageLock` leaves the in-game Alt+L shortcut in step with it (#1022)
+  - Add `Control.PrecisionMode`, the precision control mode that the Caps Lock key
+    toggles (#1082)
 
 - Parts
   - **Breaking:** `RCS.TranslationOverride` thrusts along the right, up and forward axes it
@@ -149,6 +151,9 @@
     `RCS.OverrideForce` and `RCS.OverrideTorque`, what a given demand would apply (#1080)
   - Add `Thruster.Thrust`, the thrust a single nozzle of an engine or RCS block is producing
     (#1080)
+  - `RCS.AvailableForce` and `RCS.AvailableTorque`, and the vessel level force, torque and
+    acceleration properties that include them, account for precision mode (#1082)
+  - Precision mode leaves a block driven by `RCS.InputOverride` at full thrust (#1082)
   - `RCS.Thrusters`, `RCS.AvailableForce` and `RCS.AvailableTorque` count only the nozzles of
     the part's selected variant (#1079)
   - `Decoupler.IsOmniDecoupler` reports what the part is configured as for every decoupler,

--- a/service/SpaceCenter/src/ActuatorControlAddon.cs
+++ b/service/SpaceCenter/src/ActuatorControlAddon.cs
@@ -92,11 +92,15 @@ namespace KRPC.SpaceCenter
         }
 
         /// <summary>
-        /// An RCS override, installed as an adjuster on the module.
+        /// An RCS override, installed as an adjuster on the module. Precision mode weakens
+        /// every nozzle, and the two fields its branch reads are saved and neutralized so
+        /// that an overridden block thrusts at full force.
         /// </summary>
         sealed class RCSEntry : ClientOwnedEntry
         {
             public RCSAdjuster Adjuster;
+            public bool SavedUseLever;
+            public float SavedPrecisionFactor;
         }
 
         /// <summary>
@@ -215,15 +219,26 @@ namespace KRPC.SpaceCenter
 
         static RCSEntry InstallRCS (ModuleRCS module)
         {
-            var entry = new RCSEntry { Adjuster = new RCSAdjuster { Module = module } };
+            var entry = new RCSEntry {
+                Adjuster = new RCSAdjuster { Module = module },
+                SavedUseLever = module.useLever,
+                SavedPrecisionFactor = module.precisionFactor
+            };
+            // ModuleRCS reads these two fields only inside its precision mode branch, so a
+            // fixed factor of one makes the branch a no-op
+            module.useLever = false;
+            module.precisionFactor = 1f;
             CacheAdd (rcsAdjusterCache, module, entry.Adjuster);
             return entry;
         }
 
         static void ReleaseRCS (ModuleRCS module, RCSEntry entry)
         {
-            if (!Destroyed (module))
-                CacheRemove (rcsAdjusterCache, module, entry.Adjuster);
+            if (Destroyed (module))
+                return;
+            CacheRemove (rcsAdjusterCache, module, entry.Adjuster);
+            module.useLever = entry.SavedUseLever;
+            module.precisionFactor = entry.SavedPrecisionFactor;
         }
 
         internal static bool GetRCSOverride (ModuleRCS module)

--- a/service/SpaceCenter/src/Services/Control.cs
+++ b/service/SpaceCenter/src/Services/Control.cs
@@ -575,6 +575,37 @@ namespace KRPC.SpaceCenter.Services
         }
 
         /// <summary>
+        /// Whether precision control mode is enabled.
+        /// Equivalent to the Caps Lock key.
+        /// This is a game setting rather than a vessel setting,
+        /// and can only be accessed for the active vessel.
+        /// Unlike the pitch, yaw and roll control inputs, precision mode is not cleared
+        /// when clients disconnect.
+        /// </summary>
+        /// <remarks>
+        /// Precision mode weakens the RCS thrust that the control inputs produce. A block
+        /// driven by <see cref="Parts.RCS.InputOverride"/> is exempt.
+        /// </remarks>
+        [KRPCProperty]
+        public bool PrecisionMode {
+            get {
+                CheckActiveVessel ();
+                var handler = FlightInputHandler.fetch;
+                return handler != null && handler.precisionMode;
+            }
+            set {
+                CheckActiveVessel ();
+                var handler = FlightInputHandler.fetch;
+                if (handler == null || handler.precisionMode == value)
+                    return;
+                handler.precisionMode = value;
+                // The nav-ball control gauges recolor off this event, which the game fires
+                // when the keybinding toggles the flag
+                GameEvents.Input.OnPrecisionModeToggle.Fire (value);
+            }
+        }
+
+        /// <summary>
         /// The state of the forward translational control.
         /// A value between -1 and 1.
         /// Equivalent to the h and n keys.

--- a/service/SpaceCenter/src/Services/Parts/RCS.cs
+++ b/service/SpaceCenter/src/Services/Parts/RCS.cs
@@ -196,6 +196,11 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// correspond to the coordinate axes of the <see cref="Vessel.ReferenceFrame"/>.
         /// Returns zero if RCS is disable.
         /// </summary>
+        /// <remarks>
+        /// Precision mode weakens the block, and the available torque follows it. A block
+        /// driven by <see cref="InputOverride"/> is exempt, so <see cref="OverrideTorque"/>
+        /// can report the larger torque an override reaches.
+        /// </remarks>
         [KRPCProperty]
         public TupleT3 AvailableTorque {
             get { return AvailableTorqueVectors.ToTuple (); }
@@ -215,6 +220,11 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// correspond to the coordinate axes of the <see cref="Vessel.ReferenceFrame"/>.
         /// Returns zero if RCS is disabled.
         /// </summary>
+        /// <remarks>
+        /// Precision mode weakens the block, and the available force follows it. A block
+        /// driven by <see cref="InputOverride"/> is exempt, so <see cref="OverrideForce"/>
+        /// can report the larger force an override reaches.
+        /// </remarks>
         [KRPCProperty]
         public TupleT3 AvailableForce {
             get { return AvailableForceVectors.ToTuple (); }
@@ -354,6 +364,24 @@ namespace KRPC.SpaceCenter.Services.Parts
         }
 
         /// <summary>
+        /// The factor precision mode applies to a nozzle's thrust. The game either divides by
+        /// the nozzle's lever arm about the center of mass, or scales by a fixed factor. The
+        /// vessel reference frame is centered on the center of mass, so the thrust position is
+        /// the lever arm. Reading the module's own two fields keeps an overridden block, whose
+        /// install neutralizes them, at full thrust.
+        /// </summary>
+        double PrecisionFactor (Tuple3 direction, Tuple3 position)
+        {
+            var handler = FlightInputHandler.fetch;
+            if (handler == null || !handler.precisionMode)
+                return 1;
+            if (!InternalRCS.useLever)
+                return InternalRCS.precisionFactor;
+            var lever = Vector3d.Exclude (direction.ToVector (), position.ToVector ()).magnitude;
+            return lever > 1 ? 1 / lever : 1;
+        }
+
+        /// <summary>
         /// Calculates available torque vectors.
         /// We use this custom code rather than KSPs ITorqueProvider as it produces erroneous values.
         /// </summary>
@@ -371,9 +399,10 @@ namespace KRPC.SpaceCenter.Services.Parts
                 // torque = cross product of position and force
                 var thrustPosition = thruster.ThrustPosition(frame);
                 var thrustDirection = thruster.ThrustDirection(frame);
-                var forceX = thrustDirection.Item1 * thrust;
-                var forceY = thrustDirection.Item2 * thrust;
-                var forceZ = thrustDirection.Item3 * thrust;
+                var nozzleThrust = thrust * PrecisionFactor (thrustDirection, thrustPosition);
+                var forceX = thrustDirection.Item1 * nozzleThrust;
+                var forceY = thrustDirection.Item2 * nozzleThrust;
+                var forceZ = thrustDirection.Item3 * nozzleThrust;
                 var posX = thrustPosition.Item1;
                 var posY = thrustPosition.Item2;
                 var posZ = thrustPosition.Item3;
@@ -409,9 +438,11 @@ namespace KRPC.SpaceCenter.Services.Parts
             var forceN = Vector3d.zero;
             foreach (var thruster in Thrusters) {
                 var thrustDirection = thruster.ThrustDirection (frame);
-                var forceX = thrustDirection.Item1 * thrust;
-                var forceY = thrustDirection.Item2 * thrust;
-                var forceZ = thrustDirection.Item3 * thrust;
+                var thrustPosition = thruster.ThrustPosition (frame);
+                var nozzleThrust = thrust * PrecisionFactor (thrustDirection, thrustPosition);
+                var forceX = thrustDirection.Item1 * nozzleThrust;
+                var forceY = thrustDirection.Item2 * nozzleThrust;
+                var forceZ = thrustDirection.Item3 * nozzleThrust;
                 if (forceX > 0)
                     force.x += forceX;
                 else

--- a/service/SpaceCenter/src/Services/Parts/RCS.cs
+++ b/service/SpaceCenter/src/Services/Parts/RCS.cs
@@ -161,6 +161,7 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// <see cref="RotationOverride"/> and <see cref="TranslationOverride"/> instead of the
         /// normal control inputs. The override is automatically released if the
         /// controlling client disconnects or the vessel changes.
+        /// Precision mode leaves an overridden block at full thrust.
         /// </summary>
         [KRPCProperty]
         public bool InputOverride {
@@ -258,8 +259,8 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// <param name="translation">A translation demand, as set by
         /// <see cref="TranslationOverride"/>.</param>
         /// <remarks>
-        /// The demands do not have to be applied. The prediction leaves out precision mode,
-        /// full thrust and the lever divisor, which <see cref="Force"/> includes.
+        /// The demands do not have to be applied. The prediction leaves out full thrust,
+        /// which <see cref="Force"/> includes.
         /// </remarks>
         [KRPCMethod]
         public Tuple3 OverrideForce (Tuple3 rotation, Tuple3 translation)
@@ -278,8 +279,8 @@ namespace KRPC.SpaceCenter.Services.Parts
         /// <param name="translation">A translation demand, as set by
         /// <see cref="TranslationOverride"/>.</param>
         /// <remarks>
-        /// The demands do not have to be applied. The prediction leaves out precision mode,
-        /// full thrust and the lever divisor, which <see cref="Torque"/> includes.
+        /// The demands do not have to be applied. The prediction leaves out full thrust,
+        /// which <see cref="Torque"/> includes.
         /// </remarks>
         [KRPCMethod]
         public Tuple3 OverrideTorque (Tuple3 rotation, Tuple3 translation)

--- a/service/SpaceCenter/test/test_control.py
+++ b/service/SpaceCenter/test/test_control.py
@@ -139,6 +139,26 @@ class ControlMixin:
     def test_roll_trim(self):
         self.check_trim("roll")
 
+    def test_precision_mode(self):
+        # Precision mode is a game setting, so it is only available for the active vessel
+        if self.vessel != self.space_center.active_vessel:
+            self.assertRaises(RuntimeError, getattr, self.control, "precision_mode")
+            self.assertRaises(
+                RuntimeError, setattr, self.control, "precision_mode", True
+            )
+            return
+        try:
+            self.assertFalse(self.control.precision_mode)
+            self.control.precision_mode = True
+            self.assertTrue(self.control.precision_mode)
+            # Setting it to what it already is leaves it alone
+            self.control.precision_mode = True
+            self.assertTrue(self.control.precision_mode)
+            self.control.precision_mode = False
+            self.assertFalse(self.control.precision_mode)
+        finally:
+            self.control.precision_mode = False
+
     def test_sas_mode(self):
         sas_mode = self.space_center.SASMode
         active = self.vessel == self.space_center.active_vessel

--- a/service/SpaceCenter/test/test_parts_rcs.py
+++ b/service/SpaceCenter/test/test_parts_rcs.py
@@ -1,6 +1,6 @@
 import unittest
 import krpctest
-from krpctest.geometry import cross, distance, norm
+from krpctest.geometry import cross, distance, dot, norm
 
 
 class RCSTestBase:
@@ -349,6 +349,101 @@ class TestPartsRCS(krpctest.TestCase, RCSTestBase):
                 for i in range(3):
                     self.assertLessEqual(force[i], positive[i] + 1)
                     self.assertGreaterEqual(force[i], negative[i] - 1)
+
+    def lever_distance(self, thruster, frame):
+        """The perpendicular distance from the center of mass to a nozzle's thrust
+        line, which precision mode divides the nozzle's thrust by."""
+        position = thruster.thrust_position(frame)
+        direction = thruster.thrust_direction(frame)
+        along = dot(position, direction)
+        return norm(tuple(p - along * d for p, d in zip(position, direction)))
+
+    def firing_translation(self, rcs):
+        """A translation demand that fires the part. The cooked control axes reach the
+        module through the same mapping, so the demand doubles as a control setting."""
+        for demand in (
+            (1, 0, 0),
+            (-1, 0, 0),
+            (0, 1, 0),
+            (0, -1, 0),
+            (0, 0, 1),
+            (0, 0, -1),
+        ):
+            if norm(rcs.override_force((0, 0, 0), demand)) > 0:
+                return demand
+        raise AssertionError("no translation demand fires the part")
+
+    def set_translation(self, demand):
+        self.control.right, self.control.up, self.control.forward = demand
+
+    def test_precision_mode_weakens_the_cooked_control(self):
+        rcs = self.get_rcs("linearRcs")
+        self.control.rcs = True
+        self.wait()
+        lever = self.lever_distance(rcs.thrusters[0], self.vessel.reference_frame)
+        # Below one meter the game does not divide, and the test is vacuous
+        self.assertGreater(lever, 1)
+        demand = self.firing_translation(rcs)
+        try:
+            self.set_translation(demand)
+            self.wait(0.5)
+            full = rcs.force
+            self.assertGreater(norm(full), 0)
+            self.control.precision_mode = True
+            self.wait(0.5)
+            self.assertAlmostEqual(tuple(x / lever for x in full), rcs.force, delta=2)
+        finally:
+            self.control.precision_mode = False
+            self.set_translation((0, 0, 0))
+            self.wait()
+
+    def test_precision_mode_leaves_the_override_alone(self):
+        rcs = self.get_rcs("linearRcs")
+        self.control.rcs = True
+        self.wait()
+        demand = self.firing_translation(rcs)
+        try:
+            self.override(rcs, translation=demand)
+            full = rcs.force
+            self.assertGreater(norm(full), 0)
+            rcs.input_override = False
+            self.wait(0.5)
+            # Install the override while precision mode is on
+            self.control.precision_mode = True
+            self.override(rcs, translation=demand)
+            self.assertAlmostEqual(full, rcs.force, delta=2)
+            self.assertAlmostEqual(
+                rcs.override_force((0, 0, 0), demand), rcs.force, delta=2
+            )
+        finally:
+            self.control.precision_mode = False
+            rcs.input_override = False
+            self.wait()
+
+    def test_releasing_the_override_restores_precision_mode(self):
+        rcs = self.get_rcs("linearRcs")
+        self.control.rcs = True
+        self.wait()
+        lever = self.lever_distance(rcs.thrusters[0], self.vessel.reference_frame)
+        self.assertGreater(lever, 1)
+        demand = self.firing_translation(rcs)
+        try:
+            self.override(rcs, translation=demand)
+            full = rcs.force
+            self.assertGreater(norm(full), 0)
+            self.control.precision_mode = True
+            self.wait(0.5)
+            rcs.input_override = False
+            self.wait(0.5)
+            # The same demand through the cooked control is weakened again
+            self.set_translation(demand)
+            self.wait(0.5)
+            self.assertAlmostEqual(tuple(x / lever for x in full), rcs.force, delta=2)
+        finally:
+            self.control.precision_mode = False
+            self.set_translation((0, 0, 0))
+            rcs.input_override = False
+            self.wait()
 
     def test_thruster_thrust(self):
         rcs = self.get_rcs("RCSBlock.v2")

--- a/service/SpaceCenter/test/test_parts_rcs.py
+++ b/service/SpaceCenter/test/test_parts_rcs.py
@@ -445,6 +445,37 @@ class TestPartsRCS(krpctest.TestCase, RCSTestBase):
             rcs.input_override = False
             self.wait()
 
+    def test_precision_mode_scales_available_force_and_torque(self):
+        rcs = self.get_rcs("linearRcs")
+        self.control.rcs = True
+        self.wait()
+        lever = self.lever_distance(rcs.thrusters[0], self.vessel.reference_frame)
+        self.assertGreater(lever, 1)
+        force = rcs.available_force
+        torque = rcs.available_torque
+        vessel_torque = self.vessel.available_rcs_torque
+        try:
+            self.control.precision_mode = True
+            for expected, actual in zip(force, rcs.available_force):
+                self.assertAlmostEqual(
+                    tuple(x / lever for x in expected), actual, delta=2
+                )
+            for expected, actual in zip(torque, rcs.available_torque):
+                self.assertAlmostEqual(
+                    tuple(x / lever for x in expected), actual, delta=2
+                )
+            self.assertLess(
+                norm(self.vessel.available_rcs_torque[0]), norm(vessel_torque[0])
+            )
+            # An overridden block is exempt, so its available force comes back
+            rcs.input_override = True
+            for expected, actual in zip(force, rcs.available_force):
+                self.assertAlmostEqual(expected, actual, delta=2)
+        finally:
+            rcs.input_override = False
+            self.control.precision_mode = False
+            self.wait()
+
     def test_thruster_thrust(self):
         rcs = self.get_rcs("RCSBlock.v2")
         self.control.rcs = True


### PR DESCRIPTION
Adds `Control.PrecisionMode`, the precision control mode that the Caps Lock key toggles.

**RCS override.** Precision mode weakens every nozzle from inside `ModuleRCS`, downstream of the flight control state, so it cut a block driven by `RCS.InputOverride` along with the cooked control input. Installing an override now neutralizes the two fields that branch reads, and releasing it puts them back.

**Available force and torque.** `RCS.AvailableForce` and `RCS.AvailableTorque` are calculated per nozzle rather than taken from the game, so they reported full authority while precision mode was weakening it. They now apply the same factor, which the vessel level force, torque and acceleration properties follow.
