### PR TITLE
Fix delta-v stats after staging

### DIFF
--- a/core/src/Service/YieldException.cs
+++ b/core/src/Service/YieldException.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Reflection;
+using System.Runtime.ExceptionServices;
 
 namespace KRPC.Service
 {
@@ -33,8 +34,12 @@ namespace KRPC.Service
                 }
                 catch (TargetInvocationException e)
                 {
-                    if (e.InnerException is YieldException)
-                        throw e.InnerException;
+                    // DynamicInvoke wraps whatever the continuation threw. Rethrow the
+                    // original, so that a yield reads as a yield and an error keeps its
+                    // type and message.
+                    if (e.InnerException == null)
+                        throw;
+                    ExceptionDispatchInfo.Capture (e.InnerException).Throw ();
                     throw;
                 }
             }

--- a/core/test/Service/ServicesTest.cs
+++ b/core/test/Service/ServicesTest.cs
@@ -732,6 +732,44 @@ namespace KRPC.Test.Service
             Assert.AreEqual (expectedResult, (int)result.Value);
         }
 
+        int BlockingProcedureThrowsFnCount;
+
+        int BlockingProcedureThrowsFn (int n)
+        {
+            BlockingProcedureThrowsFnCount++;
+            if (n == 0)
+                throw new ArgumentException ("test exception");
+            throw new YieldException<Func<int>> (() => BlockingProcedureThrowsFn (n - 1));
+        }
+
+        [Test]
+        public void HandleBlockingRequestArgsThrows ()
+        {
+            const int num = 3;
+            var mock = new Mock<ITestService> (MockBehavior.Strict);
+            mock.Setup (x => x.BlockingProcedureReturns (It.IsAny<int> (), It.IsAny<int> ()))
+                .Returns ((int n, int sum) => BlockingProcedureThrowsFn (n));
+            TestService.Service = mock.Object;
+            var call = Call ("TestService", "BlockingProcedureReturns", Arg (0, num));
+            BlockingProcedureThrowsFnCount = 0;
+            ProcedureResult result = null;
+            var continuation = new ProcedureCallContinuation (call);
+            while (result == null) {
+                try {
+                    result = continuation.Run ();
+                } catch (YieldException<ProcedureCallContinuation> e) {
+                    continuation = e.Value;
+                } catch (RPCException e) {
+                    result = new ProcedureResult {
+                        Error = global::KRPC.Service.Services.Instance.HandleException (e)
+                    };
+                }
+            }
+            // The exception a continuation throws keeps its type and message
+            Assert.AreEqual (num + 1, BlockingProcedureThrowsFnCount);
+            CheckError ("ArgumentException", "test exception", result);
+        }
+
         [Test]
         public void HandleEchoList ()
         {

--- a/server/CHANGELOG.md
+++ b/server/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## [v0.7.0] - unreleased
+- Fix the error from a call that waits on the game being reported as `Exception has been
+  thrown by the target of an invocation` (#1083)
 - Add the `TickHoldTimeout` setting, which bounds how long a client may hold the game on one
   physics tick (#1070)
 - The server updates before the game collects control inputs, so a control input takes effect

--- a/service/SpaceCenter/src/Services/FlightDeltaV.cs
+++ b/service/SpaceCenter/src/Services/FlightDeltaV.cs
@@ -96,6 +96,19 @@ namespace KRPC.SpaceCenter.Services
                 return false;
             if (vessel.id == requestedFor && Time.fixedTime <= requestedAt)
                 return false;
+            return HasFigures (vessel);
+        }
+
+        /// <summary>
+        /// Whether the game holds figures for the vessel. It keeps the ones from the last
+        /// run while it works on the next, so a read has figures to report throughout a
+        /// run.
+        /// </summary>
+        static bool HasFigures (global::Vessel vessel)
+        {
+            var simulation = vessel.VesselDeltaV;
+            if (simulation == null)
+                return false;
             // A vessel between scenes holds no parts yet, and reads as engine-less until
             // the game has rebuilt it.
             return simulation.IsReady || (vessel.parts.Count > 0 && !HasEngines (vessel));
@@ -122,14 +135,19 @@ namespace KRPC.SpaceCenter.Services
         }
 
         /// <summary>
-        /// Read a figure off the simulation, asking the game for a run when the figures
-        /// are out of date and yielding until it has finished. Callers pass no tick; the
+        /// Read a figure off the simulation, asking the game for a run when it holds no
+        /// figures and yielding until it has finished. Callers pass no tick; the
         /// continuations count it up.
         /// </summary>
+        /// <remarks>
+        /// A read reports the figures the game holds, rather than waiting out a run it has
+        /// under way. Staging marks the figures out of date, and a read that waited would
+        /// come back to a stage the game has since dropped.
+        /// </remarks>
         internal static T Read<T> (Guid id, Func<VesselDeltaV, T> figure, int tick = 0)
         {
             var vessel = FlightGlobalsExtensions.GetVesselById (id);
-            if (Ready (vessel))
+            if (HasFigures (vessel))
                 return figure (vessel.VesselDeltaV);
             if (tick > WaitTicks)
                 throw TimedOut ();

--- a/service/SpaceCenter/src/Services/Vessel.cs
+++ b/service/SpaceCenter/src/Services/Vessel.cs
@@ -499,8 +499,8 @@ namespace KRPC.SpaceCenter.Services
         /// </summary>
         /// <remarks>
         /// The game calculates delta-v for the active vessel alone, over the several ticks
-        /// after the vessel changes. Reading a delta-v member waits for the figures, so poll
-        /// this instead when a call must not block.
+        /// after the vessel changes. A delta-v member reports the figures from the last
+        /// calculation, and waits only when the game has calculated none.
         /// </remarks>
         [KRPCProperty (GameScene = GameScene.Flight)]
         public bool DeltaVReady {

--- a/service/SpaceCenter/test/test_stage.py
+++ b/service/SpaceCenter/test/test_stage.py
@@ -57,10 +57,13 @@ class TestStage(krpctest.TestCase):
 
     def test_delta_v_ready(self):
         # The game drops the first calculation of a vessel whose staging is not built yet,
-        # and never repeats it. Reading a figure asks for another calculation, so a figure
-        # read at any point in the flight is a figure the game has produced.
+        # and never repeats it. A read asks for another calculation when the game holds no
+        # figures, so a figure is available at any point in the flight. The read reports
+        # what the game holds, so the figures become current a run later.
         self.assertGreater(self.vessel.vacuum_delta_v, 0)
-        self.assertTrue(self.vessel.delta_v_ready)
+        self.wait_until(
+            lambda: self.vessel.delta_v_ready, message="delta-v figures current"
+        )
 
     def test_recalculate_delta_v(self):
         before = self.vessel.vacuum_delta_v


### PR DESCRIPTION
**Delta-v reads.** `FlightDeltaV.Read` treated a run the game had under way as no figures, and waited it out. Staging is what starts a run, so a read made before a staging event came back to the rebuilt stage list, where the stage it was made for is gone, and threw. A read now reports the figures the game holds and waits only when it holds none. `Vessel.DeltaVReady` and `Vessel.RecalculateDeltaV` still mean the figures are current.

**Error reporting.** `YieldException.CallUntyped` resumes a continuation with `Delegate.DynamicInvoke`, which wraps whatever the continuation threw, and it unwrapped that only for a nested `YieldException`. Every other error reached the client as `TargetInvocationException`, reported as "Exception has been thrown by the target of an invocation". Almost every yielding RPC throws `YieldException<Action>`, which takes the unwrapped path, so the bug stayed latent until the delta-v getters started yielding. Fixed by rethrowing the original exception through `ExceptionDispatchInfo`, so a resumed call keeps its type and message.

**Testing.** `ServicesTest.HandleBlockingRequestArgsThrows` covers the error a continuation throws; it fails on the old `CallUntyped` with an empty error name. `test_stage.py` covers the reads, and `test_delta_v_ready` now waits for the figures to become current rather than expecting a read to leave them so. Measured in flight, 14 of 60,628 stage delta-v reads yielded, the longest for 153 ms, which is the window the staging failure lived in.