### PR TITLE
Fix the orbital speed reported for a vessel under physics

### DIFF
--- a/doc/order.txt
+++ b/doc/order.txt
@@ -410,6 +410,8 @@ SpaceCenter.Orbit.RadiusAt
 SpaceCenter.Orbit.PositionAt
 SpaceCenter.Orbit.VelocityAt
 SpaceCenter.Orbit.Speed
+SpaceCenter.Orbit.SpeedAt
+SpaceCenter.Orbit.SpecificEnergy
 SpaceCenter.Orbit.Period
 SpaceCenter.Orbit.TimeToApoapsis
 SpaceCenter.Orbit.TimeToPeriapsis

--- a/service/SpaceCenter/CHANGELOG.md
+++ b/service/SpaceCenter/CHANGELOG.md
@@ -103,6 +103,15 @@
     frame (#1046)
   - `Orbit.Epoch` is documented as the universal time at which the mean anomaly at epoch is
     measured. It was described as the time since that point (#1046)
+  - Fix `Orbit.OrbitalSpeed`, which reported the speed the vessel had when it was last on
+    rails (#1086)
+  - Add `Orbit.SpeedAt` and `Orbit.SpecificEnergy`, the speed at a given universal time and
+    the specific orbital energy (#1086)
+  - **Breaking:** `Orbit.OrbitalSpeedAt` takes a universal time, in a parameter renamed from
+    `time` to `ut`. It took the time since the orbit's periapsis. Deprecated in favor of
+    `Orbit.SpeedAt` (#1086)
+  - **Deprecated:** `Orbit.OrbitalSpeed` and `Orbit.OrbitalEnergy`, superseded by
+    `Orbit.Speed` and `Orbit.SpecificEnergy` (#1086)
 
 - Maneuver nodes
   - Using a maneuver node that has been removed raises `KRPC.ObjectDestroyedException`.

--- a/service/SpaceCenter/src/Services/Orbit.cs
+++ b/service/SpaceCenter/src/Services/Orbit.cs
@@ -367,6 +367,19 @@ namespace KRPC.SpaceCenter.Services
         }
 
         /// <summary>
+        /// The specific orbital energy, in Joules per kilogram (equivalently,
+        /// meters squared per second squared).
+        /// </summary>
+        /// <remarks>
+        /// This is the sum of the orbit's specific kinetic and potential energy, and
+        /// is negative for a bound (elliptical) orbit.
+        /// </remarks>
+        [KRPCProperty]
+        public double SpecificEnergy {
+            get { return InternalOrbit.orbitalEnergy; }
+        }
+
+        /// <summary>
         /// The orbital period, in seconds.
         /// </summary>
         [KRPCProperty]
@@ -502,7 +515,7 @@ namespace KRPC.SpaceCenter.Services
         /// <see cref="Radius"/>, <see cref="Speed"/>, <see cref="TrueAnomaly"/>,
         /// <see cref="TimeToApoapsis"/> and the like describe the orbit at
         /// <paramref name="ut"/> and stay there. Use <see cref="RadiusAt"/>,
-        /// <see cref="PositionAt"/>, <see cref="VelocityAt"/> and
+        /// <see cref="SpeedAt"/>, <see cref="PositionAt"/>, <see cref="VelocityAt"/> and
         /// <see cref="TrueAnomalyAtUT"/> for another time, and
         /// <see cref="ReferenceFrame"/> and <see cref="OrbitalReferenceFrame"/> to follow
         /// the orbit as time passes.
@@ -588,7 +601,7 @@ namespace KRPC.SpaceCenter.Services
         /// <see cref="Radius"/>, <see cref="Speed"/>, <see cref="TrueAnomaly"/>,
         /// <see cref="TimeToApoapsis"/> and the like describe the orbit at
         /// <paramref name="epoch"/> and stay there. Use <see cref="RadiusAt"/>,
-        /// <see cref="PositionAt"/>, <see cref="VelocityAt"/> and
+        /// <see cref="SpeedAt"/>, <see cref="PositionAt"/>, <see cref="VelocityAt"/> and
         /// <see cref="TrueAnomalyAtUT"/> for another time, and
         /// <see cref="ReferenceFrame"/> and <see cref="OrbitalReferenceFrame"/> to follow
         /// the orbit as time passes.
@@ -775,30 +788,30 @@ namespace KRPC.SpaceCenter.Services
         /// <summary>
         /// The current orbital speed in meters per second.
         /// </summary>
+        [Obsolete ("Use <see cref='Speed'/> instead.")]
         [KRPCProperty]
         public double OrbitalSpeed {
-            get { return InternalOrbit.vel.magnitude; }
+            get { return Speed; }
         }
 
         /// <summary>
         /// The orbital speed at the given time, in meters per second.
         /// </summary>
         /// <param name="ut">The universal time to measure the speed at.</param>
+        [Obsolete ("Use <see cref='SpeedAt'/> instead.")]
         [KRPCMethod]
         public double OrbitalSpeedAt (double ut)
         {
-            return InternalOrbit.getOrbitalSpeedAtDistance (RadiusAt (ut));
+            return SpeedAt (ut);
         }
 
         /// <summary>
-        /// The specific orbital energy of the orbit, in Joules per kilogram
-        /// (equivalently, meters squared per second squared). This is the sum
-        /// of the orbit's specific kinetic and potential energy, and is
-        /// negative for a bound (elliptical) orbit.
+        /// The specific orbital energy of the orbit, in Joules per kilogram.
         /// </summary>
+        [Obsolete ("Use <see cref='SpecificEnergy'/> instead.")]
         [KRPCProperty]
         public double OrbitalEnergy {
-            get { return InternalOrbit.orbitalEnergy; }
+            get { return SpecificEnergy; }
         }
 
         /// <summary>
@@ -809,6 +822,16 @@ namespace KRPC.SpaceCenter.Services
         public double RadiusAt (double ut)
         {
             return InternalOrbit.getRelativePositionAtUT(ut).magnitude;
+        }
+
+        /// <summary>
+        /// The orbital speed at the given time, in meters per second.
+        /// </summary>
+        /// <param name="ut">The universal time to measure the speed at.</param>
+        [KRPCMethod]
+        public double SpeedAt (double ut)
+        {
+            return InternalOrbit.getOrbitalSpeedAtDistance (RadiusAt (ut));
         }
 
         /// <summary>

--- a/service/SpaceCenter/src/Services/Orbit.cs
+++ b/service/SpaceCenter/src/Services/Orbit.cs
@@ -777,17 +777,17 @@ namespace KRPC.SpaceCenter.Services
         /// </summary>
         [KRPCProperty]
         public double OrbitalSpeed {
-            get { return InternalOrbit.orbitalSpeed; }
+            get { return InternalOrbit.vel.magnitude; }
         }
 
         /// <summary>
         /// The orbital speed at the given time, in meters per second.
         /// </summary>
-        /// <param name="time">Time from now, in seconds.</param>
+        /// <param name="ut">The universal time to measure the speed at.</param>
         [KRPCMethod]
-        public double OrbitalSpeedAt (double time)
+        public double OrbitalSpeedAt (double ut)
         {
-            return InternalOrbit.getOrbitalSpeedAt (time);
+            return InternalOrbit.getOrbitalSpeedAtDistance (RadiusAt (ut));
         }
 
         /// <summary>

--- a/service/SpaceCenter/test/test_orbit.py
+++ b/service/SpaceCenter/test/test_orbit.py
@@ -127,6 +127,38 @@ class TestOrbit(krpctest.TestCase):
         self.check_anomalies(vessel, orbit)
         # self.assertNone(orbit.next_orbit)
 
+    def test_orbital_speed_at(self):
+        """orbital_speed_at is the vis-viva speed at the radius the orbit has reached
+        at the given universal time."""
+        self.set_orbit("Bop", 320000, 0.18, 27, 38, 241, 2.3, 0)
+        orbit = self.space_center.active_vessel.orbit
+        ut = self.space_center.ut
+        for offset in (0, 300, 1200):
+            at = ut + offset
+            expected = math.sqrt(
+                orbit.body.gravitational_parameter
+                * ((2 / orbit.radius_at(at)) - (1 / orbit.semi_major_axis))
+            )
+            self.assertAlmostEqual(expected, orbit.orbital_speed_at(at), delta=1)
+        self.assertAlmostEqual(orbit.speed, orbit.orbital_speed_at(ut), delta=1)
+
+    def test_orbital_speed_of_a_vessel_under_physics(self):
+        """orbital_speed follows the orbit as the game runs. KSP caches an orbital
+        speed of its own and leaves it behind while a vessel is off rails."""
+        self.set_orbit("Kerbin", 1000000, 0.32, 0, 0, 0, 0.6, 0)
+        orbit = self.space_center.active_vessel.orbit
+        mu = orbit.body.gravitational_parameter
+        first = orbit.orbital_speed
+        for _ in range(2):
+            self.wait(10)
+            expected = math.sqrt(
+                mu * ((2 / orbit.radius) - (1 / orbit.semi_major_axis))
+            )
+            self.assertAlmostEqual(expected, orbit.orbital_speed, delta=1)
+        # The orbit sheds about 1.4 m/s of speed each second here, so a value cached
+        # when the vessel went off rails fails the check above within one wait
+        self.assertGreater(abs(first - orbit.orbital_speed), 10)
+
     def test_vessel_orbiting_mun_on_escape_soi(self):
         self.set_orbit("Mun", 1800000, 0.52, 0, 13, 67, 6.25, 0)
         vessel = self.space_center.active_vessel

--- a/service/SpaceCenter/test/test_orbit.py
+++ b/service/SpaceCenter/test/test_orbit.py
@@ -24,12 +24,12 @@ class TestOrbit(krpctest.TestCase):
         )
         self.assertAlmostEqual(speed, orbit.speed, delta=1)
 
-    def check_orbital_energy(self, orbit):
+    def check_specific_energy(self, orbit):
         # Specific orbital energy is -mu / (2a) for a bound orbit. KSP derives
         # it from the instantaneous state vectors, so compare as a ratio to
         # tolerate the small jitter in an active vessel's velocity.
         energy = -orbit.body.gravitational_parameter / (2 * orbit.semi_major_axis)
-        self.assertAlmostEqual(energy / orbit.orbital_energy, 1, places=3)
+        self.assertAlmostEqual(energy / orbit.specific_energy, 1, places=3)
 
     def check_angles_close(self, angle, other_angle, places=2):
         # Compare two angles, in radians, ignoring multiples of 2*pi
@@ -85,7 +85,7 @@ class TestOrbit(krpctest.TestCase):
         self.assertAlmostEqual(700000, orbit.radius, delta=50)
         self.assertAlmostEqual(2246.1, orbit.speed, delta=1)
         self.check_radius_and_speed(vessel, orbit)
-        self.check_orbital_energy(orbit)
+        self.check_specific_energy(orbit)
         # self.check_time_to_apoapsis_and_periapsis(vessel, orbit)
         self.assertIsNaN(orbit.time_to_soi_change)
         self.assertAlmostEqual(0, orbit.eccentricity, places=1)
@@ -127,9 +127,9 @@ class TestOrbit(krpctest.TestCase):
         self.check_anomalies(vessel, orbit)
         # self.assertNone(orbit.next_orbit)
 
-    def test_orbital_speed_at(self):
-        """orbital_speed_at is the vis-viva speed at the radius the orbit has reached
-        at the given universal time."""
+    def test_speed_at(self):
+        """speed_at is the vis-viva speed at the radius the orbit has reached at
+        the given universal time."""
         self.set_orbit("Bop", 320000, 0.18, 27, 38, 241, 2.3, 0)
         orbit = self.space_center.active_vessel.orbit
         ut = self.space_center.ut
@@ -139,25 +139,39 @@ class TestOrbit(krpctest.TestCase):
                 orbit.body.gravitational_parameter
                 * ((2 / orbit.radius_at(at)) - (1 / orbit.semi_major_axis))
             )
-            self.assertAlmostEqual(expected, orbit.orbital_speed_at(at), delta=1)
-        self.assertAlmostEqual(orbit.speed, orbit.orbital_speed_at(ut), delta=1)
+            self.assertAlmostEqual(expected, orbit.speed_at(at), delta=1)
+        self.assertAlmostEqual(orbit.speed, orbit.speed_at(ut), delta=1)
 
-    def test_orbital_speed_of_a_vessel_under_physics(self):
-        """orbital_speed follows the orbit as the game runs. KSP caches an orbital
-        speed of its own and leaves it behind while a vessel is off rails."""
+    def test_speed_of_a_vessel_under_physics(self):
+        """The speed of a vessel under physics follows its orbit as the game runs.
+        KSP caches an orbital speed of its own and leaves it behind while a vessel is
+        off rails, so orbital_speed is read here too."""
         self.set_orbit("Kerbin", 1000000, 0.32, 0, 0, 0, 0.6, 0)
         orbit = self.space_center.active_vessel.orbit
         mu = orbit.body.gravitational_parameter
-        first = orbit.orbital_speed
+        first = orbit.speed
         for _ in range(2):
             self.wait(10)
             expected = math.sqrt(
                 mu * ((2 / orbit.radius) - (1 / orbit.semi_major_axis))
             )
+            self.assertAlmostEqual(expected, orbit.speed, delta=1)
             self.assertAlmostEqual(expected, orbit.orbital_speed, delta=1)
         # The orbit sheds about 1.4 m/s of speed each second here, so a value cached
-        # when the vessel went off rails fails the check above within one wait
-        self.assertGreater(abs(first - orbit.orbital_speed), 10)
+        # when the vessel went off rails fails the checks above within one wait
+        self.assertGreater(abs(first - orbit.speed), 10)
+
+    def test_the_deprecated_speed_and_energy_members(self):
+        """orbital_speed, orbital_speed_at and orbital_energy report what the
+        members that supersede them report."""
+        self.set_orbit("Bop", 320000, 0.18, 27, 38, 241, 2.3, 0)
+        orbit = self.space_center.active_vessel.orbit
+        ut = self.space_center.ut
+        self.assertAlmostEqual(orbit.speed, orbit.orbital_speed, delta=1)
+        self.assertAlmostEqual(orbit.speed_at(ut), orbit.orbital_speed_at(ut), delta=1)
+        self.assertAlmostEqual(
+            orbit.specific_energy / orbit.orbital_energy, 1, places=3
+        )
 
     def test_vessel_orbiting_mun_on_escape_soi(self):
         self.set_orbit("Mun", 1800000, 0.52, 0, 13, 67, 6.25, 0)
@@ -230,7 +244,7 @@ class TestOrbit(krpctest.TestCase):
         self.assertAlmostEqual(13599840256, orbit.radius)
         self.assertAlmostEqual(9284.50, orbit.speed, places=1)
         self.check_radius_and_speed(body, orbit)
-        self.check_orbital_energy(orbit)
+        self.check_specific_energy(orbit)
         # self.check_time_to_apoapsis_and_periapsis(body, orbit)
         self.assertIsNaN(orbit.time_to_soi_change)
         self.assertAlmostEqual(0, orbit.eccentricity)
@@ -252,7 +266,7 @@ class TestOrbit(krpctest.TestCase):
         self.assertAlmostEqual(47000000, orbit.radius)
         self.assertAlmostEqual(274.1, orbit.speed, delta=0.5)
         self.check_radius_and_speed(body, orbit)
-        self.check_orbital_energy(orbit)
+        self.check_specific_energy(orbit)
         # self.check_time_to_apoapsis_and_periapsis(body, orbit)
         self.assertIsNaN(orbit.time_to_soi_change)
         self.assertAlmostEqual(0, orbit.eccentricity)


### PR DESCRIPTION
**Root cause.** `Orbit.OrbitalSpeed` read KSP's `Orbit.orbitalSpeed` field, which the game writes only in `Orbit.UpdateFromUT`. A vessel under physics is driven through `Orbit.UpdateFromFixedVectors`, so the field held the speed the vessel had when it was last on rails. `Orbit.OrbitalSpeedAt` measured its argument from the orbit's periapsis, while documenting it as a time from now.

**Fix.** The speed comes from the orbit's velocity. `OrbitalSpeedAt` takes a universal time, matching `RadiusAt`, `PositionAt` and `VelocityAt`. That is a breaking change to a method whose own documentation was wrong either way.

**Naming.** `OrbitalSpeed` duplicated `Orbit.Speed`, so `Orbit.SpeedAt` and `Orbit.SpecificEnergy` join it and the three superseded members are deprecated.

**Testing.** The in-game orbit tests cover the speed of a vessel under physics across twenty seconds of flight, over which the orbit sheds about 28 m/s. A value cached when the vessel went off rails fails them.

Fixes #1084
