### PR TITLE
Expand orbit API

### DIFF
--- a/doc/order.txt
+++ b/doc/order.txt
@@ -405,7 +405,9 @@ SpaceCenter.Orbit.ApoapsisAltitude
 SpaceCenter.Orbit.PeriapsisAltitude
 SpaceCenter.Orbit.SemiMajorAxis
 SpaceCenter.Orbit.SemiMinorAxis
+SpaceCenter.Orbit.SemiLatusRectum
 SpaceCenter.Orbit.Radius
+SpaceCenter.Orbit.Altitude
 SpaceCenter.Orbit.RadiusAt
 SpaceCenter.Orbit.RadiusAtTrueAnomaly
 SpaceCenter.Orbit.Position
@@ -419,7 +421,9 @@ SpaceCenter.Orbit.SpeedAt
 SpaceCenter.Orbit.SpeedAtRadius
 SpaceCenter.Orbit.SpeedAtTrueAnomaly
 SpaceCenter.Orbit.SpecificEnergy
+SpaceCenter.Orbit.SpecificAngularMomentum
 SpaceCenter.Orbit.Period
+SpaceCenter.Orbit.MeanMotion
 SpaceCenter.Orbit.TimeToApoapsis
 SpaceCenter.Orbit.TimeToPeriapsis
 SpaceCenter.Orbit.Eccentricity

--- a/doc/order.txt
+++ b/doc/order.txt
@@ -407,12 +407,17 @@ SpaceCenter.Orbit.SemiMajorAxis
 SpaceCenter.Orbit.SemiMinorAxis
 SpaceCenter.Orbit.Radius
 SpaceCenter.Orbit.RadiusAt
+SpaceCenter.Orbit.RadiusAtTrueAnomaly
 SpaceCenter.Orbit.Position
 SpaceCenter.Orbit.PositionAt
+SpaceCenter.Orbit.PositionAtTrueAnomaly
 SpaceCenter.Orbit.Velocity
 SpaceCenter.Orbit.VelocityAt
+SpaceCenter.Orbit.VelocityAtTrueAnomaly
 SpaceCenter.Orbit.Speed
 SpaceCenter.Orbit.SpeedAt
+SpaceCenter.Orbit.SpeedAtRadius
+SpaceCenter.Orbit.SpeedAtTrueAnomaly
 SpaceCenter.Orbit.SpecificEnergy
 SpaceCenter.Orbit.Period
 SpaceCenter.Orbit.TimeToApoapsis
@@ -431,7 +436,6 @@ SpaceCenter.Orbit.TrueAnomaly
 SpaceCenter.Orbit.TrueAnomalyAtUT
 SpaceCenter.Orbit.TrueAnomalyAtRadius
 SpaceCenter.Orbit.UTAtTrueAnomaly
-SpaceCenter.Orbit.RadiusAtTrueAnomaly
 SpaceCenter.Orbit.TrueAnomalyAtAN
 SpaceCenter.Orbit.TrueAnomalyAtDN
 SpaceCenter.Orbit.OrbitalSpeed

--- a/doc/order.txt
+++ b/doc/order.txt
@@ -407,7 +407,9 @@ SpaceCenter.Orbit.SemiMajorAxis
 SpaceCenter.Orbit.SemiMinorAxis
 SpaceCenter.Orbit.Radius
 SpaceCenter.Orbit.RadiusAt
+SpaceCenter.Orbit.Position
 SpaceCenter.Orbit.PositionAt
+SpaceCenter.Orbit.Velocity
 SpaceCenter.Orbit.VelocityAt
 SpaceCenter.Orbit.Speed
 SpaceCenter.Orbit.SpeedAt

--- a/doc/src/dictionary.txt
+++ b/doc/src/dictionary.txt
@@ -100,6 +100,7 @@ kerbal
 krpc
 krpctest
 laplace
+latus
 libxml
 libxslt
 libz

--- a/doc/src/dictionary.txt
+++ b/doc/src/dictionary.txt
@@ -201,6 +201,8 @@ vcpkg
 ve
 vertices
 virtualenv
+vis
+viva
 waypoint
 waypoints
 websockets

--- a/service/SpaceCenter/CHANGELOG.md
+++ b/service/SpaceCenter/CHANGELOG.md
@@ -112,6 +112,14 @@
     `Orbit.SpeedAt` (#1086)
   - **Deprecated:** `Orbit.OrbitalSpeed` and `Orbit.OrbitalEnergy`, superseded by
     `Orbit.Speed` and `Orbit.SpecificEnergy` (#1086)
+  - Add `Orbit.Position` and `Orbit.Velocity`, the position and velocity the orbit has
+    reached at the current time (#1087)
+  - `Orbit.PositionAt` takes an optional reference frame, defaulting to the non-rotating
+    reference frame of the body being orbited (#1087)
+  - Add `Orbit.PositionAtTrueAnomaly`, `Orbit.VelocityAtTrueAnomaly`,
+    `Orbit.SpeedAtTrueAnomaly` and `Orbit.SpeedAtRadius` (#1087)
+  - Add `Orbit.Altitude`, `Orbit.MeanMotion`, `Orbit.SemiLatusRectum` and
+    `Orbit.SpecificAngularMomentum` (#1087)
 
 - Maneuver nodes
   - Using a maneuver node that has been removed raises `KRPC.ObjectDestroyedException`.

--- a/service/SpaceCenter/src/Services/ClosestApproach.cs
+++ b/service/SpaceCenter/src/Services/ClosestApproach.cs
@@ -130,14 +130,13 @@ namespace KRPC.SpaceCenter.Services
         // of the absolute ones
         Vector3d WorldVelocity (Orbit o, double ut)
         {
-            var internalOrbit = o.InternalOrbit;
-            return internalOrbit.getOrbitalVelocityAtUT (ut).SwapYZ () +
-                   internalOrbit.referenceBody.GetWorldVelocity ();
+            return o.WorldVelocity (o.InternalOrbit.getOrbitalVelocityAtUT (ut));
         }
 
-        ReferenceFrame DefaultedFrame (ReferenceFrame referenceFrame)
+        ReferenceFrame FrameOrOwnerOrbital (ReferenceFrame referenceFrame)
         {
-            return ReferenceEquals (referenceFrame, null) ? orbit.DefaultReferenceFrame : referenceFrame;
+            return ReferenceEquals (referenceFrame, null)
+                ? orbit.OwnerOrbitalReferenceFrame : referenceFrame;
         }
 
         /// <summary>
@@ -225,7 +224,7 @@ namespace KRPC.SpaceCenter.Services
         [KRPCMethod]
         public Tuple3 Position (ReferenceFrame referenceFrame = null)
         {
-            referenceFrame = DefaultedFrame (referenceFrame);
+            referenceFrame = FrameOrOwnerOrbital (referenceFrame);
             return referenceFrame.PositionFromWorldSpace (WorldPosition (orbit, Solve ())).ToTuple ();
         }
 
@@ -239,7 +238,7 @@ namespace KRPC.SpaceCenter.Services
         [KRPCMethod]
         public Tuple3 TargetPosition (ReferenceFrame referenceFrame = null)
         {
-            referenceFrame = DefaultedFrame (referenceFrame);
+            referenceFrame = FrameOrOwnerOrbital (referenceFrame);
             return referenceFrame.PositionFromWorldSpace (WorldPosition (target, Solve ())).ToTuple ();
         }
 
@@ -253,7 +252,7 @@ namespace KRPC.SpaceCenter.Services
         [KRPCMethod]
         public Tuple3 Velocity (ReferenceFrame referenceFrame = null)
         {
-            referenceFrame = DefaultedFrame (referenceFrame);
+            referenceFrame = FrameOrOwnerOrbital (referenceFrame);
             var ut = Solve ();
             return referenceFrame.VelocityFromWorldSpace (
                 WorldPosition (orbit, ut), WorldVelocity (orbit, ut)).ToTuple ();
@@ -269,7 +268,7 @@ namespace KRPC.SpaceCenter.Services
         [KRPCMethod]
         public Tuple3 TargetVelocity (ReferenceFrame referenceFrame = null)
         {
-            referenceFrame = DefaultedFrame (referenceFrame);
+            referenceFrame = FrameOrOwnerOrbital (referenceFrame);
             var ut = Solve ();
             return referenceFrame.VelocityFromWorldSpace (
                 WorldPosition (target, ut), WorldVelocity (target, ut)).ToTuple ();
@@ -286,7 +285,7 @@ namespace KRPC.SpaceCenter.Services
         [KRPCMethod]
         public Tuple3 RelativePosition (ReferenceFrame referenceFrame = null)
         {
-            referenceFrame = DefaultedFrame (referenceFrame);
+            referenceFrame = FrameOrOwnerOrbital (referenceFrame);
             var ut = Solve ();
             return referenceFrame.DirectionFromWorldSpace (
                 WorldPosition (target, ut) - WorldPosition (orbit, ut)).ToTuple ();
@@ -303,7 +302,7 @@ namespace KRPC.SpaceCenter.Services
         [KRPCMethod]
         public Tuple3 RelativeVelocity (ReferenceFrame referenceFrame = null)
         {
-            referenceFrame = DefaultedFrame (referenceFrame);
+            referenceFrame = FrameOrOwnerOrbital (referenceFrame);
             var ut = Solve ();
             return referenceFrame.DirectionFromWorldSpace (
                 WorldVelocity (target, ut) - WorldVelocity (orbit, ut)).ToTuple ();

--- a/service/SpaceCenter/src/Services/Orbit.cs
+++ b/service/SpaceCenter/src/Services/Orbit.cs
@@ -246,11 +246,9 @@ namespace KRPC.SpaceCenter.Services
             get { CheckExists (); return ReferenceFrame.Orbital (this); }
         }
 
-        // The reference frame used by the closest-approach members when the caller
-        // does not specify one: the orbital frame of the object the orbit belongs to,
-        // falling back to the reference body's non-rotating (inertial) frame when the
-        // owner is unknown.
-        internal ReferenceFrame DefaultReferenceFrame {
+        // The orbital frame of the object the orbit belongs to, falling back to the
+        // reference body's non-rotating (inertial) frame when the owner is unknown
+        internal ReferenceFrame OwnerOrbitalReferenceFrame {
             get {
                 if (ownerNode != null)
                     return ownerNode.OrbitalReferenceFrame;
@@ -512,8 +510,8 @@ namespace KRPC.SpaceCenter.Services
         /// atmosphere slows it. A vessel held on rails follows its own orbit exactly,
         /// while one inside the physics bubble is simulated and drifts from it a little.
         ///
-        /// <see cref="Radius"/>, <see cref="Speed"/>, <see cref="TrueAnomaly"/>,
-        /// <see cref="TimeToApoapsis"/> and the like describe the orbit at
+        /// <see cref="Radius"/>, <see cref="Speed"/>, <see cref="Position"/>,
+        /// <see cref="Velocity"/> and the like describe the orbit at
         /// <paramref name="ut"/> and stay there. Use <see cref="RadiusAt"/>,
         /// <see cref="SpeedAt"/>, <see cref="PositionAt"/>, <see cref="VelocityAt"/> and
         /// <see cref="TrueAnomalyAtUT"/> for another time, and
@@ -540,8 +538,7 @@ namespace KRPC.SpaceCenter.Services
             var framePosition = position.ToVector ();
             var worldPosition = frame.PositionToWorldSpace (framePosition);
             var worldVelocity = frame.VelocityToWorldSpace (framePosition, velocity.ToVector ());
-            // The game states an orbit relative to the body it is around, in its own axis
-            // order, so take out the body's own position and motion and swap the axes.
+            // Take out the body's own position and motion, then swap the axes
             var relativePosition = worldPosition - internalBody.position;
             var relativeVelocity = worldVelocity - internalBody.GetWorldVelocity ();
             if (relativePosition.sqrMagnitude < 1)
@@ -598,8 +595,8 @@ namespace KRPC.SpaceCenter.Services
         /// <see cref="ReferencePlaneNormal"/> and <see cref="ReferencePlaneDirection"/>
         /// give these as vectors in a reference frame.
         ///
-        /// <see cref="Radius"/>, <see cref="Speed"/>, <see cref="TrueAnomaly"/>,
-        /// <see cref="TimeToApoapsis"/> and the like describe the orbit at
+        /// <see cref="Radius"/>, <see cref="Speed"/>, <see cref="Position"/>,
+        /// <see cref="Velocity"/> and the like describe the orbit at
         /// <paramref name="epoch"/> and stay there. Use <see cref="RadiusAt"/>,
         /// <see cref="SpeedAt"/>, <see cref="PositionAt"/>, <see cref="VelocityAt"/> and
         /// <see cref="TrueAnomalyAtUT"/> for another time, and
@@ -834,17 +831,69 @@ namespace KRPC.SpaceCenter.Services
             return InternalOrbit.getOrbitalSpeedAtDistance (RadiusAt (ut));
         }
 
+        // The frame the position and velocity members measure in when the caller gives none
+        ReferenceFrame FrameOrBodyNonRotating (ReferenceFrame referenceFrame)
+        {
+            return referenceFrame ?? ReferenceFrame.NonRotating (InternalOrbit.referenceBody);
+        }
+
+        // The game states an orbit relative to the body it is around, in its own axis order.
+        // Adding the body's position back and swapping the axes gives world space.
+        Vector3d WorldPositionNow {
+            get { return InternalOrbit.referenceBody.position + InternalOrbit.pos.SwapYZ (); }
+        }
+
+        // An orbital velocity is stated the same way, with the body's own motion in place
+        // of its position.
+        internal Vector3d WorldVelocity (Vector3d relativeVelocity)
+        {
+            return relativeVelocity.SwapYZ () + InternalOrbit.referenceBody.GetWorldVelocity ();
+        }
+
+        /// <summary>
+        /// The position the orbit has reached at the current time, in the given reference
+        /// frame.
+        /// </summary>
+        /// <returns>The position as a vector.</returns>
+        /// <param name="referenceFrame">The reference frame that the returned position vector
+        /// is in. Defaults to <see cref="CelestialBody.NonRotatingReferenceFrame"/> of
+        /// <see cref="Body"/>.</param>
+        [KRPCMethod]
+        public Tuple3 Position (ReferenceFrame referenceFrame = null)
+        {
+            return FrameOrBodyNonRotating (referenceFrame).PositionFromWorldSpace (
+                WorldPositionNow).ToTuple ();
+        }
+
+        /// <summary>
+        /// The velocity the orbit has reached at the current time, in the given reference
+        /// frame.
+        /// </summary>
+        /// <returns>The velocity as a vector. The vector points in the direction of
+        /// travel, and its magnitude is the speed in meters per second.</returns>
+        /// <param name="referenceFrame">The reference frame that the returned velocity vector
+        /// is in. Defaults to <see cref="CelestialBody.NonRotatingReferenceFrame"/> of
+        /// <see cref="Body"/>.</param>
+        [KRPCMethod]
+        public Tuple3 Velocity (ReferenceFrame referenceFrame = null)
+        {
+            return FrameOrBodyNonRotating (referenceFrame).VelocityFromWorldSpace (
+                WorldPositionNow, WorldVelocity (InternalOrbit.vel)).ToTuple ();
+        }
+
         /// <summary>
         /// The position at a given time, in the specified reference frame.
         /// </summary>
         /// <returns>The position as a vector.</returns>
         /// <param name="ut">The universal time to measure the position at.</param>
-        /// <param name="referenceFrame">The reference frame that the returned
-        /// position vector is in.</param>
+        /// <param name="referenceFrame">The reference frame that the returned position vector
+        /// is in. Defaults to <see cref="CelestialBody.NonRotatingReferenceFrame"/> of
+        /// <see cref="Body"/>.</param>
         [KRPCMethod]
-        public Tuple3 PositionAt (double ut, ReferenceFrame referenceFrame)
+        public Tuple3 PositionAt (double ut, ReferenceFrame referenceFrame = null)
         {
-            return referenceFrame.PositionFromWorldSpace(InternalOrbit.getPositionAtUT(ut)).ToTuple();
+            return FrameOrBodyNonRotating (referenceFrame).PositionFromWorldSpace (
+                InternalOrbit.getPositionAtUT (ut)).ToTuple ();
         }
 
         /// <summary>
@@ -853,18 +902,15 @@ namespace KRPC.SpaceCenter.Services
         /// <returns>The velocity as a vector. The vector points in the direction of
         /// travel, and its magnitude is the speed in meters per second.</returns>
         /// <param name="ut">The universal time to measure the velocity at.</param>
-        /// <param name="referenceFrame">The reference frame that the returned
-        /// velocity vector is in.</param>
+        /// <param name="referenceFrame">The reference frame that the returned velocity vector
+        /// is in. Defaults to <see cref="CelestialBody.NonRotatingReferenceFrame"/> of
+        /// <see cref="Body"/>.</param>
         [KRPCMethod]
-        public Tuple3 VelocityAt (double ut, ReferenceFrame referenceFrame)
+        public Tuple3 VelocityAt (double ut, ReferenceFrame referenceFrame = null)
         {
-            // An orbital velocity is relative to the body being orbited, so the body's
-            // own motion is added to it to give a velocity in world space.
-            var worldVelocity =
-                InternalOrbit.getOrbitalVelocityAtUT (ut).SwapYZ () +
-                InternalOrbit.referenceBody.GetWorldVelocity ();
-            return referenceFrame.VelocityFromWorldSpace (
-                InternalOrbit.getPositionAtUT (ut), worldVelocity).ToTuple ();
+            return FrameOrBodyNonRotating (referenceFrame).VelocityFromWorldSpace (
+                InternalOrbit.getPositionAtUT (ut),
+                WorldVelocity (InternalOrbit.getOrbitalVelocityAtUT (ut))).ToTuple ();
         }
 
         /// <summary>

--- a/service/SpaceCenter/src/Services/Orbit.cs
+++ b/service/SpaceCenter/src/Services/Orbit.cs
@@ -341,6 +341,14 @@ namespace KRPC.SpaceCenter.Services
         }
 
         /// <summary>
+        /// The semi-latus rectum of the orbit, in meters.
+        /// </summary>
+        [KRPCProperty]
+        public double SemiLatusRectum {
+            get { return InternalOrbit.semiLatusRectum; }
+        }
+
+        /// <summary>
         /// The current radius of the orbit, in meters. This is the distance between the center
         /// of mass of the object in orbit, and the center of mass of the body around which it
         /// is orbiting.
@@ -351,6 +359,18 @@ namespace KRPC.SpaceCenter.Services
         [KRPCProperty]
         public double Radius {
             get { return InternalOrbit.radius; }
+        }
+
+        /// <summary>
+        /// The current altitude of the object, in meters above the sea level of the body
+        /// being orbited.
+        /// </summary>
+        /// <remarks>
+        /// This is equal to <see cref="Radius"/> minus the equatorial radius of the body.
+        /// </remarks>
+        [KRPCProperty]
+        public double Altitude {
+            get { return InternalOrbit.altitude; }
         }
 
         /// <summary>
@@ -378,11 +398,27 @@ namespace KRPC.SpaceCenter.Services
         }
 
         /// <summary>
+        /// The specific relative angular momentum, in meters squared per second.
+        /// </summary>
+        [KRPCProperty]
+        public double SpecificAngularMomentum {
+            get { return InternalOrbit.h.magnitude; }
+        }
+
+        /// <summary>
         /// The orbital period, in seconds.
         /// </summary>
         [KRPCProperty]
         public double Period {
             get { return InternalOrbit.period; }
+        }
+
+        /// <summary>
+        /// The mean motion, in radians per second.
+        /// </summary>
+        [KRPCProperty]
+        public double MeanMotion {
+            get { return InternalOrbit.meanMotion; }
         }
 
         /// <summary>

--- a/service/SpaceCenter/src/Services/Orbit.cs
+++ b/service/SpaceCenter/src/Services/Orbit.cs
@@ -828,7 +828,32 @@ namespace KRPC.SpaceCenter.Services
         [KRPCMethod]
         public double SpeedAt (double ut)
         {
-            return InternalOrbit.getOrbitalSpeedAtDistance (RadiusAt (ut));
+            return SpeedAtRadius (RadiusAt (ut));
+        }
+
+        /// <summary>
+        /// The orbital speed at the given orbital radius, in meters per second.
+        /// </summary>
+        /// <param name="radius">The orbital radius in meters.</param>
+        /// <remarks>
+        /// This is the vis-viva speed. A radius the orbit never reaches is accepted. On
+        /// an ellipse the speed is <c>NaN</c> above twice the semi-major axis.
+        /// </remarks>
+        [KRPCMethod]
+        public double SpeedAtRadius (double radius)
+        {
+            return InternalOrbit.getOrbitalSpeedAtDistance (radius);
+        }
+
+        /// <summary>
+        /// The orbital speed at the point in the orbit given by the true anomaly, in meters
+        /// per second.
+        /// </summary>
+        /// <param name="trueAnomaly">The true anomaly.</param>
+        [KRPCMethod]
+        public double SpeedAtTrueAnomaly (double trueAnomaly)
+        {
+            return SpeedAtRadius (RadiusAtTrueAnomaly (trueAnomaly));
         }
 
         // The frame the position and velocity members measure in when the caller gives none
@@ -911,6 +936,43 @@ namespace KRPC.SpaceCenter.Services
             return FrameOrBodyNonRotating (referenceFrame).VelocityFromWorldSpace (
                 InternalOrbit.getPositionAtUT (ut),
                 WorldVelocity (InternalOrbit.getOrbitalVelocityAtUT (ut))).ToTuple ();
+        }
+
+        /// <summary>
+        /// The position at the point in the orbit given by the true anomaly, in the specified
+        /// reference frame.
+        /// </summary>
+        /// <returns>The position as a vector.</returns>
+        /// <param name="trueAnomaly">The true anomaly.</param>
+        /// <param name="referenceFrame">The reference frame that the returned position vector
+        /// is in. Defaults to <see cref="CelestialBody.NonRotatingReferenceFrame"/> of
+        /// <see cref="Body"/>.</param>
+        [KRPCMethod]
+        public Tuple3 PositionAtTrueAnomaly (
+            double trueAnomaly, ReferenceFrame referenceFrame = null)
+        {
+            return FrameOrBodyNonRotating (referenceFrame).PositionFromWorldSpace (
+                InternalOrbit.getPositionFromTrueAnomaly (trueAnomaly)).ToTuple ();
+        }
+
+        /// <summary>
+        /// The velocity at the point in the orbit given by the true anomaly, in the specified
+        /// reference frame.
+        /// </summary>
+        /// <returns>The velocity as a vector. The vector points in the direction of
+        /// travel, and its magnitude is the speed in meters per second.</returns>
+        /// <param name="trueAnomaly">The true anomaly.</param>
+        /// <param name="referenceFrame">The reference frame that the returned velocity vector
+        /// is in. Defaults to <see cref="CelestialBody.NonRotatingReferenceFrame"/> of
+        /// <see cref="Body"/>.</param>
+        [KRPCMethod]
+        public Tuple3 VelocityAtTrueAnomaly (
+            double trueAnomaly, ReferenceFrame referenceFrame = null)
+        {
+            return FrameOrBodyNonRotating (referenceFrame).VelocityFromWorldSpace (
+                InternalOrbit.getPositionFromTrueAnomaly (trueAnomaly),
+                WorldVelocity (
+                    InternalOrbit.getOrbitalVelocityAtTrueAnomaly (trueAnomaly))).ToTuple ();
         }
 
         /// <summary>

--- a/service/SpaceCenter/test/test_orbit.py
+++ b/service/SpaceCenter/test/test_orbit.py
@@ -2,7 +2,7 @@ import math
 import unittest
 
 import krpctest
-from krpctest.geometry import compute_position, norm
+from krpctest.geometry import compute_position, cross, norm
 
 
 class TestOrbit(krpctest.TestCase):
@@ -652,6 +652,23 @@ class TestCreateFromPositionAndVelocity(krpctest.TestCase):
         )
         # Above twice the semi-major axis the vis-viva speed has no real value
         self.assertIsNaN(orbit.speed_at_radius(3 * orbit.semi_major_axis))
+
+    def test_the_orbit_shape_scalars(self):
+        """altitude, semi_latus_rectum, mean_motion and specific_angular_momentum
+        follow from the shape of the orbit."""
+        radius = 1500000
+        orbit = self.create((0, 0, radius), (0.9 * self.circular_speed(radius), 0, 0))
+        mu = self.kerbin.gravitational_parameter
+        sma = orbit.semi_major_axis
+        self.assertAlmostEqual(
+            radius - self.kerbin.equatorial_radius, orbit.altitude, delta=1
+        )
+        self.assertAlmostEqual(
+            sma * (1 - orbit.eccentricity**2), orbit.semi_latus_rectum, delta=1
+        )
+        self.assertAlmostEqual(math.sqrt(mu / sma**3) / orbit.mean_motion, 1, places=6)
+        momentum = norm(cross(orbit.position(self.frame), orbit.velocity(self.frame)))
+        self.assertAlmostEqual(momentum / orbit.specific_angular_momentum, 1, places=6)
 
     def test_rotating_construction_frame(self):
         """The frame the state vectors are given in is taken into account.

--- a/service/SpaceCenter/test/test_orbit.py
+++ b/service/SpaceCenter/test/test_orbit.py
@@ -592,6 +592,7 @@ class TestCreateFromPositionAndVelocity(krpctest.TestCase):
         radius = 1500000
         orbit = self.create((0, 0, radius), (0.9 * self.circular_speed(radius), 0, 0))
         ut = self.space_center.ut
+        true_anomaly = orbit.true_anomaly_at_ut(ut)
         self.assertAlmostEqual(orbit.position(self.frame), orbit.position(), delta=0.1)
         self.assertAlmostEqual(orbit.velocity(self.frame), orbit.velocity(), delta=0.1)
         self.assertAlmostEqual(
@@ -600,6 +601,57 @@ class TestCreateFromPositionAndVelocity(krpctest.TestCase):
         self.assertAlmostEqual(
             orbit.velocity_at(ut, self.frame), orbit.velocity_at(ut), delta=0.1
         )
+        self.assertAlmostEqual(
+            orbit.position_at_true_anomaly(true_anomaly, self.frame),
+            orbit.position_at_true_anomaly(true_anomaly),
+            delta=0.1,
+        )
+        self.assertAlmostEqual(
+            orbit.velocity_at_true_anomaly(true_anomaly, self.frame),
+            orbit.velocity_at_true_anomaly(true_anomaly),
+            delta=0.1,
+        )
+
+    def test_the_true_anomaly_members(self):
+        """The true anomaly members describe the same point of the orbit as the
+        universal time members that reach it."""
+        radius = 1500000
+        orbit = self.create((0, 0, radius), (0.9 * self.circular_speed(radius), 0, 0))
+        ut = self.space_center.ut
+        for offset in (0, 300, 1200):
+            at = ut + offset
+            true_anomaly = orbit.true_anomaly_at_ut(at)
+            position = orbit.position_at_true_anomaly(true_anomaly, self.frame)
+            self.assertAlmostEqual(
+                orbit.position_at(at, self.frame), position, delta=0.1
+            )
+            self.assertAlmostEqual(
+                orbit.velocity_at(at, self.frame),
+                orbit.velocity_at_true_anomaly(true_anomaly, self.frame),
+                delta=0.1,
+            )
+            self.assertAlmostEqual(
+                orbit.speed_at(at), orbit.speed_at_true_anomaly(true_anomaly), delta=0.1
+            )
+            self.assertAlmostEqual(
+                orbit.radius_at_true_anomaly(true_anomaly), norm(position), delta=0.1
+            )
+
+    def test_speed_at_radius(self):
+        """speed_at_radius is the vis-viva speed at a given orbital radius."""
+        radius = 1500000
+        orbit = self.create((0, 0, radius), (0.9 * self.circular_speed(radius), 0, 0))
+        mu = self.kerbin.gravitational_parameter
+        for at_radius in (1300000, 1500000, 1700000):
+            expected = math.sqrt(mu * ((2 / at_radius) - (1 / orbit.semi_major_axis)))
+            self.assertAlmostEqual(
+                expected, orbit.speed_at_radius(at_radius), delta=0.1
+            )
+        self.assertAlmostEqual(
+            orbit.speed, orbit.speed_at_radius(orbit.radius), delta=0.1
+        )
+        # Above twice the semi-major axis the vis-viva speed has no real value
+        self.assertIsNaN(orbit.speed_at_radius(3 * orbit.semi_major_axis))
 
     def test_rotating_construction_frame(self):
         """The frame the state vectors are given in is taken into account.

--- a/service/SpaceCenter/test/test_orbit.py
+++ b/service/SpaceCenter/test/test_orbit.py
@@ -148,6 +148,7 @@ class TestOrbit(krpctest.TestCase):
         off rails, so orbital_speed is read here too."""
         self.set_orbit("Kerbin", 1000000, 0.32, 0, 0, 0, 0.6, 0)
         orbit = self.space_center.active_vessel.orbit
+        frame = orbit.body.non_rotating_reference_frame
         mu = orbit.body.gravitational_parameter
         first = orbit.speed
         for _ in range(2):
@@ -157,6 +158,7 @@ class TestOrbit(krpctest.TestCase):
             )
             self.assertAlmostEqual(expected, orbit.speed, delta=1)
             self.assertAlmostEqual(expected, orbit.orbital_speed, delta=1)
+            self.assertAlmostEqual(expected, norm(orbit.velocity(frame)), delta=1)
         # The orbit sheds about 1.4 m/s of speed each second here, so a value cached
         # when the vessel went off rails fails the checks above within one wait
         self.assertGreater(abs(first - orbit.speed), 10)
@@ -172,6 +174,25 @@ class TestOrbit(krpctest.TestCase):
         self.assertAlmostEqual(
             orbit.specific_energy / orbit.orbital_energy, 1, places=3
         )
+
+    def test_position_and_velocity(self):
+        """position and velocity are the point the orbit has reached now, so their
+        magnitudes are radius and speed."""
+        self.set_orbit("Bop", 320000, 0.18, 27, 38, 241, 2.3, 0)
+        orbit = self.space_center.active_vessel.orbit
+        frame = orbit.body.non_rotating_reference_frame
+        self.assertAlmostEqual(orbit.radius, norm(orbit.position(frame)), delta=10)
+        self.assertAlmostEqual(orbit.speed, norm(orbit.velocity(frame)), delta=1)
+
+    def test_position_and_velocity_follow_the_vessel(self):
+        """A vessel under physics is simulated rather than held on its orbit, and
+        position and velocity report the state it is in."""
+        self.set_orbit("Bop", 320000, 0.18, 27, 38, 241, 2.3, 0)
+        vessel = self.space_center.active_vessel
+        orbit = vessel.orbit
+        frame = orbit.body.non_rotating_reference_frame
+        self.assertAlmostEqual(vessel.position(frame), orbit.position(frame), delta=50)
+        self.assertAlmostEqual(vessel.velocity(frame), orbit.velocity(frame), delta=1)
 
     def test_vessel_orbiting_mun_on_escape_soi(self):
         self.set_orbit("Mun", 1800000, 0.52, 0, 13, 67, 6.25, 0)
@@ -562,6 +583,23 @@ class TestCreateFromPositionAndVelocity(krpctest.TestCase):
         )
         self.assertAlmostEqual(position, orbit.position_at(ut, self.frame), delta=1)
         self.assertAlmostEqual(velocity, orbit.velocity_at(ut, self.frame), delta=0.1)
+        self.assertAlmostEqual(position, orbit.position(self.frame), delta=1)
+        self.assertAlmostEqual(velocity, orbit.velocity(self.frame), delta=0.1)
+
+    def test_omitting_the_reference_frame(self):
+        """The position and velocity members measure in the non-rotating frame of the
+        body being orbited when no frame is given."""
+        radius = 1500000
+        orbit = self.create((0, 0, radius), (0.9 * self.circular_speed(radius), 0, 0))
+        ut = self.space_center.ut
+        self.assertAlmostEqual(orbit.position(self.frame), orbit.position(), delta=0.1)
+        self.assertAlmostEqual(orbit.velocity(self.frame), orbit.velocity(), delta=0.1)
+        self.assertAlmostEqual(
+            orbit.position_at(ut, self.frame), orbit.position_at(ut), delta=0.1
+        )
+        self.assertAlmostEqual(
+            orbit.velocity_at(ut, self.frame), orbit.velocity_at(ut), delta=0.1
+        )
 
     def test_rotating_construction_frame(self):
         """The frame the state vectors are given in is taken into account.


### PR DESCRIPTION
`Orbit` offered `PositionAt` and `VelocityAt` with nothing giving the position and velocity at the current time. `RadiusAtTrueAnomaly` had no position, velocity or speed counterpart.

**Position and velocity.** `Position` and `Velocity` read the orbit's own state fields, so their magnitudes are `Radius` and `Speed`. A vessel inside the physics bubble is simulated rather than held on its orbit, and those fields follow it.

**True anomaly and radius.** `PositionAtTrueAnomaly`, `VelocityAtTrueAnomaly` and `SpeedAtTrueAnomaly` mirror the members that take a universal time. `SpeedAtRadius` gives the vis-viva speed at a given radius.

**Shape scalars.** `Altitude`, `MeanMotion`, `SemiLatusRectum` and `SpecificAngularMomentum` join `ApoapsisAltitude`, `Period`, `SemiMinorAxis` and `SpecificEnergy`.

**Reference frames.** `PositionAt` and `VelocityAt` take the frame as an optional parameter, defaulting to the non-rotating frame of the body being orbited. `CreateFromPositionAndVelocity` already defaults to that frame, so the two round-trip against each other.

**Testing.** Verified in game against a vessel on rails, a vessel under physics and constructed orbits.

#1084 
