### PR TITLE
Expose a control surface's deploy angle

### DIFF
--- a/doc/order.txt
+++ b/doc/order.txt
@@ -920,6 +920,9 @@ SpaceCenter.ControlSurface.RollEnabled
 SpaceCenter.ControlSurface.AuthorityLimiter
 SpaceCenter.ControlSurface.Inverted
 SpaceCenter.ControlSurface.Deployed
+SpaceCenter.ControlSurface.DeployAngle
+SpaceCenter.ControlSurface.MinDeployAngle
+SpaceCenter.ControlSurface.MaxDeployAngle
 SpaceCenter.ControlSurface.DeflectionOverride
 SpaceCenter.ControlSurface.Deflection
 SpaceCenter.ControlSurface.SurfaceArea

--- a/service/SpaceCenter/CHANGELOG.md
+++ b/service/SpaceCenter/CHANGELOG.md
@@ -173,6 +173,13 @@
   - Precision mode leaves a block driven by `RCS.InputOverride` at full thrust (#1082)
   - `RCS.Thrusters`, `RCS.AvailableForce` and `RCS.AvailableTorque` count only the nozzles of
     the part's selected variant (#1079)
+  - Add `ControlSurface.DeployAngle`, `ControlSurface.MinDeployAngle` and
+    `ControlSurface.MaxDeployAngle` (#1088)
+  - Fix `ControlSurface.DeflectionOverride` leaving the deploy angle at the last deflection
+    command when it is released (#1088)
+  - `ControlSurface.Deployed` raises an error when set while
+    `ControlSurface.DeflectionOverride` is enabled, which holds the surface deployed. The
+    setting was discarded when the override was released (#1088)
   - `Decoupler.IsOmniDecoupler` reports what the part is configured as for every decoupler,
     including radial ones. It was false for all of them (#1048)
   - A force added with `Part.AddForce` stops being applied, and is freed, once its part is

--- a/service/SpaceCenter/src/ActuatorControlAddon.cs
+++ b/service/SpaceCenter/src/ActuatorControlAddon.cs
@@ -340,6 +340,25 @@ namespace KRPC.SpaceCenter
                 : entry.Deflection * -limits.x;
         }
 
+        /// <summary>
+        /// The surface's deploy angle. While the override is active the module's own field
+        /// carries the deflection command, so the angle is the value saved for release.
+        /// </summary>
+        internal static float GetControlSurfaceDeployAngle (ModuleControlSurface module)
+        {
+            var entry = controlSurfaces.Get (module);
+            return entry != null ? entry.SavedDeployAngle : module.deployAngle;
+        }
+
+        internal static void SetControlSurfaceDeployAngle (ModuleControlSurface module, float angle)
+        {
+            var entry = controlSurfaces.Get (module);
+            if (entry != null)
+                entry.SavedDeployAngle = angle;
+            else
+                module.deployAngle = angle;
+        }
+
         internal static bool GetControlSurfaceOverride (ModuleControlSurface module)
         {
             return controlSurfaces.IsSet (module);

--- a/service/SpaceCenter/src/ActuatorControlAddon.cs
+++ b/service/SpaceCenter/src/ActuatorControlAddon.cs
@@ -117,6 +117,7 @@ namespace KRPC.SpaceCenter
             public bool SavedIgnoreYaw;
             public bool SavedIgnoreRoll;
             public bool SavedDeploy;
+            public float SavedDeployAngle;
         }
 
         static readonly ClientOwnedOverrides<ModuleGimbal, GimbalEntry> gimbals =
@@ -305,7 +306,8 @@ namespace KRPC.SpaceCenter
                 SavedIgnorePitch = module.ignorePitch,
                 SavedIgnoreYaw = module.ignoreYaw,
                 SavedIgnoreRoll = module.ignoreRoll,
-                SavedDeploy = module.deploy
+                SavedDeploy = module.deploy,
+                SavedDeployAngle = module.deployAngle
             };
             // Remove the cooked-control contribution and drive the surface through the
             // deploy offset, which the module applies persistently every frame.
@@ -325,6 +327,7 @@ namespace KRPC.SpaceCenter
             module.ignoreYaw = entry.SavedIgnoreYaw;
             module.ignoreRoll = entry.SavedIgnoreRoll;
             module.deploy = entry.SavedDeploy;
+            module.deployAngle = entry.SavedDeployAngle;
         }
 
         static void ApplyControlSurfaceDeflection (ModuleControlSurface module, ControlSurfaceEntry entry)

--- a/service/SpaceCenter/src/Services/Parts/ControlSurface.cs
+++ b/service/SpaceCenter/src/Services/Parts/ControlSurface.cs
@@ -116,12 +116,19 @@ namespace KRPC.SpaceCenter.Services.Parts
         }
 
         /// <summary>
-        /// Whether the control surface has been fully deployed.
+        /// Whether the control surface has been fully deployed. Throws an exception if set
+        /// while <see cref="DeflectionOverride"/> is enabled, which holds the surface deployed.
         /// </summary>
         [KRPCProperty (GameScene = GameScene.Flight | GameScene.Editor)]
         public bool Deployed {
             get { return InternalControlSurface.deploy; }
-            set { InternalControlSurface.deploy = value; }
+            set {
+                var surface = InternalControlSurface;
+                if (ActuatorControlAddon.GetControlSurfaceOverride (surface))
+                    throw new InvalidOperationException (
+                        "Control surface deflection is being overridden");
+                surface.deploy = value;
+            }
         }
 
         /// <summary>

--- a/service/SpaceCenter/src/Services/Parts/ControlSurface.cs
+++ b/service/SpaceCenter/src/Services/Parts/ControlSurface.cs
@@ -125,6 +125,42 @@ namespace KRPC.SpaceCenter.Services.Parts
         }
 
         /// <summary>
+        /// The deploy angle of the control surface, in degrees.
+        /// </summary>
+        /// <remarks>
+        /// Applied when <see cref="Deployed"/> is true, and clamped to the range given by
+        /// <see cref="MinDeployAngle"/> and <see cref="MaxDeployAngle"/>. While
+        /// <see cref="DeflectionOverride"/> is enabled, <see cref="Deflection"/> drives the
+        /// angle. A value set here takes effect when the override is released.
+        /// </remarks>
+        [KRPCProperty (GameScene = GameScene.Flight | GameScene.Editor)]
+        public float DeployAngle {
+            get { return ActuatorControlAddon.GetControlSurfaceDeployAngle (InternalControlSurface); }
+            set {
+                var surface = InternalControlSurface;
+                var limits = surface.deployAngleLimits;
+                ActuatorControlAddon.SetControlSurfaceDeployAngle (
+                    surface, value.Clamp (limits.x, limits.y));
+            }
+        }
+
+        /// <summary>
+        /// The minimum <see cref="DeployAngle"/> of the control surface, in degrees.
+        /// </summary>
+        [KRPCProperty (GameScene = GameScene.Flight | GameScene.Editor)]
+        public float MinDeployAngle {
+            get { return InternalControlSurface.deployAngleLimits.x; }
+        }
+
+        /// <summary>
+        /// The maximum <see cref="DeployAngle"/> of the control surface, in degrees.
+        /// </summary>
+        [KRPCProperty (GameScene = GameScene.Flight | GameScene.Editor)]
+        public float MaxDeployAngle {
+            get { return InternalControlSurface.deployAngleLimits.y; }
+        }
+
+        /// <summary>
         /// Whether the control surface deflection is being set directly, bypassing the vessel's
         /// normal flight control. When enabled, the surface holds the deflection set by
         /// <see cref="Deflection"/> instead of responding to pitch, yaw and roll control inputs.

--- a/service/SpaceCenter/test/test_parts_control_surface.py
+++ b/service/SpaceCenter/test/test_parts_control_surface.py
@@ -96,6 +96,41 @@ class TestPartsControlSurface(krpctest.TestCase):
         self.wait()
         self.assertFalse(self.ctrlsrf.deployed)
 
+    def test_deploy_angle(self):
+        # The limits default to +/-1.5 * ctrlSurfaceRange, and the angle itself
+        # to ctrlSurfaceRange, so they differ between the two part types
+        self.assertAlmostEqual(-22.5, self.ctrlsrf.min_deploy_angle)
+        self.assertAlmostEqual(22.5, self.ctrlsrf.max_deploy_angle)
+        self.assertAlmostEqual(15, self.ctrlsrf.deploy_angle)
+        self.assertAlmostEqual(-37.5, self.winglet.min_deploy_angle)
+        self.assertAlmostEqual(37.5, self.winglet.max_deploy_angle)
+        self.assertAlmostEqual(25, self.winglet.deploy_angle)
+        self.ctrlsrf.deploy_angle = -10
+        self.wait()
+        self.assertAlmostEqual(-10, self.ctrlsrf.deploy_angle)
+        # Out of range values clamp to the limits
+        self.ctrlsrf.deploy_angle = 100
+        self.assertAlmostEqual(22.5, self.ctrlsrf.deploy_angle)
+        self.ctrlsrf.deploy_angle = -100
+        self.assertAlmostEqual(-22.5, self.ctrlsrf.deploy_angle)
+        # The angle is persistent, so restore it for the other tests
+        self.ctrlsrf.deploy_angle = 15
+        self.wait()
+        self.assertAlmostEqual(15, self.ctrlsrf.deploy_angle)
+
+    def test_deploy_angle_during_override(self):
+        cs = self.ctrlsrf
+        cs.deflection_override = True
+        self.wait()
+        # The override drives the angle, so a value set here is held for the release
+        cs.deploy_angle = -5
+        self.assertAlmostEqual(-5, cs.deploy_angle)
+        cs.deflection_override = False
+        self.wait()
+        self.assertAlmostEqual(-5, cs.deploy_angle)
+        cs.deploy_angle = 15
+        self.wait()
+
     def test_deflection_override(self):
         cs = self.ctrlsrf
         self.assertFalse(cs.deflection_override)
@@ -126,6 +161,7 @@ class TestPartsControlSurface(krpctest.TestCase):
         self.assertTrue(cs.yaw_enabled)
         self.assertFalse(cs.roll_enabled)
         self.assertFalse(cs.deployed)
+        self.assertAlmostEqual(15, cs.deploy_angle)
 
     def test_deflection_override_released_on_disconnect(self):
         cs = self.ctrlsrf
@@ -149,6 +185,7 @@ class TestPartsControlSurface(krpctest.TestCase):
         self.assertTrue(cs.yaw_enabled)
         self.assertFalse(cs.roll_enabled)
         self.assertFalse(cs.deployed)
+        self.assertAlmostEqual(15, cs.deploy_angle)
 
     def test_surface_area(self):
         self.assertAlmostEqual(1, self.ctrlsrf.surface_area)

--- a/service/SpaceCenter/test/test_parts_control_surface.py
+++ b/service/SpaceCenter/test/test_parts_control_surface.py
@@ -131,6 +131,19 @@ class TestPartsControlSurface(krpctest.TestCase):
         cs.deploy_angle = 15
         self.wait()
 
+    def test_deployed_during_override(self):
+        cs = self.ctrlsrf
+        self.assertFalse(cs.deployed)
+        cs.deflection_override = True
+        self.wait()
+        # The override holds the surface deployed, so it cannot be set
+        self.assertTrue(cs.deployed)
+        self.assertRaises(RuntimeError, setattr, cs, "deployed", False)
+        self.assertRaises(RuntimeError, setattr, cs, "deployed", True)
+        cs.deflection_override = False
+        self.wait()
+        self.assertFalse(cs.deployed)
+
     def test_deflection_override(self):
         cs = self.ctrlsrf
         self.assertFalse(cs.deflection_override)


### PR DESCRIPTION
Adds `ControlSurface.DeployAngle`, along with `MinDeployAngle` and `MaxDeployAngle` for the range KSP derives from the part's control surface range. The setter clamps to that range, matching the bounds the flight UI slider is given.

**Deflection override.** The override drives the module's deploy angle field to apply the deflection, and forces the deploy flag on. Releasing it left the angle at the last deflection command, which persists into the save file. `Deployed` meanwhile accepted a value that the release then discarded.

**Fix.** `DeployAngle` reads and writes the value the release restores, so the override is invisible through it. `Deployed` reports the module, which the override genuinely holds deployed, and setting it during an override now raises an error.

**Testing.** Verified in game. The control surface suite covers the range and the clamp, and both properties across an override and its release.