### PR TITLE
Hold the auto-pilot's control loop while the vessel is unloaded

### DIFF
--- a/service/SpaceCenter/src/AutoPilot/AttitudeController.cs
+++ b/service/SpaceCenter/src/AutoPilot/AttitudeController.cs
@@ -48,6 +48,9 @@ namespace KRPC.SpaceCenter.AutoPilot
         // apart from lastStepFixedTime so that a step which fails part way through does not run
         // again in the same tick, and does not make the output it did not produce look recent.
         float lastAttemptFixedTime = float.NaN;
+        // Whether the vessel was unloaded on the last step, which makes the next step on a loaded
+        // vessel start the loop over (see Step).
+        bool wasUnloaded;
         // The time the last output stays usable. The loop runs once per tick, but the tick it is
         // applied in is not always the tick it ran in, and a program driving it by hand may miss
         // one. Holding the last command over a short gap is smoother than dropping to zero. Past
@@ -805,9 +808,9 @@ namespace KRPC.SpaceCenter.AutoPilot
 
         /// <summary>
         /// Run one tick of the control loop, writing its result to <see cref="Output"/>. Does
-        /// nothing while not engaged, when it has already been tried on this physics tick, or
-        /// while the reference frame cannot be measured in. If the client that engaged the
-        /// auto-pilot has disconnected, disengages instead.
+        /// nothing while not engaged, when it has already been tried on this physics tick, while
+        /// the vessel is unloaded, or while the reference frame cannot be measured in. If the
+        /// client that engaged the auto-pilot has disconnected, disengages instead.
         /// </summary>
         public void Step ()
         {
@@ -828,8 +831,22 @@ namespace KRPC.SpaceCenter.AutoPilot
             // another one, and the output hold time releases the controls in the meantime.
             if (ReferenceFrame.GameObjectState != GameObjectState.Live)
                 return;
+            var internalVessel = vessel.InternalVessel;
+            // A vessel the game has unloaded is flown on rails, and its parts are gone, so there
+            // is no rate to measure and no actuator to command. The loop waits for the game to
+            // load the vessel again, and the output hold time releases the controls meanwhile.
+            if (internalVessel.rootPart == null) {
+                wasUnloaded = true;
+                return;
+            }
+            // A vessel the game has loaded again comes back with a fresh orientation and rate, so
+            // the loop starts over instead of carrying its frame and integrators across the gap.
+            if (wasUnloaded) {
+                wasUnloaded = false;
+                Start ();
+            }
             // The auto-pilot fights stock SAS, so hold it off while engaged.
-            vessel.InternalVessel.ActionGroups.SetGroup (KSPActionGroup.SAS, false);
+            internalVessel.ActionGroups.SetGroup (KSPActionGroup.SAS, false);
             Update (Output);
             // Only a step that got this far produced an output to fly the vessel with.
             lastStepFixedTime = Time.fixedTime;

--- a/service/SpaceCenter/test/test_autopilot_unload.py
+++ b/service/SpaceCenter/test/test_autopilot_unload.py
@@ -1,0 +1,68 @@
+"""Tests the auto-pilot against a vessel that the game unloads.
+
+A vessel that leaves physics range is unloaded: its parts are destroyed and it flies on
+rails. The control loop has no rate to measure and no actuator to command until the game
+loads it again, and a loop that runs anyway throws once per physics tick.
+"""
+
+import os
+
+import krpctest
+from krpctest.env import get_ksp_dir
+
+
+class TestAutoPilotUnload(krpctest.TestCase):
+    """Both halves of Multi.craft are undocked into two vessels sharing an orbit, the
+    auto-pilot is engaged on the one that is not active, and the active vessel is
+    teleported onto a much higher orbit to take the other one out of range."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.new_save()
+        cls.launch_vessel_from_vab("Multi")
+        cls.remove_other_vessels()
+        cls.set_circular_orbit("Kerbin", 100000)
+        cls.space_center = cls.connect().space_center
+        next(iter(cls.space_center.active_vessel.parts.docking_ports)).undock()
+        cls.wait(1)
+        cls.vessel = cls.space_center.active_vessel
+        cls.other = next(v for v in cls.space_center.vessels if v != cls.vessel)
+
+    @staticmethod
+    def log_position():
+        return os.path.getsize(os.path.join(get_ksp_dir(), "KSP.log"))
+
+    @staticmethod
+    def log_since(position):
+        """The text the game has logged since the given position in its log file."""
+        with open(
+            os.path.join(get_ksp_dir(), "KSP.log"), encoding="utf-8", errors="replace"
+        ) as log:
+            log.seek(position)
+            return log.read()
+
+    def test_unloaded_vessel_is_not_flown(self):
+        auto_pilot = self.other.auto_pilot
+        auto_pilot.reference_frame = self.other.surface_reference_frame
+        auto_pilot.target_pitch_and_heading(0, 90)
+        auto_pilot.engaged = True
+        self.wait(1)
+        self.assertTrue(self.other.loaded)
+
+        position = self.log_position()
+        self.set_circular_orbit("Kerbin", 200000)
+        self.wait_until(
+            lambda: not self.other.loaded, message="the other vessel to unload"
+        )
+        self.wait(3)
+
+        self.assertTrue(auto_pilot.engaged, "the auto-pilot stays engaged")
+        # Report the first failure rather than the whole log, which runs to megabytes.
+        errors = [
+            line
+            for line in self.log_since(position).splitlines()
+            if "Auto-pilot failed" in line
+        ]
+        self.assertEqual(
+            [], errors[:1], "the auto-pilot ran against the unloaded vessel"
+        )


### PR DESCRIPTION
The auto-pilot's control loop runs from the server update, which steps every engaged controller once per physics tick. A vessel that leaves physics range is unloaded and its parts are destroyed, so measuring its angular velocity throws. The failure is caught and logged, so an engaged auto-pilot on an unloaded vessel wrote a stack trace to the log every tick.

The loop now waits while the vessel is unloaded, and starts over once the game loads it again. The vessel comes back with a fresh orientation and rate, which the carried-forward pointing frame and integrators would deliver as a kick on the first tick back.

**Testing.** A new in-game test engages the auto-pilot on a non-active vessel, teleports the active vessel out of range, and checks the game log over that window. Without the fix that run logged 275 failures.