### PR TITLE
Fix the C++ client's stream update locking

### DIFF
--- a/client/cpp/CHANGELOG.md
+++ b/client/cpp/CHANGELOG.md
@@ -9,6 +9,11 @@
   sockets (#1065)
 - Add a `timeout` parameter to `krpc::connect`, bounding how long a connection is waited for
   (#1065)
+- Fix `Stream::start` hanging when a stream's only update notification is lost (#1090)
+- Fix a race between a stream update arriving and a stream update callback being added or
+  removed (#1090)
+- Fix a removed stream returning the value it last received (#1090)
+- Fix a thread waiting on a stream being left blocked when the stream is removed (#1090)
 - Fix a service with a collection of enumerations in a procedure signature failing to
   compile (#1044)
 - Fix `krpc::Connection::close` failing to link (#1065)

--- a/client/cpp/include/krpc/stream.hpp
+++ b/client/cpp/include/krpc/stream.hpp
@@ -79,7 +79,7 @@ inline void Stream<T>::start(bool wait) {
   } else {
     if (!acquired) impl->get_condition_lock().lock();
     impl->start();
-    impl->get_condition().wait(impl->get_condition_lock());
+    impl->get_condition().wait(impl->get_condition_lock(), [this] { return impl->has_updated(); });
     if (!acquired) impl->get_condition_lock().unlock();
   }
 }

--- a/client/cpp/include/krpc/stream_impl.hpp
+++ b/client/cpp/include/krpc/stream_impl.hpp
@@ -42,6 +42,7 @@ class StreamImpl {
   std::recursive_mutex* update_lock;
   bool started;
   bool updated;
+  bool removed;
   std::string data;
   bool _is_null;
   std::exception_ptr exception;

--- a/client/cpp/include/krpc/stream_impl.hpp
+++ b/client/cpp/include/krpc/stream_impl.hpp
@@ -24,6 +24,8 @@ class StreamImpl {
   const std::string& get_data();
   bool is_null() const;
   void update(const std::string& data, bool is_null, const std::exception_ptr& exception);
+  void update_and_notify(const std::string& data, bool is_null,
+                         const std::exception_ptr& exception);
   bool has_updated() const;
   std::condition_variable& get_condition();
   std::unique_lock<std::mutex>& get_condition_lock();

--- a/client/cpp/src/stream_impl.cpp
+++ b/client/cpp/src/stream_impl.cpp
@@ -56,6 +56,16 @@ void StreamImpl::update(const std::string& data, bool is_null,
   this->exception = exception;
 }
 
+// Store an update and wake the threads waiting for one. We hold the condition across both,
+// so that a notification cannot fire between a waiter checking the value and entering its
+// wait.
+void StreamImpl::update_and_notify(const std::string& data, bool is_null,
+                                   const std::exception_ptr& exception) {
+  std::lock_guard<std::mutex> guard(condition_mutex);
+  update(data, is_null, exception);
+  condition.notify_all();
+}
+
 bool StreamImpl::has_updated() const { return updated; }
 
 std::condition_variable& StreamImpl::get_condition() { return condition; }

--- a/client/cpp/src/stream_impl.cpp
+++ b/client/cpp/src/stream_impl.cpp
@@ -50,10 +50,13 @@ bool StreamImpl::is_null() const { return _is_null; }
 void StreamImpl::update(const std::string& data, bool is_null,
                         const std::exception_ptr& exception) {
   std::lock_guard<std::recursive_mutex> guard(*update_lock);
-  updated = true;
+  // Store the value before the flag that says there is one. A reader checks the flag first
+  // and takes no lock, so the other order lets it see the flag set and read the value that
+  // has not been stored yet.
   this->data = data;
   this->_is_null = is_null;
   this->exception = exception;
+  updated = true;
 }
 
 // Store an update and wake the threads waiting for one. We hold the condition across both,

--- a/client/cpp/src/stream_impl.cpp
+++ b/client/cpp/src/stream_impl.cpp
@@ -1,5 +1,6 @@
 #include "krpc/stream_impl.hpp"
 
+#include <exception>
 #include <string>
 
 #include "krpc/client.hpp"
@@ -14,6 +15,7 @@ StreamImpl::StreamImpl(Client* client, uint64_t id, std::recursive_mutex* update
       update_lock(update_lock),
       started(false),
       updated(false),
+      removed(false),
       _is_null(false),
       condition_lock(condition_mutex, std::defer_lock),
       next_callback_tag(0),
@@ -65,7 +67,14 @@ void StreamImpl::update(const std::string& data, bool is_null,
 void StreamImpl::update_and_notify(const std::string& data, bool is_null,
                                    const std::exception_ptr& exception) {
   std::lock_guard<std::mutex> guard(condition_mutex);
-  update(data, is_null, exception);
+  {
+    std::lock_guard<std::recursive_mutex> update_guard(*update_lock);
+    // The stream can be removed while an update for it is in flight. Removal stores the
+    // error saying so, which this value must not overwrite: no further update arrives to
+    // replace it, and the stream would read as live forever.
+    if (removed) return;
+    update(data, is_null, exception);
+  }
   condition.notify_all();
 }
 
@@ -90,6 +99,17 @@ void StreamImpl::remove_callback(int tag) {
   callbacks.erase(tag);
 }
 
-void StreamImpl::remove() { client->remove_stream(id); }
+void StreamImpl::remove() {
+  client->remove_stream(id);
+  std::lock_guard<std::mutex> guard(condition_mutex);
+  {
+    std::lock_guard<std::recursive_mutex> update_guard(*update_lock);
+    removed = true;
+    update("", false, std::make_exception_ptr(StreamError("Stream does not exist")));
+  }
+  // No further update arrives for a removed stream, so a thread waiting on it has to be
+  // woken here. It reads the error stored above on waking.
+  condition.notify_all();
+}
 
 }  // namespace krpc

--- a/client/cpp/src/stream_manager.cpp
+++ b/client/cpp/src/stream_manager.cpp
@@ -66,30 +66,40 @@ void StreamManager::remove_stream(uint64_t id) {
 }
 
 void StreamManager::update(uint64_t id, const schema::ProcedureResult& result) {
-  std::lock_guard<std::recursive_mutex> guard(*update_lock);
-  auto it = streams.find(id);
-  if (it == streams.end()) return;
-  auto stream = it->second.lock();
-  if (!stream) return;
+  std::shared_ptr<StreamImpl> stream;
+  StreamImpl::Callbacks callbacks;
+  // The update lock is held only to find the stream and copy its callbacks, and is released
+  // before the stream's condition is taken. A thread waiting for an update holds the
+  // condition and then needs the update lock, as Event::wait resets the stream value while
+  // holding it. Taking the two in the opposite order here deadlocks. The callbacks are
+  // copied for the same reason: they run below without the lock held.
+  {
+    std::lock_guard<std::recursive_mutex> guard(*update_lock);
+    auto it = streams.find(id);
+    if (it == streams.end()) return;
+    stream = it->second.lock();
+    if (!stream) return;
+    callbacks = stream->get_callbacks();
+  }
+
   if (!result.has_error()) {
-    stream->update(result.value(), result.is_null(), nullptr);
+    stream->update_and_notify(result.value(), result.is_null(), nullptr);
   } else {
     try {
       client->throw_exception(result.error());
     } catch (...) {
-      stream->update("", false, std::current_exception());
+      stream->update_and_notify("", false, std::current_exception());
     }
   }
-  stream->get_condition().notify_all();
+
   // A stream in an error state has no value to give a callback: a callback takes the encoded
-  // value and there is nowhere to put an exception, so reading the stream would rethrow the
-  // error into this thread. Skip them for such an update. Anything a callback itself throws
-  // is contained here too, as an exception leaving the update thread calls std::terminate and
-  // ends the process.
+  // value and there is nowhere to put an exception. Skip them for such an update. Anything a
+  // callback itself throws is contained here too, as an exception leaving the update thread
+  // calls std::terminate and ends the process.
   if (!result.has_error()) {
-    for (const auto& callback : stream->get_callbacks()) {
+    for (const auto& callback : callbacks) {
       try {
-        callback.second(stream->get_data());
+        callback.second(result.value());
       } catch (const std::exception& exn) {
         std::cerr << "kRPC: exception thrown by a stream callback: " << exn.what() << "\n";
       } catch (...) {

--- a/client/cpp/src/stream_manager.cpp
+++ b/client/cpp/src/stream_manager.cpp
@@ -151,13 +151,19 @@ void StreamManager::update_thread_main(StreamManager* stream_manager,
     for (const auto& result : update.results())
       stream_manager->update(result.id(), result.result());
     {
-      // Notify while holding the condition mutex, so that a notification cannot
-      // fire between a waiter checking the stream value and entering its wait --
-      // it would be lost and the waiter would sleep through the update.
+      // Notify while holding the condition mutex. A notification firing between a
+      // waiter checking the stream value and entering its wait is lost, and the
+      // waiter sleeps through the update.
       std::lock_guard<std::mutex> guard(stream_manager->condition_mutex);
       stream_manager->condition.notify_all();
     }
-    for (const auto& callback : stream_manager->callbacks) callback.second();
+    // Copy the callbacks under the update lock, as they run below without it held
+    Callbacks callbacks;
+    {
+      std::lock_guard<std::recursive_mutex> guard(*stream_manager->update_lock);
+      callbacks = stream_manager->callbacks;
+    }
+    for (const auto& callback : callbacks) callback.second();
   };
 
   while (!stop->load()) {

--- a/client/cpp/test/test_stream.cpp
+++ b/client/cpp/test/test_stream.cpp
@@ -153,6 +153,39 @@ TEST_F(test_stream, test_interleaved) {
   ASSERT_THROW(s2(), krpc::StreamError);
 }
 
+// Removing a stream stores the error saying so on it, which another handle to the same
+// stream reports in place of the value it last received.
+TEST_F(test_stream, test_remove_errors_another_handle) {
+  auto x = test_service.int32_to_string_stream(42);
+  krpc::Stream<std::string> y = x;
+  ASSERT_EQ("42", x());
+  ASSERT_EQ("42", y());
+  x.remove();
+  ASSERT_THROW(y(), krpc::StreamError);
+}
+
+// No further update arrives for a removed stream, so removing one has to wake a thread
+// already waiting on it. This waits on a stream whose value never changes, which gets
+// exactly one update. A regression leaves the waiting thread blocked and the test times out.
+TEST_F(test_stream, test_remove_wakes_a_waiting_thread) {
+  krpc::Stream<std::string> x = test_service.float_to_string_stream(3.14159);
+  krpc::Stream<std::string> y = x;
+  x.start();
+  std::atomic_bool waiting(false);
+  std::thread waiter([&y, &waiting] {
+    y.acquire();
+    waiting.store(true);
+    y.wait();
+    y.release();
+  });
+  // The waiter holds the condition until it enters its wait, so the removal below cannot
+  // notify before then
+  while (!waiting.load()) {
+  }
+  x.remove();
+  waiter.join();
+}
+
 TEST_F(test_stream, test_remove_stream_twice) {
   auto s = test_service.int32_to_string_stream(0);
   ASSERT_EQ("0", s());

--- a/client/cpp/test/test_stream.cpp
+++ b/client/cpp/test/test_stream.cpp
@@ -283,6 +283,22 @@ TEST_F(test_stream, test_wait_timeout_long) {
   x.release();
 }
 
+// The update thread must not hold the update lock while waiting for a stream's condition.
+// This test holds the condition, which is how waiting for an update is documented to work,
+// and then calls something needing the update lock. A regression deadlocks the two, and the
+// test times out.
+TEST_F(test_stream, test_remove_callback_while_holding_condition) {
+  auto x = test_service.counter_stream("test_stream.test_remove_callback_while_holding_condition");
+  auto tag = x.add_callback([](int) {});
+  x.start();
+  x.acquire();
+  x.wait();
+  // Let the update thread reach the next update and block on the condition we hold
+  std::this_thread::sleep_for(std::chrono::milliseconds(200));
+  x.remove_callback(tag);
+  x.release();
+}
+
 // These tests wait for an update first, to synchronize on an update message
 // boundary before reading their baseline count; each subsequent wait then
 // corresponds to exactly one update message, which advances the counter value

--- a/client/csharp/src/StreamManager.cs
+++ b/client/csharp/src/StreamManager.cs
@@ -93,7 +93,7 @@ namespace KRPC.Client
             // The update lock is held only to find the stream and decode its new value, and is
             // released before the stream's condition is taken. A thread waiting for an update
             // holds the condition and then needs the update lock, as Event.Wait resets the
-            // stream value while holding it, so taking the two in the opposite order here
+            // stream value while holding it. Taking the two in the opposite order here
             // deadlocks. The callbacks are copied for the same reason: they run below without
             // the lock held.
             lock (updateLock) {

--- a/client/java/src/krpc/client/StreamManager.java
+++ b/client/java/src/krpc/client/StreamManager.java
@@ -74,9 +74,9 @@ class StreamManager {
     List<Consumer<Object>> callbacks;
     // The update lock is held only to find the stream and decode its new value, and is released
     // before the stream's condition is taken. A thread waiting for an update holds the condition
-    // and then needs the update lock, as Event.waitFor resets the stream value while holding it,
-    // so taking the two in the opposite order here deadlocks. The callbacks are copied for the
-    // same reason: they run below without the lock held.
+    // and then needs the update lock, as Event.waitFor resets the stream value while holding it.
+    // Taking the two in the opposite order here deadlocks. The callbacks are copied for the same
+    // reason: they run below without the lock held.
     synchronized (updateLock) {
       if (!streams.containsKey(id)) {
         return;

--- a/client/python/krpc/streammanager.py
+++ b/client/python/krpc/streammanager.py
@@ -194,9 +194,9 @@ class StreamManager:
         # The update lock is held only to find the streams and decode their new values, and
         # is released before any stream condition is taken. A thread waiting for an update
         # holds a condition and then needs the update lock, as Event.wait resets the stream
-        # value while holding it, so taking the two in the opposite order here deadlocks.
-        # The callbacks are read under the lock for the same reason: they run below without
-        # it held.
+        # value while holding it. Taking the two in the opposite order here deadlocks. The
+        # callbacks are read under the lock for the same reason: they run below without it
+        # held.
         decoded = []
         with self._update_lock:
             for result in results:


### PR DESCRIPTION
**Root cause.** The update thread notified a stream's condition without holding its mutex, so an update arriving between a waiter checking the stream value and entering its wait was lost. A stream whose value never changes gets exactly one update, and losing it left `Stream::start` waiting forever. This is what hung `test_stream.test_method` on the CI runner.

**Fix.** The update lock is held only to find the stream and copy its callbacks, and the stream's condition is taken after releasing it. A waiting thread reaches for the two in that order through `Event::wait`, so wrapping the notify in place would have deadlocked instead. `Stream::start` now also waits on a predicate. This mirrors the Python, C# and Java clients.

Reviewing the same code turned up three more defects, each fixed in its own commit:

- The connection's stream update callbacks were iterated with no lock, racing the registry that adding and removing one mutates.
- A stream's `updated` flag was set before its value, which a reader checks without taking the update lock.
- Removing a stream left its last value in place, so another handle kept reading it as live and a thread waiting on it was never woken.

**Testing.** Both hangs have a regression test. Reverting the fix under each one deadlocks its test and times the target out.

Fixes #1085