### PR TITLE
Support nullable values inside structures and collections

### DIFF
--- a/client/cnano/CHANGELOG.md
+++ b/client/cnano/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## [v0.7.0] - unreleased
+- Support a nullable structure field, list element, tuple item and dictionary value, each
+  generated as a type holding the value beside a `bool` presence flag (#1091)
 - Support structure types, generated as a C struct with a member per field (#1066)
 - **Breaking:** Support null for any nullable type; a nullable non-class return adds a
   `bool* returnValueIsNull` out-parameter and a nullable argument is a pointer (#1017)

--- a/client/cnano/test/test_client.cpp
+++ b/client/cnano/test/test_client.cpp
@@ -434,6 +434,90 @@ TEST_F(test_client, test_structs) {
   KRPC_FREE_LIST(result.list_field);
 }
 
+TEST_F(test_client, test_nullable_struct_fields) {
+  krpc_TestService_TestClass_t obj = KRPC_NULL;
+  ASSERT_EQ(KRPC_OK, krpc_TestService_CreateTestObject(conn, &obj, "jeb"));
+
+  krpc_TestService_TestNullableStruct_t value = {
+      0, {0, false}, {0, false}, {NULL, false}, {KRPC_NULL, false}};
+  value.int_field = 1;
+  value.nullable_int_field.value = 2;
+  value.nullable_int_field.has_value = true;
+  value.nullable_enum_field.value = KRPC_TESTSERVICE_TESTENUM_VALUEB;
+  value.nullable_enum_field.has_value = true;
+  value.nullable_string_field.value = (char*)"jeb";
+  value.nullable_string_field.has_value = true;
+  value.nullable_object_field.value = obj;
+  value.nullable_object_field.has_value = true;
+
+  krpc_TestService_TestNullableStruct_t result = {
+      0, {0, false}, {0, false}, {NULL, false}, {KRPC_NULL, false}};
+  ASSERT_EQ(KRPC_OK, krpc_TestService_NullableStructEcho(conn, &result, &value));
+  ASSERT_EQ(1, result.int_field);
+  ASSERT_TRUE(result.nullable_int_field.has_value);
+  ASSERT_EQ(2, result.nullable_int_field.value);
+  ASSERT_TRUE(result.nullable_enum_field.has_value);
+  ASSERT_EQ(KRPC_TESTSERVICE_TESTENUM_VALUEB, result.nullable_enum_field.value);
+  ASSERT_TRUE(result.nullable_string_field.has_value);
+  ASSERT_STREQ("jeb", result.nullable_string_field.value);
+  ASSERT_TRUE(result.nullable_object_field.has_value);
+  ASSERT_EQ(obj, result.nullable_object_field.value);
+
+  krpc_free(result.nullable_string_field.value);
+}
+
+TEST_F(test_client, test_null_struct_fields) {
+  krpc_TestService_TestNullableStruct_t value = {
+      0, {0, false}, {0, false}, {NULL, false}, {KRPC_NULL, false}};
+  value.int_field = 1;
+
+  krpc_TestService_TestNullableStruct_t result = {
+      0, {0, false}, {0, false}, {NULL, false}, {KRPC_NULL, false}};
+  ASSERT_EQ(KRPC_OK, krpc_TestService_NullableStructEcho(conn, &result, &value));
+  ASSERT_EQ(1, result.int_field);
+  ASSERT_FALSE(result.nullable_int_field.has_value);
+  ASSERT_FALSE(result.nullable_enum_field.has_value);
+  ASSERT_FALSE(result.nullable_string_field.has_value);
+  ASSERT_FALSE(result.nullable_object_field.has_value);
+}
+
+TEST_F(test_client, test_nullable_list_elements) {
+  krpc_nullable_int32_t items[3] = {{1, true}, {0, false}, {3, true}};
+  krpc_list_nullable_int32_t list = KRPC_NULL_LIST;
+  list.size = 3;
+  list.items = items;
+
+  krpc_list_nullable_int32_t result = KRPC_NULL_LIST;
+  ASSERT_EQ(KRPC_OK, krpc_TestService_EchoListOfNullableInts(conn, &result, &list));
+  ASSERT_EQ(3u, result.size);
+  ASSERT_TRUE(result.items[0].has_value);
+  ASSERT_EQ(1, result.items[0].value);
+  ASSERT_FALSE(result.items[1].has_value);
+  ASSERT_TRUE(result.items[2].has_value);
+  ASSERT_EQ(3, result.items[2].value);
+
+  KRPC_FREE_LIST(result);
+}
+
+TEST_F(test_client, test_nullable_list_of_objects) {
+  krpc_TestService_TestClass_t obj = KRPC_NULL;
+  ASSERT_EQ(KRPC_OK, krpc_TestService_CreateTestObject(conn, &obj, "jeb"));
+
+  krpc_nullable_object_t items[2] = {{obj, true}, {KRPC_NULL, false}};
+  krpc_list_nullable_object_t list = KRPC_NULL_LIST;
+  list.size = 2;
+  list.items = items;
+
+  krpc_list_nullable_object_t result = KRPC_NULL_LIST;
+  ASSERT_EQ(KRPC_OK, krpc_TestService_EchoListOfNullableObjects(conn, &result, &list));
+  ASSERT_EQ(2u, result.size);
+  ASSERT_TRUE(result.items[0].has_value);
+  ASSERT_EQ(obj, result.items[0].value);
+  ASSERT_FALSE(result.items[1].has_value);
+
+  KRPC_FREE_LIST(result);
+}
+
 TEST_F(test_client, test_nested_structs) {
   krpc_TestService_TestClass_t obj = KRPC_NULL;
   ASSERT_EQ(KRPC_OK, krpc_TestService_CreateTestObject(conn, &obj, "bob"));

--- a/client/cpp/CHANGELOG.md
+++ b/client/cpp/CHANGELOG.md
@@ -1,10 +1,11 @@
 ## [v0.7.0] - unreleased
+- Support a nullable structure field, list element, tuple item and dictionary value (#1091)
 - Support structure types, a compound value with named fields a service defines, generated as
   a `struct` with a constructor, equality, ordering and a `std::hash` over its fields (#1066)
 - Add `krpc::hash_value` and the `krpc::hash` function object, which hash any type the client
   carries, so a tuple or a collection can key an unordered container (#1067)
-- **Breaking:** Support null for any nullable type; nullable non-class values use
-  `std::optional`, changing generated signatures (#1017)
+- **Breaking:** Support null for any nullable type, held as `std::optional`, changing
+  generated signatures (#1017)
 - Add `krpc::connect_local`, which connects to a server on the same machine over unix domain
   sockets (#1065)
 - Add a `timeout` parameter to `krpc::connect`, bounding how long a connection is waited for

--- a/client/cpp/include/krpc/decoder.hpp
+++ b/client/cpp/include/krpc/decoder.hpp
@@ -59,6 +59,11 @@ void decode(std::set<T>& set, const std::string& data, Client* client = nullptr)
 template <typename K, typename V>
 void decode(std::map<K, V>& dictionary, const std::string& data, Client* client = nullptr);
 
+template <typename T>
+void decode_item(std::optional<T>& value, const std::string& data, Client* client);
+template <typename T>
+void decode_item(T& value, const std::string& data, Client* client);
+
 uint32_t decode_size(const std::string& data);
 
 /** Read the size prefix a message is preceded by out of a buffer. Returns false if the buffer
@@ -79,7 +84,8 @@ inline void decode(std::tuple<Ts...>& tuple, const std::string& data, Client* cl
   static thread_local krpc::schema::Tuple tupleMessage;
   if (!tupleMessage.ParseFromString(data)) throw EncodingError("Failed to decode message");
   int index = 0;
-  std::apply([&](Ts&... args) { (decode(args, tupleMessage.items(index++), client), ...); }, tuple);
+  std::apply([&](Ts&... args) { (decode_item(args, tupleMessage.items(index++), client), ...); },
+             tuple);
 }
 
 template <typename T>
@@ -89,6 +95,27 @@ inline void decode(std::optional<T>& value, const std::string& data, Client* cli
   T inner;
   decode(inner, data, client);
   value = inner;
+}
+
+// Decode one of the values a collection or a structure holds, where a nullable position is
+// a std::optional.
+template <typename T>
+inline void decode_item(std::optional<T>& value, const std::string& data, Client* client) {
+  // The presence bool is one byte, as a bool value always is, and is read from it directly
+  // rather than through a copy of it
+  if (data.empty()) throw EncodingError("Failed to decode message");
+  if (data[0] == 0) {
+    value.reset();
+    return;
+  }
+  T inner;
+  decode(inner, data.substr(1), client);
+  value = inner;
+}
+
+template <typename T>
+inline void decode_item(T& value, const std::string& data, Client* client) {
+  decode(value, data, client);
 }
 
 // A collection arrives as a message holding its items, one encoded value each. That message is
@@ -108,7 +135,7 @@ inline void decode(std::vector<T>& list, const std::string& data, Client* client
   list.reserve(listMessage.items_size());
   for (int i = 0; i < listMessage.items_size(); i++) {
     T value;
-    decode(value, listMessage.items(i), client);
+    decode_item(value, listMessage.items(i), client);
     list.push_back(std::move(value));
   }
 }
@@ -135,7 +162,7 @@ inline void decode(std::map<K, V>& dictionary, const std::string& data, Client* 
     K key;
     V value;
     decode(key, entry.key(), client);
-    decode(value, entry.value(), client);
+    decode_item(value, entry.value(), client);
     dictionary[std::move(key)] = std::move(value);
   }
 }

--- a/client/cpp/include/krpc/encoder.hpp
+++ b/client/cpp/include/krpc/encoder.hpp
@@ -47,6 +47,11 @@ std::string encode(const std::set<T>& set);
 template <typename... Ts>
 std::string encode(const std::tuple<Ts...>& tuple);
 
+template <typename T>
+std::string encode_item(const std::optional<T>& value);
+template <typename T>
+std::string encode_item(const T& value);
+
 std::string encode_message_with_size(const google::protobuf::MessageLite& message);
 /** Encode a message, preceded by its size, into data. Reuses whatever data has already
     allocated, for a caller that encodes one message after another. */
@@ -69,7 +74,7 @@ inline std::string encode(const std::vector<T>& list) {
   static thread_local krpc::schema::List listMessage;
   listMessage.Clear();
   for (typename std::vector<T>::const_iterator x = list.begin(); x != list.end(); ++x)
-    listMessage.add_items(encode(*x));
+    listMessage.add_items(encode_item(*x));
   return encode(listMessage);
 }
 
@@ -80,7 +85,7 @@ inline std::string encode(const std::map<K, V>& dictionary) {
   for (typename std::map<K, V>::const_iterator x = dictionary.begin(); x != dictionary.end(); ++x) {
     schema::DictionaryEntry* entry = dictionaryMessage.add_entries();
     entry->set_key(encode(x->first));
-    entry->set_value(encode(x->second));
+    entry->set_value(encode_item(x->second));
   }
   return encode(dictionaryMessage);
 }
@@ -100,8 +105,21 @@ inline std::string encode(const std::tuple<Ts...>& tuple) {
   static thread_local krpc::schema::Tuple tupleMessage;
   tupleMessage.Clear();
   // The message is not captured: it lives for the thread, not for this call.
-  std::apply([](const Ts&... args) { (tupleMessage.add_items(encode(args)), ...); }, tuple);
+  std::apply([](const Ts&... args) { (tupleMessage.add_items(encode_item(args)), ...); }, tuple);
   return encode(tupleMessage);
+}
+
+// Encode one of the values a collection or a structure holds. A nullable position is a
+// std::optional, and carries a presence bool before its value.
+template <typename T>
+inline std::string encode_item(const std::optional<T>& value) {
+  if (!value) return encode(false);
+  return encode(true) + encode(*value);
+}
+
+template <typename T>
+inline std::string encode_item(const T& value) {
+  return encode(value);
 }
 
 // An encoded argument value together with whether the argument is null. A null argument
@@ -118,19 +136,17 @@ struct Value {
   }
 };
 
-// Encode a nullable non-class argument: an empty optional is null, otherwise the
-// contained value is encoded as its underlying type.
+// Encode an argument of a call, which is a slot. A slot carries its null in is_null beside
+// the encoded bytes, so a null is sent as no value at all.
 template <typename T>
-inline Value encode_nullable(const std::optional<T>& value) {
-  if (value) return Value(encode(*value));
-  return Value::null();
+inline Value encode_arg(const std::optional<T>& value) {
+  if (!value) return Value::null();
+  return Value(encode(*value));
 }
 
-// Encode a nullable class argument: an object with id 0 is the null representation.
 template <typename T>
-inline Value encode_nullable(const Object<T>& object) {
-  if (object._id == 0) return Value::null();
-  return Value(encode(object));
+inline Value encode_arg(const T& value) {
+  return Value(encode(value));
 }
 
 }  // namespace encoder

--- a/client/cpp/include/krpc/stream.hpp
+++ b/client/cpp/include/krpc/stream.hpp
@@ -101,8 +101,8 @@ inline T Stream<T>::operator()() {
   check_exists();
   if (!impl->has_started()) start();
   std::string data = impl->get_data();
-  // A null value is signaled out-of-band by is_null; leave value default-constructed
-  // (an empty optional, or an object with id 0).
+  // A null value is signaled out-of-band by is_null, and leaves the value default
+  // constructed, which for a nullable stream is an empty optional.
   T value{};
   if (!impl->is_null()) decoder::decode(value, data, impl->get_client());
   return value;

--- a/client/cpp/test/test_client.cpp
+++ b/client/cpp/test/test_client.cpp
@@ -14,6 +14,7 @@
 #include <string>
 #include <thread>  // NOLINT(build/c++11)
 #include <tuple>
+#include <type_traits>
 #include <unordered_set>
 #include <vector>
 
@@ -148,12 +149,12 @@ TEST_F(test_client, test_class_as_return_value) {
 }
 
 TEST_F(test_client, test_class_none_value) {
-  krpc::services::TestService::TestClass none;
-  ASSERT_EQ(none, test_service.echo_test_object(none));
+  std::optional<krpc::services::TestService::TestClass> none;
+  ASSERT_FALSE(test_service.echo_test_object(none).has_value());
   krpc::services::TestService::TestClass object = test_service.create_test_object("bob");
   ASSERT_EQ("bobnull", object.object_to_string(none));
   test_service.set_object_property(none);
-  ASSERT_EQ(none, test_service.object_property());
+  ASSERT_FALSE(test_service.object_property().has_value());
 }
 
 TEST_F(test_client, test_nullable_non_class_values) {
@@ -167,33 +168,35 @@ TEST_F(test_client, test_nullable_non_class_values) {
   ASSERT_FALSE(test_service.echo_nullable_list(std::nullopt).has_value());
 }
 
-TEST_F(test_client, test_non_nullable_parameter_rejects_null) {
-  // A null argument to a parameter that is not nullable is rejected by the server
-  krpc::services::TestService::TestClass none;
-  ASSERT_THROW(test_service.not_nullable_object(none), krpc::RPCError);
-}
+// The C++ type of a parameter carries whether it can hold null, so a null at a parameter
+// that is not nullable is rejected by the compiler rather than by the server
+static_assert(std::is_invocable_v<decltype(&krpc::services::TestService::echo_test_object),
+                                  krpc::services::TestService&, std::nullopt_t>);
+static_assert(!std::is_invocable_v<decltype(&krpc::services::TestService::not_nullable_object),
+                                   krpc::services::TestService&, std::nullopt_t>);
 
 TEST_F(test_client, test_nullable_class_method) {
-  krpc::services::TestService::TestClass none;
+  std::optional<krpc::services::TestService::TestClass> none;
   krpc::services::TestService::TestClass obj = test_service.create_test_object("jeb");
   krpc::services::TestService::TestClass obj2 = test_service.create_test_object("bob");
   ASSERT_EQ(obj2, obj.echo_nullable_object(obj2));
-  ASSERT_EQ(none, obj.echo_nullable_object(none));
+  ASSERT_FALSE(obj.echo_nullable_object(none).has_value());
 }
 
 TEST_F(test_client, test_nullable_class_static_method) {
-  krpc::services::TestService::TestClass none;
+  std::optional<krpc::services::TestService::TestClass> none;
   krpc::services::TestService::TestClass obj = test_service.create_test_object("jeb");
   ASSERT_EQ(obj, krpc::services::TestService::TestClass::static_nullable_object(conn, obj));
-  ASSERT_EQ(none, krpc::services::TestService::TestClass::static_nullable_object(conn, none));
+  auto result = krpc::services::TestService::TestClass::static_nullable_object(conn, none);
+  ASSERT_FALSE(result.has_value());
 }
 
 TEST_F(test_client, test_nullable_property) {
-  krpc::services::TestService::TestClass none;
+  std::optional<krpc::services::TestService::TestClass> none;
   krpc::services::TestService::TestClass obj = test_service.create_test_object("jeb");
   // ObjectProperty is nullable and its setter accepts null
   test_service.set_object_property(none);
-  ASSERT_EQ(none, test_service.object_property());
+  ASSERT_FALSE(test_service.object_property().has_value());
   // NullableObject is nullable for reads, but its setter guards against null, so writing
   // null raises the server's ArgumentNullException
   test_service.set_nullable_object(obj);
@@ -394,6 +397,59 @@ TEST_F(test_client, test_collections_of_structs) {
   ASSERT_EQ(2, result.size());
   ASSERT_EQ(1, result[0].int_field);
   ASSERT_EQ(2, result[1].int_field);
+}
+
+TEST_F(test_client, test_nullable_struct_fields) {
+  auto obj = test_service.create_test_object("jeb");
+  krpc::services::TestService::TestNullableStruct value(
+      1, 2, krpc::services::TestService::TestEnum::value_b, "jeb", obj);
+  auto result = test_service.nullable_struct_echo(value);
+  ASSERT_EQ(value, result);
+  ASSERT_EQ(2, result.nullable_int_field);
+  ASSERT_EQ(krpc::services::TestService::TestEnum::value_b, result.nullable_enum_field);
+  ASSERT_EQ("jeb", result.nullable_string_field);
+  ASSERT_EQ(obj, result.nullable_object_field);
+}
+
+TEST_F(test_client, test_null_struct_fields) {
+  // A position inside a value is an optional, and an empty one is null
+  krpc::services::TestService::TestNullableStruct value(1, {}, {}, {}, {});
+  auto result = test_service.nullable_struct_echo(value);
+  ASSERT_EQ(1, result.int_field);
+  ASSERT_FALSE(result.nullable_int_field.has_value());
+  ASSERT_FALSE(result.nullable_enum_field.has_value());
+  ASSERT_FALSE(result.nullable_string_field.has_value());
+  ASSERT_FALSE(result.nullable_object_field.has_value());
+}
+
+TEST_F(test_client, test_nullable_list_elements) {
+  std::vector<std::optional<int32_t>> ints{1, {}, 3};
+  ASSERT_EQ(ints, test_service.echo_list_of_nullable_ints(ints));
+  auto obj = test_service.create_test_object("jeb");
+  std::vector<std::optional<krpc::services::TestService::TestClass>> objects{obj, {}};
+  ASSERT_EQ(objects, test_service.echo_list_of_nullable_objects(objects));
+}
+
+TEST_F(test_client, test_nullable_dictionary_values) {
+  auto obj = test_service.create_test_object("jeb");
+  std::map<std::string, std::optional<krpc::services::TestService::TestClass>> value{{"a", obj},
+                                                                                     {"b", {}}};
+  ASSERT_EQ(value, test_service.echo_dictionary_of_nullable_objects(value));
+}
+
+TEST_F(test_client, test_nullable_tuple_item) {
+  auto obj = test_service.create_test_object("jeb");
+  std::tuple<int32_t, std::optional<krpc::services::TestService::TestClass>> present{1, obj};
+  ASSERT_EQ(present, test_service.echo_tuple_with_a_nullable_object(present));
+  std::tuple<int32_t, std::optional<krpc::services::TestService::TestClass>> absent{1, {}};
+  ASSERT_EQ(absent, test_service.echo_tuple_with_a_nullable_object(absent));
+}
+
+TEST_F(test_client, test_nullable_nested_list_elements) {
+  auto obj = test_service.create_test_object("jeb");
+  std::vector<std::vector<std::optional<krpc::services::TestService::TestClass>>> value{{obj, {}},
+                                                                                        {}};
+  ASSERT_EQ(value, test_service.echo_nested_list_of_nullable_objects(value));
 }
 
 TEST_F(test_client, test_struct_default_value) {

--- a/client/csharp/CHANGELOG.md
+++ b/client/csharp/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## [v0.7.0] - unreleased
+- Support a nullable structure field, list element, tuple item and dictionary value; a
+  value-typed one uses the nullable form (`int?`) (#1091)
 - Support structure types, a compound value with named fields a service defines, generated as
   a `struct` with a constructor, `IEquatable`, `IComparable` and the comparison operators over
   its fields (#1066)

--- a/client/csharp/src/Attributes/KRPCNullableAttribute.cs
+++ b/client/csharp/src/Attributes/KRPCNullableAttribute.cs
@@ -1,0 +1,14 @@
+using System;
+
+namespace KRPC.Client.Attributes
+{
+    /// <summary>
+    /// Attribute attached to a field of a structure type that can be null. A field whose type is
+    /// Nullable&lt;T&gt; carries that at runtime and does not need this, where a reference-typed
+    /// field is nullable in C# whether the service declares it so or not.
+    /// </summary>
+    [AttributeUsage (AttributeTargets.Property)]
+    public sealed class KRPCNullableAttribute : Attribute
+    {
+    }
+}

--- a/client/csharp/src/Attributes/RPCAttribute.cs
+++ b/client/csharp/src/Attributes/RPCAttribute.cs
@@ -19,12 +19,30 @@ namespace KRPC.Client.Attributes
         public string Procedure { get; set; }
 
         /// <summary>
+        /// The generated class holding the type specs of the service's procedures. A call
+        /// built from an expression has only the C# type of a value, which cannot say that a
+        /// reference-typed position inside a collection is nullable, so it reads the spec the
+        /// stub itself names from here.
+        /// </summary>
+        public Type Types { get; set; }
+
+        /// <summary>
         /// Construct a RPC attribute.
         /// </summary>
         public RPCAttribute (string service, string procedure)
         {
             Service = service;
             Procedure = procedure;
+        }
+
+        /// <summary>
+        /// Construct a RPC attribute naming the class that holds the service's type specs.
+        /// </summary>
+        public RPCAttribute (string service, string procedure, Type types)
+        {
+            Service = service;
+            Procedure = procedure;
+            Types = types;
         }
     }
 }

--- a/client/csharp/src/Connection.cs
+++ b/client/csharp/src/Connection.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq.Expressions;
 using System.Net;
 using System.Net.Sockets;
+using System.Reflection;
 using System.Threading;
 using Google.Protobuf;
 using KRPC.Client.Attributes;
@@ -239,11 +240,12 @@ namespace KRPC.Client
         {
             Expression rpc;
             var call = GetCall (expression, out rpc);
+            var returnSpec = ProcedureSpecs.ReturnSpec (GetRPCAttribute (rpc), rpc.Type);
             if (ExpressionUtils.IsIdentityWrapper (expression.Body, rpc))
-                return new Stream<TResult> (this, call);
+                return new Stream<TResult> (this, call, returnSpec);
 
             var convert = ExpressionUtils.CompileTransform<TResult> (expression.Body, rpc);
-            return new Stream<TResult> (this, call, rpc.Type, convert,
+            return new Stream<TResult> (this, call, returnSpec, convert,
                 ExpressionUtils.FoldedFactor (expression.Body, rpc));
         }
 
@@ -371,15 +373,35 @@ namespace KRPC.Client
             throw new ArgumentException ("Invalid expression. Must consist of a method call or property accessor only.");
         }
 
+        /// <summary>
+        /// The RPC attribute the stub in the expression carries, which names the procedure and
+        /// the class holding the specs of its values.
+        /// </summary>
+        static RPCAttribute GetRPCAttribute (Expression rpc)
+        {
+            var methodCall = rpc as MethodCallExpression;
+            if (methodCall != null)
+                return GetRPCAttribute (methodCall.Method, "Method called");
+            var member = rpc as MemberExpression;
+            if (member != null)
+                return GetRPCAttribute (member.Member, "Property accessed");
+            throw new ArgumentException (
+                "Invalid expression. Must consist of a method call or property accessor only.");
+        }
+
+        static RPCAttribute GetRPCAttribute (MemberInfo member, string description)
+        {
+            object[] attributes = member.GetCustomAttributes (typeof(RPCAttribute), false);
+            if (attributes.Length != 1)
+                throw new ArgumentException (
+                    "Invalid expression. " + description + " must be backed by a RPC.");
+            return (RPCAttribute)attributes [0];
+        }
+
         internal static ProcedureCall GetCall (MethodCallExpression expression)
         {
             var method = expression.Method;
-
-            // Get the RPCAttribute with service and procedure names
-            object[] attributes = method.GetCustomAttributes (typeof(RPCAttribute), false);
-            if (attributes.Length != 1)
-                throw new ArgumentException ("Invalid expression. Method called must be backed by a RPC.");
-            var attribute = (RPCAttribute)attributes [0];
+            var attribute = GetRPCAttribute (method, "Method called");
 
             // Construct the encoded arguments
             var arguments = new List<ByteString> ();
@@ -394,7 +416,9 @@ namespace KRPC.Client
             // Include class instance argument for class methods
             if (ExpressionUtils.IsAClassMethod (expression)) {
                 var instanceType = method.DeclaringType;
-                arguments.Add (Encoder.Encode (instanceValue, instanceType));
+                arguments.Add (Encoder.Encode (
+                    instanceValue,
+                    ProcedureSpecs.ParameterSpec (attribute, arguments.Count, instanceType)));
             }
 
             // Include arguments from the expression
@@ -408,8 +432,10 @@ namespace KRPC.Client
                 var argumentExpr = Expression.Lambda<Func<object>> (Expression.Convert (argument, typeof(object)));
                 var value = argumentExpr.Compile () ();
                 var type = method.GetParameters () [position].ParameterType;
-                var encodedValue = Encoder.Encode (value, type);
-                arguments.Add (encodedValue);
+                // The arguments are built in the order the procedure declares its parameters,
+                // so the one being added is at the position the count has reached
+                var spec = ProcedureSpecs.ParameterSpec (attribute, arguments.Count, type);
+                arguments.Add (Encoder.Encode (value, spec));
                 position++;
             }
 
@@ -419,12 +445,7 @@ namespace KRPC.Client
         internal static ProcedureCall GetCall (MemberExpression expression)
         {
             var member = expression.Member;
-
-            // Get the RPCAttribute with service and procedure names
-            object[] attributes = member.GetCustomAttributes (typeof(RPCAttribute), false);
-            if (attributes.Length != 1)
-                throw new ArgumentException ("Invalid expression. Property accessed must be backed by a RPC.");
-            var attribute = (RPCAttribute)attributes [0];
+            var attribute = GetRPCAttribute (member, "Property accessed");
 
             // Construct the encoded arguments
             var arguments = new List<ByteString> ();
@@ -439,7 +460,9 @@ namespace KRPC.Client
             // If it's a class property, pass the class instance as an argument
             if (ExpressionUtils.IsAClassProperty (expression)) {
                 var instanceType = member.DeclaringType;
-                arguments.Add (Encoder.Encode (instanceValue, instanceType));
+                arguments.Add (Encoder.Encode (
+                    instanceValue,
+                    ProcedureSpecs.ParameterSpec (attribute, arguments.Count, instanceType)));
             }
 
             return GetCall (attribute.Service, attribute.Procedure, arguments);

--- a/client/csharp/src/Encoder.cs
+++ b/client/csharp/src/Encoder.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections;
-using System.Collections.Concurrent;
 using System.Runtime.InteropServices;
 using System.Text;
 using Google.Protobuf;
@@ -12,93 +11,34 @@ namespace KRPC.Client
     /// </summary>
     public static class Encoder
     {
+        // The presence bool a null carries at a nullable position, written exactly as a bool
+        // value is
+        static readonly ByteString absent = ByteString.CopyFrom (new byte [] { 0 });
+
         /// <summary>
-        /// Encode an object of the given type using the protocol buffer encoding scheme.
+        /// Encode a value at a slot, of the type the given spec describes.
         /// Should not be called directly. This interface is used by service client stubs.
         /// </summary>
-        public static ByteString Encode (object value, Type type)
+        /// <remarks>
+        /// A slot carries its null beside the encoded bytes, in the is_null flag of the message
+        /// around it, so a null encodes to nothing and the nullability of the spec is not read
+        /// here. A value inside another value carries a presence bool instead.
+        /// </remarks>
+        public static ByteString Encode (object value, TypeSpec spec)
         {
-            // A Nullable<T> value is boxed to a plain T (or null), so encode it as its
-            // underlying type; the null itself is signaled out-of-band by is_null.
-            type = Nullable.GetUnderlyingType (type) ?? type;
+            if (ReferenceEquals (spec, null))
+                throw new ArgumentNullException (nameof (spec));
             if (value == null)
                 return null;
-            return EncodeValue (value, type);
+            if (!spec.Type.IsInstanceOfType (value))
+                throw new ArgumentException (
+                    "Value of type " + value.GetType () +
+                    " cannot be encoded to type " + spec.Type);
+            return EncoderFor (spec) (value);
         }
 
         /// <summary>
-        /// Encode a value of the given type.
-        /// </summary>
-        /// <remarks>
-        /// A number, a string or an object identifier is a handful of bytes on the wire, and its
-        /// bytes are written into a buffer of that size. A coded output stream carries a buffer
-        /// of several kilobytes of its own, which is far more to allocate for one number than
-        /// writing the number costs. Anything carried by a protobuf message is left to protobuf
-        /// to serialize.
-        /// </remarks>
-        static ByteString EncodeValue (object value, Type type)
-        {
-            if (value == null)
-                throw new ArgumentException ("null cannot be encoded to type " + type);
-            if (!type.IsInstanceOfType (value))
-                throw new ArgumentException ("Value of type " + value.GetType () + " cannot be encoded to type " + type);
-            if (value is Enum)
-                return Varint (EncodeZigZag ((int)value));
-            switch (Type.GetTypeCode (type)) {
-            case TypeCode.Double:
-                return Fixed64 ((ulong)BitConverter.DoubleToInt64Bits ((double)value));
-            case TypeCode.Single:
-                return Fixed32 (ToBits ((float)value));
-            case TypeCode.Int32:
-                return Varint (EncodeZigZag ((int)value));
-            case TypeCode.Int64:
-                return Varint (EncodeZigZag ((long)value));
-            case TypeCode.UInt32:
-                return Varint ((uint)value);
-            case TypeCode.UInt64:
-                return Varint ((ulong)value);
-            case TypeCode.Boolean:
-                return Varint ((bool)value ? 1UL : 0UL);
-            case TypeCode.String:
-                return EncodeString ((string)value);
-            default:
-                return EncodeObject (value, type);
-            }
-        }
-
-        /// <summary>
-        /// Encode a value that is not a number, a string or an enumeration, from what is known
-        /// about its type.
-        /// </summary>
-        static ByteString EncodeObject (object value, Type type)
-        {
-            var info = TypeInfo.For (type);
-            switch (info.Kind) {
-            case TypeKind.Bytes:
-                return EncodeBytes ((byte[])value);
-            case TypeKind.Class:
-                return Varint (((RemoteObject)value).id);
-            case TypeKind.Struct:
-            case TypeKind.Tuple:
-                return EncodeTuple (value, info).ToByteString ();
-            case TypeKind.List:
-                return EncodeList (value, info).ToByteString ();
-            case TypeKind.Set:
-                return EncodeSet (value, info).ToByteString ();
-            case TypeKind.Dictionary:
-                return EncodeDictionary (value, info).ToByteString ();
-            case TypeKind.Message:
-                return ((IMessage)value).ToByteString ();
-            default:
-                throw new ArgumentException (type + " is not a serializable type");
-            }
-        }
-
-        static readonly ConcurrentDictionary<Type, Func<object, ByteString>> encoders =
-            new ConcurrentDictionary<Type, Func<object, ByteString>> ();
-
-        /// <summary>
-        /// A function that encodes one value of the given type.
+        /// A function that encodes one value of the type the given spec describes.
         /// </summary>
         /// <remarks>
         /// A collection carries many values of the same type, and reaching the code that writes
@@ -107,36 +47,69 @@ namespace KRPC.Client
         /// None of those answers change, so a collection asks once and calls what it gets back
         /// for each of its items.
         /// </remarks>
-        static Func<object, ByteString> EncoderFor (Type type)
+        static Func<object, ByteString> EncoderFor (TypeSpec spec)
         {
-            Func<object, ByteString> encode;
-            if (encoders.TryGetValue (type, out encode))
-                return encode;
-            return encoders.GetOrAdd (type, BuildEncoder (type));
+            var encode = spec.valueEncoder;
+            if (encode == null)
+                spec.valueEncoder = encode = BuildEncoder (spec);
+            return encode;
+        }
+
+        /// <summary>
+        /// A function that encodes one of the values a collection or a structure holds, at the
+        /// position the given spec describes. A position that can hold null carries a presence
+        /// bool before its value, and holds nothing else when that bool is false.
+        /// </summary>
+        static Func<object, ByteString> ItemEncoderFor (TypeSpec spec)
+        {
+            var encode = spec.itemEncoder;
+            if (encode == null)
+                spec.itemEncoder = encode = BuildItemEncoder (spec);
+            return encode;
         }
 
         /// <remarks>
         /// A value reached this way is an item of a collection whose type says what its items
-        /// are, so unlike <see cref="EncodeValue"/> this does not ask each one whether it is of
-        /// that type. Asking is a call into the type system, and asking it once per item is what
-        /// made writing a collection cost several times what reading one back costs. A null is
-        /// still rejected, as a collection of a class type can hold one.
+        /// are, so unlike <see cref="Encode"/> this does not ask each one whether it is of that
+        /// type. Asking is a call into the type system, and asking it once per item is what made
+        /// writing a collection cost several times what reading one back costs. A null is still
+        /// rejected, as a collection of a class type can hold one.
         /// </remarks>
-        static Func<object, ByteString> BuildEncoder (Type type)
+        static Func<object, ByteString> BuildItemEncoder (TypeSpec spec)
         {
-            Func<object, ByteString> write = WriterFor (type);
-            return value => {
-                if (value == null)
-                    throw new ArgumentException ("null cannot be encoded to type " + type);
-                return write (value);
-            };
+            var write = EncoderFor (spec);
+            var type = spec.Type;
+            if (!spec.Nullable)
+                return value => {
+                    if (value == null)
+                        throw new ArgumentException ("null cannot be encoded to type " + type);
+                    return write (value);
+                };
+            return value => value == null ? absent : WithPresence (write (value));
+        }
+
+        static ByteString WithPresence (ByteString encoded)
+        {
+            var buffer = new byte [encoded.Length + 1];
+            buffer [0] = 1;
+            encoded.CopyTo (buffer, 1);
+            return ByteString.CopyFrom (buffer, 0, buffer.Length);
         }
 
         /// <summary>
-        /// A function that writes one value of the given type, without checking it first.
+        /// A function that writes one value of the type the given spec describes, without
+        /// checking it first.
         /// </summary>
-        static Func<object, ByteString> WriterFor (Type type)
+        /// <remarks>
+        /// A number, a string or an object identifier is a handful of bytes on the wire, and its
+        /// bytes are written into a buffer of that size. A coded output stream carries a buffer
+        /// of several kilobytes of its own, which is far more to allocate for one number than
+        /// writing the number costs. Anything carried by a protobuf message is left to protobuf
+        /// to serialize.
+        /// </remarks>
+        static Func<object, ByteString> BuildEncoder (TypeSpec spec)
         {
+            var type = spec.Type;
             if (type.IsEnum)
                 return value => Varint (EncodeZigZag ((int)value));
             switch (Type.GetTypeCode (type)) {
@@ -167,13 +140,13 @@ namespace KRPC.Client
                 return value => Varint (((RemoteObject)value).id);
             case TypeKind.Struct:
             case TypeKind.Tuple:
-                return value => EncodeTuple (value, info).ToByteString ();
+                return value => EncodeTuple (value, info, spec);
             case TypeKind.List:
-                return value => EncodeList (value, info).ToByteString ();
+                return value => EncodeList (value, spec);
             case TypeKind.Set:
-                return value => EncodeSet (value, info).ToByteString ();
+                return value => EncodeSet (value, spec);
             case TypeKind.Dictionary:
-                return value => EncodeDictionary (value, info).ToByteString ();
+                return value => EncodeDictionary (value, spec);
             case TypeKind.Message:
                 return value => ((IMessage)value).ToByteString ();
             default:
@@ -181,36 +154,36 @@ namespace KRPC.Client
             }
         }
 
-        static IMessage EncodeTuple (object value, TypeInfo info)
+        static ByteString EncodeTuple (object value, TypeInfo info, TypeSpec spec)
         {
             var encodedTuple = new Schema.KRPC.Tuple ();
-            for (int i = 0; i < info.Arguments.Length; i++)
-                encodedTuple.Items.Add (EncodeValue (info.Items [i] (value), info.Arguments [i]));
-            return encodedTuple;
+            for (int i = 0; i < info.Items.Length; i++)
+                encodedTuple.Items.Add (ItemEncoderFor (spec.At (i)) (info.Items [i] (value)));
+            return encodedTuple.ToByteString ();
         }
 
-        static IMessage EncodeList (object value, TypeInfo info)
+        static ByteString EncodeList (object value, TypeSpec spec)
         {
             var encodedList = new Schema.KRPC.List ();
-            var encodeItem = EncoderFor (info.Arguments [0]);
+            var encodeItem = ItemEncoderFor (spec.At (0));
             foreach (var item in (IList)value)
                 encodedList.Items.Add (encodeItem (item));
-            return encodedList;
+            return encodedList.ToByteString ();
         }
 
-        static IMessage EncodeSet (object value, TypeInfo info)
+        static ByteString EncodeSet (object value, TypeSpec spec)
         {
             var encodedSet = new Schema.KRPC.Set ();
-            var encodeItem = EncoderFor (info.Arguments [0]);
+            var encodeItem = ItemEncoderFor (spec.At (0));
             foreach (var item in (IEnumerable)value)
                 encodedSet.Items.Add (encodeItem (item));
-            return encodedSet;
+            return encodedSet.ToByteString ();
         }
 
-        static IMessage EncodeDictionary (object value, TypeInfo info)
+        static ByteString EncodeDictionary (object value, TypeSpec spec)
         {
-            var encodeKey = EncoderFor (info.Arguments [0]);
-            var encodeValue = EncoderFor (info.Arguments [1]);
+            var encodeKey = ItemEncoderFor (spec.At (0));
+            var encodeValue = ItemEncoderFor (spec.At (1));
             var encodedDictionary = new Schema.KRPC.Dictionary ();
             foreach (DictionaryEntry entry in (IDictionary)value) {
                 var encodedEntry = new Schema.KRPC.DictionaryEntry ();
@@ -218,107 +191,77 @@ namespace KRPC.Client
                 encodedEntry.Value = encodeValue (entry.Value);
                 encodedDictionary.Entries.Add (encodedEntry);
             }
-            return encodedDictionary;
+            return encodedDictionary.ToByteString ();
         }
 
         /// <summary>
-        /// Decode a value of the given type.
+        /// Decode a value at a slot, of the type the given spec describes. The counterpart of
+        /// <see cref="Encode"/>.
         /// Should not be called directly. This interface is used by service client stubs.
+        /// </summary>
+        public static object Decode (ByteString value, TypeSpec spec, IConnection client)
+        {
+            if (ReferenceEquals (spec, null))
+                throw new ArgumentNullException (nameof (spec));
+            return DecoderFor (spec) (value, client);
+        }
+
+        /// <summary>
+        /// A function that decodes one value of the type the given spec describes. The
+        /// counterpart of <see cref="EncoderFor"/>, and there for the same reason.
+        /// </summary>
+        static Func<ByteString, IConnection, object> DecoderFor (TypeSpec spec)
+        {
+            var decode = spec.valueDecoder;
+            if (decode == null)
+                spec.valueDecoder = decode = BuildDecoder (spec);
+            return decode;
+        }
+
+        /// <summary>
+        /// A function that decodes one of the values a collection or a structure holds, which
+        /// <see cref="ItemEncoderFor"/> wrote.
+        /// </summary>
+        static Func<ByteString, IConnection, object> ItemDecoderFor (TypeSpec spec)
+        {
+            var decode = spec.itemDecoder;
+            if (decode == null)
+                spec.itemDecoder = decode = BuildItemDecoder (spec);
+            return decode;
+        }
+
+        static Func<ByteString, IConnection, object> BuildItemDecoder (TypeSpec spec)
+        {
+            var decode = DecoderFor (spec);
+            if (!spec.Nullable)
+                return decode;
+            var type = spec.Type;
+            var decodeValue = decode;
+            // An enumeration decodes to its integer value, which unboxes to the enumeration
+            // itself but not to a Nullable of it
+            if (type.IsEnum)
+                decodeValue = (data, client) => Enum.ToObject (type, decode (data, client));
+            return (data, client) => {
+                if (data.Length == 0)
+                    throw new ArgumentException ("A nullable value carries no presence bool");
+                // The presence bool is one byte, as a bool value always is
+                if (data [0] == 0)
+                    return null;
+                return decodeValue (ByteString.CopyFrom (data.Span.Slice (1)), client);
+            };
+        }
+
+        /// <summary>
+        /// A function that reads one value of the type the given spec describes.
         /// </summary>
         /// <remarks>
         /// The bytes of a number, a string or an object identifier are read where they are, for
         /// the same reason the encoding writes them there: a coded input stream of its own is
         /// more to allocate for one value than reading the value costs.
         /// </remarks>
-        public static object Decode (ByteString value, Type type, IConnection client)
+        static Func<ByteString, IConnection, object> BuildDecoder (TypeSpec spec)
         {
-            if (ReferenceEquals (type, null))
-                throw new ArgumentNullException (nameof (type));
-            // A Nullable<T> value decodes as its underlying type T; a null value is
-            // signaled out-of-band by is_null and never reaches this method.
-            type = Nullable.GetUnderlyingType (type) ?? type;
-            if (type.IsEnum)
-                return DecodeZigZag32 (ReadVarint (value));
-            switch (Type.GetTypeCode (type)) {
-            case TypeCode.Double:
-                return BitConverter.Int64BitsToDouble ((long)ReadFixed64 (value));
-            case TypeCode.Single:
-                return ToSingle (ReadFixed32 (value));
-            case TypeCode.Int32:
-                return DecodeZigZag32 (ReadVarint (value));
-            case TypeCode.Int64:
-                return DecodeZigZag64 (ReadVarint (value));
-            case TypeCode.UInt32:
-                return (uint)ReadVarint (value);
-            case TypeCode.UInt64:
-                return ReadVarint (value);
-            case TypeCode.Boolean:
-                return ReadVarint (value) != 0;
-            case TypeCode.String:
-                return value.CreateCodedInput ().ReadString ();
-            default:
-                return DecodeObject (value, type, client);
-            }
-        }
-
-        /// <summary>
-        /// Decode a value that is not a number, a string or an enumeration, from what is known
-        /// about its type.
-        /// </summary>
-        static object DecodeObject (ByteString value, Type type, IConnection client)
-        {
-            var info = TypeInfo.For (type);
-            switch (info.Kind) {
-            case TypeKind.Bytes:
-                return value.CreateCodedInput ().ReadBytes ().ToByteArray ();
-            case TypeKind.Class:
-                if (client == null)
-                    throw new ArgumentException ("Client not passed when decoding remote object");
-                return info.NewObject (client, ReadVarint (value));
-            case TypeKind.Struct:
-            case TypeKind.Tuple:
-                return DecodeTuple (value, info, client);
-            case TypeKind.List:
-                return DecodeList (value, info, client);
-            case TypeKind.Set:
-                return DecodeSet (value, info, client);
-            case TypeKind.Dictionary:
-                return DecodeDictionary (value, info, client);
-            case TypeKind.Message: {
-                    var message = (IMessage)Activator.CreateInstance (type);
-                    message.MergeFrom (value);
-                    return message;
-                }
-            case TypeKind.Event: {
-                    var message = new Schema.KRPC.Event ();
-                    message.MergeFrom (value);
-                    return new Event ((Connection)client, message);
-                }
-            default:
-                throw new ArgumentException (type + " is not a serializable type");
-            }
-        }
-
-        static readonly ConcurrentDictionary<Type, Func<ByteString, IConnection, object>> decoders =
-            new ConcurrentDictionary<Type, Func<ByteString, IConnection, object>> ();
-
-        /// <summary>
-        /// A function that decodes one value of the given type. The counterpart of
-        /// <see cref="EncoderFor"/>, and there for the same reason.
-        /// </summary>
-        static Func<ByteString, IConnection, object> DecoderFor (Type type)
-        {
-            Func<ByteString, IConnection, object> decode;
-            if (decoders.TryGetValue (type, out decode))
-                return decode;
-            return decoders.GetOrAdd (type, BuildDecoder (type));
-        }
-
-        static Func<ByteString, IConnection, object> BuildDecoder (Type type)
-        {
-            // A Nullable<T> value decodes as its underlying type T; a null value is
-            // signaled out-of-band by is_null and never reaches here.
-            type = Nullable.GetUnderlyingType (type) ?? type;
+            var type = spec.Type;
             if (type.IsEnum)
                 return (value, client) => DecodeZigZag32 (ReadVarint (value));
             switch (Type.GetTypeCode (type)) {
@@ -353,13 +296,13 @@ namespace KRPC.Client
                 };
             case TypeKind.Struct:
             case TypeKind.Tuple:
-                return (value, client) => DecodeTuple (value, info, client);
+                return (value, client) => DecodeTuple (value, info, spec, client);
             case TypeKind.List:
-                return (value, client) => DecodeList (value, info, client);
+                return (value, client) => DecodeList (value, info, spec, client);
             case TypeKind.Set:
-                return (value, client) => DecodeSet (value, info, client);
+                return (value, client) => DecodeSet (value, info, spec, client);
             case TypeKind.Dictionary:
-                return (value, client) => DecodeDictionary (value, info, client);
+                return (value, client) => DecodeDictionary (value, info, spec, client);
             case TypeKind.Message:
                 return (value, client) => {
                     var message = (IMessage)Activator.CreateInstance (type);
@@ -384,50 +327,51 @@ namespace KRPC.Client
         /// ignored. Fewer items than the type names is an error, as the missing ones cannot be
         /// given a value.
         /// </remarks>
-        static object DecodeTuple (ByteString data, TypeInfo info, IConnection client)
+        static object DecodeTuple (
+            ByteString data, TypeInfo info, TypeSpec spec, IConnection client)
         {
             var encodedTuple = Schema.KRPC.Tuple.Parser.ParseFrom (data);
-            var values = new object [info.Arguments.Length];
+            var values = new object [info.Items.Length];
             if (encodedTuple.Items.Count < values.Length)
                 throw new ArgumentException (
                     "Value has " + encodedTuple.Items.Count + " items; expected at least " +
                     values.Length);
             for (int i = 0; i < values.Length; i++)
-                values [i] = Decode (encodedTuple.Items [i], info.Arguments [i], client);
+                values [i] = ItemDecoderFor (spec.At (i)) (encodedTuple.Items [i], client);
             return info.NewTuple (values);
         }
 
-        static object DecodeList (ByteString data, TypeInfo info, IConnection client)
+        static object DecodeList (
+            ByteString data, TypeInfo info, TypeSpec spec, IConnection client)
         {
             var encodedList = Schema.KRPC.List.Parser.ParseFrom (data);
-            var decodeItem = DecoderFor (info.Arguments [0]);
             var list = (IList)info.New ();
+            var decodeItem = ItemDecoderFor (spec.At (0));
             foreach (var item in encodedList.Items)
                 list.Add (decodeItem (item, client));
             return list;
         }
 
-        static object DecodeSet (ByteString data, TypeInfo info, IConnection client)
+        static object DecodeSet (
+            ByteString data, TypeInfo info, TypeSpec spec, IConnection client)
         {
             var encodedSet = Schema.KRPC.Set.Parser.ParseFrom (data);
-            var decodeItem = DecoderFor (info.Arguments [0]);
+            var decodeItem = ItemDecoderFor (spec.At (0));
             var set = info.New ();
             foreach (var item in encodedSet.Items)
                 info.Add (set, decodeItem (item, client));
             return set;
         }
 
-        static object DecodeDictionary (ByteString data, TypeInfo info, IConnection client)
+        static object DecodeDictionary (
+            ByteString data, TypeInfo info, TypeSpec spec, IConnection client)
         {
             var encodedDictionary = Schema.KRPC.Dictionary.Parser.ParseFrom (data);
-            var decodeKey = DecoderFor (info.Arguments [0]);
-            var decodeValue = DecoderFor (info.Arguments [1]);
+            var decodeKey = ItemDecoderFor (spec.At (0));
+            var decodeValue = ItemDecoderFor (spec.At (1));
             var dictionary = (IDictionary)info.New ();
-            foreach (var entry in encodedDictionary.Entries) {
-                var key = decodeKey (entry.Key, client);
-                var value = decodeValue (entry.Value, client);
-                dictionary [key] = value;
-            }
+            foreach (var entry in encodedDictionary.Entries)
+                dictionary [decodeKey (entry.Key, client)] = decodeValue (entry.Value, client);
             return dictionary;
         }
 

--- a/client/csharp/src/KRPC.Client.csproj
+++ b/client/csharp/src/KRPC.Client.csproj
@@ -30,6 +30,7 @@
     <Compile Include="..\InternalsVisibleTo.cs">
       <Link>InternalsVisibleTo.cs</Link>
     </Compile>
+    <Compile Include="Attributes\KRPCNullableAttribute.cs" />
     <Compile Include="Attributes\KRPCStructAttribute.cs" />
     <Compile Include="Attributes\RPCAttribute.cs" />
     <Compile Include="Connection.cs" />
@@ -39,12 +40,14 @@
     <Compile Include="ExpressionUtils.cs" />
     <Compile Include="IConnection.cs" />
     <Compile Include="MessageReader.cs" />
+    <Compile Include="ProcedureSpecs.cs" />
     <Compile Include="RPCException.cs" />
     <Compile Include="RemoteObject.cs" />
     <Compile Include="Stream.cs" />
     <Compile Include="StreamImpl.cs" />
     <Compile Include="StreamManager.cs" />
     <Compile Include="TypeInfo.cs" />
+    <Compile Include="TypeSpec.cs" />
     <Compile Include="UnixEndPoint.cs" />
     <Compile Include="ValueUtils.cs" />
     <Compile Include="$(bazel-bin)\protobuf\KRPC.cs">

--- a/client/csharp/src/ProcedureSpecs.cs
+++ b/client/csharp/src/ProcedureSpecs.cs
@@ -1,0 +1,79 @@
+using System;
+using System.Collections.Concurrent;
+using System.Reflection;
+using KRPC.Client.Attributes;
+
+namespace KRPC.Client
+{
+    /// <summary>
+    /// The type specs a generated service declares for its procedures, reached through the RPC
+    /// attribute on a stub. A stub names the spec of every value it encodes and decodes, and a
+    /// call built from an expression has only the C# types of those values, which cannot say
+    /// that a reference-typed position inside a collection is nullable.
+    /// </summary>
+    static class ProcedureSpecs
+    {
+        sealed class Lookup
+        {
+            public Func<string, TypeSpec> ReturnSpec;
+            public Func<string, TypeSpec[]> ParameterSpecs;
+        }
+
+        static readonly ConcurrentDictionary<Type, Lookup> lookups =
+            new ConcurrentDictionary<Type, Lookup> ();
+
+        /// <summary>
+        /// The spec of the value the procedure returns, or the spec the given type gives on
+        /// its own where the service declares no nullable position inside it.
+        /// </summary>
+        public static TypeSpec ReturnSpec (RPCAttribute attribute, Type type)
+        {
+            var lookup = LookupFor (attribute.Types);
+            var spec = lookup == null ? null : lookup.ReturnSpec (attribute.Procedure);
+            return spec ?? TypeSpec.For (type);
+        }
+
+        /// <summary>
+        /// The spec of the argument at the given position of the procedure, or the spec the
+        /// given type gives on its own.
+        /// </summary>
+        public static TypeSpec ParameterSpec (RPCAttribute attribute, int position, Type type)
+        {
+            var lookup = LookupFor (attribute.Types);
+            var specs = lookup == null ? null : lookup.ParameterSpecs (attribute.Procedure);
+            if (specs != null && position < specs.Length)
+                return specs [position];
+            return TypeSpec.For (type);
+        }
+
+        /// <summary>
+        /// The lookup a service's generated spec class gives. A service generated before the
+        /// class existed names none, leaving the C# type as all there is.
+        /// </summary>
+        static Lookup LookupFor (Type types)
+        {
+            if (ReferenceEquals (types, null))
+                return null;
+            Lookup lookup;
+            if (lookups.TryGetValue (types, out lookup))
+                return lookup;
+            return lookups.GetOrAdd (types, BuildLookup (types));
+        }
+
+        static Lookup BuildLookup (Type types)
+        {
+            var returnSpec = types.GetMethod (
+                "ReturnSpec", BindingFlags.Public | BindingFlags.Static);
+            var parameterSpecs = types.GetMethod (
+                "ParameterSpecs", BindingFlags.Public | BindingFlags.Static);
+            if (returnSpec == null || parameterSpecs == null)
+                return null;
+            return new Lookup {
+                ReturnSpec = (Func<string, TypeSpec>)Delegate.CreateDelegate (
+                    typeof(Func<string, TypeSpec>), returnSpec),
+                ParameterSpecs = (Func<string, TypeSpec[]>)Delegate.CreateDelegate (
+                    typeof(Func<string, TypeSpec[]>), parameterSpecs)
+            };
+        }
+    }
+}

--- a/client/csharp/src/Stream.cs
+++ b/client/csharp/src/Stream.cs
@@ -15,15 +15,20 @@ namespace KRPC.Client
 
         internal Stream (Connection connection, ulong id)
         {
-            stream = connection.StreamManager.GetStream (typeof(TReturnType), id);
+            stream = connection.StreamManager.GetStream (TypeSpec.For (typeof(TReturnType)), id);
         }
 
         internal Stream (Connection connection, ProcedureCall call)
         {
-            stream = connection.StreamManager.AddStream (typeof(TReturnType), call);
+            stream = connection.StreamManager.AddStream (TypeSpec.For (typeof(TReturnType)), call);
         }
 
-        internal Stream (Connection connection, ProcedureCall call, System.Type rpcReturnType,
+        internal Stream (Connection connection, ProcedureCall call, TypeSpec returnType)
+        {
+            stream = connection.StreamManager.AddStream (returnType, call);
+        }
+
+        internal Stream (Connection connection, ProcedureCall call, TypeSpec rpcReturnType,
                          Func<object, TReturnType> convert, object convertKey)
         {
             stream = connection.StreamManager.AddStream (rpcReturnType, call);

--- a/client/csharp/src/StreamImpl.cs
+++ b/client/csharp/src/StreamImpl.cs
@@ -21,7 +21,7 @@ namespace KRPC.Client
         float rate = 0;
 
         public StreamImpl (Connection connection, ulong id,
-                           System.Type returnType, object updateLock)
+                           TypeSpec returnType, object updateLock)
         {
             this.connection = connection;
             Id = id;
@@ -31,7 +31,7 @@ namespace KRPC.Client
 
         public ulong Id { get; private set; }
 
-        public System.Type ReturnType { get; private set; }
+        public TypeSpec ReturnType { get; private set; }
 
         public void Start () {
             if (!Started) {

--- a/client/csharp/src/StreamManager.cs
+++ b/client/csharp/src/StreamManager.cs
@@ -53,7 +53,7 @@ namespace KRPC.Client
                 throw new ObjectDisposedException (GetType ().Name);
         }
 
-        public StreamImpl AddStream (System.Type returnType, ProcedureCall call)
+        public StreamImpl AddStream (TypeSpec returnType, ProcedureCall call)
         {
             CheckDisposed ();
             var id = connection.KRPC ().AddStream (call, false).Id;
@@ -64,7 +64,7 @@ namespace KRPC.Client
             }
         }
 
-        public StreamImpl GetStream (System.Type returnType, ulong id)
+        public StreamImpl GetStream (TypeSpec returnType, ulong id)
         {
             CheckDisposed ();
             lock (updateLock) {

--- a/client/csharp/src/TypeInfo.cs
+++ b/client/csharp/src/TypeInfo.cs
@@ -67,27 +67,32 @@ namespace KRPC.Client
             } else if (type.IsDefined (typeof(KRPCStructAttribute), false)) {
                 Kind = TypeKind.Struct;
                 var fields = StructFields (type);
-                Arguments = Array.ConvertAll (fields, field => field.PropertyType);
+                var fieldTypes = Array.ConvertAll (fields, field => field.PropertyType);
+                Types = Array.ConvertAll (fields, FieldSpec);
                 Items = StructItems (type, fields);
-                NewTuple = StructConstructor (type, Arguments);
+                NewTuple = StructConstructor (type, fieldTypes);
             } else if (IsATupleType (type)) {
                 Kind = TypeKind.Tuple;
-                Arguments = type.GetGenericArguments ();
-                Items = TupleItems (Arguments);
-                NewTuple = TupleConstructor (Arguments);
+                var itemTypes = type.GetGenericArguments ();
+                Types = Array.ConvertAll (itemTypes, TypeSpec.For);
+                Items = TupleItems (itemTypes);
+                NewTuple = TupleConstructor (itemTypes);
             } else if (IsAGenericType (type, typeof(IList<>))) {
                 Kind = TypeKind.List;
-                Arguments = type.GetGenericArguments ();
-                New = Constructor (typeof(List<>).MakeGenericType (Arguments));
+                var itemTypes = type.GetGenericArguments ();
+                Types = Array.ConvertAll (itemTypes, TypeSpec.For);
+                New = Constructor (typeof(List<>).MakeGenericType (itemTypes));
             } else if (IsAGenericType (type, typeof(ISet<>))) {
                 Kind = TypeKind.Set;
-                Arguments = type.GetGenericArguments ();
-                New = Constructor (typeof(HashSet<>).MakeGenericType (Arguments));
-                Add = SetAdder (type, Arguments [0]);
+                var itemTypes = type.GetGenericArguments ();
+                Types = Array.ConvertAll (itemTypes, TypeSpec.For);
+                New = Constructor (typeof(HashSet<>).MakeGenericType (itemTypes));
+                Add = SetAdder (type, itemTypes [0]);
             } else if (IsAGenericType (type, typeof(IDictionary<,>))) {
                 Kind = TypeKind.Dictionary;
-                Arguments = type.GetGenericArguments ();
-                New = Constructor (typeof(Dictionary<,>).MakeGenericType (Arguments));
+                var itemTypes = type.GetGenericArguments ();
+                Types = Array.ConvertAll (itemTypes, TypeSpec.For);
+                New = Constructor (typeof(Dictionary<,>).MakeGenericType (itemTypes));
             } else if (typeof(IMessage).IsAssignableFrom (type)) {
                 Kind = TypeKind.Message;
             } else if (type.Equals (typeof(Event))) {
@@ -103,10 +108,10 @@ namespace KRPC.Client
         public TypeKind Kind { get; private set; }
 
         /// <summary>
-        /// The types of the values a collection holds: the item types of a tuple, the element
-        /// type of a list or a set, or the key and value types of a dictionary.
+        /// The specs of the values the type holds: the items of a tuple, the fields of a
+        /// structure, the element of a list or a set, or the key and value of a dictionary.
         /// </summary>
-        public Type[] Arguments { get; private set; }
+        public TypeSpec[] Types { get; private set; }
 
         /// <summary>
         /// Build a remote object of the type, given the connection it lives on and its
@@ -125,14 +130,14 @@ namespace KRPC.Client
         public Action<object, object> Add { get; private set; }
 
         /// <summary>
-        /// Build a tuple, or a structure, from its items, in the order <see cref="Arguments"/>
+        /// Build a tuple, or a structure, from its items, in the order <see cref="Types"/>
         /// names them.
         /// </summary>
         public Func<object[], object> NewTuple { get; private set; }
 
         /// <summary>
         /// Take the items out of a tuple, or the fields out of a structure, in the order
-        /// <see cref="Arguments"/> names them.
+        /// <see cref="Types"/> names them.
         /// </summary>
         public Func<object, object>[] Items { get; private set; }
 
@@ -175,6 +180,17 @@ namespace KRPC.Client
             var fields = type.GetProperties (BindingFlags.Public | BindingFlags.Instance);
             Array.Sort (fields, (x, y) => x.MetadataToken.CompareTo (y.MetadataToken));
             return fields;
+        }
+
+        /// <summary>
+        /// The spec of a field of a structure. A field whose type is Nullable&lt;T&gt; declares
+        /// its own nullability; a reference-typed one is marked with KRPCNullable.
+        /// </summary>
+        static TypeSpec FieldSpec (PropertyInfo field)
+        {
+            if (field.IsDefined (typeof(KRPCNullableAttribute), false))
+                return TypeSpec.Null (field.PropertyType);
+            return TypeSpec.For (field.PropertyType);
         }
 
         static Func<object[], object> StructConstructor (Type type, Type[] fieldTypes)

--- a/client/csharp/src/TypeSpec.cs
+++ b/client/csharp/src/TypeSpec.cs
@@ -1,0 +1,92 @@
+using System;
+using System.Collections.Concurrent;
+using Google.Protobuf;
+
+namespace KRPC.Client
+{
+    /// <summary>
+    /// The type of a value, together with whether the position holding it can be null. A
+    /// generated stub names one wherever it encodes or decodes a value, in place of the type.
+    /// </summary>
+    /// <remarks>
+    /// A C# type declares a nullable position where the value there is a value type, as
+    /// <c>T?</c>, and a structure field declares one with <c>KRPCNullable</c>. A reference type
+    /// inside a collection declares nothing, so a stub names that position by building a spec
+    /// for it.
+    /// </remarks>
+    public sealed class TypeSpec
+    {
+        static readonly TypeSpec[] noTypes = new TypeSpec [0];
+
+        static readonly ConcurrentDictionary<Type, TypeSpec> specs =
+            new ConcurrentDictionary<Type, TypeSpec> ();
+
+        readonly TypeSpec[] types;
+
+        // The functions that encode and decode a value at this position, built on first use.
+        // They are held here so that a collection asks for one once and calls it for each of
+        // the values it holds.
+        internal Func<object, ByteString> valueEncoder;
+        internal Func<object, ByteString> itemEncoder;
+        internal Func<ByteString, IConnection, object> valueDecoder;
+        internal Func<ByteString, IConnection, object> itemDecoder;
+
+        /// <summary>
+        /// A spec for the given type, with the specs of the values it contains, in the order a
+        /// collection holds them. A position left unnamed is read from the type.
+        /// </summary>
+        public TypeSpec (Type type, params TypeSpec[] containedTypes)
+        {
+            if (ReferenceEquals (type, null))
+                throw new ArgumentNullException (nameof (type));
+            // A Nullable<T> value is boxed to a plain T, so the type of the value is T and the
+            // position it sits in is the nullable one
+            var underlying = System.Nullable.GetUnderlyingType (type);
+            Type = underlying ?? type;
+            Nullable = underlying != null;
+            types = containedTypes ?? noTypes;
+        }
+
+        /// <summary>
+        /// A spec for a value at a position that can hold null.
+        /// </summary>
+        public static TypeSpec Null (Type type, params TypeSpec[] containedTypes)
+        {
+            return new TypeSpec (type, containedTypes) { Nullable = true };
+        }
+
+        /// <summary>
+        /// The spec the given type gives on its own, kept for the life of the program. A value
+        /// reached through reflection is encoded and decoded as this, where the only nullable
+        /// positions to be had are the ones the type declares.
+        /// </summary>
+        public static TypeSpec For (Type type)
+        {
+            TypeSpec spec;
+            if (specs.TryGetValue (type, out spec))
+                return spec;
+            return specs.GetOrAdd (type, new TypeSpec (type));
+        }
+
+        /// <summary>
+        /// The type of the value.
+        /// </summary>
+        public Type Type { get; private set; }
+
+        /// <summary>
+        /// Whether the position this value sits in can hold null.
+        /// </summary>
+        public bool Nullable { get; private set; }
+
+        /// <summary>
+        /// The spec of the value at the given position, which is the one named here or, where
+        /// this spec names none, the one the type declares.
+        /// </summary>
+        internal TypeSpec At (int position)
+        {
+            if (position < types.Length)
+                return types [position];
+            return TypeInfo.For (Type).Types [position];
+        }
+    }
+}

--- a/client/csharp/test/ConnectionTest.cs
+++ b/client/csharp/test/ConnectionTest.cs
@@ -402,6 +402,84 @@ namespace KRPC.Client.Test
         }
 
         [Test]
+        public void NullableListElements ()
+        {
+            var ints = new List<int?> { 1, null, 3 };
+            CollectionAssert.AreEqual (
+                ints, Connection.TestService ().EchoListOfNullableInts (ints));
+            var obj = Connection.TestService ().CreateTestObject ("jeb");
+            var objects = new List<TestClass> { obj, null };
+            CollectionAssert.AreEqual (
+                objects, Connection.TestService ().EchoListOfNullableObjects (objects));
+        }
+
+        [Test]
+        public void NullableDictionaryValues ()
+        {
+            var obj = Connection.TestService ().CreateTestObject ("jeb");
+            var value = new Dictionary<string,TestClass> { { "a", obj }, { "b", null } };
+            CollectionAssert.AreEqual (
+                value, Connection.TestService ().EchoDictionaryOfNullableObjects (value));
+        }
+
+        [Test]
+        public void NullableTupleItem ()
+        {
+            var obj = Connection.TestService ().CreateTestObject ("jeb");
+            Assert.AreEqual (
+                Tuple.Create (1, obj),
+                Connection.TestService ().EchoTupleWithANullableObject (Tuple.Create (1, obj)));
+            Assert.AreEqual (
+                Tuple.Create (1, (TestClass)null),
+                Connection.TestService ().EchoTupleWithANullableObject (
+                    Tuple.Create (1, (TestClass)null)));
+        }
+
+        [Test]
+        public void NullableNestedListElements ()
+        {
+            var obj = Connection.TestService ().CreateTestObject ("jeb");
+            var value = new List<IList<TestClass>> {
+                new List<TestClass> { obj, null }, new List<TestClass> ()
+            };
+            var result = Connection.TestService ().EchoNestedListOfNullableObjects (value);
+            Assert.AreEqual (2, result.Count);
+            CollectionAssert.AreEqual (value [0], result [0]);
+            Assert.AreEqual (0, result [1].Count);
+        }
+
+        [Test]
+        public void NullableStructFields ()
+        {
+            var obj = Connection.TestService ().CreateTestObject ("jeb");
+            var value = new TestNullableStruct (1, 2, TestEnum.ValueB, "jeb", obj);
+            Assert.AreEqual (value, Connection.TestService ().NullableStructEcho (value));
+        }
+
+        [Test]
+        public void NullStructFields ()
+        {
+            var value = new TestNullableStruct (1, null, null, null, null);
+            var result = Connection.TestService ().NullableStructEcho (value);
+            Assert.AreEqual (1, result.IntField);
+            Assert.IsNull (result.NullableIntField);
+            Assert.IsNull (result.NullableEnumField);
+            Assert.IsNull (result.NullableStringField);
+            Assert.IsNull (result.NullableObjectField);
+        }
+
+        [Test]
+        public void NullableElementOfAStructField ()
+        {
+            var obj = Connection.TestService ().CreateTestObject ("jeb");
+            var value = new TestNestedNullableStruct (
+                new List<TestClass> { obj, null }, "jeb");
+            var result = Connection.TestService ().EchoNestedNullableStruct (value);
+            CollectionAssert.AreEqual (value.ListField, result.ListField);
+            Assert.AreEqual ("jeb", result.StringField);
+        }
+
+        [Test]
         public void StructDefaultValue ()
         {
             var result = Connection.TestService ().StructDefault ();

--- a/client/csharp/test/EncoderTest.cs
+++ b/client/csharp/test/EncoderTest.cs
@@ -14,7 +14,7 @@ namespace KRPC.Client.Test
             var call = new Schema.KRPC.ProcedureCall ();
             call.Service = "ServiceName";
             call.Procedure = "ProcedureName";
-            var data = Encoder.Encode (call, typeof(Schema.KRPC.ProcedureCall));
+            var data = Encoder.Encode (call, TypeSpec.For (typeof(Schema.KRPC.ProcedureCall)));
             const string expected = "0a0b536572766963654e616d65120d50726f6365647572654e616d65";
             Assert.AreEqual (expected, data.ToHexString ());
         }
@@ -22,14 +22,14 @@ namespace KRPC.Client.Test
         [Test]
         public void EncodeValue ()
         {
-            var data = Encoder.Encode (300u, typeof(uint));
+            var data = Encoder.Encode (300u, TypeSpec.For (typeof(uint)));
             Assert.AreEqual ("ac02", data.ToHexString ());
         }
 
         [Test]
         public void EncodeUnicodeString ()
         {
-            var data = Encoder.Encode ("\u2122", typeof(string));
+            var data = Encoder.Encode ("\u2122", TypeSpec.For (typeof(string)));
             Assert.AreEqual ("03e284a2", data.ToHexString ());
         }
 
@@ -40,7 +40,7 @@ namespace KRPC.Client.Test
             var obj = new Services.SpaceCenter.Vessel (mockClient.Object, 300);
             Assert.AreEqual (300, obj.id);
             Assert.AreSame (mockClient.Object, obj.connection);
-            var data = Encoder.Encode (obj, typeof(Services.SpaceCenter.Vessel));
+            var data = Encoder.Encode (obj, TypeSpec.For (typeof(Services.SpaceCenter.Vessel)));
             Assert.AreEqual ("ac02", data.ToHexString ());
         }
 
@@ -49,10 +49,10 @@ namespace KRPC.Client.Test
         {
             // A null value is signaled out-of-band by is_null; the encoder returns null to
             // indicate this, regardless of the type.
-            Assert.IsNull (Encoder.Encode (null, typeof(Services.SpaceCenter.Vessel)));
-            Assert.IsNull (Encoder.Encode (null, typeof(string)));
-            Assert.IsNull (Encoder.Encode (null, typeof(int?)));
-            Assert.IsNull (Encoder.Encode (null, typeof(IList<int>)));
+            Assert.IsNull (Encoder.Encode (null, TypeSpec.For (typeof(Services.SpaceCenter.Vessel))));
+            Assert.IsNull (Encoder.Encode (null, TypeSpec.For (typeof(string))));
+            Assert.IsNull (Encoder.Encode (null, TypeSpec.For (typeof(int?))));
+            Assert.IsNull (Encoder.Encode (null, TypeSpec.For (typeof(IList<int>))));
         }
 
         [Test]
@@ -60,9 +60,9 @@ namespace KRPC.Client.Test
         {
             // A Nullable<T> value encodes and decodes as its underlying type.
             int? value = 300;
-            var data = Encoder.Encode (value, typeof(int?));
+            var data = Encoder.Encode (value, TypeSpec.For (typeof(int?)));
             Assert.AreEqual ("d804", data.ToHexString ());
-            var result = (int?)Encoder.Decode (data, typeof(int?), null);
+            var result = (int?)Encoder.Decode (data, TypeSpec.For (typeof(int?)), null);
             Assert.AreEqual (300, result);
         }
 
@@ -70,7 +70,7 @@ namespace KRPC.Client.Test
         public void DecodeMessage ()
         {
             var message = "0a0b536572766963654e616d65120d50726f6365647572654e616d65".ToByteString ();
-            var call = (Schema.KRPC.ProcedureCall)Encoder.Decode (message, typeof(Schema.KRPC.ProcedureCall), null);
+            var call = (Schema.KRPC.ProcedureCall)Encoder.Decode (message, TypeSpec.For (typeof(Schema.KRPC.ProcedureCall)), null);
             Assert.AreEqual ("ServiceName", call.Service);
             Assert.AreEqual ("ProcedureName", call.Procedure);
         }
@@ -78,14 +78,14 @@ namespace KRPC.Client.Test
         [Test]
         public void DecodeValue ()
         {
-            var value = (uint)Encoder.Decode ("ac02".ToByteString (), typeof(uint), null);
+            var value = (uint)Encoder.Decode ("ac02".ToByteString (), TypeSpec.For (typeof(uint)), null);
             Assert.AreEqual (300, value);
         }
 
         [Test]
         public void DecodeUnicodeString ()
         {
-            var value = (string)Encoder.Decode ("03e284a2".ToByteString (), typeof(string), null);
+            var value = (string)Encoder.Decode ("03e284a2".ToByteString (), TypeSpec.For (typeof(string)), null);
             Assert.AreEqual ("\u2122", value);
         }
 
@@ -93,7 +93,7 @@ namespace KRPC.Client.Test
         public void DecodeRemoteObject ()
         {
             var mockClient = new Mock<IConnection> ();
-            var value = (Services.SpaceCenter.Vessel)Encoder.Decode ("ac02".ToByteString (), typeof(Services.SpaceCenter.Vessel), mockClient.Object);
+            var value = (Services.SpaceCenter.Vessel)Encoder.Decode ("ac02".ToByteString (), TypeSpec.For (typeof(Services.SpaceCenter.Vessel)), mockClient.Object);
             Assert.AreEqual (300, value.id);
             Assert.AreSame (mockClient.Object, value.connection);
         }
@@ -106,9 +106,9 @@ namespace KRPC.Client.Test
         [TestCase (float.NaN, "0000c0ff")]
         public void SingleValue (float value, string data)
         {
-            var encodeResult = Encoder.Encode (value, typeof(float));
+            var encodeResult = Encoder.Encode (value, TypeSpec.For (typeof(float)));
             Assert.AreEqual (data, encodeResult.ToHexString ());
-            var decodeResult = (float)Encoder.Decode (data.ToByteString (), typeof(float), null);
+            var decodeResult = (float)Encoder.Decode (data.ToByteString (), TypeSpec.For (typeof(float)), null);
             Assert.AreEqual (value, decodeResult);
         }
 
@@ -120,9 +120,9 @@ namespace KRPC.Client.Test
         [TestCase (double.NaN, "000000000000f8ff")]
         public void DoubleValue (double value, string data)
         {
-            var encodeResult = Encoder.Encode (value, typeof(double));
+            var encodeResult = Encoder.Encode (value, TypeSpec.For (typeof(double)));
             Assert.AreEqual (data, encodeResult.ToHexString ());
-            var decodeResult = (double)Encoder.Decode (data.ToByteString (), typeof(double), null);
+            var decodeResult = (double)Encoder.Decode (data.ToByteString (), TypeSpec.For (typeof(double)), null);
             Assert.AreEqual (value, decodeResult);
         }
 
@@ -135,9 +135,9 @@ namespace KRPC.Client.Test
         [TestCase (-2147483648, "ffffffff0f")]
         public void Int32Value (int value, string data)
         {
-            var encodeResult = Encoder.Encode (value, typeof(int));
+            var encodeResult = Encoder.Encode (value, TypeSpec.For (typeof(int)));
             Assert.AreEqual (data, encodeResult.ToHexString ());
-            var decodeResult = (int)Encoder.Decode (data.ToByteString (), typeof(int), null);
+            var decodeResult = (int)Encoder.Decode (data.ToByteString (), TypeSpec.For (typeof(int)), null);
             Assert.AreEqual (value, decodeResult);
         }
 
@@ -149,9 +149,9 @@ namespace KRPC.Client.Test
         [TestCase (-33, "41")]
         public void Int64Value (long value, string data)
         {
-            var encodeResult = Encoder.Encode (value, typeof(long));
+            var encodeResult = Encoder.Encode (value, TypeSpec.For (typeof(long)));
             Assert.AreEqual (data, encodeResult.ToHexString ());
-            var decodeResult = (long)Encoder.Decode (data.ToByteString (), typeof(long), null);
+            var decodeResult = (long)Encoder.Decode (data.ToByteString (), TypeSpec.For (typeof(long)), null);
             Assert.AreEqual (value, decodeResult);
         }
 
@@ -162,9 +162,9 @@ namespace KRPC.Client.Test
         [TestCase (uint.MaxValue, "ffffffff0f")]
         public void UInt32Value (uint value, string data)
         {
-            var encodeResult = Encoder.Encode (value, typeof(uint));
+            var encodeResult = Encoder.Encode (value, TypeSpec.For (typeof(uint)));
             Assert.AreEqual (data, encodeResult.ToHexString ());
-            var decodeResult = (uint)Encoder.Decode (data.ToByteString (), typeof(uint), null);
+            var decodeResult = (uint)Encoder.Decode (data.ToByteString (), TypeSpec.For (typeof(uint)), null);
             Assert.AreEqual (value, decodeResult);
         }
 
@@ -172,7 +172,7 @@ namespace KRPC.Client.Test
         [TestCase (-849)]
         public void InvalidUInt32Value (int value)
         {
-            Assert.Throws<ArgumentException> (() => Encoder.Encode (value, typeof(uint)));
+            Assert.Throws<ArgumentException> (() => Encoder.Encode (value, TypeSpec.For (typeof(uint))));
         }
 
         [TestCase (0u, "00")]
@@ -183,9 +183,9 @@ namespace KRPC.Client.Test
         [TestCase (ulong.MaxValue, "ffffffffffffffffff01")]
         public void UInt64Value (ulong value, string data)
         {
-            var encodeResult = Encoder.Encode (value, typeof(ulong));
+            var encodeResult = Encoder.Encode (value, TypeSpec.For (typeof(ulong)));
             Assert.AreEqual (data, encodeResult.ToHexString ());
-            var decodeResult = (ulong)Encoder.Decode (data.ToByteString (), typeof(ulong), null);
+            var decodeResult = (ulong)Encoder.Decode (data.ToByteString (), TypeSpec.For (typeof(ulong)), null);
             Assert.AreEqual (value, decodeResult);
         }
 
@@ -193,16 +193,16 @@ namespace KRPC.Client.Test
         [TestCase (-849)]
         public void InvalidUInt64Value (int value)
         {
-            Assert.Throws<ArgumentException> (() => Encoder.Encode (value, typeof(ulong)));
+            Assert.Throws<ArgumentException> (() => Encoder.Encode (value, TypeSpec.For (typeof(ulong))));
         }
 
         [TestCase (true, "01")]
         [TestCase (false, "00")]
         public void BooleanValue (bool value, string data)
         {
-            var encodeResult = Encoder.Encode (value, typeof(bool));
+            var encodeResult = Encoder.Encode (value, TypeSpec.For (typeof(bool)));
             Assert.AreEqual (data, encodeResult.ToHexString ());
-            var decodeResult = (bool)Encoder.Decode (data.ToByteString (), typeof(bool), null);
+            var decodeResult = (bool)Encoder.Decode (data.ToByteString (), TypeSpec.For (typeof(bool)), null);
             Assert.AreEqual (value, decodeResult);
         }
 
@@ -213,9 +213,9 @@ namespace KRPC.Client.Test
         [TestCase ("Mystery Goo\u2122 Containment Unit", "1f4d79737465727920476f6fe284a220436f6e7461696e6d656e7420556e6974")]
         public void StringValue (string value, string data)
         {
-            var encodeResult = Encoder.Encode (value, typeof(string));
+            var encodeResult = Encoder.Encode (value, TypeSpec.For (typeof(string)));
             Assert.AreEqual (data, encodeResult.ToHexString ());
-            var decodeResult = (string)Encoder.Decode (data.ToByteString (), typeof(string), null);
+            var decodeResult = (string)Encoder.Decode (data.ToByteString (), TypeSpec.For (typeof(string)), null);
             Assert.AreEqual (value, decodeResult);
         }
 
@@ -224,9 +224,9 @@ namespace KRPC.Client.Test
         [TestCase ("deadbeef", "04deadbeef")]
         public void BytesValue (string value, string data)
         {
-            var encodeResult = Encoder.Encode (value.ToByteString ().ToByteArray (), typeof(byte[]));
+            var encodeResult = Encoder.Encode (value.ToByteString ().ToByteArray (), TypeSpec.For (typeof(byte[])));
             Assert.AreEqual (data, encodeResult.ToHexString ());
-            var decodeResult = (byte[])Encoder.Decode (data.ToByteString (), typeof(byte[]), null);
+            var decodeResult = (byte[])Encoder.Decode (data.ToByteString (), TypeSpec.For (typeof(byte[])), null);
             Assert.AreEqual (value.ToByteString (), decodeResult);
         }
 
@@ -236,9 +236,9 @@ namespace KRPC.Client.Test
         public void ListCollection (IList<uint> values, string data)
         {
             IList<uint> value = new List<uint> (values);
-            var encodeResult = Encoder.Encode (value, typeof(IList<uint>));
+            var encodeResult = Encoder.Encode (value, TypeSpec.For (typeof(IList<uint>)));
             Assert.AreEqual (data, encodeResult.ToHexString ());
-            var decodeResult = (IList<uint>)Encoder.Decode (data.ToByteString (), typeof(IList<uint>), null);
+            var decodeResult = (IList<uint>)Encoder.Decode (data.ToByteString (), TypeSpec.For (typeof(IList<uint>)), null);
             CollectionAssert.AreEqual (value, decodeResult);
         }
 
@@ -250,9 +250,9 @@ namespace KRPC.Client.Test
             IDictionary<string,uint> value = new Dictionary<string,uint> ();
             for (int i = 0; i < keys.Count; i++)
                 value [keys [i]] = values [i];
-            var encodeResult = Encoder.Encode (value, typeof(IDictionary<string,uint>));
+            var encodeResult = Encoder.Encode (value, TypeSpec.For (typeof(IDictionary<string,uint>)));
             Assert.AreEqual (data, encodeResult.ToHexString ());
-            var decodeResult = (IDictionary<string,uint>)Encoder.Decode (data.ToByteString (), typeof(IDictionary<string,uint>), null);
+            var decodeResult = (IDictionary<string,uint>)Encoder.Decode (data.ToByteString (), TypeSpec.For (typeof(IDictionary<string,uint>)), null);
             CollectionAssert.AreEqual (value, decodeResult);
         }
 
@@ -262,9 +262,9 @@ namespace KRPC.Client.Test
         public void SetCollection (IList<uint> values, string data)
         {
             ISet<uint> value = new HashSet<uint> (values);
-            var encodeResult = Encoder.Encode (value, typeof(ISet<uint>));
+            var encodeResult = Encoder.Encode (value, TypeSpec.For (typeof(ISet<uint>)));
             Assert.AreEqual (data, encodeResult.ToHexString ());
-            var decodeResult = (ISet<uint>)Encoder.Decode (data.ToByteString (), typeof(ISet<uint>), null);
+            var decodeResult = (ISet<uint>)Encoder.Decode (data.ToByteString (), TypeSpec.For (typeof(ISet<uint>)), null);
             CollectionAssert.AreEqual (value, decodeResult);
         }
 
@@ -273,9 +273,9 @@ namespace KRPC.Client.Test
         {
             var value = new Tuple<uint> (1);
             const string data = "0a0101";
-            var encodeResult = Encoder.Encode (value, value.GetType ());
+            var encodeResult = Encoder.Encode (value, TypeSpec.For (value.GetType ()));
             Assert.AreEqual (data, encodeResult.ToHexString ());
-            var decodeResult = (Tuple<uint>)Encoder.Decode (data.ToByteString (), value.GetType (), null);
+            var decodeResult = (Tuple<uint>)Encoder.Decode (data.ToByteString (), TypeSpec.For (value.GetType ()), null);
             Assert.AreEqual (value, decodeResult);
         }
 
@@ -284,10 +284,117 @@ namespace KRPC.Client.Test
         {
             var value = new Tuple<uint,string,bool> (1, "jeb", false);
             const string data = "0a01010a04036a65620a0100";
-            var encodeResult = Encoder.Encode (value, value.GetType ());
+            var encodeResult = Encoder.Encode (value, TypeSpec.For (value.GetType ()));
             Assert.AreEqual (data, encodeResult.ToHexString ());
-            var decodeResult = (Tuple<uint,string,bool>)Encoder.Decode (data.ToByteString (), value.GetType (), null);
+            var decodeResult = (Tuple<uint,string,bool>)Encoder.Decode (data.ToByteString (), TypeSpec.For (value.GetType ()), null);
             Assert.AreEqual (value, decodeResult);
+        }
+
+        // Check that the value encodes to the given data, and that the data decodes back to it
+        static void CheckValue (object value, string data, TypeSpec spec)
+        {
+            Assert.AreEqual (data, Encoder.Encode (value, spec).ToHexString ());
+            Assert.AreEqual (value, Encoder.Decode (data.ToByteString (), spec, null));
+        }
+
+        [Test]
+        public void NullableSpecSharesItsType ()
+        {
+            // A nullable position holds a value of the type it holds anywhere else, so the
+            // nullable form of a type is that type with the position marked
+            Assert.AreEqual (typeof(string), TypeSpec.Null (typeof(string)).Type);
+            Assert.AreEqual (typeof(uint), TypeSpec.For (typeof(uint?)).Type);
+            Assert.AreEqual (
+                typeof(Services.TestService.TestEnum),
+                TypeSpec.For (typeof(Services.TestService.TestEnum?)).Type);
+            Assert.IsTrue (TypeSpec.For (typeof(uint?)).Nullable);
+            Assert.IsFalse (TypeSpec.For (typeof(uint)).Nullable);
+        }
+
+        [Test]
+        public void NullableListElements ()
+        {
+            var spec = TypeSpec.For (typeof(IList<uint?>));
+            CheckValue (new List<uint?> (), string.Empty, spec);
+            CheckValue (new List<uint?> { null }, "0a0100", spec);
+            // A zero is a value like any other, and is told apart from a null by the presence
+            // bool
+            CheckValue (new List<uint?> { 0 }, "0a020100", spec);
+            CheckValue (new List<uint?> { 1, null, 3 }, "0a0201010a01000a020103", spec);
+        }
+
+        [Test]
+        public void NullableDictionaryValues ()
+        {
+            CheckValue (
+                new Dictionary<string,uint?> { { string.Empty, null } },
+                "0a060a0100120100", TypeSpec.For (typeof(IDictionary<string,uint?>)));
+        }
+
+        [Test]
+        public void NullableTupleItem ()
+        {
+            var spec = new TypeSpec (
+                typeof(Tuple<uint,string>),
+                TypeSpec.For (typeof(uint)), TypeSpec.Null (typeof(string)));
+            CheckValue (new Tuple<uint,string> (1, "jeb"), "0a01010a0501036a6562", spec);
+            CheckValue (new Tuple<uint,string> (1, null), "0a01010a0100", spec);
+        }
+
+        [Test]
+        public void NullableCollectionValues ()
+        {
+            // A nullable position holding a collection carries the presence bool ahead of the
+            // collection's own encoding
+            var spec = new TypeSpec (
+                typeof(IList<IList<uint>>), TypeSpec.Null (typeof(IList<uint>)));
+            CheckValue (new List<IList<uint>> { null }, "0a0100", spec);
+            CheckValue (new List<IList<uint>> { new List<uint> () }, "0a0101", spec);
+            CheckValue (new List<IList<uint>> { new List<uint> { 1 } }, "0a04010a0101", spec);
+        }
+
+        [Test]
+        public void NullableStructFields ()
+        {
+            // Each nullable field carries its own presence bool, and a null field is that
+            // bool alone
+            CheckValue (
+                new Services.TestService.TestNullableStruct (1, 2, null, null, null),
+                "0a01020a0201040a01000a01000a0100",
+                TypeSpec.For (typeof(Services.TestService.TestNullableStruct)));
+        }
+
+        [Test]
+        public void NullabilityIsReadAtEveryPosition ()
+        {
+            // A service declares no nullable set element and no nullable dictionary key. The
+            // client reads what the type says at every position rather than naming the ones a
+            // value can be null at
+            CheckValue (
+                new HashSet<uint?> { null }, "0a0100", TypeSpec.For (typeof(ISet<uint?>)));
+            // A C# dictionary rejects a null key, so a key can only be read back where the
+            // presence bool says it is there
+            CheckValue (
+                new Dictionary<string,uint> { { "foo", 1 } }, "0a0a0a050103666f6f120101",
+                new TypeSpec (
+                    typeof(IDictionary<string,uint>), TypeSpec.Null (typeof(string))));
+        }
+
+        [Test]
+        public void NullAtANonNullablePosition ()
+        {
+            Assert.Throws<ArgumentException> (
+                () => Encoder.Encode (
+                    new List<string> { null }, TypeSpec.For (typeof(IList<string>))));
+        }
+
+        [Test]
+        public void NullableValueWithoutPresenceBool ()
+        {
+            // A list holding one item of zero length
+            Assert.Throws<ArgumentException> (
+                () => Encoder.Decode (
+                    "0a00".ToByteString (), TypeSpec.For (typeof(IList<uint?>)), null));
         }
 
         [Test]
@@ -297,7 +404,7 @@ namespace KRPC.Client.Test
             // for one this client has more fields for
             const string data = "0a0101";
             Assert.Throws<ArgumentException> (
-                () => Encoder.Decode (data.ToByteString (), typeof(Tuple<uint,string>), null));
+                () => Encoder.Decode (data.ToByteString (), TypeSpec.For (typeof(Tuple<uint,string>)), null));
         }
     }
 }

--- a/client/csharp/test/StreamTest.cs
+++ b/client/csharp/test/StreamTest.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Threading;
 using KRPC.Client.Services.TestService;
@@ -163,6 +164,36 @@ namespace KRPC.Client.Test
             for (int i = 0; i < 5; i++) {
                 Assert.IsNull (x.Get ());
                 Assert.IsNull (y.Get ());
+                Wait ();
+            }
+        }
+
+        [Test]
+        public void NullableListElements ()
+        {
+            // A stream carries the value itself, so a null inside a collection reaches the
+            // decoder as a presence bool where a null result does not
+            var value = new List<int?> { 1, null, 3 };
+            var x = Connection.AddStream (
+                () => Connection.TestService ().EchoListOfNullableInts (value));
+            for (int i = 0; i < 5; i++) {
+                CollectionAssert.AreEqual (value, x.Get ());
+                Wait ();
+            }
+        }
+
+        [Test]
+        public void NullableObjectListElements ()
+        {
+            // A stream is built from an expression, which has only the C# types of the
+            // values it passes. A nullable element of a class type is invisible there, and
+            // is read from the specs the generated service declares
+            var obj = Connection.TestService ().CreateTestObject ("bob");
+            var value = new List<TestClass> { obj, null };
+            var x = Connection.AddStream (
+                () => Connection.TestService ().EchoListOfNullableObjects (value));
+            for (int i = 0; i < 5; i++) {
+                CollectionAssert.AreEqual (value, x.Get ());
                 Wait ();
             }
         }

--- a/client/java/CHANGELOG.md
+++ b/client/java/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## [v0.7.0] - unreleased
+- Support a nullable structure field, list element, tuple item and dictionary value, held as
+  the boxed type (`Integer`, `Double`, …) where the value is a primitive (#1091)
 - Support structure types, a compound value with named fields a service defines, generated as
   a class with a constructor, getters, `equals`, `hashCode` and `Comparable` over its
   fields (#1066)

--- a/client/java/src/krpc/client/Encoder.java
+++ b/client/java/src/krpc/client/Encoder.java
@@ -34,6 +34,11 @@ import org.javatuples.Unit;
 
 /** Encodes and decodes values for kRPC procedure calls. */
 public class Encoder {
+  // The presence bool a nullable position carries ahead of its value, written exactly as a
+  // bool value is
+  private static final ByteString ABSENT = ByteString.copyFrom(new byte[] { 0 });
+  private static final ByteString PRESENT = ByteString.copyFrom(new byte[] { 1 });
+
   static String guidToString(byte[] guid) {
     StringBuilder builder = new StringBuilder();
     for (int i = 3; i >= 0; i--) {
@@ -64,6 +69,25 @@ public class Encoder {
     if (value == null) {
       return null;
     }
+    return encodeValue(value, type);
+  }
+
+  /**
+   * Encode one of the values a collection or a structure holds, at the position the given type
+   * describes. A position that can hold null carries a presence bool before its value, and
+   * holds nothing else when that bool is false.
+   */
+  static ByteString encodeItem(Object value, KRPC.Type type) {
+    if (!type.getNullable()) {
+      if (value == null) {
+        throw new EncodingException("Failed to encode a null at a position that cannot hold one");
+      }
+      return encodeValue(value, type);
+    }
+    return value == null ? ABSENT : PRESENT.concat(encodeValue(value, type));
+  }
+
+  private static ByteString encodeValue(Object value, KRPC.Type type) {
     try {
       switch (type.getCode()) {
         case DOUBLE:
@@ -109,6 +133,24 @@ public class Encoder {
     } catch (IOException exn) {
       throw new EncodingException("Failed to encode value", exn);
     }
+  }
+
+  /**
+   * Decode one of the values a collection or a structure holds, which encodeItem wrote.
+   */
+  static Object decodeItem(ByteString data, KRPC.Type type, Connection connection) {
+    if (!type.getNullable()) {
+      return decode(data, type, connection);
+    }
+    if (data.isEmpty()) {
+      throw new EncodingException("A nullable value carries no presence bool");
+    }
+    // The presence bool is one byte, as a bool value always is, and is read from the data
+    // directly
+    if (data.byteAt(0) == 0) {
+      return null;
+    }
+    return decode(data.substring(1), type, connection);
   }
 
   /** Decode an object. */
@@ -298,7 +340,7 @@ public class Encoder {
     }
     KRPC.Tuple.Builder struct = KRPC.Tuple.newBuilder();
     for (int i = 0; i < values.length; i++) {
-      struct.addItems(encode(values[i], fieldTypes.get(i)));
+      struct.addItems(encodeItem(values[i], fieldTypes.get(i)));
     }
     return UnsafeByteOperations.unsafeWrap(struct.build().toByteArray());
   }
@@ -317,7 +359,7 @@ public class Encoder {
     }
     Object[] values = new Object[info.fieldTypes.size()];
     for (int i = 0; i < values.length; i++) {
-      values[i] = decode(structMessage.getItems(i), info.fieldTypes.get(i), connection);
+      values[i] = decodeItem(structMessage.getItems(i), info.fieldTypes.get(i), connection);
     }
     try {
       return (T) info.fromFieldValues.invoke(null, (Object) values);
@@ -332,7 +374,7 @@ public class Encoder {
     }
     KRPC.Tuple.Builder tuple = KRPC.Tuple.newBuilder();
     for (int i = 0; i < value.getSize(); i++) {
-      tuple.addItems(encode(value.getValue(i), valueTypes.get(i)));
+      tuple.addItems(encodeItem(value.getValue(i), valueTypes.get(i)));
     }
     return UnsafeByteOperations.unsafeWrap(tuple.build().toByteArray());
   }
@@ -340,7 +382,7 @@ public class Encoder {
   static ByteString encodeList(List<?> value, KRPC.Type valueType) throws IOException {
     KRPC.List.Builder list = KRPC.List.newBuilder();
     for (Object item : value) {
-      list.addItems(encode(item, valueType));
+      list.addItems(encodeItem(item, valueType));
     }
     return UnsafeByteOperations.unsafeWrap(list.build().toByteArray());
   }
@@ -348,7 +390,7 @@ public class Encoder {
   static ByteString encodeSet(Set<?> value, KRPC.Type valueType) throws IOException {
     KRPC.Set.Builder set = KRPC.Set.newBuilder();
     for (Object item : value) {
-      set.addItems(encode(item, valueType));
+      set.addItems(encodeItem(item, valueType));
     }
     return UnsafeByteOperations.unsafeWrap(set.build().toByteArray());
   }
@@ -358,8 +400,8 @@ public class Encoder {
     KRPC.Dictionary.Builder dictionary = KRPC.Dictionary.newBuilder();
     KRPC.DictionaryEntry.Builder dictionaryEntry = KRPC.DictionaryEntry.newBuilder();
     for (Map.Entry<?, ?> entry : value.entrySet()) {
-      dictionaryEntry.setKey(encode(entry.getKey(), keyType));
-      dictionaryEntry.setValue(encode(entry.getValue(), valueType));
+      dictionaryEntry.setKey(encodeItem(entry.getKey(), keyType));
+      dictionaryEntry.setValue(encodeItem(entry.getValue(), valueType));
       dictionary.addEntries(dictionaryEntry.build());
     }
     return UnsafeByteOperations.unsafeWrap(dictionary.build().toByteArray());
@@ -463,7 +505,7 @@ public class Encoder {
     int numElements = tupleMessage.getItemsCount();
     Object[] es = new Object[numElements];
     for (int i = 0; i < numElements; i++) {
-      es[i] = decode(tupleMessage.getItems(i), valueTypes.get(i), connection);
+      es[i] = decodeItem(tupleMessage.getItems(i), valueTypes.get(i), connection);
     }
     switch (numElements) {
       case 1:
@@ -497,7 +539,7 @@ public class Encoder {
     KRPC.List listMessage = KRPC.List.newBuilder().mergeFrom(data).build();
     List<T> list = new ArrayList<T>(listMessage.getItemsCount());
     for (ByteString item : listMessage.getItemsList()) {
-      list.add((T) decode(item, valueType, connection));
+      list.add((T) decodeItem(item, valueType, connection));
     }
     return list;
   }
@@ -508,7 +550,7 @@ public class Encoder {
     KRPC.Set setMessage = KRPC.Set.newBuilder().mergeFrom(data).build();
     Set<T> set = new HashSet<T>(setMessage.getItemsCount());
     for (ByteString item : setMessage.getItemsList()) {
-      set.add((T) decode(item, valueType, connection));
+      set.add((T) decodeItem(item, valueType, connection));
     }
     return set;
   }
@@ -519,8 +561,8 @@ public class Encoder {
     KRPC.Dictionary dictionaryMessage = KRPC.Dictionary.newBuilder().mergeFrom(data).build();
     Map<K, V> dictionary = new HashMap<K, V>(dictionaryMessage.getEntriesCount());
     for (KRPC.DictionaryEntry entry : dictionaryMessage.getEntriesList()) {
-      K key = (K) decode(entry.getKey(), keyType, connection);
-      V value = (V) decode(entry.getValue(), valueType, connection);
+      K key = (K) decodeItem(entry.getKey(), keyType, connection);
+      V value = (V) decodeItem(entry.getValue(), valueType, connection);
       dictionary.put(key, value);
     }
     return dictionary;

--- a/client/java/src/krpc/client/Types.java
+++ b/client/java/src/krpc/client/Types.java
@@ -77,4 +77,9 @@ public class Types {
     type.addTypes(valueType);
     return type.build();
   }
+
+  /** The given type at a position that can hold null. */
+  public static Type nullable(Type type) {
+    return type.toBuilder().setNullable(true).build();
+  }
 }

--- a/client/java/test/krpc/client/ConnectionTest.java
+++ b/client/java/test/krpc/client/ConnectionTest.java
@@ -12,6 +12,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
@@ -293,6 +294,70 @@ public class ConnectionTest {
     TestService.TestStruct value = new TestService.TestStruct(
         1, "jeb", TestService.TestEnum.VALUE_A, new ArrayList<Integer>());
     assertEquals(value, testService.structEchoNullable(value));
+  }
+
+  @Test
+  public void testNullableListElements() throws RPCException {
+    List<Integer> ints = Arrays.asList(1, null, 3);
+    assertEquals(ints, testService.echoListOfNullableInts(ints));
+    TestService.TestClass obj = testService.createTestObject("jeb");
+    List<TestService.TestClass> objects = Arrays.asList(obj, null);
+    assertEquals(objects, testService.echoListOfNullableObjects(objects));
+  }
+
+  @Test
+  public void testNullableDictionaryValues() throws RPCException {
+    TestService.TestClass obj = testService.createTestObject("jeb");
+    Map<String, TestService.TestClass> value = new HashMap<String, TestService.TestClass>();
+    value.put("a", obj);
+    value.put("b", null);
+    assertEquals(value, testService.echoDictionaryOfNullableObjects(value));
+  }
+
+  @Test
+  public void testNullableTupleItem() throws RPCException {
+    TestService.TestClass obj = testService.createTestObject("jeb");
+    assertEquals(new Pair<Integer, TestService.TestClass>(1, obj),
+        testService.echoTupleWithANullableObject(new Pair<Integer, TestService.TestClass>(1, obj)));
+    assertEquals(new Pair<Integer, TestService.TestClass>(1, null),
+        testService.echoTupleWithANullableObject(
+            new Pair<Integer, TestService.TestClass>(1, null)));
+  }
+
+  @Test
+  public void testNullableNestedListElements() throws RPCException {
+    TestService.TestClass obj = testService.createTestObject("jeb");
+    List<List<TestService.TestClass>> value = Arrays.asList(
+        Arrays.asList(obj, null), Arrays.<TestService.TestClass>asList());
+    assertEquals(value, testService.echoNestedListOfNullableObjects(value));
+  }
+
+  @Test
+  public void testNullableStructFields() throws RPCException {
+    TestService.TestClass obj = testService.createTestObject("jeb");
+    TestService.TestNullableStruct value = new TestService.TestNullableStruct(
+        1, 2, TestService.TestEnum.VALUE_B, "jeb", obj);
+    assertEquals(value, testService.nullableStructEcho(value));
+  }
+
+  @Test
+  public void testNullStructFields() throws RPCException {
+    TestService.TestNullableStruct value =
+        new TestService.TestNullableStruct(1, null, null, null, null);
+    TestService.TestNullableStruct result = testService.nullableStructEcho(value);
+    assertEquals(1, result.getIntField());
+    assertNull(result.getNullableIntField());
+    assertNull(result.getNullableEnumField());
+    assertNull(result.getNullableStringField());
+    assertNull(result.getNullableObjectField());
+  }
+
+  @Test
+  public void testNullableElementsOfStructField() throws RPCException {
+    TestService.TestClass obj = testService.createTestObject("jeb");
+    TestService.TestNestedNullableStruct value = new TestService.TestNestedNullableStruct(
+        Arrays.asList(obj, null), "jeb");
+    assertEquals(value, testService.echoNestedNullableStruct(value));
   }
 
   @Test

--- a/client/java/test/krpc/client/EncoderTest.java
+++ b/client/java/test/krpc/client/EncoderTest.java
@@ -5,13 +5,21 @@ import static krpc.client.TestUtils.repeatedString;
 import static krpc.client.TestUtils.unhexlify;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 
 import com.google.protobuf.ByteString;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
 import krpc.client.Types;
 import krpc.client.services.TestService;
 import krpc.schema.KRPC;
 import krpc.schema.KRPC.Type;
 import krpc.schema.KRPC.Type.TypeCode;
+import org.javatuples.Pair;
 import org.javatuples.Triplet;
 import org.javatuples.Unit;
 import org.junit.Test;
@@ -95,6 +103,87 @@ public class EncoderTest {
     assertEquals(new TestService.TestClass(null, 300), value);
   }
 
+
+  // Check that the value encodes to the given data, and that the data decodes back to it
+  private static void checkValue(Object value, String data, Type type) {
+    assertEquals(data, hexlify(Encoder.encode(value, type)));
+    assertEquals(value, Encoder.decode(unhexlify(data), type, null));
+  }
+
+  @Test
+  public void testNullableListElements() {
+    Type type = Types.createList(Types.nullable(Types.createValue(TypeCode.UINT32)));
+    checkValue(new ArrayList<Integer>(), "", type);
+    checkValue(Arrays.asList((Integer) null), "0a0100", type);
+    // A zero is a value like any other, and is told apart from a null by the presence bool
+    checkValue(Arrays.asList(0), "0a020100", type);
+    checkValue(Arrays.asList(1, null, 3), "0a0201010a01000a020103", type);
+  }
+
+  @Test
+  public void testNullableDictionaryValues() {
+    Type type = Types.createDictionary(
+        Types.createValue(TypeCode.STRING), Types.nullable(Types.createValue(TypeCode.UINT32)));
+    Map<String, Integer> value = new HashMap<String, Integer>();
+    value.put("", null);
+    checkValue(value, "0a060a0100120100", type);
+  }
+
+  @Test
+  public void testNullableTupleItem() {
+    Type type = Types.createTuple(
+        Types.createValue(TypeCode.UINT32), Types.nullable(Types.createValue(TypeCode.STRING)));
+    checkValue(new Pair<Integer, String>(1, "jeb"), "0a01010a0501036a6562", type);
+    checkValue(new Pair<Integer, String>(1, null), "0a01010a0100", type);
+  }
+
+  @Test
+  public void testNullableCollectionValues() {
+    // A nullable position holding a collection carries the presence bool ahead of the
+    // collection's own encoding
+    Type type = Types.createList(
+        Types.nullable(Types.createList(Types.createValue(TypeCode.UINT32))));
+    checkValue(Arrays.asList((List<Integer>) null), "0a0100", type);
+    checkValue(Arrays.asList(new ArrayList<Integer>()), "0a0101", type);
+    checkValue(Arrays.asList(Arrays.asList(1)), "0a04010a0101", type);
+  }
+
+  @Test
+  public void testNullableStructFields() {
+    // Each nullable field carries its own presence bool, and a null field is that bool alone
+    Type type = Types.createStruct("TestService", "TestNullableStruct");
+    TestService.TestNullableStruct value =
+        new TestService.TestNullableStruct(1, 2, null, null, null);
+    checkValue(value, "0a01020a0201040a01000a01000a0100", type);
+  }
+
+  @Test
+  public void testNullabilityIsReadAtEveryPosition() {
+    // A service declares no nullable set element and no nullable dictionary key. The client
+    // reads what the type says at every position rather than naming the ones a value can be
+    // null at
+    Type setType = Types.createSet(Types.nullable(Types.createValue(TypeCode.UINT32)));
+    checkValue(new HashSet<Integer>(Arrays.asList((Integer) null)), "0a0100", setType);
+    Type dictionaryType = Types.createDictionary(
+        Types.nullable(Types.createValue(TypeCode.STRING)), Types.createValue(TypeCode.UINT32));
+    Map<String, Integer> dictionary = new HashMap<String, Integer>();
+    dictionary.put(null, 1);
+    checkValue(dictionary, "0a060a0100120101", dictionaryType);
+  }
+
+  @Test
+  public void testNullAtNonNullablePosition() {
+    Type type = Types.createList(Types.createValue(TypeCode.UINT32));
+    assertThrows(
+        EncodingException.class, () -> Encoder.encode(Arrays.asList((Integer) null), type));
+  }
+
+  @Test
+  public void testNullableValueWithoutPresenceBool() {
+    // A list holding one item of zero length
+    Type type = Types.createList(Types.nullable(Types.createValue(TypeCode.UINT32)));
+    assertThrows(EncodingException.class, () -> Encoder.decode(unhexlify("0a00"), type, null));
+  }
 
   @Test
   public void testGuid() {

--- a/client/java/test/krpc/client/StreamTest.java
+++ b/client/java/test/krpc/client/StreamTest.java
@@ -7,6 +7,8 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
 import krpc.client.services.TestService;
 import krpc.client.services.TestService.CustomException;
 import krpc.client.services.TestService.TestClass;
@@ -62,6 +64,20 @@ public class StreamTest {
         connection.addStream(TestService.class, "echoNullableInt", (Object) null);
     for (int i = 0; i < 5; i++) {
       assertNull(stream.get());
+      pause();
+    }
+  }
+
+  @Test
+  public void testNullableListElements()
+      throws RPCException, StreamException, NoSuchMethodException {
+    // A stream carries the value itself, so a null inside a collection reaches the decoder
+    // as a presence bool where a null result does not
+    List<Integer> value = Arrays.asList(1, null, 3);
+    Stream<List<Integer>> stream =
+        connection.addStream(TestService.class, "echoListOfNullableInts", value);
+    for (int i = 0; i < 5; i++) {
+      assertEquals(value, stream.get());
       pause();
     }
   }

--- a/client/lua/CHANGELOG.md
+++ b/client/lua/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## [v0.7.0] - unreleased
+- Support a nullable structure field, list element, tuple item and dictionary value, which is
+  `Types.none` when absent (#1091)
 - Support structure types, built from their field values in order and giving them named
   access (#1066)
 - A service definition naming an unknown type skips the member that names it with a warning,

--- a/client/lua/krpc/decoder.lua
+++ b/client/lua/krpc/decoder.lua
@@ -129,6 +129,26 @@ local function _decode_entry(data)
   return key, value
 end
 
+-- Decode one value at a position inside another value, which the given type describes. A
+-- nullable position carries a presence bool before its value, and holds nothing else when that
+-- bool is false.
+local function _decode_item(data, typ)
+  if not typ.nullable then
+    return decoder.decode(data, typ)
+  end
+  -- The presence bool is one byte, as a bool value always is
+  if data:len() == 0 then
+    error('A nullable value carries no presence bool')
+  end
+  if not _value_decoders[Types.BOOL](data:sub(1, 1)) then
+    return Types.none
+  end
+  return decoder.decode(data:sub(2), typ)
+end
+
+-- Decode a value at a slot, where a null is carried by the is_null flag of the message around
+-- it. A value at a position inside another value carries its own presence bool, which
+-- _decode_item reads.
 function decoder.decode(data, typ)
   local code = typ.code
   local decode_value = _value_decoders[code]
@@ -140,7 +160,7 @@ function decoder.decode(data, typ)
     local value_type = typ.value_type
     local result = List{}
     for i = 1, count do
-      result[i] = decoder.decode(items[i], value_type)
+      result[i] = _decode_item(items[i], value_type)
     end
     return result
   elseif code == Types.DICTIONARY then
@@ -150,7 +170,7 @@ function decoder.decode(data, typ)
     local result = Map{}
     for i = 1, count do
       local key, value = _decode_entry(entries[i])
-      result[decoder.decode(key, key_type)] = decoder.decode(value, value_type)
+      result[_decode_item(key, key_type)] = _decode_item(value, value_type)
     end
     return result
   elseif code == Types.SET then
@@ -158,7 +178,7 @@ function decoder.decode(data, typ)
     local value_type = typ.value_type
     local result = Set{}
     for i = 1, count do
-      result[decoder.decode(items[i], value_type)] = true
+      result[_decode_item(items[i], value_type)] = true
     end
     return result
   elseif code == Types.TUPLE then
@@ -166,7 +186,7 @@ function decoder.decode(data, typ)
     local value_types = typ.value_types
     local result = List{}
     for i = 1, count do
-      result[i] = decoder.decode(items[i], value_types[i])
+      result[i] = _decode_item(items[i], value_types[i])
     end
     return result
   elseif code == Types.STRUCT then
@@ -179,7 +199,7 @@ function decoder.decode(data, typ)
     end
     local values = {}
     for i = 1, #field_types do
-      values[i] = decoder.decode(items[i], field_types[i])
+      values[i] = _decode_item(items[i], field_types[i])
     end
     return typ.lua_type(unpack(values))
   elseif typ:is_a(Types.MessageType) then

--- a/client/lua/krpc/encoder.lua
+++ b/client/lua/krpc/encoder.lua
@@ -103,6 +103,28 @@ local function _delimited(tag, data)
   return tag .. _encode_varint(data:len()) .. data
 end
 
+-- Encode one value at a position inside another value, which the given type describes. A
+-- nullable position carries a presence bool before its value, and holds nothing else when that
+-- bool is false.
+local function _encode_item(x, typ)
+  local absent = x == nil or x == Types.none
+  if not typ.nullable then
+    -- Types.none carries the object id 0, which would encode as a value of the type
+    if absent then
+      error('A null cannot be encoded at a position that cannot hold one')
+    end
+    return encoder.encode(x, typ)
+  end
+  local encode_bool = _value_encoders[Types.BOOL]
+  if absent then
+    return encode_bool(false)
+  end
+  return encode_bool(true) .. encoder.encode(x, typ)
+end
+
+-- Encode a value at a slot, where a null is carried by the is_null flag of the message around
+-- it. A value at a position inside another value carries its own presence bool, which
+-- _encode_item writes.
 function encoder.encode(x, typ)
   local code = typ.code
   local encode_value = _value_encoders[code]
@@ -115,7 +137,7 @@ function encoder.encode(x, typ)
     local count = 0
     for item in x:iter() do
       count = count + 1
-      parts[count] = _delimited(_ITEMS, encoder.encode(item, value_type))
+      parts[count] = _delimited(_ITEMS, _encode_item(item, value_type))
     end
     return _concat(parts)
   elseif code == Types.DICTIONARY then
@@ -124,8 +146,8 @@ function encoder.encode(x, typ)
     local parts = {}
     local count = 0
     for key,value in tablex.sort(x) do
-      local entry = _delimited(_ENTRY_KEY, encoder.encode(key, key_type)) ..
-                    _delimited(_ENTRY_VALUE, encoder.encode(value, value_type))
+      local entry = _delimited(_ENTRY_KEY, _encode_item(key, key_type)) ..
+                    _delimited(_ENTRY_VALUE, _encode_item(value, value_type))
       count = count + 1
       parts[count] = _delimited(_ENTRIES, entry)
     end
@@ -136,15 +158,14 @@ function encoder.encode(x, typ)
     local count = 0
     for item in pairs(x) do
       count = count + 1
-      parts[count] = _delimited(_ITEMS, encoder.encode(item, value_type))
+      parts[count] = _delimited(_ITEMS, _encode_item(item, value_type))
     end
     return _concat(parts)
   elseif code == Types.TUPLE then
+    local value_types = typ.value_types
     local parts = {}
-    local count = 0
-    for _,item in ipairs(tablex.zip(x, typ.value_types)) do
-      count = count + 1
-      parts[count] = _delimited(_ITEMS, encoder.encode(item[1], item[2]))
+    for i = 1, #value_types do
+      parts[i] = _delimited(_ITEMS, _encode_item(x[i], value_types[i]))
     end
     return _concat(parts)
   elseif code == Types.STRUCT then
@@ -154,7 +175,7 @@ function encoder.encode(x, typ)
     local field_types = typ.field_types
     local parts = {}
     for i = 1, #field_names do
-      parts[i] = _delimited(_ITEMS, encoder.encode(x[field_names[i]], field_types[i]))
+      parts[i] = _delimited(_ITEMS, _encode_item(x[field_names[i]], field_types[i]))
     end
     return _concat(parts)
   elseif typ:is_a(Types.MessageType) then

--- a/client/lua/krpc/encoder.lua
+++ b/client/lua/krpc/encoder.lua
@@ -109,7 +109,7 @@ end
 local function _encode_item(x, typ)
   local absent = x == nil or x == Types.none
   if not typ.nullable then
-    -- Types.none carries the object id 0, which would encode as a value of the type
+    -- A position that cannot hold null takes a value of its type and nothing else
     if absent then
       error('A null cannot be encoded at a position that cannot hold one')
     end

--- a/client/lua/krpc/test/test_client.lua
+++ b/client/lua/krpc/test/test_client.lua
@@ -129,6 +129,13 @@ function TestClient:test_nullable_class_method()
   luaunit.assertEquals(Types.none, obj:echo_nullable_object(Types.none))
 end
 
+function TestClient:test_nullable_class_type_shares_one_class()
+  -- A nullable class-typed value is the class of the non-nullable one, and not a second
+  -- class built for the nullable declaration
+  local obj = self.conn.test_service.create_test_object('jeb')
+  luaunit.assertIs(getmetatable(obj:echo_nullable_object(obj)), getmetatable(obj))
+end
+
 function TestClient:test_nullable_class_static_method()
   local obj = self.conn.test_service.create_test_object('jeb')
   luaunit.assertEquals(obj, self.conn.test_service.TestClass.static_nullable_object(obj))
@@ -320,6 +327,77 @@ function TestClient:test_nullable_structs()
   luaunit.assertEquals(value, service.struct_echo_nullable(value))
 end
 
+function TestClient:test_nullable_list_elements()
+  local service = self.conn.test_service
+  luaunit.assertEquals(List{1, Types.none, 3},
+                       service.echo_list_of_nullable_ints(List{1, Types.none, 3}))
+  local obj = service.create_test_object('jeb')
+  luaunit.assertEquals(List{obj, Types.none},
+                       service.echo_list_of_nullable_objects(List{obj, Types.none}))
+end
+
+function TestClient:test_nullable_positions_coerced_from_a_plain_table()
+  -- A plain table is coerced to the collection the position declares, and a null in it is
+  -- carried through to the nullable position that holds it
+  local service = self.conn.test_service
+  luaunit.assertEquals(List{1, Types.none, 3},
+                       service.echo_list_of_nullable_ints({1, Types.none, 3}))
+  local obj = service.create_test_object('jeb')
+  luaunit.assertEquals(List{1, Types.none},
+                       service.echo_tuple_with_a_nullable_object({1, Types.none}))
+  luaunit.assertEquals(List{List{obj, Types.none}},
+                       service.echo_nested_list_of_nullable_objects({{obj, Types.none}}))
+end
+
+function TestClient:test_nullable_dictionary_values()
+  local service = self.conn.test_service
+  local obj = service.create_test_object('jeb')
+  local value = Map{a = obj, b = Types.none}
+  luaunit.assertEquals(value, service.echo_dictionary_of_nullable_objects(value))
+end
+
+function TestClient:test_nullable_tuple_item()
+  local service = self.conn.test_service
+  local obj = service.create_test_object('jeb')
+  luaunit.assertEquals(List{1, obj},
+                       service.echo_tuple_with_a_nullable_object(List{1, obj}))
+  luaunit.assertEquals(List{1, Types.none},
+                       service.echo_tuple_with_a_nullable_object(List{1, Types.none}))
+end
+
+function TestClient:test_nullable_nested_list_elements()
+  local service = self.conn.test_service
+  local obj = service.create_test_object('jeb')
+  local value = List{List{obj, Types.none}, List{}}
+  luaunit.assertEquals(value, service.echo_nested_list_of_nullable_objects(value))
+end
+
+function TestClient:test_nullable_struct_fields()
+  local service = self.conn.test_service
+  local obj = service.create_test_object('jeb')
+  local value = service.TestNullableStruct(1, 2, service.TestEnum.value_b, 'jeb', obj)
+  luaunit.assertEquals(value, service.nullable_struct_echo(value))
+end
+
+function TestClient:test_null_struct_fields()
+  local service = self.conn.test_service
+  local value = service.TestNullableStruct(
+    1, Types.none, Types.none, Types.none, Types.none)
+  local result = service.nullable_struct_echo(value)
+  luaunit.assertEquals(1, result.int_field)
+  luaunit.assertEquals(Types.none, result.nullable_int_field)
+  luaunit.assertEquals(Types.none, result.nullable_enum_field)
+  luaunit.assertEquals(Types.none, result.nullable_string_field)
+  luaunit.assertEquals(Types.none, result.nullable_object_field)
+end
+
+function TestClient:test_nullable_elements_of_a_struct_field()
+  local service = self.conn.test_service
+  local obj = service.create_test_object('jeb')
+  local value = service.TestNestedNullableStruct(List{obj, Types.none}, 'jeb')
+  luaunit.assertEquals(value, service.echo_nested_nullable_struct(value))
+end
+
 function TestClient:test_struct_default_value()
   local service = self.conn.test_service
   luaunit.assertEquals(
@@ -452,7 +530,9 @@ function TestClient:test_test_service_service_members()
      'DeprecatedStruct',
      'TestClass',
      'TestEnum',
+     'TestNestedNullableStruct',
      'TestNestedStruct',
+     'TestNullableStruct',
      'TestStruct',
      'add_multiple_values',
      'add_to_object_list',
@@ -467,10 +547,16 @@ function TestClient:test_test_service_service_members()
      'dictionary_default',
      'double_special_defaults',
      'double_to_string',
+     'echo_dictionary_of_nullable_objects',
+     'echo_list_of_nullable_ints',
+     'echo_list_of_nullable_objects',
+     'echo_nested_list_of_nullable_objects',
+     'echo_nested_nullable_struct',
      'echo_nullable_int',
      'echo_nullable_list',
      'echo_nullable_string',
      'echo_test_object',
+     'echo_tuple_with_a_nullable_object',
      'empty_list_default',
      'enum_default_arg',
      'enum_echo',
@@ -496,6 +582,7 @@ function TestClient:test_test_service_service_members()
      'list_default',
      'nested_struct_echo',
      'not_nullable_object',
+     'nullable_struct_echo',
      'on_timer',
      'on_timer_using_lambda',
      'optional_arguments',

--- a/client/lua/krpc/test/test_encodedecode.lua
+++ b/client/lua/krpc/test/test_encodedecode.lua
@@ -159,6 +159,29 @@ function TestEncodeDecode:test_tuple()
   _run_test_decode_value(typ, cases)
 end
 
+function TestEncodeDecode:test_tuple_with_a_nullable_item()
+  local cases = {
+    {List{1, 'jeb'}, '0a01010a0501036a6562'},
+    {List{1, Types.none}, '0a01010a0100'}
+  }
+  typ = types:tuple_type({types:uint32_type(), types:nullable(types:string_type())})
+  _run_test_encode_value(typ, cases)
+  _run_test_decode_value(typ, cases)
+end
+
+function TestEncodeDecode:test_struct_with_nullable_fields()
+  typ = types:struct_type('ServiceName', 'NullableStructName')
+  typ:set_fields({{'count', types:uint32_type()},
+                  {'name', types:nullable(types:string_type())}})
+  -- The 01 ahead of the name is its presence bool, and a null field is that bool alone
+  local cases = {
+    {typ.lua_type(1, 'jeb'), '0a01010a0501036a6562'},
+    {typ.lua_type(1, Types.none), '0a01010a0100'}
+  }
+  _run_test_encode_value(typ, cases)
+  _run_test_decode_value(typ, cases)
+end
+
 function TestEncodeDecode:test_list()
   local cases = {
     {List{}, ''},
@@ -166,6 +189,20 @@ function TestEncodeDecode:test_list()
     {List{1,2,3,4}, '0a01010a01020a01030a0104'}
   }
   typ = types:list_type(types:uint32_type())
+  _run_test_encode_value(typ, cases)
+  _run_test_decode_value(typ, cases)
+end
+
+function TestEncodeDecode:test_list_of_nullable_values()
+  -- A zero is a value like any other, and is told apart from a null by the presence bool
+  -- alone
+  local cases = {
+    {List{}, ''},
+    {List{Types.none}, '0a0100'},
+    {List{0}, '0a020100'},
+    {List{1, Types.none, 3}, '0a0201010a01000a020103'}
+  }
+  typ = types:list_type(types:nullable(types:uint32_type()))
   _run_test_encode_value(typ, cases)
   _run_test_decode_value(typ, cases)
 end
@@ -192,6 +229,83 @@ function TestEncodeDecode:test_dictionary()
   typ = types:dictionary_type(types:string_type(), types:uint32_type())
   _run_test_encode_value(typ, cases)
   _run_test_decode_value(typ, cases)
+end
+
+function TestEncodeDecode:test_dictionary_of_nullable_values()
+  local zero = Map{}
+  zero[''] = 0
+  local null = Map{}
+  null[''] = Types.none
+  local cases = {
+    {zero, '0a070a010012020100'},
+    {null, '0a060a0100120100'},
+    {Map{foo = 42, bar = Types.none}, '0a090a04036261721201000a0a0a0403666f6f1202012a'}
+  }
+  typ = types:dictionary_type(types:string_type(), types:nullable(types:uint32_type()))
+  _run_test_encode_value(typ, cases)
+  _run_test_decode_value(typ, cases)
+end
+
+function TestEncodeDecode:test_nullability_is_read_at_every_position()
+  -- A service declares no nullable set element and no nullable dictionary key. The client
+  -- reads what the type says at every position rather than naming the ones a value can be
+  -- null at
+  local set_type = types:set_type(types:nullable(types:uint32_type()))
+  local set_cases = {
+    {Set{Types.none}, '0a0100'},
+    {Set{1}, '0a020101'}
+  }
+  _run_test_encode_value(set_type, set_cases)
+  _run_test_decode_value(set_type, set_cases)
+  local null_key = Map{}
+  null_key[Types.none] = 1
+  local dictionary_type = types:dictionary_type(types:nullable(types:string_type()),
+                                                types:uint32_type())
+  local dictionary_cases = {
+    {null_key, '0a060a0100120101'},
+    {Map{jeb = 1}, '0a0a0a0501036a6562120101'}
+  }
+  _run_test_encode_value(dictionary_type, dictionary_cases)
+  _run_test_decode_value(dictionary_type, dictionary_cases)
+end
+
+function TestEncodeDecode:test_nullable_collection_values()
+  -- A nullable position holding a collection carries the presence bool ahead of the
+  -- collection's own encoding
+  local cases = {
+    {List{Types.none}, '0a0100'},
+    {List{List{}}, '0a0101'},
+    {List{List{1}}, '0a04010a0101'}
+  }
+  typ = types:list_type(types:nullable(types:list_type(types:uint32_type())))
+  _run_test_encode_value(typ, cases)
+  _run_test_decode_value(typ, cases)
+end
+
+function TestEncodeDecode:test_nullable_struct_values()
+  local struct_type = types:struct_type('ServiceName', 'NestedStructName')
+  struct_type:set_fields({{'count', types:uint32_type()}})
+  local cases = {
+    {List{Types.none}, '0a0100'},
+    {List{struct_type.lua_type(1)}, '0a04010a0101'}
+  }
+  typ = types:list_type(types:nullable(struct_type))
+  _run_test_encode_value(typ, cases)
+  _run_test_decode_value(typ, cases)
+end
+
+function TestEncodeDecode:test_null_at_a_position_that_cannot_hold_one()
+  -- Types.none carries the object id 0, so a class-typed position takes it for a value
+  -- unless the encoder rejects it
+  typ = types:list_type(types:class_type('ServiceName', 'ClassName'))
+  luaunit.assertError(encoder.encode, List{Types.none}, typ)
+  luaunit.assertError(encoder.encode, List{Types.none}, types:list_type(types:uint32_type()))
+end
+
+function TestEncodeDecode:test_nullable_value_without_a_presence_bool()
+  -- A list holding one item of zero length
+  typ = types:list_type(types:nullable(types:uint32_type()))
+  luaunit.assertError(decoder.decode, platform.unhexlify('0a00'), typ)
 end
 
 return TestEncodeDecode

--- a/client/lua/krpc/test/test_types.lua
+++ b/client/lua/krpc/test/test_types.lua
@@ -179,6 +179,95 @@ function TestTypes:test_dictionary_types()
   self:check_protobuf_type(Types.UINT32, '', '', 0, typ.value_type.protobuf_type)
 end
 
+function TestTypes:test_nullable_types()
+  local types = Types()
+  local typ = types:nullable(types:uint32_type())
+  luaunit.assertTrue(typ:is_a(Types.ValueType))
+  luaunit.assertTrue(typ.nullable)
+  luaunit.assertFalse(types:uint32_type().nullable)
+  luaunit.assertTrue(typ.protobuf_type.nullable)
+  luaunit.assertEquals('<type: uint32?>', tostring(typ))
+  -- The nullable form of a type is the same type in every position that names it
+  luaunit.assertIs(typ, types:nullable(typ))
+  luaunit.assertIs(typ, types:nullable(types:uint32_type()))
+  luaunit.assertIs(typ, types:as_type(typ.protobuf_type))
+end
+
+function TestTypes:test_nullable_type_shares_its_lua_type()
+  local types = Types()
+  -- Nullability belongs to the position a value sits in, so a class has one metatable
+  -- however the position that holds it is declared
+  local cls = types:class_type('ServiceName', 'ClassName')
+  luaunit.assertIs(cls.lua_type, types:nullable(cls).lua_type)
+  local enumeration = types:enumeration_type('ServiceName', 'EnumName')
+  local nullable_enumeration = types:nullable(enumeration)
+  enumeration:set_values({a = 0})
+  luaunit.assertIs(enumeration.lua_type, nullable_enumeration.lua_type)
+  local struct = types:struct_type('ServiceName', 'StructName')
+  local nullable_struct = types:nullable(struct)
+  struct:set_fields({{'count', types:uint32_type()}})
+  luaunit.assertIs(struct.lua_type, nullable_struct.lua_type)
+  luaunit.assertEquals(struct.field_types, nullable_struct.field_types)
+end
+
+function TestTypes:test_nullable_list_types()
+  local types = Types()
+  local typ = types:list_type(types:nullable(types:uint32_type()))
+  luaunit.assertTrue(typ:is_a(Types.ListType))
+  luaunit.assertTrue(typ.value_type.nullable)
+  self:check_protobuf_type(Types.LIST, '', '', 1, typ.protobuf_type)
+  luaunit.assertTrue(typ.protobuf_type.types[1].nullable)
+  luaunit.assertEquals('<type: List(uint32?)>', tostring(typ))
+  -- A nullable element makes a list type of its own
+  luaunit.assertNotIs(types:list_type(types:uint32_type()), typ)
+end
+
+function TestTypes:test_nullable_dictionary_types()
+  local types = Types()
+  local typ = types:dictionary_type(types:string_type(),
+                                    types:nullable(types:uint32_type()))
+  luaunit.assertTrue(typ:is_a(Types.DictionaryType))
+  luaunit.assertFalse(typ.key_type.nullable)
+  luaunit.assertTrue(typ.value_type.nullable)
+  self:check_protobuf_type(Types.DICTIONARY, '', '', 2, typ.protobuf_type)
+  luaunit.assertFalse(typ.protobuf_type.types[1].nullable)
+  luaunit.assertTrue(typ.protobuf_type.types[2].nullable)
+  luaunit.assertEquals('<type: Dict(string,uint32?)>', tostring(typ))
+  luaunit.assertNotIs(types:dictionary_type(types:string_type(), types:uint32_type()), typ)
+end
+
+function TestTypes:test_nullable_tuple_types()
+  local types = Types()
+  local typ = types:tuple_type({types:sint32_type(), types:nullable(types:string_type())})
+  luaunit.assertTrue(typ:is_a(Types.TupleType))
+  luaunit.assertFalse(typ.value_types[1].nullable)
+  luaunit.assertTrue(typ.value_types[2].nullable)
+  self:check_protobuf_type(Types.TUPLE, '', '', 2, typ.protobuf_type)
+  luaunit.assertFalse(typ.protobuf_type.types[1].nullable)
+  luaunit.assertTrue(typ.protobuf_type.types[2].nullable)
+  luaunit.assertEquals('<type: Tuple(sint32,string?)>', tostring(typ))
+  luaunit.assertNotIs(types:tuple_type({types:sint32_type(), types:string_type()}), typ)
+end
+
+function TestTypes:test_nullable_set_types()
+  local types = Types()
+  local typ = types:set_type(types:nullable(types:uint32_type()))
+  luaunit.assertTrue(typ.value_type.nullable)
+  luaunit.assertEquals('<type: Set(uint32?)>', tostring(typ))
+end
+
+function TestTypes:test_struct_with_nullable_fields()
+  local types = Types()
+  local typ = types:struct_type('ServiceName', 'NullableStructName')
+  typ:set_fields({{'count', types:uint32_type()},
+                  {'name', types:nullable(types:string_type())}})
+  luaunit.assertFalse(typ.field_types[1].nullable)
+  luaunit.assertTrue(typ.field_types[2].nullable)
+  local value = typ.lua_type(42, Types.none)
+  luaunit.assertEquals(42, value.count)
+  luaunit.assertEquals(Types.none, value.name)
+end
+
 function TestTypes:test_coerce_to()
   local types = Types()
   local cases = List{
@@ -208,6 +297,33 @@ function TestTypes:test_coerce_to()
   luaunit.assertError(types.coerce_to, types, List{}, types:tuple_type({types:uint32_type()}))
   luaunit.assertError(types.coerce_to, types, List{'foo', 2}, types:tuple_type({types:string_type()}))
   luaunit.assertError(types.coerce_to, types, List{1}, types:tuple_type({types:string_type()}))
+end
+
+function TestTypes:test_coerce_to_struct_with_a_nullable_field()
+  local types = Types()
+  local typ = types:struct_type('ServiceName', 'CoercedNullableStruct')
+  typ:set_fields({{'count', types:uint32_type()},
+                  {'name', types:nullable(types:string_type())}})
+  luaunit.assertEquals(typ.lua_type(42, Types.none),
+                       types:coerce_to({42, Types.none}, typ))
+  -- A null in a field that cannot hold one is not a value of the structure
+  luaunit.assertError(types.coerce_to, types, {Types.none, 'jeb'}, typ)
+end
+
+function TestTypes:test_coerce_to_collection_holding_a_null()
+  local types = Types()
+  local list_type = types:list_type(types:nullable(types:sint32_type()))
+  luaunit.assertEquals(List{1, Types.none, 3},
+                       types:coerce_to({1, Types.none, 3}, list_type))
+  local tuple_type = types:tuple_type({types:sint32_type(),
+                                       types:nullable(types:string_type())})
+  luaunit.assertEquals(List{1, Types.none}, types:coerce_to({1, Types.none}, tuple_type))
+  -- A null in a position that cannot hold one is not a value of the collection
+  luaunit.assertError(types.coerce_to, types, {1, Types.none},
+                      types:list_type(types:sint32_type()))
+  -- A class type is no different, though a class value carries a null of its own
+  luaunit.assertError(types.coerce_to, types, {Types.none},
+                      types:list_type(types:class_type('ServiceName', 'ClassName')))
 end
 
 function TestTypes:test_struct_comparison()

--- a/client/lua/krpc/types.lua
+++ b/client/lua/krpc/types.lua
@@ -112,18 +112,28 @@ function _set_protobuf_type(src, dst)
   dst.code = src.code
   dst.service = src.service
   dst.name = src.name
+  dst.nullable = src.nullable
   for _, typ in ipairs(src.types) do
     local newtyp = dst.types:add()
     _set_protobuf_type(typ, newtyp)
   end
 end
 
--- The key a type is cached under, built from the type code, the names and the types nested
--- inside it in turn. It is built here rather than by serializing the message, as the protobuf
--- library writes the fields of a message in the order its own table happens to hold them,
--- which is not the same order every time.
+-- A copy of the given protocol buffer type, marked as the given nullability
+local function _nullable_protobuf_type(protobuf_type, nullable)
+  local result = schema.Type()
+  _set_protobuf_type(protobuf_type, result)
+  result.nullable = nullable
+  return result
+end
+
+-- The key a type is cached under, built from the type code, the names, whether the position
+-- holding it can be null and the types nested inside it in turn. It is built here rather than
+-- by serializing the message, as the protobuf library writes the fields of a message in the
+-- order its own table happens to hold them, which is not the same order every time.
 local function _type_key(protobuf_type)
-  local parts = { protobuf_type.code, protobuf_type.service, protobuf_type.name }
+  local parts = { protobuf_type.code, protobuf_type.service, protobuf_type.name,
+                  protobuf_type.nullable and 'null' or '' }
   for _, typ in ipairs(protobuf_type.types) do
     parts[#parts + 1] = '(' .. _type_key(typ) .. ')'
   end
@@ -137,6 +147,14 @@ function Types:as_type(protobuf_type)
   local key = _type_key(protobuf_type)
   if self._types:get(key) then
     return self._types:get(key)
+  end
+
+  -- A nullable type is built from the type it is the nullable form of, so that the two share
+  -- a lua type
+  if protobuf_type.nullable then
+    local typ = self:as_type(_nullable_protobuf_type(protobuf_type, false)):_as_nullable()
+    self._types:set(key, typ)
+    return typ
   end
 
   local typ
@@ -270,15 +288,28 @@ function Types:status_type()
   return self:as_type(_protobuf_type(Types.STATUS))
 end
 
+function Types:nullable(typ)
+  -- Get the given type at a position that can hold null
+  if typ.nullable then
+    return typ
+  end
+  local nullable_type = typ:_as_nullable()
+  local key = _type_key(nullable_type.protobuf_type)
+  if not self._types:get(key) then
+    self._types:set(key, nullable_type)
+  end
+  return nullable_type
+end
+
 function Types:coerce_to(value, typ)
   -- Coerce a value to the specified type (specified by a type object).
   --        Raises an error if the coercion is not possible.
+  -- A null stands at a position that can hold one, whatever the type there is
+  if typ.nullable and value == Types.none then
+    return Types.none
+  end
   if type(value) == typ.lua_type then
     return value
-  end
-  -- Types.none can be coerced to a ClassType
-  if typ:is_a(Types.ClassType) and value == Types.none then
-    return Types.none
   end
   -- Coerce identical class types from different client connections
   if typ:is_a(Types.ClassType) and Types.ClassBase:class_of(value) then
@@ -345,6 +376,15 @@ local function _create_enum_type(service_name, class_name, values)
   return cls
 end
 
+-- A shallow copy of a type object, of the same class as the one it was made from
+local function _copy_type(typ)
+  local copy = {}
+  for name, value in pairs(typ) do
+    copy[name] = value
+  end
+  return setmetatable(copy, getmetatable(typ))
+end
+
 Types.TypeBase = class()
 
 function Types.TypeBase:_init(protobuf_type, lua_type, type_string)
@@ -353,12 +393,34 @@ function Types.TypeBase:_init(protobuf_type, lua_type, type_string)
   -- about a type, and is read once for every value encoded or decoded, where reading it off the
   -- protobuf message goes through that message's field lookup every time.
   self.code = protobuf_type.code
+  -- Whether the position a value of this type sits in can hold null
+  self.nullable = protobuf_type.nullable
+  -- The nullable form of this type, built on demand by _as_nullable
+  self._nullable_type = nil
   self.lua_type = lua_type
   self._string = type_string
 end
 
 function Types.TypeBase:__tostring()
   return '<type: ' .. self._string .. '>'
+end
+
+--- This type at a position that can hold null.
+--
+-- A copy of this type, so that the two share a lua type and a class has one metatable however
+-- the position that holds it is declared.
+function Types.TypeBase:_as_nullable()
+  if self.nullable then
+    return self
+  end
+  if self._nullable_type == nil then
+    local typ = _copy_type(self)
+    typ.protobuf_type = _nullable_protobuf_type(self.protobuf_type, true)
+    typ.nullable = true
+    typ._string = self._string .. '?'
+    self._nullable_type = typ
+  end
+  return self._nullable_type
 end
 
 Types.ValueType = class(Types.TypeBase)
@@ -409,6 +471,9 @@ end
 
 function Types.EnumerationType:set_values(values)
   self.lua_type = _create_enum_type(self._service_name, self._class_name, values)
+  if self._nullable_type ~= nil then
+    self._nullable_type.lua_type = self.lua_type
+  end
 end
 
 Types.StructType = class(Types.TypeBase)
@@ -433,16 +498,24 @@ function Types.StructType:_init(protobuf_type)
   self:super(protobuf_type, nil, type_string)
 end
 
---- Set the fields of the structure, as a list of {name, type} pairs in the order the
---- structure declares them
-function Types.StructType:set_fields(fields)
+--- Set the fields of the structure, as a list of {name, type} pairs in the order the structure
+--- declares them. The nullable form of the structure takes the same fields and the same
+--- metatable, so a structure value is one lua type however the position that holds it is
+--- declared.
+function Types.StructType:set_fields(fields, lua_type)
   self.field_names = List{}
   self.field_types = List{}
   for _, field in ipairs(fields) do
     self.field_names:append(field[1])
     self.field_types:append(field[2])
   end
-  self.lua_type = _create_struct_type(self._service_name, self._struct_name, self.field_names)
+  if lua_type == nil then
+    lua_type = _create_struct_type(self._service_name, self._struct_name, self.field_names)
+  end
+  self.lua_type = lua_type
+  if self._nullable_type ~= nil then
+    self._nullable_type:set_fields(fields, lua_type)
+  end
 end
 
 Types.TupleType = class(Types.TypeBase)
@@ -455,11 +528,13 @@ function Types.TupleType:_init(protobuf_type, types)
     error('Wrong number of sub-types for tuple type')
   end
   self.value_types = List{}
+  local parts = List{}
   for _, subtype in ipairs(protobuf_type.types) do
-    self.value_types:append(types:as_type(subtype))
+    local value_type = types:as_type(subtype)
+    self.value_types:append(value_type)
+    parts:append(value_type._string)
   end
-  local protobuf_substrings = seq.copy(seq.map(function (x) return x._string end, self.value_types))
-  local type_string = 'Tuple(' .. stringx.join(',', protobuf_substrings) .. ')'
+  local type_string = 'Tuple(' .. stringx.join(',', parts) .. ')'
   self:super(protobuf_type, List, type_string)
 end
 

--- a/client/lua/krpc/types.lua
+++ b/client/lua/krpc/types.lua
@@ -320,7 +320,7 @@ function Types:coerce_to(value, typ)
   end
   -- Collection types
   -- Coerce tuples to lists
-  if type(value) == 'table' and value._object_id ~= 0 and typ:is_a(Types.ListType) then
+  if type(value) == 'table' and value ~= Types.none and typ:is_a(Types.ListType) then
     local result = typ.lua_type()
     for _, x in ipairs(value) do
       result:append(self:coerce_to(x, typ.value_type))
@@ -328,7 +328,7 @@ function Types:coerce_to(value, typ)
     return result
   end
   -- Coerce lists (with appropriate number of elements) to tuples
-  if type(value) == 'table' and value._object_id ~= 0 and typ:is_a(Types.TupleType) and #(value) == #(typ.value_types) then
+  if type(value) == 'table' and value ~= Types.none and typ:is_a(Types.TupleType) and #(value) == #(typ.value_types) then
     local result = typ.lua_type()
     for i, x in ipairs(value) do
       result:append(self:coerce_to(x, typ.value_types[i]))
@@ -337,7 +337,7 @@ function Types:coerce_to(value, typ)
   end
   -- Coerce lists (with one element per field) to structs, taking their elements as the
   -- fields in order
-  if type(value) == 'table' and value._object_id ~= 0 and typ:is_a(Types.StructType) and #(value) == #(typ.field_types) then
+  if type(value) == 'table' and value ~= Types.none and typ:is_a(Types.StructType) and #(value) == #(typ.field_types) then
     local values = {}
     for i, x in ipairs(value) do
       values[i] = self:coerce_to(x, typ.field_types[i])
@@ -719,11 +719,9 @@ function Types.ClassBase:__tostring()
   return string.format('<%s.%s remote object #%d>', self._service_name, self._class_name, self._object_id)
 end
 
+-- The value a null takes in lua, where nil in a table leaves a hole rather than an entry.
+-- It stands for a null at any position, and is not an instance of any class
 local None = class()
-
-function None:_init()
-  self._object_id = 0
-end
 
 function None:__tostring()
   return 'none'

--- a/client/python/CHANGELOG.md
+++ b/client/python/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## [v0.7.0] - unreleased
+- Support a nullable structure field, list element, tuple item and dictionary value, which is
+  `None` when absent (#1091)
 - A service with pre-generated stubs also gains the class members that only the server
   declares (#1077)
 - Support structure types. A value is a named tuple, and a tuple or list with one element per

--- a/client/python/krpc/decoder.py
+++ b/client/python/krpc/decoder.py
@@ -1,5 +1,15 @@
 from __future__ import annotations
-from typing import cast, Callable, Mapping, Optional, Tuple, Type, TYPE_CHECKING
+from typing import (
+    cast,
+    Callable,
+    Iterable,
+    List,
+    Mapping,
+    Optional,
+    Tuple,
+    Type,
+    TYPE_CHECKING,
+)
 import struct
 import google.protobuf
 
@@ -77,7 +87,11 @@ class Decoder:
 
     @classmethod
     def decode(cls, client: Optional[Client], data: bytes, typ: TypeBase) -> object:
-        """Given a python type, and serialized data, decode the value"""
+        """Given a python type, and serialized data, decode the value.
+
+        This decodes a value at a slot, where a null is carried by the is_null flag of the
+        message around it. A value at a position inside another value carries its own
+        presence bool, which _item_decoder reads."""
         # The value types come first, as most results are one, and this is on the hot path
         # of every remote procedure call
         if isinstance(typ, ValueType):
@@ -110,10 +124,7 @@ class Decoder:
             return set(decode_item(item) for item in msg.items)
         if isinstance(typ, TupleType):
             msg = cast(KRPC.Tuple, cls.decode_message(data, KRPC.Tuple))
-            return tuple(
-                cls.decode(client, item, value_type)
-                for item, value_type in zip(msg.items, typ.value_types)
-            )
+            return tuple(cls._decode_items(client, msg.items, typ.value_types))
         if isinstance(typ, StructType):
             # A structure is encoded as the values of its fields in order, which is the
             # same encoding as a tuple of those values
@@ -125,10 +136,7 @@ class Decoder:
                     % (len(typ.field_types), len(msg.items))
                 )
             return typ.python_type(
-                *[
-                    cls.decode(client, item, field_type)
-                    for item, field_type in zip(msg.items, typ.field_types)
-                ]
+                *cls._decode_items(client, msg.items, typ.field_types)
             )
         raise EncodingError("Cannot decode type %s" % str(typ))
 
@@ -152,7 +160,35 @@ class Decoder:
         return message
 
     @classmethod
+    def _decode_items(
+        cls,
+        client: Optional[Client],
+        items: Iterable[bytes],
+        types: Iterable[TypeBase],
+    ) -> List[object]:
+        """The decoded value of each item of a tuple or a structure"""
+        return [cls._item_decoder(client, typ)(item) for item, typ in zip(items, types)]
+
+    @classmethod
     def _item_decoder(
+        cls, client: Optional[Client], typ: TypeBase
+    ) -> Callable[[bytes], object]:
+        """A function that decodes one value at a position of the given type"""
+        decode = cls._value_decoder(client, typ)
+        if not typ.nullable:
+            return decode
+
+        # The presence bool is one byte, as a bool value always is, and is read from the
+        # data directly
+        def decode_nullable(data: bytes) -> object:
+            if not data:
+                raise EncodingError("A nullable value carries no presence bool")
+            return decode(data[1:]) if data[0] else None
+
+        return decode_nullable
+
+    @classmethod
+    def _value_decoder(
         cls, client: Optional[Client], typ: TypeBase
     ) -> Callable[[bytes], object]:
         """A function that decodes one value of the given type.
@@ -160,8 +196,7 @@ class Decoder:
         A collection carries many values of the same type, so working out how to decode
         one of them is worth doing once for the collection rather than once for every
         item in it. The types a collection usually holds are answered directly; anything
-        else falls back to the full decode.
-        """
+        else falls back to the full decode."""
         if isinstance(typ, ValueType):
             decode = _VALUE_DECODERS.get(typ.code)
             if decode is None:

--- a/client/python/krpc/encoder.py
+++ b/client/python/krpc/encoder.py
@@ -50,7 +50,11 @@ class Encoder:
 
     @classmethod
     def encode(cls, x: object, typ: TypeBase) -> bytes:
-        """Encode a message or value of the given protocol buffer type"""
+        """Encode a message or value of the given protocol buffer type.
+
+        This encodes a value at a slot, where a null is carried by the is_null flag of the
+        message around it. A value at a position inside another value carries its own
+        presence bool, which _item_encoder writes."""
         # The value types come first, as most arguments are one, and this is on the hot
         # path of every remote procedure call
         if isinstance(typ, ValueType):
@@ -99,10 +103,7 @@ class Encoder:
                     "Tuple has wrong number of elements. "
                     + "Expected %d, got %d." % (len(typ.value_types), len(tuple_obj))
                 )
-            tuple_msg.items.extend(
-                cls.encode(item, value_type)
-                for item, value_type in zip(tuple_obj, typ.value_types)
-            )
+            tuple_msg.items.extend(cls._encode_items(tuple_obj, typ.value_types))
             return tuple_msg.SerializeToString()
         if isinstance(typ, StructType):
             # A structure is encoded as the values of its fields in order, which is the
@@ -114,10 +115,7 @@ class Encoder:
                     "Struct has wrong number of fields. "
                     + "Expected %d, got %d." % (len(typ.field_types), len(struct_obj))
                 )
-            struct_msg.items.extend(
-                cls.encode(item, field_type)
-                for item, field_type in zip(struct_obj, typ.field_types)
-            )
+            struct_msg.items.extend(cls._encode_items(struct_obj, typ.field_types))
             return struct_msg.SerializeToString()
         raise EncodingError("Cannot encode objects of type " + str(type(x)))
 
@@ -134,14 +132,35 @@ class Encoder:
         return size + data
 
     @classmethod
+    def _encode_items(
+        cls, values: Iterable[object], types: Iterable[TypeBase]
+    ) -> List[bytes]:
+        """The encoded value of each item of a tuple or a structure.
+
+        A tuple is encoded on the hot path of every remote procedure call. Extending the
+        protobuf repeated field from a list costs less than from a generator."""
+        return [cls._item_encoder(typ)(value) for value, typ in zip(values, types)]
+
+    @classmethod
     def _item_encoder(cls, typ: TypeBase) -> Callable[[Any], bytes]:
+        """A function that encodes one value at a position of the given type"""
+        encode = cls._value_encoder(typ)
+        if not typ.nullable:
+            return encode
+        # A nullable position carries a presence bool before its value, and holds nothing
+        # else when that bool is false
+        present = cls._encode_value(True, cls._types.bool_type)
+        absent = cls._encode_value(False, cls._types.bool_type)
+        return lambda x: absent if x is None else present + encode(x)
+
+    @classmethod
+    def _value_encoder(cls, typ: TypeBase) -> Callable[[Any], bytes]:
         """A function that encodes one value of the given type.
 
         A collection carries many values of the same type, so working out how to encode
         one of them is worth doing once for the collection rather than once for every
         item in it. The types a collection usually holds are answered directly; anything
-        else falls back to the full encode.
-        """
+        else falls back to the full encode."""
         if isinstance(typ, ValueType):
             encode = _VALUE_ENCODERS.get(typ.code)
             if encode is None:

--- a/client/python/krpc/test/test_client.py
+++ b/client/python/krpc/test/test_client.py
@@ -233,6 +233,12 @@ class TestClient(ServerTestCase, unittest.TestCase):
         self.assertEqual(obj2, obj.echo_nullable_object(obj2))
         self.assertIsNone(obj.echo_nullable_object(None))
 
+    def test_nullable_class_type_shares_one_python_type(self) -> None:
+        # A nullable class-typed value is the generated class of the non-nullable one, and
+        # not a second class minted for the nullable declaration
+        obj = self.conn.test_service.create_test_object("jeb")
+        self.assertIs(type(obj.echo_nullable_object(obj)), type(obj))
+
     def test_nullable_class_static_method(self) -> None:
         obj = self.conn.test_service.create_test_object("jeb")
         self.assertEqual(
@@ -275,6 +281,15 @@ class TestClient(ServerTestCase, unittest.TestCase):
     def test_nullable_stream(self) -> None:
         with self.conn.stream(self.conn.test_service.echo_nullable_int, None) as stream:
             self.assertIsNone(stream())
+
+    def test_stream_of_nullable_list_elements(self) -> None:
+        # A stream carries the value itself, so a null inside a collection reaches the
+        # decoder as a presence bool where a null result does not
+        service = self.conn.test_service
+        with self.conn.stream(
+            service.echo_list_of_nullable_ints, [1, None, 3]
+        ) as stream:
+            self.assertEqual([1, None, 3], stream())
 
     def test_class_methods(self) -> None:
         obj = self.conn.test_service.create_test_object("bob")
@@ -521,6 +536,67 @@ class TestClient(ServerTestCase, unittest.TestCase):
         )
         self.assertEqual(value, service.struct_echo_nullable(value))
 
+    def test_nullable_list_elements(self) -> None:
+        service = self.conn.test_service
+        self.assertEqual([1, None, 3], service.echo_list_of_nullable_ints([1, None, 3]))
+        # A zero is a value like any other, and survives a position that could hold a null
+        self.assertEqual([0, None], service.echo_list_of_nullable_ints([0, None]))
+        obj = service.create_test_object("jeb")
+        self.assertEqual(
+            [obj, None], service.echo_list_of_nullable_objects([obj, None])
+        )
+
+    def test_nullable_dictionary_values(self) -> None:
+        service = self.conn.test_service
+        obj = service.create_test_object("jeb")
+        value = {"a": obj, "b": None}
+        self.assertEqual(value, service.echo_dictionary_of_nullable_objects(value))
+
+    def test_nullable_tuple_item(self) -> None:
+        service = self.conn.test_service
+        obj = service.create_test_object("jeb")
+        self.assertEqual((1, obj), service.echo_tuple_with_a_nullable_object((1, obj)))
+        self.assertEqual(
+            (1, None), service.echo_tuple_with_a_nullable_object((1, None))
+        )
+
+    def test_nullable_nested_list_elements(self) -> None:
+        service = self.conn.test_service
+        obj = service.create_test_object("jeb")
+        value = [[obj, None], []]
+        self.assertEqual(value, service.echo_nested_list_of_nullable_objects(value))
+
+    def test_nullable_struct_fields(self) -> None:
+        service = self.conn.test_service
+        obj = service.create_test_object("jeb")
+        value = service.TestNullableStruct(
+            int_field=1,
+            nullable_int_field=2,
+            nullable_enum_field=service.TestEnum.value_b,
+            nullable_string_field="jeb",
+            nullable_object_field=obj,
+        )
+        self.assertEqual(value, service.nullable_struct_echo(value))
+
+    def test_null_struct_fields(self) -> None:
+        service = self.conn.test_service
+        value = service.TestNullableStruct(
+            int_field=1,
+            nullable_int_field=None,
+            nullable_enum_field=None,
+            nullable_string_field=None,
+            nullable_object_field=None,
+        )
+        self.assertEqual(value, service.nullable_struct_echo(value))
+
+    def test_nullable_elements_of_a_struct_field(self) -> None:
+        service = self.conn.test_service
+        obj = service.create_test_object("jeb")
+        value = service.TestNestedNullableStruct(
+            list_field=[obj, None], string_field="jeb"
+        )
+        self.assertEqual(value, service.echo_nested_nullable_struct(value))
+
     def test_struct_default_value(self) -> None:
         service = self.conn.test_service
         self.assertEqual(
@@ -759,7 +835,16 @@ class TestClient(ServerTestCase, unittest.TestCase):
                     "counter",
                     "TestStruct",
                     "TestNestedStruct",
+                    "TestNullableStruct",
+                    "TestNestedNullableStruct",
+                    "echo_nested_nullable_struct",
+                    "echo_list_of_nullable_ints",
+                    "echo_list_of_nullable_objects",
+                    "echo_dictionary_of_nullable_objects",
+                    "echo_tuple_with_a_nullable_object",
+                    "echo_nested_list_of_nullable_objects",
                     "struct_echo",
+                    "nullable_struct_echo",
                     "nested_struct_echo",
                     "increment_list_of_structs",
                     "struct_default",

--- a/client/python/krpc/test/test_encodedecode.py
+++ b/client/python/krpc/test/test_encodedecode.py
@@ -157,6 +157,17 @@ class TestEncodeDecode(unittest.TestCase):
         self._run_test_encode_value(typ, cases)
         self._run_test_decode_value(typ, cases)
 
+    def test_tuple_with_a_nullable_item(self) -> None:
+        cases: List[Tuple[object, str]] = [
+            ((1, "jeb"), "0a01010a0501036a6562"),
+            ((1, None), "0a01010a0100"),
+        ]
+        typ = self.types.tuple_type(
+            self.types.uint32_type, self.types.nullable(self.types.string_type)
+        )
+        self._run_test_encode_value(typ, cases)
+        self._run_test_decode_value(typ, cases)
+
     def test_struct(self) -> None:
         typ = self.types.struct_type("ServiceName", "StructName")
         typ.set_fields(
@@ -170,6 +181,23 @@ class TestEncodeDecode(unittest.TestCase):
         # A structure carries the values of its fields in order, the same encoding as a
         # tuple of those values
         cases: List[Tuple[object, str]] = [(value, "0a01010a04036a65620a0100")]
+        self._run_test_encode_value(typ, cases)
+        self._run_test_decode_value(typ, cases)
+
+    def test_struct_with_nullable_fields(self) -> None:
+        typ = self.types.struct_type("ServiceName", "NullableStructName")
+        typ.set_fields(
+            [
+                ("count", self.types.uint32_type),
+                ("name", self.types.nullable(self.types.string_type)),
+            ]
+        )
+        # The 01 ahead of the name is its presence bool, and a null field is that bool
+        # alone
+        cases: List[Tuple[object, str]] = [
+            (typ.python_type(count=1, name="jeb"), "0a01010a0501036a6562"),
+            (typ.python_type(count=1, name=None), "0a01010a0100"),
+        ]
         self._run_test_encode_value(typ, cases)
         self._run_test_decode_value(typ, cases)
 
@@ -197,6 +225,19 @@ class TestEncodeDecode(unittest.TestCase):
         self._run_test_encode_value(typ, cases)
         self._run_test_decode_value(typ, cases)
 
+    def test_list_of_nullable_values(self) -> None:
+        # A zero is a value like any other, and is told apart from a null by the presence
+        # bool alone
+        cases: List[Tuple[object, str]] = [
+            ([], ""),
+            ([None], "0a0100"),
+            ([0], "0a020100"),
+            ([1, None, 3], "0a0201010a01000a020103"),
+        ]
+        typ = self.types.list_type(self.types.nullable(self.types.uint32_type))
+        self._run_test_encode_value(typ, cases)
+        self._run_test_decode_value(typ, cases)
+
     def test_set(self) -> None:
         cases: List[Tuple[object, str]] = [
             (set(), ""),
@@ -220,6 +261,72 @@ class TestEncodeDecode(unittest.TestCase):
         typ = self.types.dictionary_type(self.types.string_type, self.types.uint32_type)
         self._run_test_encode_value(typ, cases)
         self._run_test_decode_value(typ, cases)
+
+    def test_dictionary_of_nullable_values(self) -> None:
+        cases: List[Tuple[object, str]] = [
+            ({"": 0}, "0a070a010012020100"),
+            ({"": None}, "0a060a0100120100"),
+            (
+                {"foo": 42, "bar": None},
+                "0a090a04036261721201000a0a0a0403666f6f1202012a",
+            ),
+        ]
+        typ = self.types.dictionary_type(
+            self.types.string_type, self.types.nullable(self.types.uint32_type)
+        )
+        self._run_test_encode_value(typ, cases)
+        self._run_test_decode_value(typ, cases)
+
+    def test_nullability_is_read_at_every_position(self) -> None:
+        # A service declares no nullable set element and no nullable dictionary key. The
+        # client reads what the type says at every position rather than naming the ones a
+        # value can be null at
+        set_type = self.types.set_type(self.types.nullable(self.types.uint32_type))
+        set_cases: List[Tuple[object, str]] = [
+            (set([None]), "0a0100"),
+            (set([1]), "0a020101"),
+        ]
+        self._run_test_encode_value(set_type, set_cases)
+        self._run_test_decode_value(set_type, set_cases)
+        dictionary_type = self.types.dictionary_type(
+            self.types.nullable(self.types.string_type), self.types.uint32_type
+        )
+        dictionary_cases: List[Tuple[object, str]] = [
+            ({None: 1}, "0a060a0100120101"),
+            ({"jeb": 1}, "0a0a0a0501036a6562120101"),
+        ]
+        self._run_test_encode_value(dictionary_type, dictionary_cases)
+        self._run_test_decode_value(dictionary_type, dictionary_cases)
+
+    def test_nullable_collection_values(self) -> None:
+        # A nullable position holding a collection carries the presence bool ahead of the
+        # collection's own encoding
+        cases: List[Tuple[object, str]] = [
+            ([None], "0a0100"),
+            ([[]], "0a0101"),
+            ([[1]], "0a04010a0101"),
+        ]
+        typ = self.types.list_type(
+            self.types.nullable(self.types.list_type(self.types.uint32_type))
+        )
+        self._run_test_encode_value(typ, cases)
+        self._run_test_decode_value(typ, cases)
+
+    def test_nullable_struct_values(self) -> None:
+        struct_type = self.types.struct_type("ServiceName", "NestedStructName")
+        struct_type.set_fields([("count", self.types.uint32_type)])
+        typ = self.types.list_type(self.types.nullable(struct_type))
+        cases: List[Tuple[object, str]] = [
+            ([None], "0a0100"),
+            ([struct_type.python_type(count=1)], "0a04010a0101"),
+        ]
+        self._run_test_encode_value(typ, cases)
+        self._run_test_decode_value(typ, cases)
+
+    def test_nullable_value_without_a_presence_bool(self) -> None:
+        # A list holding one item of zero length
+        typ = self.types.list_type(self.types.nullable(self.types.uint32_type))
+        self.assertRaises(EncodingError, Decoder.decode, None, unhexlify("0a00"), typ)
 
 
 if __name__ == "__main__":

--- a/client/python/krpc/test/test_types.py
+++ b/client/python/krpc/test/test_types.py
@@ -227,6 +227,90 @@ class TestTypes(unittest.TestCase):
         self.assertEqual(int, typ.value_type.python_type)
         self.check_protobuf_type(Type.UINT32, "", "", 0, typ.value_type.protobuf_type)
 
+    def test_nullable_types(self) -> None:
+        types = Types()
+        typ = types.nullable(types.uint32_type)
+        self.assertTrue(isinstance(typ, ValueType))
+        self.assertTrue(typ.nullable)
+        self.assertFalse(types.uint32_type.nullable)
+        self.assertTrue(typ.protobuf_type.nullable)
+        self.assertEqual("<type: uint32?>", str(typ))
+        # The nullable form of a type is the same type in every position that names it
+        self.assertIs(typ, types.nullable(typ))
+        self.assertIs(typ, types.nullable(types.uint32_type))
+        self.assertIs(typ, types.as_type(typ.protobuf_type))
+
+    def test_nullable_type_shares_its_python_type(self) -> None:
+        types = Types()
+        # Nullability belongs to the position a value sits in, so a class has one python
+        # type however the position that holds it is declared
+        cls = types.class_type("ServiceName", "ClassName")
+        self.assertIs(cls.python_type, types.nullable(cls).python_type)
+        enumeration = types.enumeration_type("ServiceName", "EnumName")
+        nullable_enumeration = types.nullable(enumeration)
+        enumeration.set_values({"a": {"value": 0, "doc": ""}})
+        self.assertIs(enumeration.python_type, nullable_enumeration.python_type)
+        struct = types.struct_type("ServiceName", "StructName")
+        nullable_struct = types.nullable(struct)
+        struct.set_fields([("count", types.uint32_type)])
+        self.assertIs(struct.python_type, nullable_struct.python_type)
+        self.assertEqual(struct.field_types, nullable_struct.field_types)
+
+    def test_nullable_list_types(self) -> None:
+        types = Types()
+        typ = types.list_type(types.nullable(types.uint32_type))
+        self.assertTrue(isinstance(typ, ListType))
+        self.assertTrue(typ.value_type.nullable)
+        self.check_protobuf_type(Type.LIST, "", "", 1, typ.protobuf_type)
+        self.assertTrue(typ.protobuf_type.types[0].nullable)
+        self.assertEqual("<type: List(uint32?)>", str(typ))
+        # A nullable element makes a list type of its own
+        self.assertIsNot(types.list_type(types.uint32_type), typ)
+
+    def test_nullable_dictionary_types(self) -> None:
+        types = Types()
+        typ = types.dictionary_type(
+            types.string_type, types.nullable(types.uint32_type)
+        )
+        self.assertTrue(isinstance(typ, DictionaryType))
+        self.assertFalse(typ.key_type.nullable)
+        self.assertTrue(typ.value_type.nullable)
+        self.check_protobuf_type(Type.DICTIONARY, "", "", 2, typ.protobuf_type)
+        self.assertFalse(typ.protobuf_type.types[0].nullable)
+        self.assertTrue(typ.protobuf_type.types[1].nullable)
+        self.assertEqual("<type: Dict(string,uint32?)>", str(typ))
+        self.assertIsNot(
+            types.dictionary_type(types.string_type, types.uint32_type), typ
+        )
+
+    def test_nullable_tuple_types(self) -> None:
+        types = Types()
+        typ = types.tuple_type(types.sint32_type, types.nullable(types.string_type))
+        self.assertTrue(isinstance(typ, TupleType))
+        self.assertEqual([False, True], [t.nullable for t in typ.value_types])
+        self.check_protobuf_type(Type.TUPLE, "", "", 2, typ.protobuf_type)
+        self.assertFalse(typ.protobuf_type.types[0].nullable)
+        self.assertTrue(typ.protobuf_type.types[1].nullable)
+        self.assertEqual("<type: Tuple(sint32,string?)>", str(typ))
+        self.assertIsNot(types.tuple_type(types.sint32_type, types.string_type), typ)
+
+    def test_nullable_set_types(self) -> None:
+        types = Types()
+        typ = types.set_type(types.nullable(types.uint32_type))
+        self.assertTrue(typ.value_type.nullable)
+        self.assertEqual("<type: Set(uint32?)>", str(typ))
+
+    def test_struct_with_nullable_fields(self) -> None:
+        types = Types()
+        typ = types.struct_type("ServiceName", "NullableStructName")
+        typ.set_fields(
+            [("count", types.uint32_type), ("name", types.nullable(types.string_type))]
+        )
+        self.assertEqual([False, True], [t.nullable for t in typ.field_types])
+        value = typ.python_type(count=42, name=None)
+        self.assertEqual(42, value.count)
+        self.assertIsNone(value.name)
+
     def test_struct_comparison(self) -> None:
         types = Types()
         typ = types.struct_type("ServiceName", "ComparableStruct")
@@ -268,6 +352,38 @@ class TestTypes(unittest.TestCase):
         # A value with the wrong number of fields is not a value of the structure
         self.assertRaises(ValueError, types.coerce_to, (42,), typ)
         self.assertRaises(ValueError, types.coerce_to, (42, "jeb", 1), typ)
+
+    def test_coerce_to_struct_with_a_nullable_field(self) -> None:
+        types = Types()
+        typ = types.struct_type("ServiceName", "CoercedNullableStruct")
+        typ.set_fields(
+            [("count", types.uint32_type), ("name", types.nullable(types.string_type))]
+        )
+        expected = typ.python_type(count=42, name=None)
+        for value in ((42, None), [42, None]):
+            self.assertEqual(expected, types.coerce_to(value, typ))
+        # A null in a field that cannot hold one is not a value of the structure
+        self.assertRaises(ValueError, types.coerce_to, (None, "jeb"), typ)
+
+    def test_coerce_to_collection_holding_a_null(self) -> None:
+        types = Types()
+        list_type = types.list_type(types.nullable(types.sint32_type))
+        self.assertEqual([1, None, 3], types.coerce_to((1, None, 3), list_type))
+        tuple_type = types.tuple_type(
+            types.sint32_type, types.nullable(types.string_type)
+        )
+        self.assertEqual((1, None), types.coerce_to([1, None], tuple_type))
+        # A null in a position that cannot hold one is not a value of the collection
+        self.assertRaises(
+            ValueError, types.coerce_to, (1, None), types.list_type(types.sint32_type)
+        )
+        # A class type is no different, though a class value carries a null of its own
+        self.assertRaises(
+            ValueError,
+            types.coerce_to,
+            (None,),
+            types.list_type(types.class_type("ServiceName", "ClassName")),
+        )
 
     def test_coerce_to(self) -> None:
         types = Types()

--- a/client/python/krpc/types.py
+++ b/client/python/krpc/types.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import collections
+import copy
 import functools
 import weakref
 from enum import Enum
@@ -102,6 +103,14 @@ def _protobuf_type(
     return protobuf_type
 
 
+def _nullable_protobuf_type(protobuf_type: KRPC.Type, nullable: bool) -> KRPC.Type:
+    """A copy of the given protocol buffer type, marked as the given nullability"""
+    result = KRPC.Type()
+    result.CopyFrom(protobuf_type)
+    result.nullable = nullable
+    return result
+
+
 class Types:
     """A type store. Used to obtain type objects from protocol buffer type
     strings, and stores python types for services and service defined
@@ -164,6 +173,14 @@ class Types:
         if key in self._types:
             return self._types[key]
 
+        # A nullable type is built from the type it is the nullable form of, so that the two
+        # share a python type
+        if protobuf_type.nullable:
+            non_nullable = _nullable_protobuf_type(protobuf_type, False)
+            typ = self.as_type(non_nullable, doc)._as_nullable()
+            self._types[key] = typ
+            return typ
+
         typ: TypeBase
         if protobuf_type.code in VALUE_TYPES:
             typ = ValueType(protobuf_type)
@@ -192,6 +209,20 @@ class Types:
     @classmethod
     def is_none_type(cls, protobuf_type: KRPC.Type) -> bool:
         return protobuf_type.code == KRPC.Type.NONE
+
+    def nullable(self, typ: TypeBase) -> TypeBase:
+        """Get the given type at a position that can hold null"""
+        if typ.nullable:
+            return typ
+        # The nullable form is held on the type itself, so that naming one costs an
+        # attribute lookup on the hot path of every remote procedure call
+        nullable_type = typ._nullable_type
+        if nullable_type is None:
+            nullable_type = typ._as_nullable()
+            self._types.setdefault(
+                nullable_type.protobuf_type.SerializeToString(), nullable_type
+            )
+        return nullable_type
 
     def class_type(
         self, service: str, name: str, doc: Optional[str] = None
@@ -313,11 +344,11 @@ class Types:
     def coerce_to(self, value: object, typ: TypeBase) -> object:
         """Coerce a value to the specified type (specified by a type object).
         Raises ValueError if the coercion is not possible."""
+        # A null stands at a position that can hold one, whatever the type there is
+        if typ.nullable and value is None:
+            return None
         if isinstance(value, typ.python_type):
             return value
-        # A NoneType can be coerced to a ClassType
-        if isinstance(typ, ClassType) and value is None:
-            return None
         # Coerce identical class types from different client connections
         if isinstance(typ, ClassType) and isinstance(value, ClassBase):
             value_type = type(value)
@@ -403,10 +434,29 @@ class TypeBase:
         # The type code the encoder and decoder select on. Held here as well as in the
         # protocol buffer type, as reading it from there is a protocol buffer field access
         self.code = protobuf_type.code
+        # Whether the position a value of this type sits in can hold null
+        self.nullable = protobuf_type.nullable
+        # The nullable form of this type, built on demand by _as_nullable
+        self._nullable_type: Optional[TypeBase] = None
         self._string = string
 
     def __str__(self) -> str:
         return "<type: " + str(self._string) + ">"
+
+    def _as_nullable(self) -> TypeBase:
+        """This type at a position that can hold null.
+
+        A copy of this type, so that the two share a python type and a class has one python
+        type however the position that holds it is declared."""
+        if self.nullable:
+            return self
+        if self._nullable_type is None:
+            typ = copy.copy(self)
+            typ.protobuf_type = _nullable_protobuf_type(self.protobuf_type, True)
+            typ.nullable = True
+            typ._string = self._string + "?"
+            self._nullable_type = typ
+        return self._nullable_type
 
 
 class ValueType(TypeBase):
@@ -468,6 +518,8 @@ class EnumerationType(TypeBase):
         using the given values."""
         assert self.python_type is None
         self.python_type = _create_enum_type(self._enum_name, values, self._doc)
+        if self._nullable_type is not None:
+            self._nullable_type.python_type = self.python_type
 
 
 class StructType(TypeBase):
@@ -516,6 +568,8 @@ class StructType(TypeBase):
                 self._struct_name, self.field_names, self._doc
             )
         self.python_type = python_type
+        if self._nullable_type is not None:
+            self._nullable_type.set_fields(fields, python_type)
 
 
 class TupleType(TypeBase):

--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## [v0.7.0] - unreleased
+- Encode and decode values without reflection, cutting the server cost of a call that passes
+  or returns an object by about three quarters (#1091)
 - **Breaking:** Nullability is carried by `Type.nullable` at every position a value sits in,
   replacing `Parameter.nullable` and `Procedure.return_is_nullable` (#1091)
 - A structure field can be nullable, declared by `Nullable` on its `KRPCProperty` attribute

--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -1,4 +1,11 @@
 ## [v0.7.0] - unreleased
+- **Breaking:** Nullability is carried by `Type.nullable` at every position a value sits in,
+  replacing `Parameter.nullable` and `Procedure.return_is_nullable` (#1091)
+- A structure field can be nullable, declared by `Nullable` on its `KRPCProperty` attribute
+  or by a `Nullable<T>` field type (#1091)
+- A list element, a tuple item and a dictionary value can be nullable, declared by a
+  `Nullable<T>` type or by a path of positions on `KRPCNullable`, such as
+  `[KRPCNullable (Position.Element)]` (#1091)
 - Add extension members: a service can add methods and properties to a class belonging to
   another service, declared as C# extension methods annotated with `KRPCMethod` or
   `KRPCProperty` (#1077)

--- a/core/src/KRPC.Core.csproj
+++ b/core/src/KRPC.Core.csproj
@@ -176,6 +176,7 @@
     <Compile Include="Service\Services.cs" />
     <Compile Include="Service\Stream.cs" />
     <Compile Include="Service\StreamContinuation.cs" />
+    <Compile Include="Service\TypeSpec.cs" />
     <Compile Include="Service\TypeUtils.cs" />
     <Compile Include="Service\ValueUtils.cs" />
     <Compile Include="Service\YieldException.cs" />

--- a/core/src/KRPC.Core.csproj
+++ b/core/src/KRPC.Core.csproj
@@ -177,6 +177,7 @@
     <Compile Include="Service\Services.cs" />
     <Compile Include="Service\Stream.cs" />
     <Compile Include="Service\StreamContinuation.cs" />
+    <Compile Include="Service\TypeKind.cs" />
     <Compile Include="Service\TypeSpec.cs" />
     <Compile Include="Service\TypeUtils.cs" />
     <Compile Include="Service\ValueUtils.cs" />

--- a/core/src/KRPC.Core.csproj
+++ b/core/src/KRPC.Core.csproj
@@ -109,6 +109,7 @@
     <Compile Include="Service\Attributes\KRPCExceptionAttribute.cs" />
     <Compile Include="Service\Attributes\KRPCMethodAttribute.cs" />
     <Compile Include="Service\Attributes\KRPCNullableAttribute.cs" />
+    <Compile Include="Service\Attributes\Position.cs" />
     <Compile Include="Service\Attributes\KRPCProcedureAttribute.cs" />
     <Compile Include="Service\Attributes\KRPCPropertyAttribute.cs" />
     <Compile Include="Service\Attributes\KRPCServiceAttribute.cs" />

--- a/core/src/Server/ProtocolBuffers/Encoder.cs
+++ b/core/src/Server/ProtocolBuffers/Encoder.cs
@@ -72,56 +72,61 @@ namespace KRPC.Server.ProtocolBuffers
 
         static void WriteObject (object value, TypeSpec spec, CodedOutputStream stream)
         {
-            var type = spec.Type;
-            if (type.IsEnum) {
+            switch (spec.Kind) {
+            case TypeKind.Enum:
+            case TypeKind.UndeclaredEnum:
                 stream.WriteSInt32 ((int)value);
-            } else {
-                switch (Type.GetTypeCode (type)) {
-                case TypeCode.Double:
-                    stream.WriteDouble ((double)value);
-                    break;
-                case TypeCode.Single:
-                    stream.WriteFloat ((float)value);
-                    break;
-                case TypeCode.Int32:
-                    stream.WriteSInt32 ((int)value);
-                    break;
-                case TypeCode.Int64:
-                    stream.WriteSInt64 ((long)value);
-                    break;
-                case TypeCode.UInt32:
-                    stream.WriteUInt32 ((uint)value);
-                    break;
-                case TypeCode.UInt64:
-                    stream.WriteUInt64 ((ulong)value);
-                    break;
-                case TypeCode.Boolean:
-                    stream.WriteBool ((bool)value);
-                    break;
-                case TypeCode.String:
-                    stream.WriteString ((string)value);
-                    break;
-                default:
-                    if (type == typeof(byte[]))
-                        stream.WriteBytes (ByteString.CopyFrom ((byte[])value));
-                    else if (TypeUtils.IsAClassType (type))
-                        stream.WriteUInt64 (ObjectStore.Instance.AddInstance (value));
-                    else if (TypeUtils.IsAStructType (type))
-                        WriteStruct (value, spec, stream);
-                    else if (TypeUtils.IsATupleCollectionType (type))
-                        WriteTuple (value, spec, stream);
-                    else if (TypeUtils.IsAListCollectionType (type))
-                        WriteList (value, spec, stream);
-                    else if (TypeUtils.IsASetCollectionType (type))
-                        WriteSet (value, spec, stream);
-                    else if (TypeUtils.IsADictionaryCollectionType (type))
-                        WriteDictionary (value, spec, stream);
-                    else if (TypeUtils.IsAMessageType (type))
-                        WriteMessage (value, stream);
-                    else
-                        throw new ArgumentException (type + " is not a serializable type");
-                    break;
-                }
+                break;
+            case TypeKind.Double:
+                stream.WriteDouble ((double)value);
+                break;
+            case TypeKind.Single:
+                stream.WriteFloat ((float)value);
+                break;
+            case TypeKind.Int32:
+                stream.WriteSInt32 ((int)value);
+                break;
+            case TypeKind.Int64:
+                stream.WriteSInt64 ((long)value);
+                break;
+            case TypeKind.UInt32:
+                stream.WriteUInt32 ((uint)value);
+                break;
+            case TypeKind.UInt64:
+                stream.WriteUInt64 ((ulong)value);
+                break;
+            case TypeKind.Boolean:
+                stream.WriteBool ((bool)value);
+                break;
+            case TypeKind.String:
+                stream.WriteString ((string)value);
+                break;
+            case TypeKind.Bytes:
+                stream.WriteBytes (ByteString.CopyFrom ((byte[])value));
+                break;
+            case TypeKind.Class:
+                stream.WriteUInt64 (ObjectStore.Instance.AddInstance (value));
+                break;
+            case TypeKind.Struct:
+                WriteStruct (value, spec, stream);
+                break;
+            case TypeKind.Tuple:
+                WriteTuple (value, spec, stream);
+                break;
+            case TypeKind.List:
+                WriteList (value, spec, stream);
+                break;
+            case TypeKind.Set:
+                WriteSet (value, spec, stream);
+                break;
+            case TypeKind.Dictionary:
+                WriteDictionary (value, spec, stream);
+                break;
+            case TypeKind.Message:
+                WriteMessage (value, stream);
+                break;
+            default:
+                throw new ArgumentException (spec.Type + " is not a serializable type");
             }
         }
 
@@ -280,46 +285,41 @@ namespace KRPC.Server.ProtocolBuffers
             // the null itself is read by the caller, from the presence bool or a flag beside
             // the value
             var type = spec.Type;
-            if (type.IsEnum) {
-                if (TypeUtils.IsAnEnumType (type))
-                    return Enum.ToObject (type, stream.ReadSInt32 ());
-            } else {
-                switch (Type.GetTypeCode (type)) {
-                case TypeCode.Double:
-                    return stream.ReadDouble ();
-                case TypeCode.Single:
-                    return stream.ReadFloat ();
-                case TypeCode.Int32:
-                    return stream.ReadSInt32 ();
-                case TypeCode.Int64:
-                    return stream.ReadSInt64 ();
-                case TypeCode.UInt32:
-                    return stream.ReadUInt32 ();
-                case TypeCode.UInt64:
-                    return stream.ReadUInt64 ();
-                case TypeCode.Boolean:
-                    return stream.ReadBool ();
-                case TypeCode.String:
-                    return stream.ReadString ();
-                default:
-                    if (type == typeof(byte[]))
-                        return stream.ReadBytes ().ToByteArray ();
-                    if (TypeUtils.IsAClassType (type))
-                        return ObjectStore.Instance.GetInstance (stream.ReadUInt64 ());
-                    if (TypeUtils.IsAStructType (type))
-                        return DecodeStruct (stream, type);
-                    if (TypeUtils.IsATupleCollectionType (type))
-                        return DecodeTuple (stream, spec);
-                    if (TypeUtils.IsAListCollectionType (type))
-                        return DecodeList (stream, spec);
-                    if (TypeUtils.IsASetCollectionType (type))
-                        return DecodeSet (stream, spec);
-                    if (TypeUtils.IsADictionaryCollectionType (type))
-                        return DecodeDictionary (stream, spec);
-                    if (TypeUtils.IsAMessageType (type))
-                        return DecodeMessage (stream, type);
-                    break;
-                }
+            switch (spec.Kind) {
+            case TypeKind.Enum:
+                return Enum.ToObject (type, stream.ReadSInt32 ());
+            case TypeKind.Double:
+                return stream.ReadDouble ();
+            case TypeKind.Single:
+                return stream.ReadFloat ();
+            case TypeKind.Int32:
+                return stream.ReadSInt32 ();
+            case TypeKind.Int64:
+                return stream.ReadSInt64 ();
+            case TypeKind.UInt32:
+                return stream.ReadUInt32 ();
+            case TypeKind.UInt64:
+                return stream.ReadUInt64 ();
+            case TypeKind.Boolean:
+                return stream.ReadBool ();
+            case TypeKind.String:
+                return stream.ReadString ();
+            case TypeKind.Bytes:
+                return stream.ReadBytes ().ToByteArray ();
+            case TypeKind.Class:
+                return ObjectStore.Instance.GetInstance (stream.ReadUInt64 ());
+            case TypeKind.Struct:
+                return DecodeStruct (stream, type);
+            case TypeKind.Tuple:
+                return DecodeTuple (stream, spec);
+            case TypeKind.List:
+                return DecodeList (stream, spec);
+            case TypeKind.Set:
+                return DecodeSet (stream, spec);
+            case TypeKind.Dictionary:
+                return DecodeDictionary (stream, spec);
+            case TypeKind.Message:
+                return DecodeMessage (stream, type);
             }
             throw new ArgumentException (type + " is not a serializable type");
         }

--- a/core/src/Server/ProtocolBuffers/Encoder.cs
+++ b/core/src/Server/ProtocolBuffers/Encoder.cs
@@ -28,6 +28,27 @@ namespace KRPC.Server.ProtocolBuffers
                 throw new ArgumentNullException (nameof (value));
             }
             buffer.SetLength (0);
+            WriteObject (value, stream);
+            stream.Flush ();
+            return ByteString.CopyFrom (buffer.GetBuffer (), 0, (int)buffer.Length);
+        }
+
+        /// <summary>
+        /// Encode a value at a position that allows a null: a presence bool, followed by the
+        /// value itself when it is present.
+        /// </summary>
+        static ByteString EncodeNullableObject (object value, MemoryStream buffer, CodedOutputStream stream)
+        {
+            buffer.SetLength (0);
+            stream.WriteBool (value != null);
+            if (value != null)
+                WriteObject (value, stream);
+            stream.Flush ();
+            return ByteString.CopyFrom (buffer.GetBuffer (), 0, (int)buffer.Length);
+        }
+
+        static void WriteObject (object value, CodedOutputStream stream)
+        {
             if (value is Enum) {
                 stream.WriteSInt32 ((int)value);
             } else {
@@ -79,8 +100,6 @@ namespace KRPC.Server.ProtocolBuffers
                     break;
                 }
             }
-            stream.Flush ();
-            return ByteString.CopyFrom (buffer.GetBuffer (), 0, (int)buffer.Length);
         }
 
         static void WriteTuple (object value, CodedOutputStream stream)
@@ -108,13 +127,21 @@ namespace KRPC.Server.ProtocolBuffers
         {
             var encodedStruct = new Schema.KRPC.Tuple ();
             var type = value.GetType ();
+            System.Collections.Generic.IList<PropertyInfo> fields;
+            System.Collections.Generic.IList<TypeSpec> specs;
+            TypeUtils.GetStructFieldsAndSpecs (type, out fields, out specs);
             using (var internalBuffer = new MemoryStream ()) {
                 var internalStream = new CodedOutputStream (internalBuffer);
-                foreach (var field in TypeUtils.GetStructFields (type)) {
+                for (int i = 0; i < fields.Count; i++) {
+                    var field = fields [i];
                     var item = field.GetGetMethod ().Invoke (value, null);
+                    if (specs [i].Nullable) {
+                        encodedStruct.Items.Add (EncodeNullableObject (item, internalBuffer, internalStream));
+                        continue;
+                    }
                     if (item == null)
                         throw new ServiceException (
-                            "Field " + field.Name + " of " + type.Name + " is null; struct fields cannot be null");
+                            "Field " + field.Name + " of " + type.Name + " is null; the field is not nullable");
                     encodedStruct.Items.Add (EncodeObject (item, internalBuffer, internalStream));
                 }
             }
@@ -178,7 +205,21 @@ namespace KRPC.Server.ProtocolBuffers
         /// </summary>
         public static object Decode (ByteString value, Type type)
         {
+            return DecodeValue (value.CreateCodedInput (), type);
+        }
+
+        /// <summary>
+        /// Decode a value at a position that allows a null, which EncodeNullableObject
+        /// writes.
+        /// </summary>
+        static object DecodeNullable (ByteString value, Type type)
+        {
             var stream = value.CreateCodedInput ();
+            return stream.ReadBool () ? DecodeValue (stream, type) : null;
+        }
+
+        static object DecodeValue (CodedInputStream stream, Type type)
+        {
             if (type.IsEnum) {
                 if (TypeUtils.IsAnEnumType (type))
                     return Enum.ToObject (type, stream.ReadSInt32 ());
@@ -243,13 +284,15 @@ namespace KRPC.Server.ProtocolBuffers
         /// <summary>
         /// Read a structure value from the values of its fields, in the order the structure
         /// declares them. Fields may only ever be appended to a structure, so items beyond the
-        /// ones the structure declares come from a newer definition and are ignored. A field is
-        /// never null, so a value that decodes one is rejected rather than passed to a service.
+        /// ones the structure declares come from a newer definition and are ignored. A null is
+        /// only accepted for a field declared nullable.
         /// </summary>
         static object DecodeStruct (CodedInputStream stream, Type type)
         {
             var encodedStruct = Schema.KRPC.Tuple.Parser.ParseFrom (stream);
-            var fields = TypeUtils.GetStructFields (type);
+            System.Collections.Generic.IList<PropertyInfo> fields;
+            System.Collections.Generic.IList<TypeSpec> specs;
+            TypeUtils.GetStructFieldsAndSpecs (type, out fields, out specs);
             if (encodedStruct.Items.Count < fields.Count)
                 throw new ArgumentException (
                     "Value for " + type.Name + " has " + encodedStruct.Items.Count +
@@ -257,10 +300,16 @@ namespace KRPC.Server.ProtocolBuffers
             var value = Activator.CreateInstance (type);
             for (int i = 0; i < fields.Count; i++) {
                 var field = fields [i];
-                var item = Decode (encodedStruct.Items [i], field.PropertyType);
-                if (item == null)
-                    throw new ArgumentException (
-                        "Field " + field.Name + " of " + type.Name + " is null; struct fields cannot be null");
+                var spec = specs [i];
+                object item;
+                if (spec.Nullable) {
+                    item = DecodeNullable (encodedStruct.Items [i], spec.Type);
+                } else {
+                    item = Decode (encodedStruct.Items [i], spec.Type);
+                    if (item == null)
+                        throw new ArgumentException (
+                            "Field " + field.Name + " of " + type.Name + " is null; the field is not nullable");
+                }
                 field.GetSetMethod ().Invoke (value, new [] { item });
             }
             return value;

--- a/core/src/Server/ProtocolBuffers/Encoder.cs
+++ b/core/src/Server/ProtocolBuffers/Encoder.cs
@@ -15,20 +15,23 @@ namespace KRPC.Server.ProtocolBuffers
         static CodedOutputStream cachedStream = new CodedOutputStream (cachedBuffer);
 
         /// <summary>
-        /// Encode an object using the protocol buffer encoding scheme.
+        /// Encode an object using the protocol buffer encoding scheme. The spec names the type
+        /// the value is encoded as, and which of the positions inside it can hold null.
         /// </summary>
-        public static ByteString Encode (object value)
+        public static ByteString Encode (object value, TypeSpec spec)
         {
-            return EncodeObject (value, cachedBuffer, cachedStream);
+            if (spec == null)
+                throw new ArgumentNullException (nameof (spec));
+            return EncodeObject (value, spec, cachedBuffer, cachedStream);
         }
 
-        static ByteString EncodeObject (object value, MemoryStream buffer, CodedOutputStream stream)
+        static ByteString EncodeObject (object value, TypeSpec spec, MemoryStream buffer, CodedOutputStream stream)
         {
             if (value == null) {
                 throw new ArgumentNullException (nameof (value));
             }
             buffer.SetLength (0);
-            WriteObject (value, stream);
+            WriteObject (value, spec, stream);
             stream.Flush ();
             return ByteString.CopyFrom (buffer.GetBuffer (), 0, (int)buffer.Length);
         }
@@ -37,22 +40,42 @@ namespace KRPC.Server.ProtocolBuffers
         /// Encode a value at a position that allows a null: a presence bool, followed by the
         /// value itself when it is present.
         /// </summary>
-        static ByteString EncodeNullableObject (object value, MemoryStream buffer, CodedOutputStream stream)
+        static ByteString EncodeNullableObject (object value, TypeSpec spec, MemoryStream buffer, CodedOutputStream stream)
         {
             buffer.SetLength (0);
             stream.WriteBool (value != null);
             if (value != null)
-                WriteObject (value, stream);
+                WriteObject (value, spec, stream);
             stream.Flush ();
             return ByteString.CopyFrom (buffer.GetBuffer (), 0, (int)buffer.Length);
         }
 
-        static void WriteObject (object value, CodedOutputStream stream)
+        /// <summary>
+        /// Encode one of the values a collection holds, at the position the given spec
+        /// describes.
+        /// </summary>
+        static ByteString EncodeItem (object value, TypeSpec spec, MemoryStream buffer, CodedOutputStream stream)
         {
-            if (value is Enum) {
+            if (spec.Nullable)
+                return EncodeNullableObject (value, spec, buffer, stream);
+            return EncodeObject (value, spec, buffer, stream);
+        }
+
+        /// <summary>
+        /// The error for a null at a position that does not allow one. A null carries nothing
+        /// about where it came from, so the message names the position and the type holding it.
+        /// </summary>
+        static ServiceException NullAt (string position, Type type, string reason)
+        {
+            return new ServiceException (position + " of " + type + " is null; " + reason);
+        }
+
+        static void WriteObject (object value, TypeSpec spec, CodedOutputStream stream)
+        {
+            var type = spec.Type;
+            if (type.IsEnum) {
                 stream.WriteSInt32 ((int)value);
             } else {
-                var type = value.GetType ();
                 switch (Type.GetTypeCode (type)) {
                 case TypeCode.Double:
                     stream.WriteDouble ((double)value);
@@ -84,15 +107,15 @@ namespace KRPC.Server.ProtocolBuffers
                     else if (TypeUtils.IsAClassType (type))
                         stream.WriteUInt64 (ObjectStore.Instance.AddInstance (value));
                     else if (TypeUtils.IsAStructType (type))
-                        WriteStruct (value, stream);
+                        WriteStruct (value, spec, stream);
                     else if (TypeUtils.IsATupleCollectionType (type))
-                        WriteTuple (value, stream);
+                        WriteTuple (value, spec, stream);
                     else if (TypeUtils.IsAListCollectionType (type))
-                        WriteList (value, stream);
+                        WriteList (value, spec, stream);
                     else if (TypeUtils.IsASetCollectionType (type))
-                        WriteSet (value, stream);
+                        WriteSet (value, spec, stream);
                     else if (TypeUtils.IsADictionaryCollectionType (type))
-                        WriteDictionary (value, stream);
+                        WriteDictionary (value, spec, stream);
                     else if (TypeUtils.IsAMessageType (type))
                         WriteMessage (value, stream);
                     else
@@ -102,18 +125,21 @@ namespace KRPC.Server.ProtocolBuffers
             }
         }
 
-        static void WriteTuple (object value, CodedOutputStream stream)
+        static void WriteTuple (object value, TypeSpec spec, CodedOutputStream stream)
         {
             var encodedTuple = new Schema.KRPC.Tuple ();
-            var valueTypes = value.GetType ().GetGenericArguments ().ToArray ();
-            var genericType = Type.GetType ("System.Tuple`" + valueTypes.Length);
-            var tupleType = genericType.MakeGenericType (valueTypes);
+            var tupleType = spec.Type;
             using (var internalBuffer = new MemoryStream ()) {
                 var internalStream = new CodedOutputStream (internalBuffer);
-                for (int i = 0; i < valueTypes.Length; i++) {
+                for (int i = 0; i < spec.Types.Count; i++) {
                     var property = tupleType.GetProperty ("Item" + (i + 1));
                     var item = property.GetGetMethod ().Invoke (value, null);
-                    encodedTuple.Items.Add (EncodeObject (item, internalBuffer, internalStream));
+                    var itemSpec = spec.Types [i];
+                    if (item == null && !itemSpec.Nullable)
+                        throw NullAt (
+                            "Item " + (i + 1), tupleType, "the item is not nullable");
+                    encodedTuple.Items.Add (
+                        EncodeItem (item, itemSpec, internalBuffer, internalStream));
                 }
             }
             encodedTuple.WriteTo (stream);
@@ -123,10 +149,10 @@ namespace KRPC.Server.ProtocolBuffers
         /// Write a structure value as the values of its fields, in the order the structure
         /// declares them, which is the same encoding as a tuple of those values.
         /// </summary>
-        static void WriteStruct (object value, CodedOutputStream stream)
+        static void WriteStruct (object value, TypeSpec spec, CodedOutputStream stream)
         {
             var encodedStruct = new Schema.KRPC.Tuple ();
-            var type = value.GetType ();
+            var type = spec.Type;
             System.Collections.Generic.IList<PropertyInfo> fields;
             System.Collections.Generic.IList<TypeSpec> specs;
             TypeUtils.GetStructFieldsAndSpecs (type, out fields, out specs);
@@ -134,53 +160,72 @@ namespace KRPC.Server.ProtocolBuffers
                 var internalStream = new CodedOutputStream (internalBuffer);
                 for (int i = 0; i < fields.Count; i++) {
                     var field = fields [i];
+                    var fieldSpec = specs [i];
                     var item = field.GetGetMethod ().Invoke (value, null);
-                    if (specs [i].Nullable) {
-                        encodedStruct.Items.Add (EncodeNullableObject (item, internalBuffer, internalStream));
-                        continue;
-                    }
-                    if (item == null)
-                        throw new ServiceException (
-                            "Field " + field.Name + " of " + type.Name + " is null; the field is not nullable");
-                    encodedStruct.Items.Add (EncodeObject (item, internalBuffer, internalStream));
+                    if (item == null && !fieldSpec.Nullable)
+                        throw NullAt (
+                            "Field " + field.Name, type, "the field is not nullable");
+                    encodedStruct.Items.Add (
+                        EncodeItem (item, fieldSpec, internalBuffer, internalStream));
                 }
             }
             encodedStruct.WriteTo (stream);
         }
 
-        static void WriteList (object value, CodedOutputStream stream)
+        static void WriteList (object value, TypeSpec spec, CodedOutputStream stream)
         {
             var encodedList = new Schema.KRPC.List ();
             var list = (IList)value;
+            var type = spec.Type;
+            var itemSpec = spec.Types [0];
+            var nullable = itemSpec.Nullable;
             using (var internalBuffer = new MemoryStream ()) {
                 var internalStream = new CodedOutputStream (internalBuffer);
-                foreach (var item in list)
-                    encodedList.Items.Add (EncodeObject (item, internalBuffer, internalStream));
+                foreach (var item in list) {
+                    if (item == null && !nullable)
+                        throw NullAt ("An element", type, "the element is not nullable");
+                    encodedList.Items.Add (
+                        EncodeItem (item, itemSpec, internalBuffer, internalStream));
+                }
             }
             encodedList.WriteTo (stream);
         }
 
-        static void WriteSet (object value, CodedOutputStream stream)
+        static void WriteSet (object value, TypeSpec spec, CodedOutputStream stream)
         {
             var encodedSet = new Schema.KRPC.Set ();
             var set = (IEnumerable)value;
+            var type = spec.Type;
+            var itemSpec = spec.Types [0];
             using (var internalBuffer = new MemoryStream ()) {
                 var internalStream = new CodedOutputStream (internalBuffer);
-                foreach (var item in set)
-                    encodedSet.Items.Add (EncodeObject (item, internalBuffer, internalStream));
+                foreach (var item in set) {
+                    if (item == null)
+                        throw NullAt ("An element", type, "a set element cannot be null");
+                    encodedSet.Items.Add (
+                        EncodeObject (item, itemSpec, internalBuffer, internalStream));
+                }
             }
             encodedSet.WriteTo (stream);
         }
 
-        static void WriteDictionary (object value, CodedOutputStream stream)
+        static void WriteDictionary (object value, TypeSpec spec, CodedOutputStream stream)
         {
             var encodedDictionary = new Schema.KRPC.Dictionary ();
+            var type = spec.Type;
+            var keySpec = spec.Types [0];
+            var valueSpec = spec.Types [1];
+            var nullable = valueSpec.Nullable;
             using (var internalBuffer = new MemoryStream ()) {
                 var internalStream = new CodedOutputStream (internalBuffer);
                 foreach (DictionaryEntry entry in (IDictionary) value) {
+                    if (entry.Key == null)
+                        throw NullAt ("A key", type, "a dictionary key cannot be null");
+                    if (entry.Value == null && !nullable)
+                        throw NullAt ("A value", type, "the value is not nullable");
                     var encodedEntry = new Schema.KRPC.DictionaryEntry ();
-                    encodedEntry.Key = EncodeObject (entry.Key, internalBuffer, internalStream);
-                    encodedEntry.Value = EncodeObject (entry.Value, internalBuffer, internalStream);
+                    encodedEntry.Key = EncodeObject (entry.Key, keySpec, internalBuffer, internalStream);
+                    encodedEntry.Value = EncodeItem (entry.Value, valueSpec, internalBuffer, internalStream);
                     encodedDictionary.Entries.Add (encodedEntry);
                 }
             }
@@ -200,26 +245,41 @@ namespace KRPC.Server.ProtocolBuffers
         }
 
         /// <summary>
-        /// Decode a value of the given type.
-        /// Should not be called directly. This interface is used by service client stubs.
+        /// Decode a value of the type the given spec describes, which says which of the
+        /// positions inside it can hold null.
         /// </summary>
-        public static object Decode (ByteString value, Type type)
+        public static object Decode (ByteString value, TypeSpec spec)
         {
-            return DecodeValue (value.CreateCodedInput (), type);
+            return DecodeValue (value.CreateCodedInput (), spec);
         }
 
         /// <summary>
         /// Decode a value at a position that allows a null, which EncodeNullableObject
         /// writes.
         /// </summary>
-        static object DecodeNullable (ByteString value, Type type)
+        static object DecodeNullable (ByteString value, TypeSpec spec)
         {
             var stream = value.CreateCodedInput ();
-            return stream.ReadBool () ? DecodeValue (stream, type) : null;
+            return stream.ReadBool () ? DecodeValue (stream, spec) : null;
         }
 
-        static object DecodeValue (CodedInputStream stream, Type type)
+        /// <summary>
+        /// Decode one of the values a collection holds, at the position the given spec
+        /// describes.
+        /// </summary>
+        static object DecodeItem (ByteString value, TypeSpec spec)
         {
+            if (spec.Nullable)
+                return DecodeNullable (value, spec);
+            return DecodeValue (value.CreateCodedInput (), spec);
+        }
+
+        static object DecodeValue (CodedInputStream stream, TypeSpec spec)
+        {
+            // The spec names the type a value decodes as, with Nullable<T> already unwrapped;
+            // the null itself is read by the caller, from the presence bool or a flag beside
+            // the value
+            var type = spec.Type;
             if (type.IsEnum) {
                 if (TypeUtils.IsAnEnumType (type))
                     return Enum.ToObject (type, stream.ReadSInt32 ());
@@ -249,13 +309,13 @@ namespace KRPC.Server.ProtocolBuffers
                     if (TypeUtils.IsAStructType (type))
                         return DecodeStruct (stream, type);
                     if (TypeUtils.IsATupleCollectionType (type))
-                        return DecodeTuple (stream, type);
+                        return DecodeTuple (stream, spec);
                     if (TypeUtils.IsAListCollectionType (type))
-                        return DecodeList (stream, type);
+                        return DecodeList (stream, spec);
                     if (TypeUtils.IsASetCollectionType (type))
-                        return DecodeSet (stream, type);
+                        return DecodeSet (stream, spec);
                     if (TypeUtils.IsADictionaryCollectionType (type))
-                        return DecodeDictionary (stream, type);
+                        return DecodeDictionary (stream, spec);
                     if (TypeUtils.IsAMessageType (type))
                         return DecodeMessage (stream, type);
                     break;
@@ -264,15 +324,15 @@ namespace KRPC.Server.ProtocolBuffers
             throw new ArgumentException (type + " is not a serializable type");
         }
 
-        static object DecodeTuple (CodedInputStream stream, Type type)
+        static object DecodeTuple (CodedInputStream stream, TypeSpec spec)
         {
             var encodedTuple = Schema.KRPC.Tuple.Parser.ParseFrom (stream);
-            var valueTypes = type.GetGenericArguments ().ToArray ();
+            var valueTypes = spec.Types.Select (x => x.DeclaredType).ToArray ();
             var genericType = Type.GetType ("System.Tuple`" + valueTypes.Length);
             var values = new object[valueTypes.Length];
             for (int i = 0; i < valueTypes.Length; i++) {
                 var item = encodedTuple.Items [i];
-                values [i] = Decode (item, valueTypes [i]);
+                values [i] = DecodeItem (item, spec.Types [i]);
             }
             var tuple = genericType
                 .MakeGenericType (valueTypes)
@@ -303,9 +363,9 @@ namespace KRPC.Server.ProtocolBuffers
                 var spec = specs [i];
                 object item;
                 if (spec.Nullable) {
-                    item = DecodeNullable (encodedStruct.Items [i], spec.Type);
+                    item = DecodeNullable (encodedStruct.Items [i], spec);
                 } else {
-                    item = Decode (encodedStruct.Items [i], spec.Type);
+                    item = DecodeValue (encodedStruct.Items [i].CreateCodedInput (), spec);
                     if (item == null)
                         throw new ArgumentException (
                             "Field " + field.Name + " of " + type.Name + " is null; the field is not nullable");
@@ -315,44 +375,47 @@ namespace KRPC.Server.ProtocolBuffers
             return value;
         }
 
-        static object DecodeList (CodedInputStream stream, Type type)
+        static object DecodeList (CodedInputStream stream, TypeSpec spec)
         {
             var encodedList = Schema.KRPC.List.Parser.ParseFrom (stream);
+            var itemSpec = spec.Types [0];
             var list = (IList)(typeof(System.Collections.Generic.List<>)
-                .MakeGenericType (type.GetGenericArguments ().Single ())
+                .MakeGenericType (itemSpec.DeclaredType)
                 .GetConstructor (Type.EmptyTypes)
                 .Invoke (null));
             foreach (var item in encodedList.Items)
-                list.Add (Decode (item, type.GetGenericArguments ().Single ()));
+                list.Add (DecodeItem (item, itemSpec));
             return list;
         }
 
-        static object DecodeSet (CodedInputStream stream, Type type)
+        static object DecodeSet (CodedInputStream stream, TypeSpec spec)
         {
             var encodedSet = Schema.KRPC.Set.Parser.ParseFrom (stream);
+            var itemSpec = spec.Types [0];
             var set = (IEnumerable)(typeof(System.Collections.Generic.HashSet<>)
-                .MakeGenericType (type.GetGenericArguments ().Single ())
+                .MakeGenericType (itemSpec.DeclaredType)
                 .GetConstructor (Type.EmptyTypes)
                 .Invoke (null));
-            MethodInfo methodInfo = type.GetMethod ("Add");
+            MethodInfo methodInfo = spec.Type.GetMethod ("Add");
             foreach (var item in encodedSet.Items) {
-                var decodedItem = Decode (item, type.GetGenericArguments ().Single ());
+                var decodedItem = DecodeValue (item.CreateCodedInput (), itemSpec);
                 methodInfo.Invoke (set, new [] { decodedItem });
             }
             return set;
         }
 
-        static object DecodeDictionary (CodedInputStream stream, Type type)
+        static object DecodeDictionary (CodedInputStream stream, TypeSpec spec)
         {
             var encodedDictionary = Schema.KRPC.Dictionary.Parser.ParseFrom (stream);
+            var keySpec = spec.Types [0];
+            var valueSpec = spec.Types [1];
             var dictionary = (IDictionary)(typeof(System.Collections.Generic.Dictionary<,>)
-                .MakeGenericType (type.GetGenericArguments () [0], type.GetGenericArguments () [1])
+                .MakeGenericType (keySpec.DeclaredType, valueSpec.DeclaredType)
                 .GetConstructor (Type.EmptyTypes)
                 .Invoke (null));
             foreach (var entry in encodedDictionary.Entries) {
-                var key = Decode (entry.Key, type.GetGenericArguments () [0]);
-                var value = Decode (entry.Value, type.GetGenericArguments () [1]);
-                dictionary [key] = value;
+                var key = DecodeValue (entry.Key.CreateCodedInput (), keySpec);
+                dictionary [key] = DecodeItem (entry.Value, valueSpec);
             }
             return dictionary;
         }

--- a/core/src/Server/ProtocolBuffers/Encoder.cs
+++ b/core/src/Server/ProtocolBuffers/Encoder.cs
@@ -330,10 +330,8 @@ namespace KRPC.Server.ProtocolBuffers
             var valueTypes = spec.Types.Select (x => x.DeclaredType).ToArray ();
             var genericType = Type.GetType ("System.Tuple`" + valueTypes.Length);
             var values = new object[valueTypes.Length];
-            for (int i = 0; i < valueTypes.Length; i++) {
-                var item = encodedTuple.Items [i];
-                values [i] = DecodeItem (item, spec.Types [i]);
-            }
+            for (int i = 0; i < valueTypes.Length; i++)
+                values [i] = DecodeItem (encodedTuple.Items [i], spec.Types [i]);
             var tuple = genericType
                 .MakeGenericType (valueTypes)
                 .GetConstructor (valueTypes)
@@ -361,15 +359,7 @@ namespace KRPC.Server.ProtocolBuffers
             for (int i = 0; i < fields.Count; i++) {
                 var field = fields [i];
                 var spec = specs [i];
-                object item;
-                if (spec.Nullable) {
-                    item = DecodeNullable (encodedStruct.Items [i], spec);
-                } else {
-                    item = DecodeValue (encodedStruct.Items [i].CreateCodedInput (), spec);
-                    if (item == null)
-                        throw new ArgumentException (
-                            "Field " + field.Name + " of " + type.Name + " is null; the field is not nullable");
-                }
+                var item = DecodeItem (encodedStruct.Items [i], spec);
                 field.GetSetMethod ().Invoke (value, new [] { item });
             }
             return value;

--- a/core/src/Server/ProtocolBuffers/MessageExtensions.cs
+++ b/core/src/Server/ProtocolBuffers/MessageExtensions.cs
@@ -99,7 +99,7 @@ namespace KRPC.Server.ProtocolBuffers
             result.Name = procedure.Name;
             result.Parameters.Add (procedure.Parameters.Select (ToProtobufMessage));
             if (procedure.ReturnType != null)
-                result.ReturnType = procedure.ReturnType.ToProtobufMessage (procedure.ReturnIsNullable);
+                result.ReturnType = procedure.ReturnType.ToProtobufMessage ();
             result.GameScenes.Add (ToProtobufMessage (procedure.GameScene));
             result.Documentation = procedure.Documentation;
             result.Deprecated = procedure.Deprecated;
@@ -132,7 +132,7 @@ namespace KRPC.Server.ProtocolBuffers
         {
             var result = new Schema.KRPC.Parameter ();
             result.Name = parameter.Name;
-            result.Type = parameter.Type.ToProtobufMessage (parameter.Nullable);
+            result.Type = parameter.Type.ToProtobufMessage ();
             result.HasDefaultValue = parameter.HasDefaultValue;
             if (parameter.HasDefaultValue) {
                 if (parameter.DefaultValue == null)
@@ -190,7 +190,7 @@ namespace KRPC.Server.ProtocolBuffers
         {
             var result = new Schema.KRPC.StructField ();
             result.Name = field.Name;
-            result.Type = field.Type.ToProtobufMessage ();
+            result.Type = TypeSpec.Create (field.Type).ToProtobufMessage ();
             result.Documentation = field.Documentation;
             result.Deprecated = field.Deprecated;
             result.DeprecatedReason = field.DeprecatedReason;
@@ -207,12 +207,11 @@ namespace KRPC.Server.ProtocolBuffers
             return result;
         }
 
-        // Nullability belongs to the position a value sits in rather than to the value, so
-        // the caller supplies it
-        public static Schema.KRPC.Type ToProtobufMessage (this Type type, bool nullable = false)
+        public static Schema.KRPC.Type ToProtobufMessage (this TypeSpec spec)
         {
+            var type = spec.Type;
             var result = new Schema.KRPC.Type ();
-            result.Nullable = nullable;
+            result.Nullable = spec.Nullable;
             if (TypeUtils.IsAValueType (type)) {
                 switch (Type.GetTypeCode (type)) {
                 case TypeCode.Single:
@@ -269,18 +268,18 @@ namespace KRPC.Server.ProtocolBuffers
                 result.Name = type.Name;
             } else if (TypeUtils.IsAListCollectionType (type)) {
                 result.Code = Schema.KRPC.Type.Types.TypeCode.List;
-                result.Types_.Add (type.GetGenericArguments () [0].ToProtobufMessage ());
+                result.Types_.Add (TypeSpec.Create (type.GetGenericArguments () [0]).ToProtobufMessage ());
             } else if (TypeUtils.IsADictionaryCollectionType (type)) {
                 result.Code = Schema.KRPC.Type.Types.TypeCode.Dictionary;
-                result.Types_.Add (type.GetGenericArguments () [0].ToProtobufMessage ());
-                result.Types_.Add (type.GetGenericArguments () [1].ToProtobufMessage ());
+                result.Types_.Add (TypeSpec.Create (type.GetGenericArguments () [0]).ToProtobufMessage ());
+                result.Types_.Add (TypeSpec.Create (type.GetGenericArguments () [1]).ToProtobufMessage ());
             } else if (TypeUtils.IsASetCollectionType (type)) {
                 result.Code = Schema.KRPC.Type.Types.TypeCode.Set;
-                result.Types_.Add (type.GetGenericArguments () [0].ToProtobufMessage ());
+                result.Types_.Add (TypeSpec.Create (type.GetGenericArguments () [0]).ToProtobufMessage ());
             } else if (TypeUtils.IsATupleCollectionType (type)) {
                 result.Code = Schema.KRPC.Type.Types.TypeCode.Tuple;
                 foreach (var subType in type.GetGenericArguments())
-                    result.Types_.Add (subType.ToProtobufMessage ());
+                    result.Types_.Add (TypeSpec.Create (subType).ToProtobufMessage ());
             }
             return result;
         }
@@ -346,7 +345,7 @@ namespace KRPC.Server.ProtocolBuffers
                     // Ignore the argument if its position is not valid
                     if (position >= procedureSignature.Parameters.Count)
                         continue;
-                    var type = procedureSignature.Parameters [position].Type;
+                    var type = procedureSignature.Parameters [position].Spec.Type;
                     result.Arguments.Add (argument.ToMessage (type));
                 }
             } catch (RPCException) {

--- a/core/src/Server/ProtocolBuffers/MessageExtensions.cs
+++ b/core/src/Server/ProtocolBuffers/MessageExtensions.cs
@@ -38,7 +38,7 @@ namespace KRPC.Server.ProtocolBuffers
                 if (procedureResult.Value == null)
                     result.IsNull = true;
                 else
-                    result.Value = Encoder.Encode (procedureResult.Value);
+                    result.Value = Encoder.Encode (procedureResult.Value, procedureResult.Spec);
             }
             if (procedureResult.HasError)
                 result.Error = procedureResult.Error.ToProtobufMessage ();
@@ -138,7 +138,7 @@ namespace KRPC.Server.ProtocolBuffers
                 if (parameter.DefaultValue == null)
                     result.DefaultValueIsNull = true;
                 else
-                    result.DefaultValue = Encoder.Encode (parameter.DefaultValue);
+                    result.DefaultValue = Encoder.Encode (parameter.DefaultValue, parameter.Type);
             }
             return result;
         }
@@ -268,18 +268,16 @@ namespace KRPC.Server.ProtocolBuffers
                 result.Name = type.Name;
             } else if (TypeUtils.IsAListCollectionType (type)) {
                 result.Code = Schema.KRPC.Type.Types.TypeCode.List;
-                result.Types_.Add (TypeSpec.Create (type.GetGenericArguments () [0]).ToProtobufMessage ());
+                result.Types_.Add (spec.Types.Select (ToProtobufMessage));
             } else if (TypeUtils.IsADictionaryCollectionType (type)) {
                 result.Code = Schema.KRPC.Type.Types.TypeCode.Dictionary;
-                result.Types_.Add (TypeSpec.Create (type.GetGenericArguments () [0]).ToProtobufMessage ());
-                result.Types_.Add (TypeSpec.Create (type.GetGenericArguments () [1]).ToProtobufMessage ());
+                result.Types_.Add (spec.Types.Select (ToProtobufMessage));
             } else if (TypeUtils.IsASetCollectionType (type)) {
                 result.Code = Schema.KRPC.Type.Types.TypeCode.Set;
-                result.Types_.Add (TypeSpec.Create (type.GetGenericArguments () [0]).ToProtobufMessage ());
+                result.Types_.Add (spec.Types.Select (ToProtobufMessage));
             } else if (TypeUtils.IsATupleCollectionType (type)) {
                 result.Code = Schema.KRPC.Type.Types.TypeCode.Tuple;
-                foreach (var subType in type.GetGenericArguments())
-                    result.Types_.Add (TypeSpec.Create (subType).ToProtobufMessage ());
+                result.Types_.Add (spec.Types.Select (ToProtobufMessage));
             }
             return result;
         }
@@ -345,17 +343,17 @@ namespace KRPC.Server.ProtocolBuffers
                     // Ignore the argument if its position is not valid
                     if (position >= procedureSignature.Parameters.Count)
                         continue;
-                    var type = procedureSignature.Parameters [position].Spec.Type;
-                    result.Arguments.Add (argument.ToMessage (type));
+                    var spec = procedureSignature.Parameters [position].Spec;
+                    result.Arguments.Add (argument.ToMessage (spec));
                 }
             } catch (RPCException) {
             }
             return result;
         }
 
-        public static Argument ToMessage (this Schema.KRPC.Argument argument, Type type)
+        public static Argument ToMessage (this Schema.KRPC.Argument argument, TypeSpec spec)
         {
-            var value = argument.IsNull ? null : Encoder.Decode (argument.Value, type);
+            var value = argument.IsNull ? null : Encoder.Decode (argument.Value, spec);
             return new Argument (argument.Position, value);
         }
     }

--- a/core/src/Server/ProtocolBuffers/MessageExtensions.cs
+++ b/core/src/Server/ProtocolBuffers/MessageExtensions.cs
@@ -190,7 +190,7 @@ namespace KRPC.Server.ProtocolBuffers
         {
             var result = new Schema.KRPC.StructField ();
             result.Name = field.Name;
-            result.Type = TypeSpec.Create (field.Type).ToProtobufMessage ();
+            result.Type = field.Type.ToProtobufMessage ();
             result.Documentation = field.Documentation;
             result.Deprecated = field.Deprecated;
             result.DeprecatedReason = field.DeprecatedReason;

--- a/core/src/Server/ProtocolBuffers/MessageExtensions.cs
+++ b/core/src/Server/ProtocolBuffers/MessageExtensions.cs
@@ -99,8 +99,7 @@ namespace KRPC.Server.ProtocolBuffers
             result.Name = procedure.Name;
             result.Parameters.Add (procedure.Parameters.Select (ToProtobufMessage));
             if (procedure.ReturnType != null)
-                result.ReturnType = procedure.ReturnType.ToProtobufMessage ();
-            result.ReturnIsNullable = procedure.ReturnIsNullable;
+                result.ReturnType = procedure.ReturnType.ToProtobufMessage (procedure.ReturnIsNullable);
             result.GameScenes.Add (ToProtobufMessage (procedure.GameScene));
             result.Documentation = procedure.Documentation;
             result.Deprecated = procedure.Deprecated;
@@ -133,8 +132,7 @@ namespace KRPC.Server.ProtocolBuffers
         {
             var result = new Schema.KRPC.Parameter ();
             result.Name = parameter.Name;
-            result.Type = parameter.Type.ToProtobufMessage ();
-            result.Nullable = parameter.Nullable;
+            result.Type = parameter.Type.ToProtobufMessage (parameter.Nullable);
             result.HasDefaultValue = parameter.HasDefaultValue;
             if (parameter.HasDefaultValue) {
                 if (parameter.DefaultValue == null)
@@ -209,9 +207,12 @@ namespace KRPC.Server.ProtocolBuffers
             return result;
         }
 
-        public static Schema.KRPC.Type ToProtobufMessage (this Type type)
+        // Nullability belongs to the position a value sits in rather than to the value, so
+        // the caller supplies it
+        public static Schema.KRPC.Type ToProtobufMessage (this Type type, bool nullable = false)
         {
             var result = new Schema.KRPC.Type ();
+            result.Nullable = nullable;
             if (TypeUtils.IsAValueType (type)) {
                 switch (Type.GetTypeCode (type)) {
                 case TypeCode.Single:

--- a/core/src/Server/ProtocolBuffers/StreamStream.cs
+++ b/core/src/Server/ProtocolBuffers/StreamStream.cs
@@ -73,7 +73,7 @@ namespace KRPC.Server.ProtocolBuffers
                     if (r.Result.Value == null)
                         pr.IsNull = true;
                     else
-                        pr.Value = Encoder.Encode (r.Result.Value);
+                        pr.Value = Encoder.Encode (r.Result.Value, r.Result.Spec);
                 } else if (r.Result.HasError)
                     pr.Error = r.Result.Error.ToProtobufMessage ();
                 streamUpdateMessage.Add (protoResult);

--- a/core/src/Service/Attributes/KRPCNullableAttribute.cs
+++ b/core/src/Service/Attributes/KRPCNullableAttribute.cs
@@ -1,13 +1,36 @@
 using System;
+using System.Collections.Generic;
 
 namespace KRPC.Service.Attributes
 {
     /// <summary>
-    /// A nullable parameter in a kRPC procedure, method or property.
-    /// This attribute can be used to mark a parameter as being nullable.
+    /// A nullable value in a kRPC procedure, method or property. On a parameter it marks the
+    /// argument as nullable, and on a method or property the return value. Giving it a path of
+    /// <see cref="Position"/> values marks a position nested inside that value instead, such as
+    /// the elements of a list. The attribute can be applied more than once, for a type with
+    /// several nullable positions.
     /// </summary>
-    [AttributeUsage (AttributeTargets.Parameter)]
+    [AttributeUsage (AttributeTargets.Parameter | AttributeTargets.Method |
+                     AttributeTargets.Property, AllowMultiple = true)]
     public sealed class KRPCNullableAttribute : Attribute
     {
+        readonly Position[] path;
+
+        /// <summary>
+        /// Mark the position the given path reaches as nullable. Each step names a position of
+        /// the type the step before it reached, outermost first, and an empty path is the value
+        /// itself.
+        /// </summary>
+        public KRPCNullableAttribute (params Position[] path)
+        {
+            this.path = path ?? new Position [0];
+        }
+
+        /// <summary>
+        /// The positions to step through to reach the nullable one, outermost first.
+        /// </summary>
+        public IList<Position> Path {
+            get { return path; }
+        }
     }
 }

--- a/core/src/Service/Attributes/Position.cs
+++ b/core/src/Service/Attributes/Position.cs
@@ -1,0 +1,47 @@
+namespace KRPC.Service.Attributes
+{
+    /// <summary>
+    /// A position inside a type that one value sits in, named so that
+    /// <see cref="KRPCNullableAttribute"/> can point at it. A dictionary key and a set element
+    /// have no name here, which is what makes them the positions that cannot be nullable.
+    /// </summary>
+    public enum Position
+    {
+        /// <summary>
+        /// The element of a list.
+        /// </summary>
+        Element,
+        /// <summary>
+        /// The value of a dictionary.
+        /// </summary>
+        Value,
+        /// <summary>
+        /// The first item of a tuple.
+        /// </summary>
+        Item1,
+        /// <summary>
+        /// The second item of a tuple.
+        /// </summary>
+        Item2,
+        /// <summary>
+        /// The third item of a tuple.
+        /// </summary>
+        Item3,
+        /// <summary>
+        /// The fourth item of a tuple.
+        /// </summary>
+        Item4,
+        /// <summary>
+        /// The fifth item of a tuple.
+        /// </summary>
+        Item5,
+        /// <summary>
+        /// The sixth item of a tuple.
+        /// </summary>
+        Item6,
+        /// <summary>
+        /// The seventh item of a tuple.
+        /// </summary>
+        Item7
+    }
+}

--- a/core/src/Service/ClassMethodHandler.cs
+++ b/core/src/Service/ClassMethodHandler.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
+using KRPC.Service.Attributes;
 
 namespace KRPC.Service
 {
@@ -16,7 +17,7 @@ namespace KRPC.Service
         readonly Func<object, object[], object> invoker;
         readonly ProcedureParameter[] parameters;
 
-        public ClassMethodHandler (Type classType, MethodInfo methodInfo, bool returnIsNullable)
+        public ClassMethodHandler (Type classType, MethodInfo methodInfo, bool returnIsNullable, IEnumerable<IList<Position>> returnNullablePaths = null)
         {
             invoker = BuildInvoker (classType, methodInfo);
             var parameterList = methodInfo.GetParameters ().Select (x => new ProcedureParameter (x)).ToList ();
@@ -24,6 +25,7 @@ namespace KRPC.Service
             parameters = parameterList.ToArray ();
             ReturnType = methodInfo.ReturnType;
             ReturnIsNullable = returnIsNullable;
+            ReturnNullablePaths = returnNullablePaths ?? new List<IList<Position>> ();
         }
 
         public bool HasInstance { get => true; }
@@ -45,13 +47,18 @@ namespace KRPC.Service
 
         public bool ReturnIsNullable { get; private set; }
 
+        public IEnumerable<IList<Position>> ReturnNullablePaths { get; private set; }
+
         /// <summary>
-        /// Mark the property value parameter (the last parameter) as nullable. Used for the setter
-        /// of a nullable property, whose synthesized value parameter cannot carry [KRPCNullable].
+        /// Give the property value parameter (the last parameter) the nullability the property
+        /// declares. Used for the setter of a property, whose synthesized value parameter
+        /// cannot carry [KRPCNullable] itself.
         /// </summary>
-        public void SetValueParameterNullable ()
+        public void SetValueParameterNullability (bool nullable, IEnumerable<IList<Position>> nullablePaths)
         {
-            parameters [parameters.Length - 1].Nullable = true;
+            var parameter = parameters [parameters.Length - 1];
+            parameter.Nullable = nullable;
+            parameter.NullablePaths = nullablePaths;
         }
 
         static Func<object, object[], object> BuildInvoker (Type classType, MethodInfo method)

--- a/core/src/Service/ClassStaticMethodHandler.cs
+++ b/core/src/Service/ClassStaticMethodHandler.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
+using KRPC.Service.Attributes;
 
 namespace KRPC.Service
 {
@@ -16,7 +17,7 @@ namespace KRPC.Service
         readonly Func<object, object[], object> invoker;
         readonly ProcedureParameter[] parameters;
 
-        public ClassStaticMethodHandler (MethodInfo methodInfo, bool returnIsNullable, bool isExtension = false)
+        public ClassStaticMethodHandler (MethodInfo methodInfo, bool returnIsNullable, IEnumerable<IList<Position>> returnNullablePaths = null, bool isExtension = false)
         {
             invoker = BuildInvoker (methodInfo);
             parameters = methodInfo.GetParameters ().Select (x => new ProcedureParameter (x)).ToArray ();
@@ -25,6 +26,7 @@ namespace KRPC.Service
                 parameters [0] = new ProcedureParameter (parameters [0].Type, "this");
             ReturnType = methodInfo.ReturnType;
             ReturnIsNullable = returnIsNullable;
+            ReturnNullablePaths = returnNullablePaths ?? new List<IList<Position>> ();
         }
 
         public bool HasInstance { get => false; }
@@ -44,6 +46,8 @@ namespace KRPC.Service
         public Type ReturnType { get; private set; }
 
         public bool ReturnIsNullable { get; private set; }
+
+        public IEnumerable<IList<Position>> ReturnNullablePaths { get; private set; }
 
         static Func<object, object[], object> BuildInvoker (MethodInfo method)
         {

--- a/core/src/Service/EventStream.cs
+++ b/core/src/Service/EventStream.cs
@@ -8,6 +8,9 @@ using KRPC.Service.Scanner;
 namespace KRPC.Service
 {
     sealed class EventStream : Stream {
+        // An event carries whether it has fired, which is the type its result is encoded as
+        static readonly TypeSpec BoolSpec = TypeSpec.Create (typeof(bool));
+
         Func<bool> continuation;
         bool shouldRemove;
 
@@ -40,6 +43,7 @@ namespace KRPC.Service
         }
 
         public void Trigger () {
+            Result.Spec = BoolSpec;
             Result.Value = true;
             Changed = true;
         }

--- a/core/src/Service/IProcedureHandler.cs
+++ b/core/src/Service/IProcedureHandler.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using KRPC.Service.Attributes;
 
 namespace KRPC.Service
 {
@@ -35,5 +36,10 @@ namespace KRPC.Service
         /// Whether the method could return null
         /// </summary>
         bool ReturnIsNullable { get; }
+
+        /// <summary>
+        /// The nullable positions inside the return type, each named by a path
+        /// </summary>
+        IEnumerable<IList<Position>> ReturnNullablePaths { get; }
     }
 }

--- a/core/src/Service/KRPC/Expression.cs
+++ b/core/src/Service/KRPC/Expression.cs
@@ -132,11 +132,9 @@ namespace KRPC.Service.KRPC
             var result = LinqExpression.Call(
                 servicesExpr, executeCallMethod,
                 new[] { procedureExpr, instanceExpr, argumentsExpr });
-            var returnType = procedure.ReturnType;
-            // A nullable value-type return may be null, so evaluate it as Nullable<T> to keep
-            // the null representable
-            if (procedure.ReturnIsNullable && returnType.IsValueType)
-                returnType = typeof(System.Nullable<>).MakeGenericType(returnType);
+            // The declared type of a nullable value-type return is Nullable<T>, which keeps a
+            // null representable
+            var returnType = procedure.ReturnSpec.DeclaredType;
             var value = LinqExpression.Convert(
                 LinqExpression.Property(result, "Value"), returnType);
             return new Expression(value);

--- a/core/src/Service/KRPC/KRPC.cs
+++ b/core/src/Service/KRPC/KRPC.cs
@@ -120,7 +120,7 @@ namespace KRPC.Service.KRPC
                     str.Deprecated = structSignature.Deprecated;
                     str.DeprecatedReason = structSignature.DeprecatedReason;
                     foreach (var fieldSignature in structSignature.Fields) {
-                        var field = new StructField (fieldSignature.Name, fieldSignature.Type);
+                        var field = new StructField (fieldSignature.Name, fieldSignature.Spec);
                         if (fieldSignature.Documentation.Length > 0)
                             field.Documentation = fieldSignature.Documentation;
                         field.Deprecated = fieldSignature.Deprecated;

--- a/core/src/Service/KRPC/KRPC.cs
+++ b/core/src/Service/KRPC/KRPC.cs
@@ -73,13 +73,11 @@ namespace KRPC.Service.KRPC
                 var service = new Messages.Service (serviceSignature.Name);
                 foreach (var procedureSignature in serviceSignature.Procedures.Values) {
                     var procedure = new Procedure (procedureSignature.Name);
-                    if (procedureSignature.HasReturnType) {
-                        procedure.ReturnType = procedureSignature.ReturnType;
-                        procedure.ReturnIsNullable = procedureSignature.ReturnIsNullable;
-                    }
+                    if (procedureSignature.HasReturnType)
+                        procedure.ReturnType = procedureSignature.ReturnSpec;
                     foreach (var parameterSignature in procedureSignature.Parameters) {
                         var parameter = new Parameter (
-                            parameterSignature.Name, parameterSignature.Type, parameterSignature.Nullable);
+                            parameterSignature.Name, parameterSignature.Spec);
                         if (parameterSignature.HasDefaultValue)
                             parameter.DefaultValue = parameterSignature.DefaultValue;
                         procedure.Parameters.Add (parameter);

--- a/core/src/Service/Messages/Parameter.cs
+++ b/core/src/Service/Messages/Parameter.cs
@@ -1,5 +1,3 @@
-using System;
-
 namespace KRPC.Service.Messages
 {
     #pragma warning disable 1591
@@ -7,7 +5,7 @@ namespace KRPC.Service.Messages
     {
         public string Name { get; private set; }
 
-        public Type Type { get; private set; }
+        public TypeSpec Type { get; private set; }
 
         public bool HasDefaultValue { get; private set; }
 
@@ -19,15 +17,12 @@ namespace KRPC.Service.Messages
             }
         }
 
-        public bool Nullable { get; private set; }
-
         object defaultValue;
 
-        public Parameter (string name, Type type, bool nullable)
+        public Parameter (string name, TypeSpec type)
         {
             Name = name;
             Type = type;
-            Nullable = nullable;
         }
     }
 }

--- a/core/src/Service/Messages/Procedure.cs
+++ b/core/src/Service/Messages/Procedure.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 
 namespace KRPC.Service.Messages
@@ -14,9 +13,7 @@ namespace KRPC.Service.Messages
             get { return ReturnType != null; }
         }
 
-        public Type ReturnType { get; set; }
-
-        public bool ReturnIsNullable { get; set; }
+        public TypeSpec ReturnType { get; set; }
 
         public GameScene GameScene { get; set; }
 

--- a/core/src/Service/Messages/ProcedureResult.cs
+++ b/core/src/Service/Messages/ProcedureResult.cs
@@ -5,6 +5,12 @@ namespace KRPC.Service.Messages
     {
         public bool HasValue { get; private set; }
 
+        /// <summary>
+        /// The type of the value, with the nullability of every position inside it. Set where
+        /// the call is executed, as that is where the procedure's signature is in hand.
+        /// </summary>
+        public TypeSpec Spec { get; set; }
+
         public object Value {
             get { return value_; }
             set {
@@ -31,6 +37,7 @@ namespace KRPC.Service.Messages
         {
             value_ = null;
             HasValue = false;
+            Spec = null;
             error = null;
             HasError = false;
         }

--- a/core/src/Service/Messages/StructField.cs
+++ b/core/src/Service/Messages/StructField.cs
@@ -1,5 +1,3 @@
-using System;
-
 namespace KRPC.Service.Messages
 {
     #pragma warning disable 1591
@@ -7,7 +5,7 @@ namespace KRPC.Service.Messages
     {
         public string Name { get; private set; }
 
-        public Type Type { get; private set; }
+        public TypeSpec Type { get; private set; }
 
         public string Documentation { get; set; }
 
@@ -15,7 +13,7 @@ namespace KRPC.Service.Messages
 
         public string DeprecatedReason { get; set; }
 
-        public StructField (string name, Type type)
+        public StructField (string name, TypeSpec type)
         {
             Name = name;
             Type = type;

--- a/core/src/Service/ObjectStore.cs
+++ b/core/src/Service/ObjectStore.cs
@@ -8,7 +8,6 @@ namespace KRPC.Service
     {
         readonly IDictionary<object, ulong> instances = new Dictionary<object, ulong> ();
         readonly IDictionary<ulong, object> objectIds = new Dictionary<ulong, object> ();
-        // Note: 0 is reserved to represent null values
         ulong nextObjectId = 1;
         static ObjectStore instance;
 
@@ -32,11 +31,12 @@ namespace KRPC.Service
         /// Register an instance with the object store, associating a unique object
         /// identifier with the instance that can be passed to clients.
         /// If the instance has already been added, this just returns it's object identifier.
+        /// A null is not an instance: it belongs to the position a value sits in.
         /// </summary>
         public ulong AddInstance (object obj)
         {
             if (obj == null)
-                return 0;
+                throw new ArgumentNullException (nameof (obj));
             ulong existingId;
             if (instances.TryGetValue (obj, out existingId))
                 return existingId;
@@ -112,8 +112,9 @@ namespace KRPC.Service
         /// </summary>
         public object GetInstance (ulong id)
         {
+            // Identifiers are allocated from 1, so 0 was never issued
             if (id == 0ul)
-                return null;
+                throw new ArgumentException ("0 is not an object identifier");
             object result;
             if (objectIds.TryGetValue (id, out result))
                 return result;
@@ -133,7 +134,7 @@ namespace KRPC.Service
         public ulong GetObjectId (object obj)
         {
             if (obj == null)
-                return 0;
+                throw new ArgumentNullException (nameof (obj));
             ulong id;
             if (!instances.TryGetValue (obj, out id))
                 throw new ArgumentException ("Instance not found");

--- a/core/src/Service/ProcedureHandler.cs
+++ b/core/src/Service/ProcedureHandler.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
+using KRPC.Service.Attributes;
 
 namespace KRPC.Service
 {
@@ -14,12 +15,13 @@ namespace KRPC.Service
         readonly Func<object, object[], object> invoker;
         readonly ProcedureParameter[] parameters;
 
-        public ProcedureHandler (MethodInfo methodInfo, bool returnIsNullable)
+        public ProcedureHandler (MethodInfo methodInfo, bool returnIsNullable, IEnumerable<IList<Position>> returnNullablePaths = null)
         {
             invoker = BuildInvoker (methodInfo);
             parameters = methodInfo.GetParameters ().Select (x => new ProcedureParameter (x)).ToArray ();
             ReturnType = methodInfo.ReturnType;
             ReturnIsNullable = returnIsNullable;
+            ReturnNullablePaths = returnNullablePaths ?? new List<IList<Position>> ();
         }
 
         public bool HasInstance { get => false; }
@@ -37,13 +39,18 @@ namespace KRPC.Service
 
         public bool ReturnIsNullable { get; private set; }
 
+        public IEnumerable<IList<Position>> ReturnNullablePaths { get; private set; }
+
         /// <summary>
-        /// Mark the property value parameter (the last parameter) as nullable. Used for the setter
-        /// of a nullable property, whose synthesized value parameter cannot carry [KRPCNullable].
+        /// Give the property value parameter (the last parameter) the nullability the property
+        /// declares. Used for the setter of a property, whose synthesized value parameter
+        /// cannot carry [KRPCNullable] itself.
         /// </summary>
-        public void SetValueParameterNullable ()
+        public void SetValueParameterNullability (bool nullable, IEnumerable<IList<Position>> nullablePaths)
         {
-            parameters [parameters.Length - 1].Nullable = true;
+            var parameter = parameters [parameters.Length - 1];
+            parameter.Nullable = nullable;
+            parameter.NullablePaths = nullablePaths;
         }
 
         static Func<object, object[], object> BuildInvoker (MethodInfo method)

--- a/core/src/Service/ProcedureParameter.cs
+++ b/core/src/Service/ProcedureParameter.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using KRPC.Service.Attributes;
@@ -39,6 +40,11 @@ namespace KRPC.Service
         public bool Nullable { get; internal set; }
 
         /// <summary>
+        /// The nullable positions inside the parameter's type, each named by a path.
+        /// </summary>
+        public IEnumerable<IList<Position>> NullablePaths { get; internal set; }
+
+        /// <summary>
         /// Create parameter information from a reflected parameter.
         /// </summary>
         public ProcedureParameter (ParameterInfo parameter)
@@ -52,7 +58,8 @@ namespace KRPC.Service
             // A parameter is nullable if it has a null default value, itself a declaration that
             // null is valid, or it is marked [KRPCNullable]. The spec reads a Nullable<T> type
             // as nullable on its own
-            Nullable = Reflection.HasAttribute<KRPCNullableAttribute> (parameter)
+            NullablePaths = TypeUtils.GetNullablePaths (parameter).ToList ();
+            Nullable = NullablePaths.Any (path => path.Count == 0)
                 || (HasDefaultValue && DefaultValue == null);
         }
 
@@ -64,6 +71,7 @@ namespace KRPC.Service
             Type = type;
             Name = name;
             DefaultValue = DBNull.Value;
+            NullablePaths = new List<IList<Position>> ();
         }
     }
 }

--- a/core/src/Service/ProcedureParameter.cs
+++ b/core/src/Service/ProcedureParameter.cs
@@ -12,7 +12,7 @@ namespace KRPC.Service
     public sealed class ProcedureParameter
     {
         /// <summary>
-        /// Type of the parameter.
+        /// The type the parameter is declared with, which a Nullable&lt;T&gt; keeps.
         /// </summary>
         public Type Type { get; private set; }
 
@@ -34,7 +34,7 @@ namespace KRPC.Service
         }
 
         /// <summary>
-        /// Whether the parameters value could be null.
+        /// Whether the parameter is declared nullable, by an attribute or a null default value.
         /// </summary>
         public bool Nullable { get; internal set; }
 
@@ -45,20 +45,14 @@ namespace KRPC.Service
         {
             Type = parameter.ParameterType;
             Name = parameter.Name;
-            // A Nullable<T> value-type parameter is represented by its underlying type T, and is
-            // implicitly nullable.
-            var underlyingType = System.Nullable.GetUnderlyingType (Type);
-            bool nullableValueType = underlyingType != null;
-            if (nullableValueType)
-                Type = underlyingType;
             bool hasDefaultValue = parameter.IsOptional && (parameter.Attributes & ParameterAttributes.HasDefault) == ParameterAttributes.HasDefault;
             DefaultValue = hasDefaultValue ? parameter.DefaultValue : DBNull.Value;
             if (Reflection.HasAttribute<KRPCDefaultValueAttribute> (parameter))
                 DefaultValue = Reflection.GetAttribute<KRPCDefaultValueAttribute> (parameter).Value;
-            // A parameter is nullable if its type is Nullable<T>, or it has a null default value
-            // (itself a declaration that null is valid), or it is marked [KRPCNullable].
-            Nullable = nullableValueType
-                || Reflection.HasAttribute<KRPCNullableAttribute> (parameter)
+            // A parameter is nullable if it has a null default value, itself a declaration that
+            // null is valid, or it is marked [KRPCNullable]. The spec reads a Nullable<T> type
+            // as nullable on its own
+            Nullable = Reflection.HasAttribute<KRPCNullableAttribute> (parameter)
                 || (HasDefaultValue && DefaultValue == null);
         }
 

--- a/core/src/Service/Scanner/ParameterSignature.cs
+++ b/core/src/Service/Scanner/ParameterSignature.cs
@@ -15,11 +15,6 @@ namespace KRPC.Service.Scanner
         public string Name { get; private set; }
 
         /// <summary>
-        /// Type of the parameter.
-        /// </summary>
-        public Type Type { get; private set; }
-
-        /// <summary>
         /// True if this parameter is optional and has a default argument.
         /// </summary>
         public bool HasDefaultValue { get; private set; }
@@ -30,9 +25,9 @@ namespace KRPC.Service.Scanner
         public object DefaultValue { get; private set; }
 
         /// <summary>
-        /// True if this parameter is nullable.
+        /// The type of the parameter, together with whether it can be null.
         /// </summary>
-        public bool Nullable { get; private set; }
+        public TypeSpec Spec { get; private set; }
 
         /// <summary>
         /// Create a parameter signature for a reflected parameter.
@@ -40,16 +35,15 @@ namespace KRPC.Service.Scanner
         public ParameterSignature (string fullProcedureName, ProcedureParameter parameter)
         {
             Name = parameter.Name;
-            Type = parameter.Type;
 
             // Check the parameter type is valid
-            if (!TypeUtils.IsAValidType (Type))
-                throw new ServiceException (Type + " is not a valid Procedure parameter type, in " + fullProcedureName);
+            if (!TypeUtils.IsAValidType (parameter.Type))
+                throw new ServiceException (parameter.Type + " is not a valid Procedure parameter type, in " + fullProcedureName);
 
             HasDefaultValue = parameter.HasDefaultValue;
             if (HasDefaultValue)
                 DefaultValue = parameter.DefaultValue;
-            Nullable = parameter.Nullable;
+            Spec = TypeSpec.Create (parameter.Type, parameter.Nullable);
         }
 
         /// <summary>
@@ -58,7 +52,7 @@ namespace KRPC.Service.Scanner
         public void GetObjectData (SerializationInfo info, StreamingContext context)
         {
             info.AddValue ("name", Name);
-            info.AddValue ("type", TypeUtils.SerializeType (Type, Nullable));
+            info.AddValue ("type", TypeUtils.SerializeType (Spec));
             if (HasDefaultValue) {
                 if (DefaultValue == null)
                     info.AddValue ("default_value", (object)null);

--- a/core/src/Service/Scanner/ParameterSignature.cs
+++ b/core/src/Service/Scanner/ParameterSignature.cs
@@ -58,15 +58,12 @@ namespace KRPC.Service.Scanner
         public void GetObjectData (SerializationInfo info, StreamingContext context)
         {
             info.AddValue ("name", Name);
-            info.AddValue ("type", TypeUtils.SerializeType (Type));
+            info.AddValue ("type", TypeUtils.SerializeType (Type, Nullable));
             if (HasDefaultValue) {
                 if (DefaultValue == null)
                     info.AddValue ("default_value", (object)null);
                 else
                     info.AddValue ("default_value", Server.ProtocolBuffers.Encoder.Encode (DefaultValue).ToByteArray ());
-            }
-            if (Nullable) {
-                info.AddValue ("nullable", Nullable);
             }
         }
     }

--- a/core/src/Service/Scanner/ParameterSignature.cs
+++ b/core/src/Service/Scanner/ParameterSignature.cs
@@ -25,7 +25,7 @@ namespace KRPC.Service.Scanner
         public object DefaultValue { get; private set; }
 
         /// <summary>
-        /// The type of the parameter, together with whether it can be null.
+        /// The type of the parameter, with the nullability of every position inside it.
         /// </summary>
         public TypeSpec Spec { get; private set; }
 
@@ -43,7 +43,9 @@ namespace KRPC.Service.Scanner
             HasDefaultValue = parameter.HasDefaultValue;
             if (HasDefaultValue)
                 DefaultValue = parameter.DefaultValue;
-            Spec = TypeSpec.Create (parameter.Type, parameter.Nullable);
+            Spec = TypeSpec.Create (
+                parameter.Type, parameter.Nullable, parameter.NullablePaths,
+                "parameter " + Name + " of " + fullProcedureName);
         }
 
         /// <summary>
@@ -57,7 +59,7 @@ namespace KRPC.Service.Scanner
                 if (DefaultValue == null)
                     info.AddValue ("default_value", (object)null);
                 else
-                    info.AddValue ("default_value", Server.ProtocolBuffers.Encoder.Encode (DefaultValue).ToByteArray ());
+                    info.AddValue ("default_value", Server.ProtocolBuffers.Encoder.Encode (DefaultValue, Spec).ToByteArray ());
             }
         }
     }

--- a/core/src/Service/Scanner/ProcedureSignature.cs
+++ b/core/src/Service/Scanner/ProcedureSignature.cs
@@ -111,10 +111,7 @@ namespace KRPC.Service.Scanner
             info.AddValue ("id", Id);
             info.AddValue ("parameters", Parameters);
             if (ReturnType != null)
-            {
-                info.AddValue("return_type", TypeUtils.SerializeType(ReturnType));
-                info.AddValue("return_is_nullable", ReturnIsNullable);
-            }
+                info.AddValue("return_type", TypeUtils.SerializeType(ReturnType, ReturnIsNullable));
             if (GameScene != GameScene.All)
                 info.AddValue ("game_scenes", GameSceneUtils.Serialize(GameScene));
             info.AddValue ("documentation", Documentation);

--- a/core/src/Service/Scanner/ProcedureSignature.cs
+++ b/core/src/Service/Scanner/ProcedureSignature.cs
@@ -64,7 +64,7 @@ namespace KRPC.Service.Scanner
         public bool HasReturnType { get; private set; }
 
         /// <summary>
-        /// The return type of the procedure, together with whether it can be null.
+        /// The return type of the procedure, with the nullability of every position inside it.
         /// </summary>
         public TypeSpec ReturnSpec { get; private set; }
 
@@ -86,7 +86,9 @@ namespace KRPC.Service.Scanner
                 // Check it's a valid return type
                 if (!TypeUtils.IsAValidType (returnType))
                     throw new ServiceException (returnType + " is not a valid Procedure return type, " + "in " + FullyQualifiedName);
-                ReturnSpec = TypeSpec.Create (returnType, handler.ReturnIsNullable);
+                ReturnSpec = TypeSpec.Create (
+                    returnType, handler.ReturnIsNullable, handler.ReturnNullablePaths,
+                    "the return value of " + FullyQualifiedName);
             }
         }
 

--- a/core/src/Service/Scanner/ProcedureSignature.cs
+++ b/core/src/Service/Scanner/ProcedureSignature.cs
@@ -64,14 +64,9 @@ namespace KRPC.Service.Scanner
         public bool HasReturnType { get; private set; }
 
         /// <summary>
-        /// Return type of the procedure.
+        /// The return type of the procedure, together with whether it can be null.
         /// </summary>
-        public Type ReturnType { get; private set; }
-
-        /// <summary>
-        /// Whether the return type of the procedure could be null.
-        /// </summary>
-        public bool ReturnIsNullable { get; private set; }
+        public TypeSpec ReturnSpec { get; private set; }
 
         internal ProcedureSignature (string serviceName, string procedureName, uint id, string documentation, IProcedureHandler handler, GameScene gameScene, bool deprecated, string deprecatedReason)
         {
@@ -88,18 +83,10 @@ namespace KRPC.Service.Scanner
             var returnType = handler.ReturnType;
             HasReturnType = (returnType != typeof(void));
             if (HasReturnType) {
-                ReturnIsNullable = handler.ReturnIsNullable;
-                // A Nullable<T> value-type return is represented by its underlying type T, and is
-                // implicitly nullable.
-                var underlyingType = System.Nullable.GetUnderlyingType (returnType);
-                if (underlyingType != null) {
-                    returnType = underlyingType;
-                    ReturnIsNullable = true;
-                }
-                ReturnType = returnType;
                 // Check it's a valid return type
                 if (!TypeUtils.IsAValidType (returnType))
                     throw new ServiceException (returnType + " is not a valid Procedure return type, " + "in " + FullyQualifiedName);
+                ReturnSpec = TypeSpec.Create (returnType, handler.ReturnIsNullable);
             }
         }
 
@@ -110,8 +97,8 @@ namespace KRPC.Service.Scanner
         {
             info.AddValue ("id", Id);
             info.AddValue ("parameters", Parameters);
-            if (ReturnType != null)
-                info.AddValue("return_type", TypeUtils.SerializeType(ReturnType, ReturnIsNullable));
+            if (HasReturnType)
+                info.AddValue("return_type", TypeUtils.SerializeType(ReturnSpec));
             if (GameScene != GameScene.All)
                 info.AddValue ("game_scenes", GameSceneUtils.Serialize(GameScene));
             info.AddValue ("documentation", Documentation);

--- a/core/src/Service/Scanner/ServiceSignature.cs
+++ b/core/src/Service/Scanner/ServiceSignature.cs
@@ -227,8 +227,8 @@ namespace KRPC.Service.Scanner
                 string fieldDeprecatedReason;
                 var fieldDeprecated = TypeUtils.GetPropertyDeprecated (property, property.GetGetMethod (), out fieldDeprecatedReason);
                 fields.Add (new StructFieldSignature (
-                    Name, name, property.Name, property.PropertyType, property.GetDocumentation (),
-                    fieldDeprecated, fieldDeprecatedReason));
+                    Name, name, property.Name, TypeUtils.GetStructFieldSpec (property),
+                    property.GetDocumentation (), fieldDeprecated, fieldDeprecatedReason));
             }
             string deprecatedReason;
             var deprecated = TypeUtils.GetDeprecated (structType, out deprecatedReason);

--- a/core/src/Service/Scanner/ServiceSignature.cs
+++ b/core/src/Service/Scanner/ServiceSignature.cs
@@ -1,7 +1,9 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 using System.Runtime.Serialization;
+using KRPC.Service.Attributes;
 using KRPC.Utils;
 
 namespace KRPC.Service.Scanner
@@ -138,7 +140,7 @@ namespace KRPC.Service.Scanner
             var deprecated = TypeUtils.GetDeprecated (method, out deprecatedReason);
             AddProcedure (new ProcedureSignature (
                 Name, method.Name, NextProcedureId, method.GetDocumentation (),
-                new ProcedureHandler (method, TypeUtils.GetNullable (method)),
+                new ProcedureHandler (method, TypeUtils.GetNullable (method), TypeUtils.GetNullablePaths (method)),
                 TypeUtils.GetProcedureGameScene(method, gameScene),
                 deprecated, deprecatedReason));
         }
@@ -152,20 +154,25 @@ namespace KRPC.Service.Scanner
             var getter = property.GetGetMethod ();
             var setter = property.GetSetMethod ();
             var nullable = TypeUtils.GetNullable (property);
+            var nullablePaths = TypeUtils.GetNullablePaths (property).ToList ();
             if (getter != null)
-                AddPropertyProcedure (property, getter, nullable, false);
+                AddPropertyProcedure (property, getter, nullable, nullablePaths, false);
             if (setter != null)
-                AddPropertyProcedure (property, setter, nullable, true);
+                AddPropertyProcedure (property, setter, nullable, nullablePaths, true);
         }
 
-        void AddPropertyProcedure (PropertyInfo property, MethodInfo method, bool nullable, bool isSetter)
+        void AddPropertyProcedure (
+            PropertyInfo property, MethodInfo method, bool nullable,
+            IList<IList<Position>> nullablePaths, bool isSetter)
         {
-            // For a getter the nullable flag makes the return value nullable. For a setter it
-            // makes the synthesized value parameter nullable, which cannot carry the attribute
-            // itself
-            var handler = new ProcedureHandler (method, isSetter ? false : nullable);
-            if (isSetter && nullable)
-                handler.SetValueParameterNullable ();
+            // For a getter the nullable flag and the paths apply to the return value. For a
+            // setter they apply to the synthesized value parameter, which cannot carry the
+            // attribute itself
+            var handler = new ProcedureHandler (
+                method, isSetter ? false : nullable,
+                isSetter ? new List<IList<Position>> () : nullablePaths);
+            if (isSetter)
+                handler.SetValueParameterNullability (nullable, nullablePaths);
             string deprecatedReason;
             var deprecated = TypeUtils.GetPropertyDeprecated (property, method, out deprecatedReason);
             AddProcedure (new ProcedureSignature (
@@ -227,7 +234,7 @@ namespace KRPC.Service.Scanner
                 string fieldDeprecatedReason;
                 var fieldDeprecated = TypeUtils.GetPropertyDeprecated (property, property.GetGetMethod (), out fieldDeprecatedReason);
                 fields.Add (new StructFieldSignature (
-                    Name, name, property.Name, TypeUtils.GetStructFieldSpec (property),
+                    Name, name, property.Name, TypeUtils.GetStructFieldSpec (structType, property),
                     property.GetDocumentation (), fieldDeprecated, fieldDeprecatedReason));
             }
             string deprecatedReason;
@@ -267,13 +274,13 @@ namespace KRPC.Service.Scanner
             string deprecatedReason;
             var deprecated = TypeUtils.GetDeprecated (method, out deprecatedReason);
             if (!method.IsStatic) {
-                var handler = new ClassMethodHandler (classType, method, TypeUtils.GetNullable(method));
+                var handler = new ClassMethodHandler (classType, method, TypeUtils.GetNullable (method), TypeUtils.GetNullablePaths (method));
                 AddProcedure (new ProcedureSignature (
                     Name, cls + '_' + name, id, method.GetDocumentation (), handler,
                     TypeUtils.GetMethodGameScene(classType, method, classGameScene),
                     deprecated, deprecatedReason));
             } else {
-                var handler = new ClassStaticMethodHandler (method, TypeUtils.GetNullable (method));
+                var handler = new ClassStaticMethodHandler (method, TypeUtils.GetNullable (method), TypeUtils.GetNullablePaths (method));
                 AddProcedure (new ProcedureSignature (
                     Name, cls + "_static_" + name, id, method.GetDocumentation (), handler,
                     TypeUtils.GetMethodGameScene(classType, method, classGameScene),
@@ -293,20 +300,25 @@ namespace KRPC.Service.Scanner
             var getter = property.GetGetMethod ();
             var setter = property.GetSetMethod ();
             var nullable = TypeUtils.GetNullable (property);
+            var nullablePaths = TypeUtils.GetNullablePaths (property).ToList ();
             if (getter != null)
-                AddClassPropertyMethod (cls, classType, property, getter, nullable, false);
+                AddClassPropertyMethod (cls, classType, property, getter, nullable, nullablePaths, false);
             if (setter != null)
-                AddClassPropertyMethod (cls, classType, property, setter, nullable, true);
+                AddClassPropertyMethod (cls, classType, property, setter, nullable, nullablePaths, true);
         }
 
-        void AddClassPropertyMethod (string cls, Type classType, PropertyInfo property, MethodInfo method, bool nullable, bool isSetter)
+        void AddClassPropertyMethod (
+            string cls, Type classType, PropertyInfo property, MethodInfo method, bool nullable,
+            IList<IList<Position>> nullablePaths, bool isSetter)
         {
-            // For a getter the nullable flag makes the return value nullable. For a setter it
-            // makes the synthesized value parameter nullable, which cannot carry the attribute
-            // itself
-            var handler = new ClassMethodHandler (classType, method, isSetter ? false : nullable);
-            if (isSetter && nullable)
-                handler.SetValueParameterNullable ();
+            // For a getter the nullable flag and the paths apply to the return value. For a
+            // setter they apply to the synthesized value parameter, which cannot carry the
+            // attribute itself
+            var handler = new ClassMethodHandler (
+                classType, method, isSetter ? false : nullable,
+                isSetter ? new List<IList<Position>> () : nullablePaths);
+            if (isSetter)
+                handler.SetValueParameterNullability (nullable, nullablePaths);
             var classGameScene = TypeUtils.GetClassGameScene(classType, gameScene);
             string deprecatedReason;
             var deprecated = TypeUtils.GetPropertyDeprecated (property, method, out deprecatedReason);
@@ -330,7 +342,7 @@ namespace KRPC.Service.Scanner
             var deprecated = TypeUtils.GetDeprecated (method, out deprecatedReason);
             AddExtensionProcedure (
                 cls + '_' + method.Name, method, method.GetDocumentation (),
-                new ClassStaticMethodHandler (method, TypeUtils.GetNullable (method), true),
+                new ClassStaticMethodHandler (method, TypeUtils.GetNullable (method), TypeUtils.GetNullablePaths (method), true),
                 TypeUtils.GetExtensionMethodGameScene (method, classGameScene),
                 deprecated, deprecatedReason);
         }
@@ -353,7 +365,7 @@ namespace KRPC.Service.Scanner
             AddExtensionProcedure (
                 cls + (isSetter ? "_set_" : "_get_") + property,
                 method, method.GetDocumentation (),
-                new ClassStaticMethodHandler (method, TypeUtils.GetNullable (method), true),
+                new ClassStaticMethodHandler (method, TypeUtils.GetNullable (method), TypeUtils.GetNullablePaths (method), true),
                 TypeUtils.GetExtensionPropertyGameScene (method, classGameScene),
                 deprecated, deprecatedReason);
         }

--- a/core/src/Service/Scanner/StructFieldSignature.cs
+++ b/core/src/Service/Scanner/StructFieldSignature.cs
@@ -58,7 +58,7 @@ namespace KRPC.Service.Scanner
         public void GetObjectData (SerializationInfo info, StreamingContext context)
         {
             info.AddValue ("name", Name);
-            info.AddValue ("type", TypeUtils.SerializeType (Type));
+            info.AddValue ("type", TypeUtils.SerializeType (TypeSpec.Create (Type)));
             info.AddValue ("documentation", Documentation);
             if (Deprecated) {
                 info.AddValue ("deprecated", true);

--- a/core/src/Service/Scanner/StructFieldSignature.cs
+++ b/core/src/Service/Scanner/StructFieldSignature.cs
@@ -20,9 +20,9 @@ namespace KRPC.Service.Scanner
         public string FullyQualifiedName { get; private set; }
 
         /// <summary>
-        /// Type of the field.
+        /// The type of the field, together with whether it can be null.
         /// </summary>
-        public Type Type { get; private set; }
+        public TypeSpec Spec { get; private set; }
 
         /// <summary>
         /// Documentation for the field.
@@ -42,11 +42,11 @@ namespace KRPC.Service.Scanner
         /// <summary>
         /// Create a signature for a field of a structure.
         /// </summary>
-        public StructFieldSignature (string serviceName, string structName, string fieldName, Type type, string documentation, bool deprecated, string deprecatedReason)
+        public StructFieldSignature (string serviceName, string structName, string fieldName, TypeSpec spec, string documentation, bool deprecated, string deprecatedReason)
         {
             Name = fieldName;
             FullyQualifiedName = serviceName + "." + structName + "." + Name;
-            Type = type;
+            Spec = spec;
             Documentation = DocumentationUtils.ResolveCrefs (documentation);
             Deprecated = deprecated;
             DeprecatedReason = deprecatedReason;
@@ -58,7 +58,7 @@ namespace KRPC.Service.Scanner
         public void GetObjectData (SerializationInfo info, StreamingContext context)
         {
             info.AddValue ("name", Name);
-            info.AddValue ("type", TypeUtils.SerializeType (TypeSpec.Create (Type)));
+            info.AddValue ("type", TypeUtils.SerializeType (Spec));
             info.AddValue ("documentation", Documentation);
             if (Deprecated) {
                 info.AddValue ("deprecated", true);

--- a/core/src/Service/Scanner/StructFieldSignature.cs
+++ b/core/src/Service/Scanner/StructFieldSignature.cs
@@ -20,7 +20,7 @@ namespace KRPC.Service.Scanner
         public string FullyQualifiedName { get; private set; }
 
         /// <summary>
-        /// The type of the field, together with whether it can be null.
+        /// The type of the field, with the nullability of every position inside it.
         /// </summary>
         public TypeSpec Spec { get; private set; }
 

--- a/core/src/Service/Services.cs
+++ b/core/src/Service/Services.cs
@@ -266,12 +266,12 @@ namespace KRPC.Service
                 var position = argument.Position;
                 var value = argument.Value;
                 var parameter = procedure.Parameters[(int)position];
-                var type = parameter.Type;
+                var type = parameter.Spec.Type;
                 if (value != null && !type.IsInstanceOfType (value))
                     throw new RPCException (
                         "Incorrect argument type for parameter " + parameter.Name + " in " + procedure.FullyQualifiedName + ". " +
                         "Expected an argument of type " + type + ", got " + value.GetType ());
-                if (value == null && !parameter.Nullable)
+                if (value == null && !parameter.Spec.Nullable)
                     throw new RPCException (
                         "Incorrect argument type for parameter " + parameter.Name + " in " + procedure.FullyQualifiedName + ". " +
                         "Expected an argument of type " + type + ", got null");
@@ -315,7 +315,7 @@ namespace KRPC.Service
             for (int i = 0; i < numParameters; i++) {
                 var value = argumentValues [i];
                 var parameter = procedure.Parameters [i];
-                var type = parameter.Type;
+                var type = parameter.Spec.Type;
                 if (!argumentSet [mask]) {
                     // If the argument is not set, set it to the default value
                     if (!parameter.HasDefaultValue)
@@ -326,7 +326,7 @@ namespace KRPC.Service
                     throw new RPCException (
                         "Incorrect argument type for parameter " + parameter.Name + " in " + procedure.FullyQualifiedName + ". " +
                         "Expected an argument of type " + type + ", got " + value.GetType ());
-                } else if (value == null && !parameter.Nullable) {
+                } else if (value == null && !parameter.Spec.Nullable) {
                     // Reject a null argument for a parameter that is not nullable
                     throw new RPCException (
                         "Incorrect argument type for parameter " + parameter.Name + " in " + procedure.FullyQualifiedName + ". " +
@@ -343,16 +343,16 @@ namespace KRPC.Service
         static void CheckReturnValue (ProcedureSignature procedure, object returnValue)
         {
             // Check if the type of the return value is valid
-            if (returnValue != null && !procedure.ReturnType.IsInstanceOfType (returnValue)) {
+            if (returnValue != null && !procedure.ReturnSpec.Type.IsInstanceOfType (returnValue)) {
                 throw new RPCException (
                     "Incorrect value returned by " + procedure.FullyQualifiedName + ". " +
-                    "Expected a value of type " + procedure.ReturnType + ", got " + returnValue.GetType ());
+                    "Expected a value of type " + procedure.ReturnSpec.Type + ", got " + returnValue.GetType ());
             }
             // Check if the return value is null, but the procedure is not marked as nullable
-            if (returnValue == null && !procedure.ReturnIsNullable)
+            if (returnValue == null && !procedure.ReturnSpec.Nullable)
                 throw new RPCException (
                     "Incorrect value returned by " + procedure.FullyQualifiedName + ". " +
-                    "Expected a non-null value of type " + procedure.ReturnType + ", got null, " +
+                    "Expected a non-null value of type " + procedure.ReturnSpec.Type + ", got null, " +
                     "but the procedure is not marked as nullable.");
         }
 

--- a/core/src/Service/Services.cs
+++ b/core/src/Service/Services.cs
@@ -139,6 +139,7 @@ namespace KRPC.Service
                 var result = new ProcedureResult ();
                 if (procedure.HasReturnType) {
                     CheckReturnValue (procedure, returnValue);
+                    result.Spec = procedure.ReturnSpec;
                     result.Value = returnValue;
                 }
                 return result;
@@ -169,6 +170,7 @@ namespace KRPC.Service
             var result = new ProcedureResult ();
             if (procedure.HasReturnType) {
                 CheckReturnValue (procedure, returnValue);
+                result.Spec = procedure.ReturnSpec;
                 result.Value = returnValue;
             }
             return result;
@@ -211,6 +213,7 @@ namespace KRPC.Service
                     result.Error = HandleException (e);
                     return;
                 }
+                result.Spec = procedure.ReturnSpec;
                 result.Value = returnValue;
             }
         }
@@ -233,6 +236,7 @@ namespace KRPC.Service
             result.Reset ();
             if (procedure.HasReturnType) {
                 CheckReturnValue (procedure, returnValue);
+                result.Spec = procedure.ReturnSpec;
                 result.Value = returnValue;
             }
         }

--- a/core/src/Service/TypeKind.cs
+++ b/core/src/Service/TypeKind.cs
@@ -1,0 +1,87 @@
+namespace KRPC.Service
+{
+    /// <summary>
+    /// What a type is on the wire, which decides how a value of it is encoded and decoded.
+    /// A spec works it out once from the type it holds, so that encoding a value costs no
+    /// reflection.
+    /// </summary>
+    public enum TypeKind
+    {
+        /// <summary>
+        /// A type nothing can be encoded as.
+        /// </summary>
+        Unknown,
+        /// <summary>
+        /// An enumeration a service declares, encoded as its integer value.
+        /// </summary>
+        Enum,
+        /// <summary>
+        /// An enumeration no service declares. A value of it encodes, and no value decodes.
+        /// </summary>
+        UndeclaredEnum,
+        /// <summary>
+        /// A double precision floating point number.
+        /// </summary>
+        Double,
+        /// <summary>
+        /// A single precision floating point number.
+        /// </summary>
+        Single,
+        /// <summary>
+        /// A signed 32-bit integer.
+        /// </summary>
+        Int32,
+        /// <summary>
+        /// A signed 64-bit integer.
+        /// </summary>
+        Int64,
+        /// <summary>
+        /// An unsigned 32-bit integer.
+        /// </summary>
+        UInt32,
+        /// <summary>
+        /// An unsigned 64-bit integer.
+        /// </summary>
+        UInt64,
+        /// <summary>
+        /// A boolean.
+        /// </summary>
+        Boolean,
+        /// <summary>
+        /// A string.
+        /// </summary>
+        String,
+        /// <summary>
+        /// An array of bytes.
+        /// </summary>
+        Bytes,
+        /// <summary>
+        /// A class a service declares, encoded as the identifier of the instance.
+        /// </summary>
+        Class,
+        /// <summary>
+        /// A structure a service declares, encoded as its field values.
+        /// </summary>
+        Struct,
+        /// <summary>
+        /// A tuple, encoded as the values of its items.
+        /// </summary>
+        Tuple,
+        /// <summary>
+        /// A list, encoded as the values of its elements.
+        /// </summary>
+        List,
+        /// <summary>
+        /// A set, encoded as the values of its elements.
+        /// </summary>
+        Set,
+        /// <summary>
+        /// A dictionary, encoded as its key and value pairs.
+        /// </summary>
+        Dictionary,
+        /// <summary>
+        /// A protocol buffer message the protocol itself defines.
+        /// </summary>
+        Message
+    }
+}

--- a/core/src/Service/TypeSpec.cs
+++ b/core/src/Service/TypeSpec.cs
@@ -1,0 +1,54 @@
+using System;
+
+namespace KRPC.Service
+{
+    /// <summary>
+    /// A type together with whether the position holding it can be null. A C# type says what a
+    /// value is, and nullability belongs to the position the value sits in, so the two travel
+    /// together wherever a value is encoded, decoded or described.
+    /// </summary>
+    public sealed class TypeSpec
+    {
+        TypeSpec (Type type, Type declaredType, bool nullable)
+        {
+            Type = type;
+            DeclaredType = declaredType;
+            Nullable = nullable;
+        }
+
+        /// <summary>
+        /// The type of the value, with Nullable&lt;T&gt; unwrapped to the type it wraps.
+        /// </summary>
+        public Type Type { get; private set; }
+
+        /// <summary>
+        /// The type the value is declared with, which a Nullable&lt;T&gt; keeps.
+        /// </summary>
+        public Type DeclaredType { get; private set; }
+
+        /// <summary>
+        /// Whether the position this value sits in can hold null.
+        /// </summary>
+        public bool Nullable { get; private set; }
+
+        /// <summary>
+        /// A spec for the given type, at a position that cannot be null.
+        /// </summary>
+        public static TypeSpec Create (Type type)
+        {
+            return Create (type, false);
+        }
+
+        /// <summary>
+        /// A spec for the given type. A Nullable&lt;T&gt; is the type it wraps, at a position
+        /// that can be null.
+        /// </summary>
+        public static TypeSpec Create (Type type, bool nullable)
+        {
+            var underlyingType = System.Nullable.GetUnderlyingType (type);
+            if (underlyingType != null)
+                return new TypeSpec (underlyingType, type, true);
+            return new TypeSpec (type, type, nullable);
+        }
+    }
+}

--- a/core/src/Service/TypeSpec.cs
+++ b/core/src/Service/TypeSpec.cs
@@ -1,19 +1,25 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
+using KRPC.Service.Attributes;
 
 namespace KRPC.Service
 {
     /// <summary>
-    /// A type together with whether the position holding it can be null. A C# type says what a
-    /// value is, and nullability belongs to the position the value sits in, so the two travel
-    /// together wherever a value is encoded, decoded or described.
+    /// A type together with which of the positions inside it can hold null. A C# type says what
+    /// a value is, and nullability belongs to the positions the value is made of, so the two
+    /// travel together wherever a value is encoded, decoded or described.
     /// </summary>
     public sealed class TypeSpec
     {
-        TypeSpec (Type type, Type declaredType, bool nullable)
+        readonly TypeSpec[] types;
+
+        TypeSpec (Type type, Type declaredType, bool nullable, TypeSpec[] containedTypes)
         {
             Type = type;
             DeclaredType = declaredType;
             Nullable = nullable;
+            types = containedTypes;
         }
 
         /// <summary>
@@ -22,7 +28,9 @@ namespace KRPC.Service
         public Type Type { get; private set; }
 
         /// <summary>
-        /// The type the value is declared with, which a Nullable&lt;T&gt; keeps.
+        /// The type the value is declared with, which a Nullable&lt;T&gt; keeps. A collection
+        /// is built from the declared types of the values it holds, so that a position that
+        /// can be null is able to hold one.
         /// </summary>
         public Type DeclaredType { get; private set; }
 
@@ -32,23 +40,96 @@ namespace KRPC.Service
         public bool Nullable { get; private set; }
 
         /// <summary>
-        /// A spec for the given type, at a position that cannot be null.
+        /// The values this one contains, in the order the wire type names them: the element of
+        /// a list or a set, the key and value of a dictionary, or the items of a tuple. The
+        /// fields of a structure are declared by the structure itself, so it contains none.
         /// </summary>
-        public static TypeSpec Create (Type type)
-        {
-            return Create (type, false);
+        public IList<TypeSpec> Types {
+            get { return types; }
         }
 
         /// <summary>
-        /// A spec for the given type. A Nullable&lt;T&gt; is the type it wraps, at a position
-        /// that can be null.
+        /// A spec for the given type, with no nullable position anywhere inside it.
         /// </summary>
-        public static TypeSpec Create (Type type, bool nullable)
+        public static TypeSpec Create (Type type)
         {
+            return Create (type, false, null, null);
+        }
+
+        /// <summary>
+        /// A spec for the given type. Each path names a nullable position, a step at a time
+        /// from the outside in, and an empty path is the value itself. Location names what the
+        /// spec is being built for, and is reported with any error.
+        /// </summary>
+        public static TypeSpec Create (
+            Type type, bool nullable, IEnumerable<IList<Position>> paths, string location)
+        {
+            var pathList = paths == null ? new List<IList<Position>> () : paths.ToList ();
+            return Build (type, nullable, pathList, location);
+        }
+
+        static TypeSpec Build (
+            Type type, bool nullable, IList<IList<Position>> paths, string location)
+        {
+            var declaredType = type;
             var underlyingType = System.Nullable.GetUnderlyingType (type);
-            if (underlyingType != null)
-                return new TypeSpec (underlyingType, type, true);
-            return new TypeSpec (type, type, nullable);
+            if (underlyingType != null) {
+                type = underlyingType;
+                nullable = true;
+            }
+            if (paths.Any (path => path.Count == 0))
+                nullable = true;
+            if (nullable && !TypeUtils.CanBeNull (declaredType))
+                throw new ServiceException (
+                    declaredType + " cannot be null, in " + location);
+            var positions = PositionsOf (type);
+            foreach (var path in paths) {
+                if (path.Count > 0 && !positions.Any (x => x.Key == path [0]))
+                    throw new ServiceException (
+                        type + " has no position " + path [0] + ", in " + location);
+            }
+            var containedTypes = new TypeSpec [positions.Count];
+            for (int i = 0; i < positions.Count; i++) {
+                var position = positions [i];
+                var innerPaths = paths
+                    .Where (path => path.Count > 0 && path [0] == position.Key)
+                    .Select (path => (IList<Position>)path.Skip (1).ToList ())
+                    .ToList ();
+                containedTypes [i] = Build (position.Value, false, innerPaths, location);
+            }
+            return new TypeSpec (type, declaredType, nullable, containedTypes);
+        }
+
+        /// <summary>
+        /// The types the given type contains, in the order the wire type names them, each with
+        /// the position a path names it by. A dictionary key and a set element have no name,
+        /// and are given one no path can spell.
+        /// </summary>
+        static IList<KeyValuePair<Position?, Type>> PositionsOf (Type type)
+        {
+            var result = new List<KeyValuePair<Position?, Type>> ();
+            var arguments = type.IsGenericType ? type.GetGenericArguments () : new Type [0];
+            if (TypeUtils.IsAListCollectionType (type)) {
+                result.Add (At (Position.Element, arguments [0]));
+            } else if (TypeUtils.IsASetCollectionType (type)) {
+                result.Add (At (null, arguments [0]));
+            } else if (TypeUtils.IsADictionaryCollectionType (type)) {
+                result.Add (At (null, arguments [0]));
+                result.Add (At (Position.Value, arguments [1]));
+            } else if (TypeUtils.IsATupleCollectionType (type)) {
+                for (int i = 0; i < arguments.Length; i++) {
+                    // A tuple longer than the positions Item1 to Item7 name has no name for its
+                    // remaining items, which no path can then reach
+                    var position = i < 7 ? (Position?)(Position.Item1 + i) : null;
+                    result.Add (At (position, arguments [i]));
+                }
+            }
+            return result;
+        }
+
+        static KeyValuePair<Position?, Type> At (Position? position, Type type)
+        {
+            return new KeyValuePair<Position?, Type> (position, type);
         }
     }
 }

--- a/core/src/Service/TypeSpec.cs
+++ b/core/src/Service/TypeSpec.cs
@@ -20,6 +20,7 @@ namespace KRPC.Service
             DeclaredType = declaredType;
             Nullable = nullable;
             types = containedTypes;
+            Kind = KindOf (type);
         }
 
         /// <summary>
@@ -38,6 +39,12 @@ namespace KRPC.Service
         /// Whether the position this value sits in can hold null.
         /// </summary>
         public bool Nullable { get; private set; }
+
+        /// <summary>
+        /// What the type is on the wire. Worked out here, once, as the answer costs
+        /// reflection and every value encoded or decoded needs it.
+        /// </summary>
+        public TypeKind Kind { get; private set; }
 
         /// <summary>
         /// The values this one contains, in the order the wire type names them: the element of
@@ -98,6 +105,50 @@ namespace KRPC.Service
                 containedTypes [i] = Build (position.Value, false, innerPaths, location);
             }
             return new TypeSpec (type, declaredType, nullable, containedTypes);
+        }
+
+        /// <summary>
+        /// What the given type is on the wire.
+        /// </summary>
+        static TypeKind KindOf (Type type)
+        {
+            if (type.IsEnum)
+                return TypeUtils.IsAnEnumType (type) ? TypeKind.Enum : TypeKind.UndeclaredEnum;
+            switch (Type.GetTypeCode (type)) {
+            case TypeCode.Double:
+                return TypeKind.Double;
+            case TypeCode.Single:
+                return TypeKind.Single;
+            case TypeCode.Int32:
+                return TypeKind.Int32;
+            case TypeCode.Int64:
+                return TypeKind.Int64;
+            case TypeCode.UInt32:
+                return TypeKind.UInt32;
+            case TypeCode.UInt64:
+                return TypeKind.UInt64;
+            case TypeCode.Boolean:
+                return TypeKind.Boolean;
+            case TypeCode.String:
+                return TypeKind.String;
+            }
+            if (type == typeof(byte[]))
+                return TypeKind.Bytes;
+            if (TypeUtils.IsAClassType (type))
+                return TypeKind.Class;
+            if (TypeUtils.IsAStructType (type))
+                return TypeKind.Struct;
+            if (TypeUtils.IsATupleCollectionType (type))
+                return TypeKind.Tuple;
+            if (TypeUtils.IsAListCollectionType (type))
+                return TypeKind.List;
+            if (TypeUtils.IsASetCollectionType (type))
+                return TypeKind.Set;
+            if (TypeUtils.IsADictionaryCollectionType (type))
+                return TypeKind.Dictionary;
+            if (TypeUtils.IsAMessageType (type))
+                return TypeKind.Message;
+            return TypeKind.Unknown;
         }
 
         /// <summary>

--- a/core/src/Service/TypeUtils.cs
+++ b/core/src/Service/TypeUtils.cs
@@ -132,6 +132,14 @@ namespace KRPC.Service
         static readonly IDictionary<Type, IList<PropertyInfo>> structFields = new Dictionary<Type, IList<PropertyInfo>> ();
 
         /// <summary>
+        /// The fields of every structure type they have been asked for, paired with their
+        /// specs. Encoding a value reads both, so one entry holds both and answers with one
+        /// lookup.
+        /// </summary>
+        static readonly IDictionary<Type, KeyValuePair<IList<PropertyInfo>, IList<TypeSpec>>> structFieldSpecs =
+            new Dictionary<Type, KeyValuePair<IList<PropertyInfo>, IList<TypeSpec>>> ();
+
+        /// <summary>
         /// Returns true if the given type can be used as a kRPC collection type.
         /// </summary>
         public static bool IsACollectionType (Type type)
@@ -580,7 +588,7 @@ namespace KRPC.Service
         /// 2. Every property marked as a field must be a public instance property with both a
         ///    getter and a setter, so that a value can be both read and constructed
         /// 3. Every field must have a valid kRPC type
-        /// 4. A field must not be nullable or restricted to a game scene
+        /// 4. A field must not be restricted to a game scene
         /// 5. There must be at least one field
         /// 6. The structure must not contain itself, directly or through the fields of another
         ///    structure
@@ -593,11 +601,9 @@ namespace KRPC.Service
                     throw new ServiceException ("KRPCStruct " + type + " field " + property.Name + " is not a public instance property");
                 if (property.GetGetMethod () == null || property.GetSetMethod () == null)
                     throw new ServiceException ("KRPCStruct " + type + " field " + property.Name + " does not have both a getter and a setter");
-                if (!IsAValidType (property.PropertyType))
+                if (!IsAValidType (GetStructFieldType (property)))
                     throw new ServiceException ("KRPCStruct " + type + " field " + property.Name + " has type " + property.PropertyType + ", which is not a valid kRPC type");
                 var propertyAttribute = Reflection.GetAttribute<KRPCPropertyAttribute> (property);
-                if (propertyAttribute.Nullable)
-                    throw new ServiceException ("KRPCStruct " + type + " field " + property.Name + " is nullable, which struct fields cannot be");
                 if (propertyAttribute.GameScene != GameScene.Inherit)
                     throw new ServiceException ("KRPCStruct " + type + " field " + property.Name + " sets a game scene, which struct fields cannot do");
             }
@@ -632,6 +638,7 @@ namespace KRPC.Service
         /// </summary>
         static IEnumerable<Type> StructTypesIn (Type type)
         {
+            type = System.Nullable.GetUnderlyingType (type) ?? type;
             if (IsAStructType (type)) {
                 yield return type;
             } else if (IsACollectionType (type)) {
@@ -827,6 +834,54 @@ namespace KRPC.Service
             if (Reflection.HasAttribute<KRPCPropertyAttribute> (member))
                 return Reflection.GetAttribute<KRPCPropertyAttribute> (member).Nullable;
             throw new ArgumentException ("member is not a kRPC procedure, attribute or property", nameof(member));
+        }
+
+        /// <summary>
+        /// The kRPC type of a structure field. A Nullable&lt;T&gt; field is represented by its
+        /// underlying type T.
+        /// </summary>
+        static Type GetStructFieldType (PropertyInfo field)
+        {
+            return System.Nullable.GetUnderlyingType (field.PropertyType) ?? field.PropertyType;
+        }
+
+        /// <summary>
+        /// Whether a structure field can be null, which it is when its type is Nullable&lt;T&gt;
+        /// or it is marked with KRPCProperty Nullable.
+        /// </summary>
+        static bool GetStructFieldNullable (PropertyInfo field)
+        {
+            return System.Nullable.GetUnderlyingType (field.PropertyType) != null ||
+                Reflection.GetAttribute<KRPCPropertyAttribute> (field).Nullable;
+        }
+
+        /// <summary>
+        /// The type of a structure field, together with whether the field can be null.
+        /// </summary>
+        public static TypeSpec GetStructFieldSpec (PropertyInfo field)
+        {
+            return TypeSpec.Create (field.PropertyType, GetStructFieldNullable (field));
+        }
+
+        /// <summary>
+        /// The fields of the given structure type and their specs, in the order their values
+        /// are encoded in. Built once per structure, as encoding a value reads both for every
+        /// value.
+        /// </summary>
+        public static void GetStructFieldsAndSpecs (
+            Type type, out IList<PropertyInfo> fields, out IList<TypeSpec> specs)
+        {
+            lock (structFieldSpecs) {
+                KeyValuePair<IList<PropertyInfo>, IList<TypeSpec>> entry;
+                if (!structFieldSpecs.TryGetValue (type, out entry)) {
+                    var typeFields = GetStructFields (type);
+                    entry = new KeyValuePair<IList<PropertyInfo>, IList<TypeSpec>> (
+                        typeFields, typeFields.Select (GetStructFieldSpec).ToList ());
+                    structFieldSpecs [type] = entry;
+                }
+                fields = entry.Key;
+                specs = entry.Value;
+            }
         }
 
         /// <summary>

--- a/core/src/Service/TypeUtils.cs
+++ b/core/src/Service/TypeUtils.cs
@@ -31,6 +31,8 @@ namespace KRPC.Service
         /// </summary>
         public static bool IsAValidType (Type type)
         {
+            // A Nullable<T> is valid wherever T is. It is T at a position that allows a null
+            type = System.Nullable.GetUnderlyingType (type) ?? type;
             return IsAValueType (type) || IsAMessageType (type) || IsAClassType (type) || IsAnEnumType (type) || IsAStructType (type) || IsACollectionType (type);
         }
 
@@ -828,12 +830,13 @@ namespace KRPC.Service
         }
 
         /// <summary>
-        /// Serialize a type into a dictionary for use in a service definition. Nullability
-        /// belongs to the position a value sits in rather than to the value, so the caller
-        /// supplies it.
+        /// Serialize a type into a dictionary for use in a service definition, from the spec
+        /// that carries whether the position holding it can be null.
         /// </summary>
-        public static object SerializeType (Type type, bool nullable = false)
+        public static object SerializeType (TypeSpec spec)
         {
+            var type = spec.Type;
+            var nullable = spec.Nullable;
             if (!IsAValidType (type))
                 throw new ArgumentException ("Type " + type + " is not a valid kRPC type");
             var result = new Dictionary<string,object> ();
@@ -882,16 +885,16 @@ namespace KRPC.Service
                 result["name"] = type.Name;
             } else if (IsATupleCollectionType (type)) {
                 result["code"] = "TUPLE";
-                result["types"] = type.GetGenericArguments ().Select (t => SerializeType (t)).ToList ();
+                result["types"] = type.GetGenericArguments ().Select (t => SerializeType (TypeSpec.Create (t))).ToList ();
             } else if (IsAListCollectionType (type)) {
                 result["code"] = "LIST";
-                result["types"] = type.GetGenericArguments ().Select (t => SerializeType (t)).ToList ();
+                result["types"] = type.GetGenericArguments ().Select (t => SerializeType (TypeSpec.Create (t))).ToList ();
             } else if (IsASetCollectionType (type)) {
                 result["code"] = "SET";
-                result["types"] = type.GetGenericArguments ().Select (t => SerializeType (t)).ToList ();
+                result["types"] = type.GetGenericArguments ().Select (t => SerializeType (TypeSpec.Create (t))).ToList ();
             } else if (IsADictionaryCollectionType (type)) {
                 result["code"] = "DICTIONARY";
-                result["types"] = type.GetGenericArguments ().Select (t => SerializeType (t)).ToList ();
+                result["types"] = type.GetGenericArguments ().Select (t => SerializeType (TypeSpec.Create (t))).ToList ();
             } else if (IsAMessageType (type)) {
                 var name = type.ToString ();
                 var camelCase = name.Substring (name.LastIndexOf ('.') + 1);

--- a/core/src/Service/TypeUtils.cs
+++ b/core/src/Service/TypeUtils.cs
@@ -828,9 +828,11 @@ namespace KRPC.Service
         }
 
         /// <summary>
-        /// Serialize a type into a dictionary for use in a service definition.
+        /// Serialize a type into a dictionary for use in a service definition. Nullability
+        /// belongs to the position a value sits in rather than to the value, so the caller
+        /// supplies it.
         /// </summary>
-        public static object SerializeType (Type type)
+        public static object SerializeType (Type type, bool nullable = false)
         {
             if (!IsAValidType (type))
                 throw new ArgumentException ("Type " + type + " is not a valid kRPC type");
@@ -905,6 +907,8 @@ namespace KRPC.Service
             }
             if (!result.ContainsKey("code"))
                 throw new ArgumentException ("Type " + type + " is not a valid kRPC type");
+            if (nullable)
+                result["nullable"] = true;
             return result;
         }
     }

--- a/core/src/Service/TypeUtils.cs
+++ b/core/src/Service/TypeUtils.cs
@@ -31,9 +31,19 @@ namespace KRPC.Service
         /// </summary>
         public static bool IsAValidType (Type type)
         {
-            // A Nullable<T> is valid wherever T is. It is T at a position that allows a null
+            // A Nullable<T> is valid wherever T is. It is T at a position that allows a null,
+            // which is how a collection declares a nullable element
             type = System.Nullable.GetUnderlyingType (type) ?? type;
             return IsAValueType (type) || IsAMessageType (type) || IsAClassType (type) || IsAnEnumType (type) || IsAStructType (type) || IsACollectionType (type);
+        }
+
+        /// <summary>
+        /// Returns true if a value of the given type can be null. A value type holds one only
+        /// as a Nullable&lt;T&gt;.
+        /// </summary>
+        public static bool CanBeNull (Type type)
+        {
+            return !type.IsValueType || System.Nullable.GetUnderlyingType (type) != null;
         }
 
         /// <summary>
@@ -173,6 +183,9 @@ namespace KRPC.Service
         {
             return Reflection.IsGenericType (type, typeof(HashSet<>)) &&
             type.GetGenericArguments ().Length == 1 &&
+            // A set element cannot be nullable. A set of them holds at most one null, which is
+            // rarely wanted, and hashing one costs every client something
+            System.Nullable.GetUnderlyingType (type.GetGenericArguments ().Single ()) == null &&
             IsAValidType (type.GetGenericArguments ().Single ());
         }
 
@@ -856,11 +869,14 @@ namespace KRPC.Service
         }
 
         /// <summary>
-        /// The type of a structure field, together with whether the field can be null.
+        /// The spec for a structure field, naming the field and the structure it is in when a
+        /// nullable position cannot be reached.
         /// </summary>
-        public static TypeSpec GetStructFieldSpec (PropertyInfo field)
+        public static TypeSpec GetStructFieldSpec (Type type, PropertyInfo field)
         {
-            return TypeSpec.Create (field.PropertyType, GetStructFieldNullable (field));
+            return TypeSpec.Create (
+                field.PropertyType, GetStructFieldNullable (field), GetNullablePaths (field),
+                type.Name + " field " + field.Name);
         }
 
         /// <summary>
@@ -876,7 +892,8 @@ namespace KRPC.Service
                 if (!structFieldSpecs.TryGetValue (type, out entry)) {
                     var typeFields = GetStructFields (type);
                     entry = new KeyValuePair<IList<PropertyInfo>, IList<TypeSpec>> (
-                        typeFields, typeFields.Select (GetStructFieldSpec).ToList ());
+                        typeFields,
+                        typeFields.Select (field => GetStructFieldSpec (type, field)).ToList ());
                     structFieldSpecs [type] = entry;
                 }
                 fields = entry.Key;
@@ -885,8 +902,18 @@ namespace KRPC.Service
         }
 
         /// <summary>
+        /// The paths the KRPCNullable attributes on the given member name, each a nullable
+        /// position inside its type.
+        /// </summary>
+        public static IEnumerable<IList<Position>> GetNullablePaths (ICustomAttributeProvider member)
+        {
+            return Reflection.GetAttributes<KRPCNullableAttribute> (member)
+                .Select (attribute => attribute.Path);
+        }
+
+        /// <summary>
         /// Serialize a type into a dictionary for use in a service definition, from the spec
-        /// that carries whether the position holding it can be null.
+        /// that carries the nullability of every position inside it.
         /// </summary>
         public static object SerializeType (TypeSpec spec)
         {
@@ -940,16 +967,16 @@ namespace KRPC.Service
                 result["name"] = type.Name;
             } else if (IsATupleCollectionType (type)) {
                 result["code"] = "TUPLE";
-                result["types"] = type.GetGenericArguments ().Select (t => SerializeType (TypeSpec.Create (t))).ToList ();
+                result["types"] = spec.Types.Select (SerializeType).ToList ();
             } else if (IsAListCollectionType (type)) {
                 result["code"] = "LIST";
-                result["types"] = type.GetGenericArguments ().Select (t => SerializeType (TypeSpec.Create (t))).ToList ();
+                result["types"] = spec.Types.Select (SerializeType).ToList ();
             } else if (IsASetCollectionType (type)) {
                 result["code"] = "SET";
-                result["types"] = type.GetGenericArguments ().Select (t => SerializeType (TypeSpec.Create (t))).ToList ();
+                result["types"] = spec.Types.Select (SerializeType).ToList ();
             } else if (IsADictionaryCollectionType (type)) {
                 result["code"] = "DICTIONARY";
-                result["types"] = type.GetGenericArguments ().Select (t => SerializeType (TypeSpec.Create (t))).ToList ();
+                result["types"] = spec.Types.Select (SerializeType).ToList ();
             } else if (IsAMessageType (type)) {
                 var name = type.ToString ();
                 var camelCase = name.Substring (name.LastIndexOf ('.') + 1);

--- a/core/src/Utils/Reflection.cs
+++ b/core/src/Utils/Reflection.cs
@@ -125,6 +125,15 @@ namespace KRPC.Utils
         }
 
         /// <summary>
+        /// Return every attribute of type T for the given member, in the order they are
+        /// declared. Does not follow inheritance.
+        /// </summary>
+        public static IEnumerable<T> GetAttributes<T> (ICustomAttributeProvider member)
+        {
+            return member.GetCustomAttributes (typeof(T), false).Cast<T> ();
+        }
+
+        /// <summary>
         /// Return true if member has the attribute of type T. Does not follow inheritance.
         /// </summary>
         public static bool HasAttribute<T> (ICustomAttributeProvider member)

--- a/core/test/KRPC.Core.Test.csproj
+++ b/core/test/KRPC.Core.Test.csproj
@@ -99,6 +99,7 @@
     <Compile Include="Service\TestServiceDeprecated.cs" />
     <Compile Include="Service\TestServiceExtensions.cs" />
     <Compile Include="Service\TestTopLevelClass.cs" />
+    <Compile Include="Service\TypeSpecTest.cs" />
     <Compile Include="Service\TypeUtilsTest.cs" />
     <Compile Include="Service\ValueUtilsTest.cs" />
     <Compile Include="TestingTools.cs" />

--- a/core/test/Server/ProtocolBuffers/EncoderTest.cs
+++ b/core/test/Server/ProtocolBuffers/EncoderTest.cs
@@ -107,10 +107,12 @@ namespace KRPC.Test.Server.ProtocolBuffers
         }
 
         [Test]
-        public void DecodeClassNone ()
+        public void DecodeClassIdZero ()
         {
-            var value = Encoder.Decode ("00".ToByteString (), TypeSpec.Create (typeof(TestService.TestClass)));
-            Assert.AreEqual (null, value);
+            // Identifiers are allocated from 1, so 0 names no object. A null is carried by
+            // the position holding the value, never by the value itself
+            Assert.Throws<ArgumentException> (
+                () => Encoder.Decode ("00".ToByteString (), TypeSpec.Create (typeof(TestService.TestClass))));
         }
 
         [TestCase (3.14159265359f, "db0f4940")]
@@ -542,6 +544,30 @@ namespace KRPC.Test.Server.ProtocolBuffers
         }
 
         [Test]
+        public void DecodeClassIdZeroInsideAValue ()
+        {
+            // A class value of id 0 is rejected at every position, so a null reaches a
+            // service only where the position holding it declares one
+            AssertIdZeroRejected (
+                Encode (new List<ulong> { 0 }), typeof(IList<TestService.TestClass>));
+            AssertIdZeroRejected (
+                Encode (new HashSet<ulong> { 0 }), typeof(HashSet<TestService.TestClass>));
+            AssertIdZeroRejected (
+                Encode (new Dictionary<string,ulong> { { "a", 0 } }),
+                typeof(IDictionary<string,TestService.TestClass>));
+            AssertIdZeroRejected (
+                Encode (Tuple.Create (42, (ulong)0)),
+                typeof(Tuple<int,TestService.TestClass>));
+        }
+
+        static void AssertIdZeroRejected (Google.Protobuf.ByteString data, Type type)
+        {
+            var exn = Assert.Throws<ArgumentException> (
+                () => Encoder.Decode (data, TypeSpec.Create (type)));
+            StringAssert.Contains ("0 is not an object identifier", exn.Message);
+        }
+
+        [Test]
         public void DecodeStructWithMissingFields ()
         {
             var data = Encode (Tuple.Create (42, "jeb")).ToHexString ();
@@ -550,13 +576,13 @@ namespace KRPC.Test.Server.ProtocolBuffers
         }
 
         [Test]
-        public void DecodeStructWithNullField ()
+        public void DecodeStructWithAnObjectFieldOfIdZero ()
         {
-            // The object id 0 decodes to a null object, which a structure field can never be
             var data = Encode (Tuple.Create (
                 42, "jeb", TestService.TestEnum.Z, (ulong)0, new List<string> ())).ToHexString ();
-            Assert.Throws<ArgumentException> (
+            var exn = Assert.Throws<ArgumentException> (
                 () => Encoder.Decode (data.ToByteString (), TypeSpec.Create (typeof(TestService.TestStruct))));
+            StringAssert.Contains ("0 is not an object identifier", exn.Message);
         }
 
         [Test]

--- a/core/test/Server/ProtocolBuffers/EncoderTest.cs
+++ b/core/test/Server/ProtocolBuffers/EncoderTest.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using KRPC.Server.ProtocolBuffers;
 using KRPC.Service;
+using KRPC.Service.Attributes;
 using KRPC.Service.Messages;
 using KRPC.Test.Service;
 using NUnit.Framework;
@@ -11,11 +12,20 @@ namespace KRPC.Test.Server.ProtocolBuffers
     [TestFixture]
     public class EncoderTest
     {
+        /// <summary>
+        /// Encode a value as the type it is. A test with no declaration to take a spec from
+        /// builds one from the value itself.
+        /// </summary>
+        static Google.Protobuf.ByteString Encode (object value)
+        {
+            return Encoder.Encode (value, TypeSpec.Create (value.GetType ()));
+        }
+
         [Test]
         public void EncodeMessage ()
         {
             var message = new KRPC.Service.Messages.Stream (42);
-            var data = Encoder.Encode (message);
+            var data = Encode (message);
             const string expected = "082a";
             Assert.AreEqual (expected, data.ToHexString ());
         }
@@ -23,21 +33,21 @@ namespace KRPC.Test.Server.ProtocolBuffers
         [Test]
         public void EncodeValue ()
         {
-            var data = Encoder.Encode (300u);
+            var data = Encode (300u);
             Assert.AreEqual ("ac02", data.ToHexString ());
         }
 
         [Test]
         public void EncodeUnicodeString ()
         {
-            var data = Encoder.Encode ("\u2122");
+            var data = Encode ("\u2122");
             Assert.AreEqual ("03e284a2", data.ToHexString ());
         }
 
         [Test]
         public void EncodeEnum ()
         {
-            var data = Encoder.Encode (TestService.TestEnum.Z);
+            var data = Encode (TestService.TestEnum.Z);
             Assert.AreEqual ("04", data.ToHexString ());
         }
 
@@ -45,7 +55,7 @@ namespace KRPC.Test.Server.ProtocolBuffers
         public void EncodeClass ()
         {
             var obj = new TestService.TestClass ("foo");
-            var data = Encoder.Encode (obj);
+            var data = Encode (obj);
             var expected = new [] { (byte)ObjectStore.Instance.AddInstance (obj) }.ToHexString ();
             Assert.AreEqual (expected, data.ToHexString ());
         }
@@ -53,14 +63,15 @@ namespace KRPC.Test.Server.ProtocolBuffers
         [Test]
         public void EncodeNull ()
         {
-            Assert.Throws<ArgumentNullException> (() => Encoder.Encode (null));
+            Assert.Throws<ArgumentNullException> (
+                () => Encoder.Encode (null, TypeSpec.Create (typeof(string))));
         }
 
         [Test]
         public void DecodeMessage ()
         {
             var message = "0a0b5465737453657276696365121750726f6365647572654e6f417267734e6f52657475726e".ToByteString ();
-            var call = (ProcedureCall)Encoder.Decode (message, typeof(ProcedureCall));
+            var call = (ProcedureCall)Encoder.Decode (message, TypeSpec.Create (typeof(ProcedureCall)));
             Assert.AreEqual ("TestService", call.Service);
             Assert.AreEqual ("ProcedureNoArgsNoReturn", call.Procedure);
         }
@@ -68,21 +79,21 @@ namespace KRPC.Test.Server.ProtocolBuffers
         [Test]
         public void DecodeValue ()
         {
-            var value = (uint)Encoder.Decode ("ac02".ToByteString (), typeof(uint));
+            var value = (uint)Encoder.Decode ("ac02".ToByteString (), TypeSpec.Create (typeof(uint)));
             Assert.AreEqual (300, value);
         }
 
         [Test]
         public void DecodeUnicodeString ()
         {
-            var value = (string)Encoder.Decode ("03e284a2".ToByteString (), typeof(string));
+            var value = (string)Encoder.Decode ("03e284a2".ToByteString (), TypeSpec.Create (typeof(string)));
             Assert.AreEqual ("\u2122", value);
         }
 
         [Test]
         public void DecodeEnum ()
         {
-            var value = Encoder.Decode ("04".ToByteString (), typeof(TestService.TestEnum));
+            var value = Encoder.Decode ("04".ToByteString (), TypeSpec.Create (typeof(TestService.TestEnum)));
             Assert.AreEqual (TestService.TestEnum.Z, value);
         }
 
@@ -91,14 +102,14 @@ namespace KRPC.Test.Server.ProtocolBuffers
         {
             var obj = new TestService.TestClass ("foo");
             var id = ObjectStore.Instance.AddInstance (obj);
-            var value = Encoder.Decode (new [] { (byte)id }.ToHexString ().ToByteString (), typeof(TestService.TestClass));
+            var value = Encoder.Decode (new [] { (byte)id }.ToHexString ().ToByteString (), TypeSpec.Create (typeof(TestService.TestClass)));
             Assert.AreEqual (obj, value);
         }
 
         [Test]
         public void DecodeClassNone ()
         {
-            var value = Encoder.Decode ("00".ToByteString (), typeof(TestService.TestClass));
+            var value = Encoder.Decode ("00".ToByteString (), TypeSpec.Create (typeof(TestService.TestClass)));
             Assert.AreEqual (null, value);
         }
 
@@ -110,9 +121,9 @@ namespace KRPC.Test.Server.ProtocolBuffers
         [TestCase (float.NaN, "0000c0ff")]
         public void FloatValue (float value, string data)
         {
-            var encodeResult = Encoder.Encode (value);
+            var encodeResult = Encode (value);
             Assert.AreEqual (data, encodeResult.ToHexString ());
-            var decodeResult = (float)Encoder.Decode (data.ToByteString (), typeof(float));
+            var decodeResult = (float)Encoder.Decode (data.ToByteString (), TypeSpec.Create (typeof(float)));
             Assert.AreEqual (value, decodeResult);
         }
 
@@ -124,9 +135,9 @@ namespace KRPC.Test.Server.ProtocolBuffers
         [TestCase (double.NaN, "000000000000f8ff")]
         public void DoubleValue (double value, string data)
         {
-            var encodeResult = Encoder.Encode (value);
+            var encodeResult = Encode (value);
             Assert.AreEqual (data, encodeResult.ToHexString ());
-            var decodeResult = (double)Encoder.Decode (data.ToByteString (), typeof(double));
+            var decodeResult = (double)Encoder.Decode (data.ToByteString (), TypeSpec.Create (typeof(double)));
             Assert.AreEqual (value, decodeResult);
         }
 
@@ -139,9 +150,9 @@ namespace KRPC.Test.Server.ProtocolBuffers
         [TestCase (-2147483648, "ffffffff0f")]
         public void Int32Value (int value, string data)
         {
-            var encodeResult = Encoder.Encode (value);
+            var encodeResult = Encode (value);
             Assert.AreEqual (data, encodeResult.ToHexString ());
-            var decodeResult = (int)Encoder.Decode (data.ToByteString (), typeof(int));
+            var decodeResult = (int)Encoder.Decode (data.ToByteString (), TypeSpec.Create (typeof(int)));
             Assert.AreEqual (value, decodeResult);
         }
 
@@ -153,9 +164,9 @@ namespace KRPC.Test.Server.ProtocolBuffers
         [TestCase (-33, "41")]
         public void Int64Value (long value, string data)
         {
-            var encodeResult = Encoder.Encode (value);
+            var encodeResult = Encode (value);
             Assert.AreEqual (data, encodeResult.ToHexString ());
-            var decodeResult = (long)Encoder.Decode (data.ToByteString (), typeof(long));
+            var decodeResult = (long)Encoder.Decode (data.ToByteString (), TypeSpec.Create (typeof(long)));
             Assert.AreEqual (value, decodeResult);
         }
 
@@ -166,9 +177,9 @@ namespace KRPC.Test.Server.ProtocolBuffers
         [TestCase (uint.MaxValue, "ffffffff0f")]
         public void UInt32Value (uint value, string data)
         {
-            var encodeResult = Encoder.Encode (value);
+            var encodeResult = Encode (value);
             Assert.AreEqual (data, encodeResult.ToHexString ());
-            var decodeResult = (uint)Encoder.Decode (data.ToByteString (), typeof(uint));
+            var decodeResult = (uint)Encoder.Decode (data.ToByteString (), TypeSpec.Create (typeof(uint)));
             Assert.AreEqual (value, decodeResult);
         }
 
@@ -180,9 +191,9 @@ namespace KRPC.Test.Server.ProtocolBuffers
         [TestCase (ulong.MaxValue, "ffffffffffffffffff01")]
         public void UInt64Value (ulong value, string data)
         {
-            var encodeResult = Encoder.Encode (value);
+            var encodeResult = Encode (value);
             Assert.AreEqual (data, encodeResult.ToHexString ());
-            var decodeResult = (ulong)Encoder.Decode (data.ToByteString (), typeof(ulong));
+            var decodeResult = (ulong)Encoder.Decode (data.ToByteString (), TypeSpec.Create (typeof(ulong)));
             Assert.AreEqual (value, decodeResult);
         }
 
@@ -190,9 +201,9 @@ namespace KRPC.Test.Server.ProtocolBuffers
         [TestCase (false, "00")]
         public void BooleanValue (bool value, string data)
         {
-            var encodeResult = Encoder.Encode (value);
+            var encodeResult = Encode (value);
             Assert.AreEqual (data, encodeResult.ToHexString ());
-            var decodeResult = (bool)Encoder.Decode (data.ToByteString (), typeof(bool));
+            var decodeResult = (bool)Encoder.Decode (data.ToByteString (), TypeSpec.Create (typeof(bool)));
             Assert.AreEqual (value, decodeResult);
         }
 
@@ -203,9 +214,9 @@ namespace KRPC.Test.Server.ProtocolBuffers
         [TestCase ("Mystery Goo\u2122 Containment Unit", "1f4d79737465727920476f6fe284a220436f6e7461696e6d656e7420556e6974")]
         public void StringValue (string value, string data)
         {
-            var encodeResult = Encoder.Encode (value);
+            var encodeResult = Encode (value);
             Assert.AreEqual (data, encodeResult.ToHexString ());
-            var decodeResult = (string)Encoder.Decode (data.ToByteString (), typeof(string));
+            var decodeResult = (string)Encoder.Decode (data.ToByteString (), TypeSpec.Create (typeof(string)));
             Assert.AreEqual (value, decodeResult);
         }
 
@@ -214,9 +225,9 @@ namespace KRPC.Test.Server.ProtocolBuffers
         [TestCase ("deadbeef", "04deadbeef")]
         public void BytesValue (string value, string data)
         {
-            var encodeResult = Encoder.Encode (value.ToByteString ().ToByteArray ());
+            var encodeResult = Encode (value.ToByteString ().ToByteArray ());
             Assert.AreEqual (data, encodeResult.ToHexString ());
-            var decodeResult = (byte[])Encoder.Decode (data.ToByteString (), typeof(byte[]));
+            var decodeResult = (byte[])Encoder.Decode (data.ToByteString (), TypeSpec.Create (typeof(byte[])));
             Assert.AreEqual (value.ToByteString (), decodeResult);
         }
 
@@ -226,9 +237,9 @@ namespace KRPC.Test.Server.ProtocolBuffers
         public void ListCollection (IList<uint> values, string data)
         {
             IList<uint> value = new List<uint> (values);
-            var encodeResult = Encoder.Encode (value);
+            var encodeResult = Encode (value);
             Assert.AreEqual (data, encodeResult.ToHexString ());
-            var decodeResult = (IList<uint>)Encoder.Decode (data.ToByteString (), typeof(IList<uint>));
+            var decodeResult = (IList<uint>)Encoder.Decode (data.ToByteString (), TypeSpec.Create (typeof(IList<uint>)));
             CollectionAssert.AreEqual (value, decodeResult);
         }
 
@@ -240,9 +251,9 @@ namespace KRPC.Test.Server.ProtocolBuffers
             IDictionary<string,uint> value = new Dictionary<string,uint> ();
             for (int i = 0; i < keys.Count; i++)
                 value [keys [i]] = values [i];
-            var encodeResult = Encoder.Encode (value);
+            var encodeResult = Encode (value);
             Assert.AreEqual (data, encodeResult.ToHexString ());
-            var decodeResult = (IDictionary<string,uint>)Encoder.Decode (data.ToByteString (), typeof(IDictionary<string,uint>));
+            var decodeResult = (IDictionary<string,uint>)Encoder.Decode (data.ToByteString (), TypeSpec.Create (typeof(IDictionary<string,uint>)));
             CollectionAssert.AreEqual (value, decodeResult);
         }
 
@@ -252,9 +263,9 @@ namespace KRPC.Test.Server.ProtocolBuffers
         public void SetCollection (IList<uint> values, string data)
         {
             ISet<uint> value = new HashSet<uint> (values);
-            var encodeResult = Encoder.Encode (value);
+            var encodeResult = Encode (value);
             Assert.AreEqual (data, encodeResult.ToHexString ());
-            var decodeResult = (ISet<uint>)Encoder.Decode (data.ToByteString (), typeof(HashSet<uint>));
+            var decodeResult = (ISet<uint>)Encoder.Decode (data.ToByteString (), TypeSpec.Create (typeof(HashSet<uint>)));
             CollectionAssert.AreEqual (value, decodeResult);
         }
 
@@ -263,9 +274,9 @@ namespace KRPC.Test.Server.ProtocolBuffers
         {
             var value = new Tuple<uint> (1);
             const string data = "0a0101";
-            var encodeResult = Encoder.Encode (value);
+            var encodeResult = Encode (value);
             Assert.AreEqual (data, encodeResult.ToHexString ());
-            var decodeResult = (Tuple<uint>)Encoder.Decode (data.ToByteString (), value.GetType ());
+            var decodeResult = (Tuple<uint>)Encoder.Decode (data.ToByteString (), TypeSpec.Create (value.GetType ()));
             Assert.AreEqual (value.Item1, decodeResult.Item1);
         }
 
@@ -274,9 +285,9 @@ namespace KRPC.Test.Server.ProtocolBuffers
         {
             var value = new Tuple<uint,string,bool> (1, "jeb", false);
             const string data = "0a01010a04036a65620a0100";
-            var encodeResult = Encoder.Encode (value);
+            var encodeResult = Encode (value);
             Assert.AreEqual (data, encodeResult.ToHexString ());
-            var decodeResult = (Tuple<uint,string,bool>)Encoder.Decode (data.ToByteString (), value.GetType ());
+            var decodeResult = (Tuple<uint,string,bool>)Encoder.Decode (data.ToByteString (), TypeSpec.Create (value.GetType ()));
             Assert.AreEqual (value.Item1, decodeResult.Item1);
             Assert.AreEqual (value.Item2, decodeResult.Item2);
             Assert.AreEqual (value.Item3, decodeResult.Item3);
@@ -293,9 +304,9 @@ namespace KRPC.Test.Server.ProtocolBuffers
                 ObjectField = obj,
                 ListField = new List<string> { "a", "b" }
             };
-            var data = Encoder.Encode (value).ToHexString ();
+            var data = Encode (value).ToHexString ();
             var decodeResult = (TestService.TestStruct)Encoder.Decode (
-                data.ToByteString (), typeof(TestService.TestStruct));
+                data.ToByteString (), TypeSpec.Create (typeof(TestService.TestStruct)));
             Assert.AreEqual (value.IntField, decodeResult.IntField);
             Assert.AreEqual (value.StringField, decodeResult.StringField);
             Assert.AreEqual (value.EnumField, decodeResult.EnumField);
@@ -316,8 +327,8 @@ namespace KRPC.Test.Server.ProtocolBuffers
                 },
                 IntField = 2
             };
-            var expected = Encoder.Encode (Tuple.Create (value.StructField, value.IntField)).ToHexString ();
-            Assert.AreEqual (expected, Encoder.Encode (value).ToHexString ());
+            var expected = Encode (Tuple.Create (value.StructField, value.IntField)).ToHexString ();
+            Assert.AreEqual (expected, Encode (value).ToHexString ());
         }
 
         [Test]
@@ -333,12 +344,104 @@ namespace KRPC.Test.Server.ProtocolBuffers
                 },
                 IntField = 2
             };
-            var data = Encoder.Encode (value).ToHexString ();
+            var data = Encode (value).ToHexString ();
             var decodeResult = (TestService.TestNestedStruct)Encoder.Decode (
-                data.ToByteString (), typeof(TestService.TestNestedStruct));
+                data.ToByteString (), TypeSpec.Create (typeof(TestService.TestNestedStruct)));
             Assert.AreEqual (1, decodeResult.StructField.IntField);
             Assert.AreEqual ("jeb", decodeResult.StructField.StringField);
             Assert.AreEqual (2, decodeResult.IntField);
+        }
+
+        [Test]
+        public void ListWithNullableElements ()
+        {
+            var spec = TypeSpec.Create (typeof(IList<int?>), false, null, "test");
+            var value = new List<int?> { 1, null, 3 };
+            var data = Encoder.Encode (value, spec).ToHexString ();
+            var decodeResult = (IList<int?>)Encoder.Decode (data.ToByteString (), spec);
+            CollectionAssert.AreEqual (value, decodeResult);
+        }
+
+        [Test]
+        public void NullableElementIsAPresenceBoolFollowedByTheValue ()
+        {
+            var spec = TypeSpec.Create (typeof(IList<int?>), false, null, "test");
+            var data = Encoder.Encode (new List<int?> { 1, null }, spec).ToHexString ();
+            var items = Schema.KRPC.List.Parser.ParseFrom (data.ToByteString ()).Items;
+            Assert.AreEqual (
+                Encode (true).ToHexString () + Encode (1).ToHexString (),
+                items [0].ToHexString ());
+            Assert.AreEqual (Encode (false).ToHexString (), items [1].ToHexString ());
+        }
+
+        [Test]
+        public void ListWithElementsThatAreNotNullable ()
+        {
+            // A collection whose elements are not nullable carries no presence bool, so the
+            // interface it is declared with encodes as the type it is
+            var spec = TypeSpec.Create (typeof(IList<int>));
+            var value = new List<int> { 1, 2, 3 };
+            Assert.AreEqual (
+                Encode (value).ToHexString (), Encoder.Encode (value, spec).ToHexString ());
+        }
+
+        [Test]
+        public void NullableElementsAreFoundInTheTypeAlone ()
+        {
+            // A List<int?> holds a nullable element whatever the spec was built from, so one
+            // built from the type alone writes the presence bool
+            var spec = TypeSpec.Create (typeof(IList<int?>), false, null, "test");
+            var value = new List<int?> { 1, null };
+            Assert.AreEqual (
+                Encoder.Encode (value, spec).ToHexString (), Encode (value).ToHexString ());
+        }
+
+        [Test]
+        public void DictionaryWithNullableValues ()
+        {
+            var spec = TypeSpec.Create (
+                typeof(IDictionary<string,TestService.TestClass>), false,
+                new [] { new [] { Position.Value } }, "test");
+            var obj = new TestService.TestClass ("foo");
+            var value = new Dictionary<string,TestService.TestClass> {
+                { "a", obj }, { "b", null }
+            };
+            var data = Encoder.Encode (value, spec).ToHexString ();
+            var decodeResult =
+                (IDictionary<string,TestService.TestClass>)Encoder.Decode (data.ToByteString (), spec);
+            Assert.AreSame (obj, decodeResult ["a"]);
+            Assert.IsNull (decodeResult ["b"]);
+        }
+
+        [Test]
+        public void TupleWithANullableItem ()
+        {
+            var spec = TypeSpec.Create (
+                typeof(Tuple<int,TestService.TestClass>), false,
+                new [] { new [] { Position.Item2 } }, "test");
+            var data = Encoder.Encode (
+                Tuple.Create (42, (TestService.TestClass)null), spec).ToHexString ();
+            var decodeResult =
+                (Tuple<int,TestService.TestClass>)Encoder.Decode (data.ToByteString (), spec);
+            Assert.AreEqual (42, decodeResult.Item1);
+            Assert.IsNull (decodeResult.Item2);
+        }
+
+        [Test]
+        public void NestedListWithNullableElements ()
+        {
+            var spec = TypeSpec.Create (
+                typeof(IList<IList<TestService.TestClass>>), false,
+                new [] { new [] { Position.Element, Position.Element } }, "test");
+            var obj = new TestService.TestClass ("foo");
+            var value = new List<IList<TestService.TestClass>> {
+                new List<TestService.TestClass> { obj, null }
+            };
+            var data = Encoder.Encode (value, spec).ToHexString ();
+            var decodeResult =
+                (IList<IList<TestService.TestClass>>)Encoder.Decode (data.ToByteString (), spec);
+            Assert.AreSame (obj, decodeResult [0] [0]);
+            Assert.IsNull (decodeResult [0] [1]);
         }
 
         [Test]
@@ -352,9 +455,9 @@ namespace KRPC.Test.Server.ProtocolBuffers
                 NullableStringField = "jeb",
                 NullableObjectField = obj
             };
-            var data = Encoder.Encode (value).ToHexString ();
+            var data = Encode (value).ToHexString ();
             var decodeResult = (TestService.TestNullableStruct)Encoder.Decode (
-                data.ToByteString (), typeof(TestService.TestNullableStruct));
+                data.ToByteString (), TypeSpec.Create (typeof(TestService.TestNullableStruct)));
             Assert.AreEqual (42, decodeResult.IntField);
             Assert.AreEqual (3, decodeResult.NullableIntField);
             Assert.AreEqual (TestService.TestEnum.Y, decodeResult.NullableEnumField);
@@ -366,9 +469,9 @@ namespace KRPC.Test.Server.ProtocolBuffers
         public void StructWithNullFields ()
         {
             var value = new TestService.TestNullableStruct { IntField = 42 };
-            var data = Encoder.Encode (value).ToHexString ();
+            var data = Encode (value).ToHexString ();
             var decodeResult = (TestService.TestNullableStruct)Encoder.Decode (
-                data.ToByteString (), typeof(TestService.TestNullableStruct));
+                data.ToByteString (), TypeSpec.Create (typeof(TestService.TestNullableStruct)));
             Assert.AreEqual (42, decodeResult.IntField);
             Assert.IsNull (decodeResult.NullableIntField);
             Assert.IsNull (decodeResult.NullableEnumField);
@@ -380,13 +483,13 @@ namespace KRPC.Test.Server.ProtocolBuffers
         public void NullableFieldIsAPresenceBoolFollowedByTheValue ()
         {
             var value = new TestService.TestNullableStruct { IntField = 42, NullableIntField = 3 };
-            var data = Encoder.Encode (value).ToHexString ();
+            var data = Encode (value).ToHexString ();
             var items = Schema.KRPC.Tuple.Parser.ParseFrom (data.ToByteString ()).Items;
-            Assert.AreEqual (Encoder.Encode (42).ToHexString (), items [0].ToHexString ());
+            Assert.AreEqual (Encode (42).ToHexString (), items [0].ToHexString ());
             Assert.AreEqual (
-                Encoder.Encode (true).ToHexString () + Encoder.Encode (3).ToHexString (),
+                Encode (true).ToHexString () + Encode (3).ToHexString (),
                 items [1].ToHexString ());
-            Assert.AreEqual (Encoder.Encode (false).ToHexString (), items [2].ToHexString ());
+            Assert.AreEqual (Encode (false).ToHexString (), items [2].ToHexString ());
         }
 
         [Test]
@@ -399,25 +502,61 @@ namespace KRPC.Test.Server.ProtocolBuffers
                 ObjectField = new TestService.TestClass ("foo"),
                 ListField = new List<string> ()
             };
-            Assert.Throws<ServiceException> (() => Encoder.Encode (value));
+            Assert.Throws<ServiceException> (() => Encode (value));
+        }
+
+        [Test]
+        public void EncodeNullListElementThatIsNotNullable ()
+        {
+            var spec = TypeSpec.Create (typeof(IList<string>));
+            var value = new List<string> { "jeb", null };
+            var exn = Assert.Throws<ServiceException> (() => Encoder.Encode (value, spec));
+            StringAssert.Contains ("An element", exn.Message);
+            StringAssert.Contains ("the element is not nullable", exn.Message);
+        }
+
+        [Test]
+        public void EncodeNullSetElement ()
+        {
+            var value = new HashSet<string> { "jeb", null };
+            var exn = Assert.Throws<ServiceException> (() => Encode (value));
+            StringAssert.Contains ("a set element cannot be null", exn.Message);
+        }
+
+        [Test]
+        public void EncodeNullDictionaryValueThatIsNotNullable ()
+        {
+            var value = new Dictionary<string,string> { { "a", null } };
+            var exn = Assert.Throws<ServiceException> (() => Encode (value));
+            StringAssert.Contains ("A value", exn.Message);
+            StringAssert.Contains ("the value is not nullable", exn.Message);
+        }
+
+        [Test]
+        public void EncodeNullTupleItemThatIsNotNullable ()
+        {
+            var value = Tuple.Create (42, (string)null);
+            var exn = Assert.Throws<ServiceException> (() => Encode (value));
+            StringAssert.Contains ("Item 2", exn.Message);
+            StringAssert.Contains ("the item is not nullable", exn.Message);
         }
 
         [Test]
         public void DecodeStructWithMissingFields ()
         {
-            var data = Encoder.Encode (Tuple.Create (42, "jeb")).ToHexString ();
+            var data = Encode (Tuple.Create (42, "jeb")).ToHexString ();
             Assert.Throws<ArgumentException> (
-                () => Encoder.Decode (data.ToByteString (), typeof(TestService.TestStruct)));
+                () => Encoder.Decode (data.ToByteString (), TypeSpec.Create (typeof(TestService.TestStruct))));
         }
 
         [Test]
         public void DecodeStructWithNullField ()
         {
             // The object id 0 decodes to a null object, which a structure field can never be
-            var data = Encoder.Encode (Tuple.Create (
+            var data = Encode (Tuple.Create (
                 42, "jeb", TestService.TestEnum.Z, (ulong)0, new List<string> ())).ToHexString ();
             Assert.Throws<ArgumentException> (
-                () => Encoder.Decode (data.ToByteString (), typeof(TestService.TestStruct)));
+                () => Encoder.Decode (data.ToByteString (), TypeSpec.Create (typeof(TestService.TestStruct))));
         }
 
         [Test]
@@ -435,9 +574,9 @@ namespace KRPC.Test.Server.ProtocolBuffers
             var extended = Tuple.Create (
                 value.IntField, value.StringField, value.EnumField, value.ObjectField,
                 value.ListField, "an appended field");
-            var data = Encoder.Encode (extended).ToHexString ();
+            var data = Encode (extended).ToHexString ();
             var decodeResult = (TestService.TestStruct)Encoder.Decode (
-                data.ToByteString (), typeof(TestService.TestStruct));
+                data.ToByteString (), TypeSpec.Create (typeof(TestService.TestStruct)));
             Assert.AreEqual (value.IntField, decodeResult.IntField);
             Assert.AreEqual (value.StringField, decodeResult.StringField);
             Assert.AreEqual (value.EnumField, decodeResult.EnumField);

--- a/core/test/Server/ProtocolBuffers/EncoderTest.cs
+++ b/core/test/Server/ProtocolBuffers/EncoderTest.cs
@@ -342,6 +342,54 @@ namespace KRPC.Test.Server.ProtocolBuffers
         }
 
         [Test]
+        public void StructWithNullableFields ()
+        {
+            var obj = new TestService.TestClass ("foo");
+            var value = new TestService.TestNullableStruct {
+                IntField = 42,
+                NullableIntField = 3,
+                NullableEnumField = TestService.TestEnum.Y,
+                NullableStringField = "jeb",
+                NullableObjectField = obj
+            };
+            var data = Encoder.Encode (value).ToHexString ();
+            var decodeResult = (TestService.TestNullableStruct)Encoder.Decode (
+                data.ToByteString (), typeof(TestService.TestNullableStruct));
+            Assert.AreEqual (42, decodeResult.IntField);
+            Assert.AreEqual (3, decodeResult.NullableIntField);
+            Assert.AreEqual (TestService.TestEnum.Y, decodeResult.NullableEnumField);
+            Assert.AreEqual ("jeb", decodeResult.NullableStringField);
+            Assert.AreSame (obj, decodeResult.NullableObjectField);
+        }
+
+        [Test]
+        public void StructWithNullFields ()
+        {
+            var value = new TestService.TestNullableStruct { IntField = 42 };
+            var data = Encoder.Encode (value).ToHexString ();
+            var decodeResult = (TestService.TestNullableStruct)Encoder.Decode (
+                data.ToByteString (), typeof(TestService.TestNullableStruct));
+            Assert.AreEqual (42, decodeResult.IntField);
+            Assert.IsNull (decodeResult.NullableIntField);
+            Assert.IsNull (decodeResult.NullableEnumField);
+            Assert.IsNull (decodeResult.NullableStringField);
+            Assert.IsNull (decodeResult.NullableObjectField);
+        }
+
+        [Test]
+        public void NullableFieldIsAPresenceBoolFollowedByTheValue ()
+        {
+            var value = new TestService.TestNullableStruct { IntField = 42, NullableIntField = 3 };
+            var data = Encoder.Encode (value).ToHexString ();
+            var items = Schema.KRPC.Tuple.Parser.ParseFrom (data.ToByteString ()).Items;
+            Assert.AreEqual (Encoder.Encode (42).ToHexString (), items [0].ToHexString ());
+            Assert.AreEqual (
+                Encoder.Encode (true).ToHexString () + Encoder.Encode (3).ToHexString (),
+                items [1].ToHexString ());
+            Assert.AreEqual (Encoder.Encode (false).ToHexString (), items [2].ToHexString ());
+        }
+
+        [Test]
         public void EncodeStructWithNullField ()
         {
             var value = new TestService.TestStruct {

--- a/core/test/Server/ProtocolBuffers/MessageExtensionsTest.cs
+++ b/core/test/Server/ProtocolBuffers/MessageExtensionsTest.cs
@@ -42,6 +42,7 @@ namespace KRPC.Test.Server.ProtocolBuffers
         public void EncodeProcedureResultWithValue ()
         {
             var result = new ProcedureResult ();
+            result.Spec = TypeSpec.Create (typeof(int));
             result.Value = 42;
             var wire = result.ToProtobufMessage ();
             Assert.IsFalse (wire.IsNull);
@@ -81,7 +82,7 @@ namespace KRPC.Test.Server.ProtocolBuffers
         [Test]
         public void EncodeParameterWithNullDefault ()
         {
-            var parameter = new Parameter ("x", TypeSpec.Create (typeof(string), true));
+            var parameter = new Parameter ("x", TypeSpec.Create (typeof(string), true, null, "x"));
             parameter.DefaultValue = null;
             var wire = parameter.ToProtobufMessage ();
             Assert.IsTrue (wire.HasDefaultValue);
@@ -94,8 +95,8 @@ namespace KRPC.Test.Server.ProtocolBuffers
         {
             var argument = new Schema.KRPC.Argument ();
             argument.Position = 0;
-            argument.Value = Encoder.Encode ("foo");
-            var message = argument.ToMessage (typeof(string));
+            argument.Value = Encoder.Encode ("foo", TypeSpec.Create (typeof(string)));
+            var message = argument.ToMessage (TypeSpec.Create (typeof(string)));
             Assert.AreEqual ("foo", message.Value);
         }
 
@@ -105,7 +106,7 @@ namespace KRPC.Test.Server.ProtocolBuffers
             var argument = new Schema.KRPC.Argument ();
             argument.Position = 0;
             argument.IsNull = true;
-            var message = argument.ToMessage (typeof(string));
+            var message = argument.ToMessage (TypeSpec.Create (typeof(string)));
             Assert.IsNull (message.Value);
         }
     }

--- a/core/test/Server/ProtocolBuffers/MessageExtensionsTest.cs
+++ b/core/test/Server/ProtocolBuffers/MessageExtensionsTest.cs
@@ -61,7 +61,7 @@ namespace KRPC.Test.Server.ProtocolBuffers
         [Test]
         public void EncodeParameterWithNoDefault ()
         {
-            var wire = new Parameter ("x", typeof(int), false).ToProtobufMessage ();
+            var wire = new Parameter ("x", TypeSpec.Create (typeof(int))).ToProtobufMessage ();
             Assert.IsFalse (wire.HasDefaultValue);
             Assert.IsFalse (wire.DefaultValueIsNull);
             Assert.AreEqual (0, wire.DefaultValue.Length);
@@ -70,7 +70,7 @@ namespace KRPC.Test.Server.ProtocolBuffers
         [Test]
         public void EncodeParameterWithValueDefault ()
         {
-            var parameter = new Parameter ("x", typeof(int), false);
+            var parameter = new Parameter ("x", TypeSpec.Create (typeof(int)));
             parameter.DefaultValue = 42;
             var wire = parameter.ToProtobufMessage ();
             Assert.IsTrue (wire.HasDefaultValue);
@@ -81,7 +81,7 @@ namespace KRPC.Test.Server.ProtocolBuffers
         [Test]
         public void EncodeParameterWithNullDefault ()
         {
-            var parameter = new Parameter ("x", typeof(string), true);
+            var parameter = new Parameter ("x", TypeSpec.Create (typeof(string), true));
             parameter.DefaultValue = null;
             var wire = parameter.ToProtobufMessage ();
             Assert.IsTrue (wire.HasDefaultValue);

--- a/core/test/Service/ClassStaticMethodHandlerTest.cs
+++ b/core/test/Service/ClassStaticMethodHandlerTest.cs
@@ -21,7 +21,7 @@ namespace KRPC.Test.Service
         {
             var instance = new TestService.TestClass ("foo");
             var method = typeof(TestServiceExtensions).GetMethod ("ExtensionMethod");
-            var handler = new ClassStaticMethodHandler (method, false, true);
+            var handler = new ClassStaticMethodHandler (method, false, isExtension: true);
             // The instance is passed as argument 0, as it is the first argument of the static call
             Assert.IsFalse (handler.HasInstance);
             Assert.AreEqual ("foo42", handler.Invoke (null, new object [] { instance, 42 }));
@@ -31,7 +31,7 @@ namespace KRPC.Test.Service
         public void ExtensionMethodProperties ()
         {
             var method = typeof(TestServiceExtensions).GetMethod ("ExtensionMethod");
-            var handler = new ClassStaticMethodHandler (method, false, true);
+            var handler = new ClassStaticMethodHandler (method, false, isExtension: true);
             var parameters = handler.Parameters.ToList ();
             Assert.AreEqual (2, parameters.Count);
             Assert.AreEqual ("this", parameters [0].Name);

--- a/core/test/Service/ITestService.cs
+++ b/core/test/Service/ITestService.cs
@@ -25,6 +25,8 @@ namespace KRPC.Test.Service
 
         string NullableProperty { get; set; }
 
+        string NullableByAttributeProperty { get; set; }
+
         TestService.TestClass CreateTestObject (string value);
 
         void DeleteTestObject (TestService.TestClass obj);
@@ -40,6 +42,19 @@ namespace KRPC.Test.Service
         TestService.TestEnum? EchoNullableEnum (TestService.TestEnum? x);
 
         IList<string> EchoNullableList (IList<string> l);
+
+        IList<int?> EchoListOfNullableInts (IList<int?> l);
+
+        IList<TestService.TestClass> EchoListOfNullableObjects (IList<TestService.TestClass> l);
+
+        IDictionary<string,TestService.TestClass> EchoDictionaryOfNullableObjects (
+            IDictionary<string,TestService.TestClass> d);
+
+        Tuple<int,TestService.TestClass> EchoTupleWithANullableObject (
+            Tuple<int,TestService.TestClass> t);
+
+        IList<IList<TestService.TestClass>> EchoNestedListOfNullableObjects (
+            IList<IList<TestService.TestClass>> l);
 
         void ProcedureSingleOptionalArgNoReturn (string x);
 

--- a/core/test/Service/MessageAssert.cs
+++ b/core/test/Service/MessageAssert.cs
@@ -21,40 +21,40 @@ namespace KRPC.Test.Service
         {
             Assert.Less (position, procedure.Parameters.Count);
             var parameter = procedure.Parameters [position];
-            Assert.AreEqual (type, parameter.Type);
+            Assert.AreEqual (type, parameter.Type.Type);
             Assert.AreEqual (name, parameter.Name);
             Assert.IsFalse (parameter.HasDefaultValue);
             Assert.IsNull (parameter.DefaultValue);
-            Assert.IsFalse (parameter.Nullable);
+            Assert.IsFalse (parameter.Type.Nullable);
         }
 
         public static void HasNullableParameter (Procedure procedure, int position, Type type, string name)
         {
             Assert.Less (position, procedure.Parameters.Count);
             var parameter = procedure.Parameters [position];
-            Assert.AreEqual (type, parameter.Type);
+            Assert.AreEqual (type, parameter.Type.Type);
             Assert.AreEqual (name, parameter.Name);
             Assert.IsFalse (parameter.HasDefaultValue);
             Assert.IsNull (parameter.DefaultValue);
-            Assert.IsTrue (parameter.Nullable);
+            Assert.IsTrue (parameter.Type.Nullable);
         }
 
         public static void HasNullableParameterWithDefaultValue (Procedure procedure, int position, Type type, string name, object defaultValue)
         {
             Assert.Less (position, procedure.Parameters.Count);
             var parameter = procedure.Parameters [position];
-            Assert.AreEqual (type, parameter.Type);
+            Assert.AreEqual (type, parameter.Type.Type);
             Assert.AreEqual (name, parameter.Name);
             Assert.IsTrue (parameter.HasDefaultValue);
             Assert.AreEqual (defaultValue, parameter.DefaultValue);
-            Assert.IsTrue (parameter.Nullable);
+            Assert.IsTrue (parameter.Type.Nullable);
         }
 
         public static void HasParameterWithDefaultValue (Procedure procedure, int position, Type type, string name, object defaultValue)
         {
             Assert.Less (position, procedure.Parameters.Count);
             var parameter = procedure.Parameters [position];
-            Assert.AreEqual (type, parameter.Type);
+            Assert.AreEqual (type, parameter.Type.Type);
             Assert.AreEqual (name, parameter.Name);
             Assert.IsTrue (parameter.HasDefaultValue);
             Assert.AreEqual (defaultValue, parameter.DefaultValue);
@@ -69,8 +69,8 @@ namespace KRPC.Test.Service
         public static void HasReturnType (Procedure procedure, Type returnType, bool returnIsNullable = false)
         {
             Assert.IsTrue (procedure.HasReturnType);
-            Assert.AreEqual (returnType, procedure.ReturnType);
-            Assert.AreEqual (returnIsNullable, procedure.ReturnIsNullable);
+            Assert.AreEqual (returnType, procedure.ReturnType.Type);
+            Assert.AreEqual (returnIsNullable, procedure.ReturnType.Nullable);
         }
 
         public static void HasGameScene (Procedure procedure, GameScene gameScene)

--- a/core/test/Service/MessageAssert.cs
+++ b/core/test/Service/MessageAssert.cs
@@ -128,8 +128,18 @@ namespace KRPC.Test.Service
             Assert.Less (position, str.Fields.Count);
             var field = str.Fields [position];
             Assert.AreEqual (name, field.Name);
-            Assert.AreEqual (type, field.Type);
+            Assert.AreEqual (type, field.Type.Type);
             Assert.AreEqual (documentation, field.Documentation);
+            Assert.IsFalse (field.Type.Nullable);
+        }
+
+        public static void HasNullableField (Struct str, int position, string name, Type type)
+        {
+            Assert.Less (position, str.Fields.Count);
+            var field = str.Fields [position];
+            Assert.AreEqual (name, field.Name);
+            Assert.AreEqual (type, field.Type.Type);
+            Assert.IsTrue (field.Type.Nullable);
         }
 
         public static void IsNotDeprecated (Struct str)

--- a/core/test/Service/MessageAssert.cs
+++ b/core/test/Service/MessageAssert.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using KRPC.Service;
 using KRPC.Service.Messages;
 using NUnit.Framework;
@@ -71,6 +72,25 @@ namespace KRPC.Test.Service
             Assert.IsTrue (procedure.HasReturnType);
             Assert.AreEqual (returnType, procedure.ReturnType.Type);
             Assert.AreEqual (returnIsNullable, procedure.ReturnType.Nullable);
+        }
+
+        /// <summary>
+        /// Assert that the nullable positions inside the given type are exactly the ones
+        /// holding the given types, in the order the spec reaches them.
+        /// </summary>
+        public static void HasNullableTypes (TypeSpec spec, params Type[] types)
+        {
+            var nullable = new List<Type> ();
+            CollectNullableTypes (spec, nullable, false);
+            CollectionAssert.AreEqual (types, nullable);
+        }
+
+        static void CollectNullableTypes (TypeSpec spec, IList<Type> nullable, bool includeSelf)
+        {
+            if (includeSelf && spec.Nullable)
+                nullable.Add (spec.Type);
+            foreach (var inner in spec.Types)
+                CollectNullableTypes (inner, nullable, true);
         }
 
         public static void HasGameScene (Procedure procedure, GameScene gameScene)

--- a/core/test/Service/ObjectStoreTest.cs
+++ b/core/test/Service/ObjectStoreTest.cs
@@ -142,13 +142,14 @@ namespace KRPC.Test.Service
         }
 
         [Test]
-        public void NullValues ()
+        public void NullIsNotAnInstance ()
         {
+            // A null belongs to the position a value sits in, so no identifier stands for one
             var store = new ObjectStore ();
-            Assert.AreEqual (0, store.AddInstance (null));
+            Assert.Throws<ArgumentNullException> (() => store.AddInstance (null));
+            Assert.Throws<ArgumentNullException> (() => store.GetObjectId (null));
+            Assert.Throws<ArgumentException> (() => store.GetInstance (0));
             Assert.DoesNotThrow (() => store.RemoveInstance (null));
-            Assert.AreEqual (null, store.GetInstance (0));
-            Assert.AreEqual (0, store.GetObjectId (null));
         }
     }
 }

--- a/core/test/Service/ProcedureParameterTest.cs
+++ b/core/test/Service/ProcedureParameterTest.cs
@@ -18,6 +18,10 @@ namespace KRPC.Test.Service
         {
         }
 
+        public static void MethodWithNullableArg (int? x)
+        {
+        }
+
         [Test]
         public void BasicUsage ()
         {
@@ -35,6 +39,15 @@ namespace KRPC.Test.Service
             Assert.AreEqual ("x", parameter.Name);
             Assert.AreEqual (typeof(int), parameter.Type);
             Assert.IsFalse (parameter.HasDefaultValue);
+        }
+
+        [Test]
+        public void FromMethodNullableArgument ()
+        {
+            var method = typeof(ProcedureParameterTest).GetMethod ("MethodWithNullableArg");
+            var parameter = new ProcedureParameter (method.GetParameters () [0]);
+            // The type is the one the parameter is declared with, which the spec unwraps
+            Assert.AreEqual (typeof(int?), parameter.Type);
         }
 
         [Test]

--- a/core/test/Service/ScannerTest.cs
+++ b/core/test/Service/ScannerTest.cs
@@ -35,7 +35,7 @@ namespace KRPC.Test.Service
             Assert.AreEqual (75, service.Procedures.Count);
             Assert.AreEqual (3, service.Classes.Count);
             Assert.AreEqual (2, service.Enumerations.Count);
-            Assert.AreEqual (2, service.Structs.Count);
+            Assert.AreEqual (3, service.Structs.Count);
             Assert.AreEqual ("<doc>\n<summary>\nTest service documentation.\n</summary>\n</doc>", service.Documentation);
             MessageAssert.IsNotDeprecated (service);
         }
@@ -651,13 +651,23 @@ namespace KRPC.Test.Service
                     MessageAssert.HasField (str, 0, "StructField", typeof(TestService.TestStruct));
                     MessageAssert.HasField (str, 1, "IntField", typeof(int));
                     MessageAssert.IsNotDeprecated (str);
+                } else if (str.Name == "TestNullableStruct") {
+                    MessageAssert.HasDocumentation (str, "<doc>\n<summary>\nDocumentation string for TestNullableStruct.\n</summary>\n</doc>");
+                    MessageAssert.HasFields (str, 5);
+                    MessageAssert.HasField (str, 0, "IntField", typeof(int));
+                    // A Nullable<T> field is declared by its underlying type T
+                    MessageAssert.HasNullableField (str, 1, "NullableIntField", typeof(int));
+                    MessageAssert.HasNullableField (str, 2, "NullableEnumField", typeof(TestService.TestEnum));
+                    MessageAssert.HasNullableField (str, 3, "NullableStringField", typeof(string));
+                    MessageAssert.HasNullableField (str, 4, "NullableObjectField", typeof(TestService.TestClass));
+                    MessageAssert.IsNotDeprecated (str);
                 } else {
                     Assert.Fail ();
                 }
                 foundStructs++;
             }
-            Assert.AreEqual (2, foundStructs);
-            Assert.AreEqual (2, service.Structs.Count);
+            Assert.AreEqual (3, foundStructs);
+            Assert.AreEqual (3, service.Structs.Count);
         }
 
         [Test]

--- a/core/test/Service/ScannerTest.cs
+++ b/core/test/Service/ScannerTest.cs
@@ -472,7 +472,7 @@ namespace KRPC.Test.Service
                 } else if (proc.Name == "StructDefault") {
                     MessageAssert.HasParameters (proc, 1);
                     var parameter = proc.Parameters [0];
-                    Assert.AreEqual (typeof(TestService.TestStruct), parameter.Type);
+                    Assert.AreEqual (typeof(TestService.TestStruct), parameter.Type.Type);
                     Assert.AreEqual ("x", parameter.Name);
                     Assert.IsTrue (parameter.HasDefaultValue);
                     var defaultValue = (TestService.TestStruct)parameter.DefaultValue;

--- a/core/test/Service/ScannerTest.cs
+++ b/core/test/Service/ScannerTest.cs
@@ -32,7 +32,7 @@ namespace KRPC.Test.Service
         public void TestService ()
         {
             var service = services.ServicesList.First (x => x.Name == "TestService");
-            Assert.AreEqual (75, service.Procedures.Count);
+            Assert.AreEqual (82, service.Procedures.Count);
             Assert.AreEqual (3, service.Classes.Count);
             Assert.AreEqual (2, service.Enumerations.Count);
             Assert.AreEqual (3, service.Structs.Count);
@@ -189,6 +189,17 @@ namespace KRPC.Test.Service
                     MessageAssert.HasNoReturnType (proc);
                     MessageAssert.HasGameScene (proc, global::KRPC.Service.GameScene.Flight);
                     MessageAssert.HasNoDocumentation (proc);
+                } else if (proc.Name == "get_NullableByAttributeProperty") {
+                    MessageAssert.HasNoParameters (proc);
+                    MessageAssert.HasReturnType (proc, typeof(string), true);
+                    MessageAssert.HasGameScene (proc, global::KRPC.Service.GameScene.Flight);
+                    MessageAssert.HasNoDocumentation (proc);
+                } else if (proc.Name == "set_NullableByAttributeProperty") {
+                    MessageAssert.HasParameters (proc, 1);
+                    MessageAssert.HasNullableParameter (proc, 0, typeof(string), "value");
+                    MessageAssert.HasNoReturnType (proc);
+                    MessageAssert.HasGameScene (proc, global::KRPC.Service.GameScene.Flight);
+                    MessageAssert.HasNoDocumentation (proc);
                 } else if (proc.Name == "CreateTestObject") {
                     MessageAssert.HasParameters (proc, 1);
                     MessageAssert.HasParameter (proc, 0, typeof(string), "value");
@@ -224,6 +235,42 @@ namespace KRPC.Test.Service
                     MessageAssert.HasNullableParameter (proc, 0, typeof(TestService.TestEnum), "x");
                     MessageAssert.HasReturnType (proc, typeof(TestService.TestEnum), true);
                     MessageAssert.HasGameScene (proc, global::KRPC.Service.GameScene.Flight);
+                    MessageAssert.HasNoDocumentation (proc);
+                } else if (proc.Name == "EchoListOfNullableInts") {
+                    MessageAssert.HasParameters (proc, 1);
+                    // A Nullable<T> element is declared by its underlying type T
+                    MessageAssert.HasParameter (proc, 0, typeof(IList<int?>), "l");
+                    MessageAssert.HasNullableTypes (proc.Parameters [0].Type, typeof(int));
+                    MessageAssert.HasReturnType (proc, typeof(IList<int?>));
+                    MessageAssert.HasNullableTypes (proc.ReturnType, typeof(int));
+                    MessageAssert.HasNoDocumentation (proc);
+                } else if (proc.Name == "EchoListOfNullableObjects") {
+                    MessageAssert.HasParameters (proc, 1);
+                    MessageAssert.HasParameter (proc, 0, typeof(IList<TestService.TestClass>), "l");
+                    MessageAssert.HasNullableTypes (
+                        proc.Parameters [0].Type, typeof(TestService.TestClass));
+                    MessageAssert.HasReturnType (proc, typeof(IList<TestService.TestClass>));
+                    MessageAssert.HasNullableTypes (proc.ReturnType, typeof(TestService.TestClass));
+                    MessageAssert.HasNoDocumentation (proc);
+                } else if (proc.Name == "EchoDictionaryOfNullableObjects") {
+                    MessageAssert.HasParameters (proc, 1);
+                    // The key is not nullable, and the value is
+                    MessageAssert.HasNullableTypes (
+                        proc.Parameters [0].Type, typeof(TestService.TestClass));
+                    MessageAssert.HasNullableTypes (proc.ReturnType, typeof(TestService.TestClass));
+                    MessageAssert.HasNoDocumentation (proc);
+                } else if (proc.Name == "EchoTupleWithANullableObject") {
+                    MessageAssert.HasParameters (proc, 1);
+                    MessageAssert.HasNullableTypes (
+                        proc.Parameters [0].Type, typeof(TestService.TestClass));
+                    MessageAssert.HasNullableTypes (proc.ReturnType, typeof(TestService.TestClass));
+                    MessageAssert.HasNoDocumentation (proc);
+                } else if (proc.Name == "EchoNestedListOfNullableObjects") {
+                    MessageAssert.HasParameters (proc, 1);
+                    // The inner lists are not nullable, and the objects they hold are
+                    MessageAssert.HasNullableTypes (
+                        proc.Parameters [0].Type, typeof(TestService.TestClass));
+                    MessageAssert.HasNullableTypes (proc.ReturnType, typeof(TestService.TestClass));
                     MessageAssert.HasNoDocumentation (proc);
                 } else if (proc.Name == "EchoNullableList") {
                     MessageAssert.HasParameters (proc, 1);
@@ -573,8 +620,8 @@ namespace KRPC.Test.Service
                 }
                 foundProcedures++;
             }
-            Assert.AreEqual (75, foundProcedures);
-            Assert.AreEqual (75, service.Procedures.Count);
+            Assert.AreEqual (82, foundProcedures);
+            Assert.AreEqual (82, service.Procedures.Count);
         }
 
         [Test]

--- a/core/test/Service/ServicesTest.cs
+++ b/core/test/Service/ServicesTest.cs
@@ -304,6 +304,18 @@ namespace KRPC.Test.Service
         }
 
         [Test]
+        public void ExecuteCallWithNullArgumentToAPropertySetterMarkedNullable ()
+        {
+            var mock = new Mock<ITestService> (MockBehavior.Strict);
+            mock.SetupSet (x => x.NullableByAttributeProperty = null);
+            TestService.Service = mock.Object;
+            var result = Run (
+                Call ("TestService", "set_NullableByAttributeProperty", Arg (0, null)));
+            CheckResultEmpty (result);
+            mock.VerifySet (x => x.NullableByAttributeProperty = null, Times.Once ());
+        }
+
+        [Test]
         public void ExecuteCallWithNullableStringArgumentAndReturn ()
         {
             var mock = new Mock<ITestService> (MockBehavior.Strict);

--- a/core/test/Service/TestService.cs
+++ b/core/test/Service/TestService.cs
@@ -411,6 +411,28 @@ namespace KRPC.Test.Service
             public int IntField { get; set; }
         }
 
+        /// <summary>
+        /// Documentation string for TestNullableStruct.
+        /// </summary>
+        [KRPCStruct]
+        public struct TestNullableStruct
+        {
+            [KRPCProperty]
+            public int IntField { get; set; }
+
+            [KRPCProperty]
+            public int? NullableIntField { get; set; }
+
+            [KRPCProperty]
+            public TestEnum? NullableEnumField { get; set; }
+
+            [KRPCProperty (Nullable = true)]
+            public string NullableStringField { get; set; }
+
+            [KRPCProperty (Nullable = true)]
+            public TestClass NullableObjectField { get; set; }
+        }
+
         [KRPCProcedure]
         public static TestStruct EchoStruct (TestStruct x)
         {

--- a/core/test/Service/TestService.cs
+++ b/core/test/Service/TestService.cs
@@ -80,6 +80,13 @@ namespace KRPC.Test.Service
             set { Service.NullableProperty = value; }
         }
 
+        [KRPCProperty]
+        [KRPCNullable]
+        public static string NullableByAttributeProperty {
+            get { return Service.NullableByAttributeProperty; }
+            set { Service.NullableByAttributeProperty = value; }
+        }
+
         [KRPCProcedure]
         public static TestClass CreateTestObject (string value)
         {
@@ -126,6 +133,44 @@ namespace KRPC.Test.Service
         public static IList<string> EchoNullableList ([KRPCNullable] IList<string> l)
         {
             return Service.EchoNullableList (l);
+        }
+
+        [KRPCProcedure]
+        public static IList<int?> EchoListOfNullableInts (IList<int?> l)
+        {
+            return Service.EchoListOfNullableInts (l);
+        }
+
+        [KRPCProcedure]
+        [KRPCNullable (Position.Element)]
+        public static IList<TestClass> EchoListOfNullableObjects (
+            [KRPCNullable (Position.Element)] IList<TestClass> l)
+        {
+            return Service.EchoListOfNullableObjects (l);
+        }
+
+        [KRPCProcedure]
+        [KRPCNullable (Position.Value)]
+        public static IDictionary<string,TestClass> EchoDictionaryOfNullableObjects (
+            [KRPCNullable (Position.Value)] IDictionary<string,TestClass> d)
+        {
+            return Service.EchoDictionaryOfNullableObjects (d);
+        }
+
+        [KRPCProcedure]
+        [KRPCNullable (Position.Item2)]
+        public static Tuple<int,TestClass> EchoTupleWithANullableObject (
+            [KRPCNullable (Position.Item2)] Tuple<int,TestClass> t)
+        {
+            return Service.EchoTupleWithANullableObject (t);
+        }
+
+        [KRPCProcedure]
+        [KRPCNullable (Position.Element, Position.Element)]
+        public static IList<IList<TestClass>> EchoNestedListOfNullableObjects (
+            [KRPCNullable (Position.Element, Position.Element)] IList<IList<TestClass>> l)
+        {
+            return Service.EchoNestedListOfNullableObjects (l);
         }
 
         [KRPCClass (GameScene = GameScene.Flight | GameScene.SpaceCenter)]

--- a/core/test/Service/TypeSpecTest.cs
+++ b/core/test/Service/TypeSpecTest.cs
@@ -1,0 +1,163 @@
+using System;
+using System.Collections.Generic;
+using KRPC.Service;
+using KRPC.Service.Attributes;
+using NUnit.Framework;
+
+namespace KRPC.Test.Service
+{
+    [TestFixture]
+    public class TypeSpecTest
+    {
+        static TypeSpec Create (Type type, params Position[] path)
+        {
+            return TypeSpec.Create (type, false, new [] { path }, "test");
+        }
+
+        [Test]
+        public void NoNullablePosition ()
+        {
+            var spec = TypeSpec.Create (typeof(IList<int>));
+            Assert.AreEqual (typeof(IList<int>), spec.Type);
+            Assert.IsFalse (spec.Nullable);
+            Assert.AreEqual (1, spec.Types.Count);
+            Assert.AreEqual (typeof(int), spec.Types [0].Type);
+            Assert.IsFalse (spec.Types [0].Nullable);
+        }
+
+        [Test]
+        public void NullableValueItself ()
+        {
+            var spec = Create (typeof(IList<int>));
+            Assert.IsTrue (spec.Nullable);
+            Assert.IsFalse (spec.Types [0].Nullable);
+        }
+
+        [Test]
+        public void NullableValueTypeIsStructural ()
+        {
+            // A Nullable<T> is the type T at a position that allows a null
+            var spec = TypeSpec.Create (typeof(IList<int?>));
+            Assert.AreEqual (typeof(int), spec.Types [0].Type);
+            Assert.IsTrue (spec.Types [0].Nullable);
+        }
+
+        [Test]
+        public void NullableListElement ()
+        {
+            var spec = Create (typeof(IList<string>), Position.Element);
+            Assert.IsFalse (spec.Nullable);
+            Assert.IsTrue (spec.Types [0].Nullable);
+        }
+
+        [Test]
+        public void NullableDictionaryValue ()
+        {
+            var spec = Create (typeof(IDictionary<string,string>), Position.Value);
+            Assert.IsFalse (spec.Types [0].Nullable);
+            Assert.IsTrue (spec.Types [1].Nullable);
+        }
+
+        [Test]
+        public void NullableTupleItem ()
+        {
+            var spec = Create (typeof(Tuple<int,string>), Position.Item2);
+            Assert.IsFalse (spec.Types [0].Nullable);
+            Assert.IsTrue (spec.Types [1].Nullable);
+        }
+
+        [Test]
+        public void NullablePositionInsideANullablePosition ()
+        {
+            var spec = Create (typeof(IList<IList<string>>), Position.Element, Position.Element);
+            Assert.IsFalse (spec.Types [0].Nullable);
+            Assert.IsTrue (spec.Types [0].Types [0].Nullable);
+        }
+
+        [Test]
+        public void SeveralNullablePositions ()
+        {
+            var spec = TypeSpec.Create (
+                typeof(IDictionary<string,Tuple<string,string>>), false,
+                new [] {
+                    new [] { Position.Value },
+                    new [] { Position.Value, Position.Item1 }
+                }, "test");
+            Assert.IsTrue (spec.Types [1].Nullable);
+            Assert.IsTrue (spec.Types [1].Types [0].Nullable);
+            Assert.IsFalse (spec.Types [1].Types [1].Nullable);
+        }
+
+        // A path step that names no position of the type it is applied to
+
+        [TestCase (typeof(IList<string>), Position.Value)]
+        [TestCase (typeof(IDictionary<string,string>), Position.Element)]
+        [TestCase (typeof(Tuple<string,string>), Position.Item3)]
+        [TestCase (typeof(HashSet<string>), Position.Element)]
+        [TestCase (typeof(int), Position.Element)]
+        [TestCase (typeof(TestService.TestStruct), Position.Element)]
+        public void PositionThatTheTypeDoesNotHave (Type type, Position position)
+        {
+            Assert.Throws<ServiceException> (() => Create (type, position));
+        }
+
+        [Test]
+        public void PositionThatTheNestedTypeDoesNotHave ()
+        {
+            Assert.Throws<ServiceException> (
+                () => Create (typeof(IList<IList<string>>), Position.Element, Position.Value));
+        }
+
+        // A position marked nullable whose type holds no null of its own
+
+        [TestCase (typeof(IList<int>), Position.Element)]
+        [TestCase (typeof(IDictionary<string,int>), Position.Value)]
+        [TestCase (typeof(Tuple<string,TestService.TestEnum>), Position.Item2)]
+        [TestCase (typeof(IList<TestService.TestStruct>), Position.Element)]
+        public void PositionThatCannotHoldNull (Type type, Position position)
+        {
+            Assert.Throws<ServiceException> (() => Create (type, position));
+        }
+
+        [Test]
+        public void NestedPositionThatCannotHoldNull ()
+        {
+            Assert.Throws<ServiceException> (
+                () => Create (typeof(IList<IList<int>>), Position.Element, Position.Element));
+        }
+
+        [Test]
+        public void NullableValueTypePositionNamedByAPath ()
+        {
+            var spec = Create (typeof(IList<int?>), Position.Element);
+            Assert.IsTrue (spec.Types [0].Nullable);
+        }
+
+        [Test]
+        public void DeclaredTypeIsTheTypeAsDeclared ()
+        {
+            var spec = TypeSpec.Create (typeof(int?), false, null, "test");
+            Assert.AreEqual (typeof(int?), spec.DeclaredType);
+            Assert.AreEqual (typeof(int), spec.Type);
+            Assert.IsTrue (spec.Nullable);
+        }
+
+        [TestCase (typeof(int))]
+        [TestCase (typeof(TestService.TestEnum))]
+        [TestCase (typeof(TestService.TestStruct))]
+        public void ValueItselfThatCannotHoldNull (Type type)
+        {
+            Assert.Throws<ServiceException> (
+                () => TypeSpec.Create (type, true, null, "test"));
+        }
+
+        [TestCase (typeof(int?))]
+        [TestCase (typeof(string))]
+        [TestCase (typeof(TestService.TestClass))]
+        [TestCase (typeof(IList<int>))]
+        public void ValueItselfThatCanHoldNull (Type type)
+        {
+            Assert.IsTrue (TypeSpec.Create (type, true, null, "test").Nullable);
+        }
+    }
+}

--- a/core/test/Service/TypeUtilsTest.cs
+++ b/core/test/Service/TypeUtilsTest.cs
@@ -47,6 +47,12 @@ namespace KRPC.Test.Service
         [TestCase (typeof(TestService.TestStruct))]
         [TestCase (typeof(TestService.TestNestedStruct))]
         [TestCase (typeof(IList<TestService.TestStruct>))]
+        // A Nullable<T> is valid wherever T is, at a position that allows a null
+        [TestCase (typeof(int?))]
+        [TestCase (typeof(IList<int?>))]
+        [TestCase (typeof(IDictionary<string,int?>))]
+        [TestCase (typeof(Tuple<int?,string>))]
+        [TestCase (typeof(IList<TestService.TestEnum?>))]
         public void IsAValidType (Type type)
         {
             Assert.IsTrue (TypeUtils.IsAValidType (type));
@@ -60,6 +66,10 @@ namespace KRPC.Test.Service
         [TestCase (typeof(IEnumerable<string>))]
         [TestCase (typeof(StructWithoutFields))]
         [TestCase (typeof(IList<StructWithoutFields>))]
+        // A set element and a dictionary key are the two positions that cannot hold a null,
+        // so a Nullable<T> at either one is not a type a service can declare
+        [TestCase (typeof(HashSet<int?>))]
+        [TestCase (typeof(IDictionary<int?,string>))]
         public void IsNotAValidType (Type type)
         {
             Assert.IsFalse (TypeUtils.IsAValidType (type));
@@ -431,6 +441,18 @@ namespace KRPC.Test.Service
             public int Field { get; set; }
         }
 
+        public struct StructWithANullableFieldThatCannotBeNull
+        {
+            [KRPCProperty (Nullable = true)]
+            public int Field { get; set; }
+        }
+
+        public struct StructWithANullableEnumFieldThatCannotBeNull
+        {
+            [KRPCProperty (Nullable = true)]
+            public TestService.TestEnum Field { get; set; }
+        }
+
         [TestCase (typeof(StructWithoutFields))]
         [TestCase (typeof(StructWithAnInvalidFieldType))]
         [TestCase (typeof(StructWithAFieldWithoutASetter))]
@@ -438,6 +460,16 @@ namespace KRPC.Test.Service
         public void InvalidStructFields (Type type)
         {
             Assert.Throws<ServiceException> (() => TypeUtils.ValidateStructFields (type));
+        }
+
+        // A field marked nullable whose type holds no null of its own
+
+        [TestCase (typeof(StructWithANullableFieldThatCannotBeNull))]
+        [TestCase (typeof(StructWithANullableEnumFieldThatCannotBeNull))]
+        public void NullableStructFieldThatCannotBeNull (Type type)
+        {
+            Assert.Throws<ServiceException> (
+                () => TypeUtils.GetStructFieldSpec (type, type.GetProperty ("Field")));
         }
 
         [TestCase (typeof(TestService.TestStruct))]

--- a/core/test/Service/TypeUtilsTest.cs
+++ b/core/test/Service/TypeUtilsTest.cs
@@ -568,7 +568,7 @@ namespace KRPC.Test.Service
                    "]}", typeof(IList<TestService.TestStruct>))]
         public void SerializeType (string name, Type type)
         {
-            Assert.AreEqual (name, JsonConvert.SerializeObject (TypeUtils.SerializeType (type)));
+            Assert.AreEqual (name, JsonConvert.SerializeObject (TypeUtils.SerializeType (TypeSpec.Create (type))));
         }
 
         [TestCase (typeof(TestService.TestEnumWithoutAttribute))]
@@ -576,7 +576,7 @@ namespace KRPC.Test.Service
         [TestCase (typeof(IDictionary<double,string>))]
         public void InvalidSerializeType (Type type)
         {
-            Assert.Throws<ArgumentException> (() => TypeUtils.SerializeType (type));
+            Assert.Throws<ArgumentException> (() => TypeUtils.SerializeType (TypeSpec.Create (type)));
         }
     }
 }

--- a/core/test/Service/TypeUtilsTest.cs
+++ b/core/test/Service/TypeUtilsTest.cs
@@ -425,12 +425,6 @@ namespace KRPC.Test.Service
             }
         }
 
-        public struct StructWithANullableField
-        {
-            [KRPCProperty (Nullable = true)]
-            public TestService.TestClass Field { get; set; }
-        }
-
         public struct StructWithAGameSceneField
         {
             [KRPCProperty (GameScene = GameScene.Flight)]
@@ -440,7 +434,6 @@ namespace KRPC.Test.Service
         [TestCase (typeof(StructWithoutFields))]
         [TestCase (typeof(StructWithAnInvalidFieldType))]
         [TestCase (typeof(StructWithAFieldWithoutASetter))]
-        [TestCase (typeof(StructWithANullableField))]
         [TestCase (typeof(StructWithAGameSceneField))]
         public void InvalidStructFields (Type type)
         {
@@ -449,6 +442,7 @@ namespace KRPC.Test.Service
 
         [TestCase (typeof(TestService.TestStruct))]
         [TestCase (typeof(TestService.TestNestedStruct))]
+        [TestCase (typeof(TestService.TestNullableStruct))]
         public void ValidStructFields (Type type)
         {
             Assert.DoesNotThrow (() => TypeUtils.ValidateStructFields (type));

--- a/core/test/Utils/ReflectionTest.cs
+++ b/core/test/Utils/ReflectionTest.cs
@@ -31,7 +31,7 @@ namespace KRPC.Test.Utils
         [Test]
         public void GetMethodsWithAttribute ()
         {
-            Assert.AreEqual (38, Reflection.GetMethodsWith<KRPCProcedureAttribute> (typeof(TestService)).Count ());
+            Assert.AreEqual (43, Reflection.GetMethodsWith<KRPCProcedureAttribute> (typeof(TestService)).Count ());
             Assert.AreEqual (8, Reflection.GetMethodsWith<KRPCMethodAttribute> (typeof(TestService.TestClass)).Count ());
             Assert.AreEqual (0, Reflection.GetMethodsWith<KRPCProcedureAttribute> (typeof(TestService.TestClass)).Count ());
             Assert.AreEqual (0, Reflection.GetMethodsWith<KRPCProcedureAttribute> (typeof(string)).Count ());
@@ -58,7 +58,7 @@ namespace KRPC.Test.Utils
         [Test]
         public void GetPropertiesWithAttribute ()
         {
-            Assert.AreEqual (7, Reflection.GetPropertiesWith<KRPCPropertyAttribute> (typeof(TestService)).Count ());
+            Assert.AreEqual (8, Reflection.GetPropertiesWith<KRPCPropertyAttribute> (typeof(TestService)).Count ());
             Assert.AreEqual (4, Reflection.GetPropertiesWith<KRPCPropertyAttribute> (typeof(TestService.TestClass)).Count ());
             Assert.AreEqual (0, Reflection.GetPropertiesWith<KRPCPropertyAttribute> (typeof(string)).Count ());
         }

--- a/core/test/Utils/ReflectionTest.cs
+++ b/core/test/Utils/ReflectionTest.cs
@@ -24,7 +24,7 @@ namespace KRPC.Test.Utils
         {
             Assert.AreEqual (5, Reflection.GetTypesWith<KRPCServiceAttribute> ().Count ());
             Assert.AreEqual (6, Reflection.GetTypesWith<KRPCClassAttribute> ().Count ());
-            Assert.AreEqual (2, Reflection.GetTypesWith<KRPCStructAttribute> ().Count ());
+            Assert.AreEqual (3, Reflection.GetTypesWith<KRPCStructAttribute> ().Count ());
             Assert.AreEqual (0, Reflection.GetTypesWith<KRPCPropertyAttribute> ().Count ());
         }
 

--- a/doc/src/communication-protocols/messages.rst
+++ b/doc/src/communication-protocols/messages.rst
@@ -409,7 +409,6 @@ Details about a procedure are given by a ``Procedure`` message, with the format:
      string name = 1;
      repeated Parameter parameters = 2;
      Type return_type = 3;
-     bool return_is_nullable = 4;
      repeated GameScene game_scenes = 6;
      string documentation = 5;
      bool deprecated = 7;
@@ -419,7 +418,6 @@ Details about a procedure are given by a ``Procedure`` message, with the format:
    message Parameter {
      string name = 1;
      Type type = 2;
-     bool nullable = 4;
      bool has_default_value = 5;
      bytes default_value = 3;
      bool default_value_is_null = 6;
@@ -435,9 +433,8 @@ The fields are:
 
   * ``name`` - The name of the parameter, to allow parameter passing by name.
 
-  * ``type`` - The :ref:`type <communication-protocol-type>` of the parameter.
-
-  * ``nullable`` - Whether null can be passed as the argument for this parameter.
+  * ``type`` - The :ref:`type <communication-protocol-type>` of the parameter. Its ``nullable``
+    field says whether null can be passed as the argument for this parameter.
 
   * ``has_default_value`` - Whether the parameter has a default value. When it is not set, the
     parameter is required and ``default_value`` and ``default_value_is_null`` are unset.
@@ -473,9 +470,8 @@ The fields are:
        - unset
 
 * ``return_type`` - The :ref:`return type <communication-protocol-type>` of the procedure. If the
-  procedure does not return anything its type is set to ``NONE``.
-
-* ``return_is_nullable`` - Whether the procedure can return null.
+  procedure does not return anything its type is set to ``NONE``. Its ``nullable`` field says
+  whether the procedure can return null.
 
 * ``game_scenes`` - The :ref:`game scenes <communication-protocol-game-scene>` that the procedure is
   available in. If this repeated field is empty, the procedure is available in all game scenes.
@@ -602,7 +598,8 @@ The fields are:
 
   * ``type`` - The type of the field, as a :ref:`Type message
     <communication-protocol-type>`. A field may have any type a parameter or return value may
-    have, including a class, a collection or another structure.
+    have, including a class, a collection or another structure. Its ``nullable`` field says
+    whether the field can be null.
 
   * ``documentation`` - Documentation for the field, as `C# XML documentation`_.
 
@@ -625,14 +622,24 @@ the structure's fields, in the order the ``fields`` list gives them. This is the
 of the field types, so a client can use the codec it already has for tuples. The field names appear
 only in the definition above.
 
-Two rules follow from that encoding:
+One rule follows from that encoding: fields are only ever appended to a structure. A client
+generated against an older definition may receive more items than it has fields for, and ignores
+the extra items. Fewer items than its fields means the definitions do not match, and is an error.
 
-* Fields are only ever appended to a structure. A client generated against an older definition may
-  receive more items than it has fields for, and ignores the extra items. Fewer items than its
-  fields means the definitions do not match, and is an error.
+A field whose type is nullable carries a presence bool before its value. The bool is one byte,
+encoded as a ``BOOL`` value. The field's ordinary encoding follows it when the bool is true. A
+list element, a tuple item and a dictionary value carry the same bool, in the item of the
+``List``, ``Tuple`` or ``DictionaryEntry`` message that holds them. For example, a structure
+whose first field is an ``SINT32`` and whose second is a nullable ``CLASS``::
 
-* A field is never null. The ``is_null`` field of the enclosing ``Argument`` or ``ProcedureResult``
-  message applies to the structure value as a whole, and carries nothing about its fields.
+   Tuple.items[0] = 54           the first field, unchanged
+   Tuple.items[1] = 01 07        present, then object id 7
+   Tuple.items[1] = 00           null
+
+A field that is not nullable is encoded as its value alone, and a null in one is an error. The
+presence bool is what separates a null field from a null structure: ``is_null`` on the enclosing
+``Argument`` or ``ProcedureResult`` message applies to the structure value as a whole, and carries
+nothing about its fields.
 
 Exceptions
 ^^^^^^^^^^
@@ -695,6 +702,7 @@ The ``GetServices`` procedure returns type information about parameters, return 
      string service = 2;
      string name = 3;
      repeated Type types = 4;
+     bool nullable = 5;
 
      enum TypeCode {
        NONE = 0;
@@ -746,6 +754,18 @@ For collection types the ``types`` repeated field will contain the sub-types:
   order.
 
 For all other types the ``types`` field is empty.
+
+The ``nullable`` field says whether the position the type describes can hold null. It is a
+property of that position rather than of the type, so the same type is nullable in one place and
+not in another. The positions that can be nullable are a parameter, a return value, a default
+value, a :ref:`structure field <communication-protocol-structures>`, a list element, a tuple item
+and a dictionary value. A dictionary key and a set element cannot.
+
+How the null itself is carried depends on the position. An argument, a result and a default value
+each have a flag of their own, ``Argument.is_null``, ``ProcedureResult.is_null`` and
+``Parameter.default_value_is_null``. A value nested inside another value has no such flag, and
+carries a leading presence bool instead, in the form the :ref:`Structures
+<communication-protocol-structures>` section shows.
 
 .. _communication-protocol-game-scene:
 

--- a/doc/src/extending.rst
+++ b/doc/src/extending.rst
@@ -289,7 +289,8 @@ to add functionality to the kRPC server.
    :parameters:
 
     * **Nullable** -- Whether the property can be null. This makes both the getter's return value
-      and the setter's argument nullable. Defaults to false.
+      and the setter's argument nullable, and on a field of a :csharp:attr:`KRPCStruct` it makes
+      the field nullable. Defaults to false.
 
     * **GameScene** -- The game scenes in which the property is available. Defaults to inherit this
       setting from the class the property is defined in.
@@ -440,9 +441,10 @@ to add functionality to the kRPC server.
    * It must have at least one field, and the type of every field must be a :ref:`serializable type
      <service-api-serializable-types>`.
 
-   * A field must not be nullable and must not restrict the game scenes it is available in, so
-     neither the ``Nullable`` nor the ``GameScene`` parameter of its :csharp:attr:`KRPCProperty`
-     attribute may be set.
+   * A field must not restrict the game scenes it is available in, so the ``GameScene`` parameter
+     of its :csharp:attr:`KRPCProperty` attribute must not be set.
+
+   * A field may be nullable. See :ref:`service-api-null-values`.
 
    * The structure must not contain itself, whether directly or through the fields of another
      structure that it contains.
@@ -482,6 +484,26 @@ to add functionality to the kRPC server.
         conn = krpc.connect()
         site = conn.space_center.launch_sites[0]
         print(site.name, site.latitude)
+
+   * Declare a structure with two nullable fields:
+
+     .. code-block:: csharp
+
+        [KRPCStruct]
+        public struct CommNodeInfo {
+            [KRPCProperty]
+            public string Name { get; set; }
+
+            [KRPCProperty (Nullable = true)]
+            public Vessel Vessel { get; set; }
+
+            [KRPCProperty]
+            public double? SignalStrength { get; set; }
+        }
+
+     A reference-typed field is made nullable by the ``Nullable`` parameter of its
+     :csharp:attr:`KRPCProperty` attribute. A field whose type is ``Nullable<T>`` needs no
+     annotation.
 
 .. csharp:attribute:: KRPCException (string Service, Type MappedException)
 
@@ -558,11 +580,19 @@ to add functionality to the kRPC server.
             ...
         }
 
-.. csharp:attribute:: KRPCNullable
+.. csharp:attribute:: KRPCNullable (params KRPC.Service.Attributes.Position[] Path)
+
+   :parameters:
+
+    * **Path** -- Optional positions to step through to reach the nullable one, outermost first.
+      An empty path, the usual case, is the value itself.
 
    This `attribute <https://msdn.microsoft.com/en-us/library/aa287992.aspx>`_ is applied to a
    kRPC procedure or class method parameter to indicate that the parameter is permitted to be
    ``null``. It can be applied to a parameter of any serializable type, not only class types.
+   Applied to a method it marks the return value instead. Applied to a property it marks both
+   the getter's return value and the setter's argument, as ``Nullable`` on
+   :csharp:attr:`KRPCProperty` does.
 
    The server enforces nullability: a call that passes ``null`` for a parameter that is not
    nullable fails with an error. A parameter is nullable if it is marked with ``KRPCNullable``,
@@ -582,6 +612,59 @@ to add functionality to the kRPC server.
               ...
           }
       }
+
+.. _service-api-nullable-positions:
+
+Nullable Positions
+""""""""""""""""""
+
+Giving :csharp:attr:`KRPCNullable` a path marks a position nested inside a value, rather than the
+value itself. Each step names a position of the type the step before it reached, outermost first:
+
+.. code-block:: csharp
+
+   using static KRPC.Service.Attributes.Position;
+
+   [KRPCNullable (Element)] IList<Vessel> crew                       // the vessels may be null
+   [KRPCNullable (Value)] IDictionary<string, Vessel> byName         // the values may be null
+   [KRPCNullable (Item2)] Tuple<string, Vessel> named                // the second item may be null
+   [KRPCNullable (Element, Element)] IList<IList<Vessel>> byStage    // the vessels may be null
+
+Without the ``using static`` each position is written ``Position.Element``, as ``GameScene``
+already is on :csharp:attr:`KRPCProcedure`.
+
+A path step that names no position of the type it is applied to is an error, which the server
+reports when it loads the service. A dictionary key and a set element have no name here, and so
+cannot be made nullable. The positions are:
+
+.. csharp:enum:: KRPC.Service.Attributes.Position
+
+   .. csharp:value:: Element
+
+      The element of a list.
+
+   .. csharp:value:: Value
+
+      The value of a dictionary.
+
+   .. csharp:value:: Item1
+
+      The first item of a tuple. ``Item2`` to ``Item7`` name the ones after it.
+
+The attribute may be applied more than once, for a type with several nullable positions:
+
+.. code-block:: csharp
+
+   [KRPCNullable]
+   [KRPCNullable (Element)]
+   IList<Vessel> maybeVessels                                        // the list, and its vessels
+
+A nested position whose type is ``Nullable<T>`` needs no attribute, exactly as a parameter of that
+type does. ``IList<int?>``, ``IDictionary<string, double?>`` and ``Tuple<int?, string>`` are all
+nullable at the position ``Nullable<T>`` marks.
+
+A path that reaches a value-typed position is an error. An ``int``, an ``enum`` and a structure
+hold a null only as ``Nullable<T>``, so ``IList<int>`` must be written ``IList<int?>``.
 
 .. _service-api-identifiers:
 
@@ -628,15 +711,18 @@ following types are serializable:
 Null Values
 ^^^^^^^^^^^
 
-A parameter or return value may be ``null`` only when it is declared *nullable*. This applies
-uniformly to every serializable type -- class types, ``string``, collections and value types
-alike. The server enforces it:
+A parameter, a return value, a structure field or a position nested inside one of them may be
+``null`` only when it is declared *nullable*. This applies uniformly to every serializable
+type -- class types, ``string``, collections and value types alike. The server enforces it:
 
 * Passing ``null`` as an argument for a parameter that is not nullable fails the call with an
   error.
 
 * Returning ``null`` from a procedure, method or property getter that is not nullable fails the
   call with an error.
+
+* A ``null`` in a structure field that is not nullable fails the call with an error, naming the
+  field.
 
 A **parameter** is nullable if any of the following hold:
 
@@ -654,22 +740,28 @@ setter's argument nullable.
 
 Return nullability is always declared, as kRPC reads the attribute rather than the method body.
 
+A **structure field** is nullable if the ``Nullable`` parameter of its
+:csharp:attr:`KRPCProperty` attribute is set, or if its type is ``Nullable<T>``. Setting
+``Nullable`` on a value-typed field is an error. Write the field as ``Nullable<T>`` instead.
+
 .. _service-api-nullable-value-types:
 
 Nullable Value Types
 """"""""""""""""""""
 
-A parameter or return value of type ``Nullable<T>`` -- ``int?``, ``float?``, ``bool?``, an
-``enum?`` and so on -- is automatically nullable; it needs neither :csharp:attr:`KRPCNullable` nor
-``Nullable = true``. To clients it appears as an ordinary value of type ``T`` that may be null.
+A parameter, return value or structure field of type ``Nullable<T>`` -- ``int?``, ``float?``,
+``bool?``, an ``enum?`` and so on -- is automatically nullable; it needs neither
+:csharp:attr:`KRPCNullable` nor ``Nullable = true``. To clients it appears as an ordinary value of
+type ``T`` that may be null.
 
 Only value types can be ``Nullable<T>``. A `nullable reference type
 <https://learn.microsoft.com/en-us/dotnet/csharp/nullable-references>`_ annotation such as
 ``string?`` or ``IList<int>?`` is a compile-time annotation, and the ``?`` is erased before kRPC
 reads the type. Such a parameter or return value is treated as non-nullable.
 
-Use :csharp:attr:`KRPCNullable` or ``Nullable = true`` to make a reference-typed parameter or
-return value nullable.
+Use :csharp:attr:`KRPCNullable` or ``Nullable = true`` to make a reference-typed parameter,
+return value or structure field nullable, and a path on :csharp:attr:`KRPCNullable` to make a
+reference-typed position nested inside one nullable. See :ref:`service-api-nullable-positions`.
 
 Events
 ^^^^^^

--- a/doc/src/scripts/client/cpp/Callbacks.cpp
+++ b/doc/src/scripts/client/cpp/Callbacks.cpp
@@ -13,7 +13,7 @@ void check_abort2(bool x) {
 int main() {
   auto conn = krpc::connect();
   krpc::services::SpaceCenter sc(&conn);
-  auto control = sc.active_vessel().control();
+  auto control = sc.active_vessel().value().control();
   auto abort = control.abort_stream();
 
   abort.add_callback(check_abort1);

--- a/doc/src/scripts/client/cpp/ConditionVariables.cpp
+++ b/doc/src/scripts/client/cpp/ConditionVariables.cpp
@@ -5,7 +5,7 @@
 int main() {
   auto conn = krpc::connect();
   krpc::services::SpaceCenter sc(&conn);
-  auto control = sc.active_vessel().control();
+  auto control = sc.active_vessel().value().control();
   auto abort = control.abort_stream();
   abort.acquire();
   while (!abort())

--- a/doc/src/scripts/client/cpp/Event.cpp
+++ b/doc/src/scripts/client/cpp/Event.cpp
@@ -7,7 +7,7 @@ int main() {
   auto conn = krpc::connect();
   krpc::services::KRPC krpc(&conn);
   krpc::services::SpaceCenter sc(&conn);
-  auto flight = sc.active_vessel().flight();
+  auto flight = sc.active_vessel().value().flight();
 
   // Get the remote procedure call as a message object,
   // so it can be passed to the server

--- a/doc/src/scripts/client/cpp/RemoteProcedures.cpp
+++ b/doc/src/scripts/client/cpp/RemoteProcedures.cpp
@@ -5,7 +5,7 @@
 int main() {
   auto conn = krpc::connect();
   krpc::services::SpaceCenter sc(&conn);
-  auto vessel = sc.active_vessel();
+  auto vessel = sc.active_vessel().value();
   vessel.set_name("My Vessel");
   auto flight_info = vessel.flight();
   std::cout << flight_info.mean_altitude() << std::endl;

--- a/doc/src/scripts/client/cpp/Streaming1.cpp
+++ b/doc/src/scripts/client/cpp/Streaming1.cpp
@@ -7,7 +7,7 @@
 int main() {
   auto conn = krpc::connect();
   krpc::services::SpaceCenter sc(&conn);
-  auto vessel = sc.active_vessel();
+  auto vessel = sc.active_vessel().value();
   auto ref_frame = vessel.orbit().body().reference_frame();
   while (true) {
     auto pos = vessel.position(ref_frame);

--- a/doc/src/scripts/client/cpp/Streaming2.cpp
+++ b/doc/src/scripts/client/cpp/Streaming2.cpp
@@ -7,7 +7,7 @@
 int main() {
   auto conn = krpc::connect();
   krpc::services::SpaceCenter sc(&conn);
-  auto vessel = sc.active_vessel();
+  auto vessel = sc.active_vessel().value();
   auto ref_frame = vessel.orbit().body().reference_frame();
   auto pos_stream = vessel.position_stream(ref_frame);
   while (true) {

--- a/doc/src/scripts/services/InfernalRoboticsExample.cpp
+++ b/doc/src/scripts/services/InfernalRoboticsExample.cpp
@@ -1,4 +1,5 @@
 #include <iostream>
+#include <optional>
 #include <vector>
 #include <thread>
 #include <krpc.hpp>
@@ -13,15 +14,18 @@ int main() {
   SpaceCenter space_center(&conn);
   InfernalRobotics infernal_robotics(&conn);
 
-  InfernalRobotics::ServoGroup group = infernal_robotics.servo_group_with_name(space_center.active_vessel(), "MyGroup");
-  if (group == InfernalRobotics::ServoGroup())
+  std::optional<InfernalRobotics::ServoGroup> group =
+    infernal_robotics.servo_group_with_name(space_center.active_vessel().value(), "MyGroup");
+  if (!group.has_value()) {
     std::cout << "Group not found" << std::endl;
+    return 1;
+  }
 
-  std::vector<InfernalRobotics::Servo> servos = group.servos();
+  std::vector<InfernalRobotics::Servo> servos = group->servos();
   for (auto servo : servos)
     std::cout << servo.name() << " " << servo.position() << std::endl;
 
-  group.move_right();
+  group->move_right();
   std::this_thread::sleep_for(std::chrono::seconds(1));
-  group.stop();
+  group->stop();
 }

--- a/doc/src/scripts/services/RemoteTechExample.cpp
+++ b/doc/src/scripts/services/RemoteTechExample.cpp
@@ -7,7 +7,7 @@ int main() {
   krpc::Client conn = krpc::connect("RemoteTech Example");
   krpc::services::SpaceCenter space_center(&conn);
   krpc::services::RemoteTech remote_tech(&conn);
-  auto vessel = space_center.active_vessel();
+  auto vessel = space_center.active_vessel().value();
 
   // Set a dish target
   auto part = vessel.parts().with_title("Reflectron KR-7").front();

--- a/doc/src/scripts/services/space-center/AttachmentModes.cpp
+++ b/doc/src/scripts/services/space-center/AttachmentModes.cpp
@@ -10,7 +10,7 @@ using SpaceCenter = krpc::services::SpaceCenter;
 int main() {
   auto conn = krpc::connect();
   SpaceCenter sc(&conn);
-  auto vessel = sc.active_vessel();
+  auto vessel = sc.active_vessel().value();
 
   auto root = vessel.parts().root();
   std::stack<std::pair<SpaceCenter::Part, int> > stack;

--- a/doc/src/scripts/services/space-center/Quaternion.cpp
+++ b/doc/src/scripts/services/space-center/Quaternion.cpp
@@ -6,7 +6,7 @@
 int main() {
   krpc::Client conn = krpc::connect();
   krpc::services::SpaceCenter sc(&conn);
-  std::tuple<double, double, double, double> q = sc.active_vessel().flight().rotation();
+  std::tuple<double, double, double, double> q = sc.active_vessel().value().flight().rotation();
   std::cout << std::get<0>(q) << " "
             << std::get<1>(q) << " "
             << std::get<2>(q) << " "

--- a/doc/src/scripts/services/space-center/TreeTraversal.cpp
+++ b/doc/src/scripts/services/space-center/TreeTraversal.cpp
@@ -10,7 +10,7 @@ using SpaceCenter = krpc::services::SpaceCenter;
 int main() {
   krpc::Client conn = krpc::connect("");
   SpaceCenter sc(&conn);
-  auto vessel = sc.active_vessel();
+  auto vessel = sc.active_vessel().value();
 
   auto root = vessel.parts().root();
   std::stack<std::pair<SpaceCenter::Part, int>> stack;

--- a/doc/src/scripts/services/space-center/Vector3.cpp
+++ b/doc/src/scripts/services/space-center/Vector3.cpp
@@ -6,7 +6,7 @@
 int main() {
   krpc::Client conn = krpc::connect();
   krpc::services::SpaceCenter sc(&conn);
-  std::tuple<double, double, double> v = sc.active_vessel().flight().prograde();
+  std::tuple<double, double, double> v = sc.active_vessel().value().flight().prograde();
   std::cout << std::get<0>(v) << " "
             << std::get<1>(v) << " "
             << std::get<2>(v) << std::endl;

--- a/doc/src/scripts/tutorials/launch-into-orbit/LaunchIntoOrbit.cpp
+++ b/doc/src/scripts/tutorials/launch-into-orbit/LaunchIntoOrbit.cpp
@@ -8,7 +8,7 @@
 int main() {
   krpc::Client conn = krpc::connect("Launch into orbit");
   krpc::services::SpaceCenter space_center(&conn);
-  auto vessel = space_center.active_vessel();
+  auto vessel = space_center.active_vessel().value();
 
   float turn_start_altitude = 250;
   float turn_end_altitude = 45000;

--- a/doc/src/scripts/tutorials/parts/CombinedIsp.cpp
+++ b/doc/src/scripts/tutorials/parts/CombinedIsp.cpp
@@ -8,7 +8,7 @@ using SpaceCenter = krpc::services::SpaceCenter;
 int main() {
   auto conn = krpc::connect();
   SpaceCenter sc(&conn);
-  auto vessel = sc.active_vessel();
+  auto vessel = sc.active_vessel().value();
 
   auto engines = vessel.parts().engines();
 

--- a/doc/src/scripts/tutorials/parts/ControlFromHere.cpp
+++ b/doc/src/scripts/tutorials/parts/ControlFromHere.cpp
@@ -5,7 +5,7 @@
 int main() {
   krpc::Client conn = krpc::connect();
   krpc::services::SpaceCenter space_center(&conn);
-  auto vessel = space_center.active_vessel();
+  auto vessel = space_center.active_vessel().value();
   auto part = vessel.parts().with_title("Clamp-O-Tron Docking Port").front();
   vessel.parts().set_controlling(part);
 }

--- a/doc/src/scripts/tutorials/parts/DeployParachutes.cpp
+++ b/doc/src/scripts/tutorials/parts/DeployParachutes.cpp
@@ -4,7 +4,7 @@
 int main() {
   krpc::Client conn = krpc::connect();
   krpc::services::SpaceCenter space_center(&conn);
-  auto vessel = space_center.active_vessel();
+  auto vessel = space_center.active_vessel().value();
   for (auto parachute : vessel.parts().parachutes())
     parachute.deploy();
 }

--- a/doc/src/scripts/tutorials/pitch-heading-roll/PitchHeadingRoll.cpp
+++ b/doc/src/scripts/tutorials/pitch-heading-roll/PitchHeadingRoll.cpp
@@ -41,7 +41,7 @@ double angle_between_vectors(const vector3& u, const vector3& v) {
 int main() {
   krpc::Client conn = krpc::connect("Pitch/Heading/Roll");
   krpc::services::SpaceCenter space_center(&conn);
-  auto vessel = space_center.active_vessel();
+  auto vessel = space_center.active_vessel().value();
 
   while (true) {
     vector3 vessel_direction = vessel.direction(vessel.surface_reference_frame());

--- a/doc/src/scripts/tutorials/reference-frames/AngleOfAttack.cpp
+++ b/doc/src/scripts/tutorials/reference-frames/AngleOfAttack.cpp
@@ -11,7 +11,7 @@ static const double pi = 3.1415926535897;
 int main() {
   krpc::Client conn = krpc::connect("Angle of attack");
   krpc::services::SpaceCenter space_center(&conn);
-  auto vessel = space_center.active_vessel();
+  auto vessel = space_center.active_vessel().value();
 
   while (true) {
     auto d = vessel.direction(vessel.orbit().body().reference_frame());

--- a/doc/src/scripts/tutorials/reference-frames/LandingSite.cpp
+++ b/doc/src/scripts/tutorials/reference-frames/LandingSite.cpp
@@ -14,7 +14,7 @@ int main() {
   krpc::Client conn = krpc::connect("Landing Site");
   krpc::services::SpaceCenter space_center(&conn);
   krpc::services::Drawing drawing(&conn);
-  auto vessel = space_center.active_vessel();
+  auto vessel = space_center.active_vessel().value();
   auto body = vessel.orbit().body();
 
   // Define the landing site as the top of the VAB

--- a/doc/src/scripts/tutorials/reference-frames/NavballDirections.cpp
+++ b/doc/src/scripts/tutorials/reference-frames/NavballDirections.cpp
@@ -4,7 +4,7 @@
 int main() {
   krpc::Client conn = krpc::connect("Navball directions");
   krpc::services::SpaceCenter space_center(&conn);
-  auto vessel = space_center.active_vessel();
+  auto vessel = space_center.active_vessel().value();
   auto ap = vessel.auto_pilot();
   ap.set_reference_frame(vessel.surface_reference_frame());
   ap.set_engaged(true);

--- a/doc/src/scripts/tutorials/reference-frames/NavballSpeed.cpp
+++ b/doc/src/scripts/tutorials/reference-frames/NavballSpeed.cpp
@@ -7,7 +7,7 @@
 int main() {
   krpc::Client conn = krpc::connect("Navball speed");
   krpc::services::SpaceCenter spaceCenter(&conn);
-  auto vessel = spaceCenter.active_vessel();
+  auto vessel = spaceCenter.active_vessel().value();
   auto obt_frame = vessel.orbit_speed_reference_frame();
   auto srf_frame = vessel.surface_speed_reference_frame();
 

--- a/doc/src/scripts/tutorials/reference-frames/OrbitalDirections.cpp
+++ b/doc/src/scripts/tutorials/reference-frames/OrbitalDirections.cpp
@@ -4,7 +4,7 @@
 int main() {
   krpc::Client conn = krpc::connect("Orbital directions");
   krpc::services::SpaceCenter space_center(&conn);
-  auto vessel = space_center.active_vessel();
+  auto vessel = space_center.active_vessel().value();
   auto ap = vessel.auto_pilot();
   ap.set_reference_frame(vessel.orbital_reference_frame());
   ap.set_engaged(true);

--- a/doc/src/scripts/tutorials/reference-frames/SurfacePrograde.cpp
+++ b/doc/src/scripts/tutorials/reference-frames/SurfacePrograde.cpp
@@ -5,7 +5,7 @@
 int main() {
   krpc::Client conn = krpc::connect("Surface prograde");
   krpc::services::SpaceCenter spaceCenter(&conn);
-  auto vessel = spaceCenter.active_vessel();
+  auto vessel = spaceCenter.active_vessel().value();
   auto ap = vessel.auto_pilot();
 
   ap.set_reference_frame(vessel.surface_velocity_reference_frame());

--- a/doc/src/scripts/tutorials/reference-frames/VesselPosition.cpp
+++ b/doc/src/scripts/tutorials/reference-frames/VesselPosition.cpp
@@ -6,7 +6,7 @@
 int main() {
   krpc::Client conn = krpc::connect();
   krpc::services::SpaceCenter spaceCenter(&conn);
-  auto vessel = spaceCenter.active_vessel();
+  auto vessel = spaceCenter.active_vessel().value();
   auto position = vessel.position(vessel.orbit().body().reference_frame());
     std::cout << std::fixed << std::setprecision(1);
   std::cout << std::get<0>(position) << ", "

--- a/doc/src/scripts/tutorials/reference-frames/VesselSpeed.cpp
+++ b/doc/src/scripts/tutorials/reference-frames/VesselSpeed.cpp
@@ -7,7 +7,7 @@
 int main() {
   krpc::Client conn = krpc::connect("Vessel speed");
   krpc::services::SpaceCenter spaceCenter(&conn);
-  auto vessel = spaceCenter.active_vessel();
+  auto vessel = spaceCenter.active_vessel().value();
   auto obt_frame = vessel.orbit().body().non_rotating_reference_frame();
   auto srf_frame = vessel.orbit().body().reference_frame();
 

--- a/doc/src/scripts/tutorials/reference-frames/VesselVelocity.cpp
+++ b/doc/src/scripts/tutorials/reference-frames/VesselVelocity.cpp
@@ -7,7 +7,7 @@
 int main() {
   krpc::Client connection = krpc::connect("Vessel velocity");
   krpc::services::SpaceCenter spaceCenter(&connection);
-  auto vessel = spaceCenter.active_vessel();
+  auto vessel = spaceCenter.active_vessel().value();
   auto ref_frame = krpc::services::SpaceCenter::ReferenceFrame::create_hybrid(
     connection,
     vessel.orbit().body().reference_frame(),

--- a/doc/src/scripts/tutorials/reference-frames/VisualDebugging.cpp
+++ b/doc/src/scripts/tutorials/reference-frames/VisualDebugging.cpp
@@ -7,7 +7,7 @@ int main() {
   krpc::Client conn = krpc::connect("Visual Debugging");
   krpc::services::SpaceCenter space_center(&conn);
   krpc::services::Drawing drawing(&conn);
-  auto vessel = space_center.active_vessel();
+  auto vessel = space_center.active_vessel().value();
 
   auto ref_frame = vessel.surface_velocity_reference_frame();
   drawing.add_direction_from_com(std::make_tuple(0, 1, 0), ref_frame);

--- a/doc/src/scripts/tutorials/sub-orbital-flight/SubOrbitalFlight.cpp
+++ b/doc/src/scripts/tutorials/sub-orbital-flight/SubOrbitalFlight.cpp
@@ -10,7 +10,7 @@ int main() {
   krpc::services::KRPC krpc(&conn);
   krpc::services::SpaceCenter space_center(&conn);
 
-  auto vessel = space_center.active_vessel();
+  auto vessel = space_center.active_vessel().value();
 
   vessel.auto_pilot().target_pitch_and_heading(90, 90);
   vessel.auto_pilot().set_engaged(true);

--- a/doc/src/scripts/tutorials/user-interface/UserInterface.cpp
+++ b/doc/src/scripts/tutorials/user-interface/UserInterface.cpp
@@ -47,7 +47,7 @@ int main() {
   auto button_clicked = button.clicked_stream();
   auto slider_changed = slider.changed_stream();
 
-  auto vessel = space_center.active_vessel();
+  auto vessel = space_center.active_vessel().value();
   while (true) {
     // Handle the throttle button being clicked
     if (button_clicked()) {

--- a/protobuf/krpc.proto
+++ b/protobuf/krpc.proto
@@ -102,7 +102,6 @@ message Procedure {
   string name = 1;
   repeated Parameter parameters = 2;
   Type return_type = 3;
-  bool return_is_nullable = 4;
   repeated GameScene game_scenes = 6;
   string documentation = 5;
   bool deprecated = 7;
@@ -125,7 +124,6 @@ message Procedure {
 message Parameter {
   string name = 1;
   Type type = 2;
-  bool nullable = 4;
   bool has_default_value = 5;
   bytes default_value = 3;
   bool default_value_is_null = 6;
@@ -182,6 +180,7 @@ message Type {
   string service = 2;
   string name = 3;
   repeated Type types = 4;
+  bool nullable = 5;
 
   enum TypeCode {
     NONE = 0;

--- a/tools/TestServer/src/TestService.cs
+++ b/tools/TestServer/src/TestService.cs
@@ -312,8 +312,95 @@ namespace TestServer
             public string StringField { get; set; }
         }
 
+        /// <summary>
+        /// Nullable struct documentation string.
+        /// </summary>
+        [KRPCStruct]
+        public struct TestNullableStruct
+        {
+            [KRPCProperty]
+            public int IntField { get; set; }
+
+            [KRPCProperty]
+            public int? NullableIntField { get; set; }
+
+            [KRPCProperty]
+            public TestEnum? NullableEnumField { get; set; }
+
+            [KRPCProperty (Nullable = true)]
+            public string NullableStringField { get; set; }
+
+            [KRPCProperty (Nullable = true)]
+            public TestClass NullableObjectField { get; set; }
+        }
+
+        /// <summary>
+        /// Nested nullable struct documentation string.
+        /// </summary>
+        [KRPCStruct]
+        public struct TestNestedNullableStruct
+        {
+            [KRPCProperty]
+            [KRPCNullable (Position.Element)]
+            public IList<TestClass> ListField { get; set; }
+
+            [KRPCProperty]
+            public string StringField { get; set; }
+        }
+
+        [KRPCProcedure]
+        public static TestNestedNullableStruct EchoNestedNullableStruct (
+            TestNestedNullableStruct value)
+        {
+            return value;
+        }
+
+        [KRPCProcedure]
+        public static IList<int?> EchoListOfNullableInts (IList<int?> l)
+        {
+            return l;
+        }
+
+        [KRPCProcedure]
+        [KRPCNullable (Position.Element)]
+        public static IList<TestClass> EchoListOfNullableObjects (
+            [KRPCNullable (Position.Element)] IList<TestClass> l)
+        {
+            return l;
+        }
+
+        [KRPCProcedure]
+        [KRPCNullable (Position.Value)]
+        public static IDictionary<string,TestClass> EchoDictionaryOfNullableObjects (
+            [KRPCNullable (Position.Value)] IDictionary<string,TestClass> d)
+        {
+            return d;
+        }
+
+        [KRPCProcedure]
+        [KRPCNullable (Position.Item2)]
+        public static Tuple<int,TestClass> EchoTupleWithANullableObject (
+            [KRPCNullable (Position.Item2)] Tuple<int,TestClass> t)
+        {
+            return t;
+        }
+
+        [KRPCProcedure]
+        [KRPCNullable (Position.Element, Position.Element)]
+        public static IList<IList<TestClass>> EchoNestedListOfNullableObjects (
+            [KRPCNullable (Position.Element, Position.Element)] IList<IList<TestClass>> l)
+        {
+            return l;
+        }
+
         [KRPCProcedure]
         public static TestStruct StructEcho (TestStruct x)
+        {
+            return x;
+        }
+
+        [KRPCProcedure]
+        public static TestNullableStruct NullableStructEcho (TestNullableStruct x)
         {
             return x;
         }

--- a/tools/krpctools/CHANGELOG.md
+++ b/tools/krpctools/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## [v0.7.0] - unreleased
+- Generate and document the nullable structure fields and collection elements a service
+  defines, for every client (#1091)
 - Generate and document the structure types a service defines, for every client (#1066)
 - **Breaking:** A generator module given to `krpc-clientgen` by path is constructed with the
   definitions of every service that was loaded, rather than those of the single service it

--- a/tools/krpctools/krpctools/clientgen/cnano.py
+++ b/tools/krpctools/krpctools/clientgen/cnano.py
@@ -34,7 +34,34 @@ class CnanoGenerator(Generator):
         return name
 
     def parse_type(self, typ):
+        """The C type of a value at a slot. A slot carries its null out of band, so the type
+        there is named without its nullability."""
         return self._parse_type(typ)
+
+    def parse_type_at_position(self, typ):
+        """The C type of a value at a position inside another value. A value is stored by
+        value, so there is nowhere to put a null: a position that can hold one takes a
+        generated type of its own, holding the value beside a bool saying whether it is
+        there."""
+        value_type = self._parse_type(typ, in_collection=True)
+        if not typ.nullable:
+            return value_type
+        name = "nullable_%s" % value_type["name"]
+        return {
+            "kind": "nullable",
+            "name": name,
+            "nullable": True,
+            "is_class": False,
+            "ctype": "krpc_%s_t" % name,
+            "cvtype": "krpc_%s_t *" % name,
+            "ccvtype": "const krpc_%s_t *" % name,
+            "getval": "",
+            "getptr": "",
+            "structgetval": "&",
+            "structgetptr": "&",
+            "removeconst": "(krpc_%s_t*)" % name,
+            "value_type": value_type,
+        }
 
     def _parse_type(self, typ, in_collection=False):
         ptr = True
@@ -45,17 +72,17 @@ class CnanoGenerator(Generator):
         elif isinstance(typ, MessageType):
             ctype = "krpc_schema_%s" % typ.python_type.__name__
         elif isinstance(typ, ListType):
-            ctype = "krpc_list_%s_t" % self.parse_type_name(typ.value_type)
+            ctype = "krpc_list_%s_t" % self.parse_type_name_at_position(typ.value_type)
         elif isinstance(typ, SetType):
-            ctype = "krpc_set_%s_t" % self.parse_type_name(typ.value_type)
+            ctype = "krpc_set_%s_t" % self.parse_type_name_at_position(typ.value_type)
         elif isinstance(typ, DictionaryType):
             ctype = "krpc_dictionary_%s_%s_t" % (
-                self.parse_type_name(typ.key_type),
-                self.parse_type_name(typ.value_type),
+                self.parse_type_name_at_position(typ.key_type),
+                self.parse_type_name_at_position(typ.value_type),
             )
         elif isinstance(typ, TupleType):
             ctype = "krpc_tuple_%s_t" % "_".join(
-                self.parse_type_name(t) for t in typ.value_types
+                self.parse_type_name_at_position(t) for t in typ.value_types
             )
         elif isinstance(typ, StructType):
             ctype = "krpc_%s_%s_t" % (
@@ -88,8 +115,12 @@ class CnanoGenerator(Generator):
         #  structgetptr - gets a pointer for a value in a struct
         #                 (equivalent to structgetval then getptr)
         #  removeconst - removes constness from a pointer for a value
+        #  nullable - whether the slot or position holding the value can be null
+        #  is_class - whether the value is an instance of a class
         return {
             "name": self.parse_type_name(typ),
+            "nullable": typ.nullable,
+            "is_class": isinstance(typ, ClassType),
             "ctype": ctype,
             "cvtype": "%s *" % ctype if ptr else ctype,
             "ccvtype": (
@@ -111,12 +142,12 @@ class CnanoGenerator(Generator):
         # named for the field they carry.
         result = self.parse_type(typ)
         if isinstance(typ, TupleType):
-            members = [self._parse_type(t, in_collection=True) for t in typ.value_types]
+            members = [self.parse_type_at_position(t) for t in typ.value_types]
             for i, member in enumerate(members):
                 member["member"] = "e%d" % i
             result.update({"kind": "tuple", "value_types": members})
         elif isinstance(typ, StructType):
-            members = [self._parse_type(t, in_collection=True) for t in typ.field_types]
+            members = [self.parse_type_at_position(t) for t in typ.field_types]
             for name, member in zip(typ.field_names, members):
                 member["member"] = self.parse_name(snake_case(name))
             result.update({"kind": "struct", "value_types": members})
@@ -124,20 +155,34 @@ class CnanoGenerator(Generator):
             result.update(
                 {
                     "kind": "list" if isinstance(typ, ListType) else "set",
-                    "value_type": self._parse_type(typ.value_type, in_collection=True),
+                    "value_type": self.parse_type_at_position(typ.value_type),
                 }
             )
         elif isinstance(typ, DictionaryType):
             result.update(
                 {
                     "kind": "dictionary",
-                    "key_type": self._parse_type(typ.key_type, in_collection=True),
-                    "value_type": self._parse_type(typ.value_type, in_collection=True),
+                    "key_type": self.parse_type_at_position(typ.key_type),
+                    "value_type": self.parse_type_at_position(typ.value_type),
                 }
             )
         else:
             raise RuntimeError("Unknown type " + str(typ))
         return result
+
+    @staticmethod
+    def nullable_types_in(collection_type):
+        """The generated types the given one holds at a position that can hold null, which
+        are declared before it"""
+        members = collection_type.get("value_types", [])
+        for key in ("key_type", "value_type"):
+            if key in collection_type:
+                members = members + [collection_type[key]]
+        return [x for x in members if x.get("kind") == "nullable"]
+
+    def parse_type_name_at_position(self, typ):
+        name = self.parse_type_name(typ)
+        return "nullable_%s" % name if typ.nullable else name
 
     def parse_type_name(self, typ):
         if isinstance(typ, ValueType):
@@ -145,17 +190,17 @@ class CnanoGenerator(Generator):
         if isinstance(typ, MessageType):
             return "message_%s" % typ.python_type.__name__
         if isinstance(typ, ListType):
-            return "list_%s" % self.parse_type_name(typ.value_type)
+            return "list_%s" % self.parse_type_name_at_position(typ.value_type)
         if isinstance(typ, SetType):
-            return "set_%s" % self.parse_type_name(typ.value_type)
+            return "set_%s" % self.parse_type_name_at_position(typ.value_type)
         if isinstance(typ, DictionaryType):
             return "dictionary_%s_%s" % (
-                self.parse_type_name(typ.key_type),
-                self.parse_type_name(typ.value_type),
+                self.parse_type_name_at_position(typ.key_type),
+                self.parse_type_name_at_position(typ.value_type),
             )
         if isinstance(typ, TupleType):
             return "tuple_%s" % "_".join(
-                self.parse_type_name(t) for t in typ.value_types
+                self.parse_type_name_at_position(t) for t in typ.value_types
             )
         if isinstance(typ, StructType):
             return "%s_%s" % (typ.protobuf_type.service, typ.protobuf_type.name)
@@ -189,10 +234,10 @@ class CnanoGenerator(Generator):
 
     def generate_context_parameters(self, name, procedure):
         parameters = super().generate_context_parameters(name, procedure)
-        for i, parameter in enumerate(parameters):
-            if not parameter["nullable"]:
+        for parameter, info in zip(parameters, procedure["parameters"]):
+            typ = as_type(self.types, info["type"])
+            if not typ.nullable:
                 continue
-            typ = as_type(self.types, procedure["parameters"][i]["type"])
             if isinstance(typ, ClassType):
                 parameter["null_check"] = "%s == KRPC_NULL" % parameter["name"]
             else:
@@ -202,10 +247,6 @@ class CnanoGenerator(Generator):
                     parameter["type"]["ccvtype"] = "const %s *" % ctype
                     parameter["type"]["getptr"] = ""
         return parameters
-
-    def _annotate_return(self, return_type, procedure):
-        return_type["nullable"] = procedure.get("return_is_nullable", False)
-        return_type["is_class"] = isinstance(self.get_return_type(procedure), ClassType)
 
     def parse_default_value(self, value, typ):  # pylint: disable=unused-argument
         # No default arguments in C
@@ -225,23 +266,13 @@ class CnanoGenerator(Generator):
             typ["ccvtype"] = typ["cvtype"]
             return typ
 
-        for info in context["procedures"].values():
-            self._annotate_return(info["return_type"], info["procedure"])
-        for class_info in context["classes"].values():
-            for info in class_info["methods"].values():
-                self._annotate_return(info["return_type"], info["procedure"])
-            for info in class_info["static_methods"].values():
-                self._annotate_return(info["return_type"], info["procedure"])
-
         properties = collections.OrderedDict()
         for name, info in context["properties"].items():
             if info["getter"]:
-                getter_return = return_type(info["type"])
-                self._annotate_return(getter_return, info["getter"]["procedure"])
                 properties[name] = {
                     "remote_id": info["getter"]["remote_id"],
                     "parameters": [],
-                    "return_type": getter_return,
+                    "return_type": return_type(info["type"]),
                     "documentation": info["documentation"],
                     "deprecated": info["deprecated"],
                     "deprecated_reason": info["deprecated_reason"],
@@ -262,12 +293,10 @@ class CnanoGenerator(Generator):
             class_properties = collections.OrderedDict()
             for name, info in class_info["properties"].items():
                 if info["getter"]:
-                    getter_return = return_type(info["type"])
-                    self._annotate_return(getter_return, info["getter"]["procedure"])
                     class_properties[name] = {
                         "remote_id": info["getter"]["remote_id"],
                         "parameters": [],
-                        "return_type": getter_return,
+                        "return_type": return_type(info["type"]),
                         "documentation": info["documentation"],
                         "deprecated": info["deprecated"],
                         "deprecated_reason": info["deprecated_reason"],
@@ -295,14 +324,15 @@ class CnanoGenerator(Generator):
         # follow the collection types it contains. Several kRPC types share one C type, as
         # every class is a krpc_object_t and every enumeration a krpc_enum_t, so collections
         # are deduplicated by what they become in C rather than by what they are here.
-        collection_types = []
+        collection_types = collections.OrderedDict()
         for typ in self._definitions.collection_types(
             sorted(self._collection_types, key=self.parse_type_name)
         ):
             ctype = self.parse_collection_type(typ)
-            if ctype not in collection_types:
-                collection_types.append(ctype)
-        context["collection_types"] = collection_types
+            for nullable_type in self.nullable_types_in(ctype):
+                collection_types.setdefault(nullable_type["name"], nullable_type)
+            collection_types.setdefault(ctype["name"], ctype)
+        context["collection_types"] = list(collection_types.values())
 
         return context
 

--- a/tools/krpctools/krpctools/clientgen/cnano.tmpl
+++ b/tools/krpctools/krpctools/clientgen/cnano.tmpl
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <string.h>
+
 #include <krpc_cnano/decoder.h>
 #include <krpc_cnano/deprecated.h>
 #include <krpc_cnano/encoder.h>
@@ -17,7 +19,7 @@ KRPC_CHECK(krpc_call(&_call, {{ service_id }}, {{ procedure_id }}, {{ parameters
 KRPC_CHECK(krpc_call(&_call, {{ service_id }}, {{ procedure_id }}, 0, NULL));
 {% endif %}
 {% for x in parameters %}
-{% if x.nullable is defined and x.nullable %}
+{% if x.type.nullable %}
 if ({{ x.null_check }}) {
   KRPC_CHECK(krpc_add_null_argument(&_call, {{ loop.index0 }}));
 } else {
@@ -93,7 +95,13 @@ typedef krpc_object_t krpc_{{ service_name }}_{{ class_name }}_t;
 #ifndef KRPC_TYPE_{{ typ.name | upper }}
 #define KRPC_TYPE_{{ typ.name | upper }}
 
-{% if typ.kind in ('tuple', 'struct') %}
+{% if typ.kind == 'nullable' %}
+typedef struct krpc_{{ typ.name }}_s krpc_{{ typ.name }}_t;
+struct krpc_{{ typ.name }}_s {
+  {{ typ.value_type.ctype }} value;
+  bool has_value;
+};
+{% elif typ.kind in ('tuple', 'struct') %}
 typedef struct krpc_{{ typ.name }}_s krpc_{{ typ.name }}_t;
 struct krpc_{{ typ.name }}_s {
 {% for value_type in typ.value_types %}
@@ -293,7 +301,13 @@ static inline bool krpc_encode_callback_entry_{{ typ.name }}(
 
 static inline krpc_error_t krpc_encode_{{ typ.name }}(
   pb_ostream_t * stream, {{ typ.ccvtype }} value) {
-{% if typ.kind in ('tuple', 'struct') %}
+{% if typ.kind == 'nullable' %}
+  // A nullable position carries a presence bool before its value, and holds nothing else
+  // when that bool is false
+  KRPC_RETURN_ON_ERROR(krpc_encode_bool(stream, value->has_value));
+  if (value->has_value)
+    KRPC_RETURN_ON_ERROR(krpc_encode_{{ typ.value_type.name }}(stream, {{ typ.value_type.structgetval }}value->value));
+{% elif typ.kind in ('tuple', 'struct') %}
   krpc_schema_Tuple message = krpc_schema_Tuple_init_default;
   message.items.funcs.encode = &krpc_encode_callback_items_{{ typ.name }};
   message.items.arg = {{ typ.removeconst }}{{ typ.getptr }}value;
@@ -416,7 +430,13 @@ static inline bool krpc_decode_callback_entry_{{ typ.name }}(
 
 static inline krpc_error_t krpc_decode_{{ typ.name }}(
   pb_istream_t * stream, {{ typ.ctype }} * value) {
-{% if typ.kind in ('tuple', 'struct') %}
+{% if typ.kind == 'nullable' %}
+  // An absent value is left zeroed, so the member is defined whatever the caller passed in
+  memset(&value->value, 0, sizeof(value->value));
+  KRPC_RETURN_ON_ERROR(krpc_decode_bool(stream, &value->has_value));
+  if (value->has_value)
+    KRPC_RETURN_ON_ERROR(krpc_decode_{{ typ.value_type.name }}(stream, {{ typ.value_type.structgetptr }}value->value));
+{% elif typ.kind in ('tuple', 'struct') %}
   krpc_schema_Tuple message = krpc_schema_Tuple_init_default;
   message.items.funcs.decode = &krpc_decode_callback_item_{{ typ.name }};
   typedef struct State { size_t pos; {{ typ.ctype }} * value; } State;
@@ -475,7 +495,7 @@ static inline krpc_error_t krpc_{{ service_name }}_{{ procedure_name }}({{ proce
 {% for method_name,method in cls.methods.items()|list + cls.properties.items()|list %}
 
 static inline krpc_error_t krpc_{{ service_name }}_{{ class_name }}_{{ method_name }}({{ method_parameters(service_name, class_name, method) }}) {
-{{ call(service_id, method.remote_id, [{'type': {'ccvtype': 'krpc_'+service_name+'_'+class_name+'_t', 'name': 'uint64', 'getptr': '&'}, 'name': 'instance'}] + method.parameters) | indent(2) }}
+{{ call(service_id, method.remote_id, [{'type': {'ccvtype': 'krpc_'+service_name+'_'+class_name+'_t', 'name': 'uint64', 'getptr': '&', 'nullable': False}, 'name': 'instance'}] + method.parameters) | indent(2) }}
 {{ return(method.return_type) | indent(2) }}
 }
 {% endfor %}

--- a/tools/krpctools/krpctools/clientgen/cpp.py
+++ b/tools/krpctools/krpctools/clientgen/cpp.py
@@ -4,7 +4,6 @@ from krpc.utils import snake_case
 from .generator import Generator
 from .docparser import DocParser
 from ..lang.cpp import CppLanguage
-from ..utils import as_type
 
 
 def _cpp_template_fix(typ):
@@ -26,38 +25,6 @@ class CppGenerator(Generator):
         return _cpp_template_fix(self.language.parse_type(typ))
 
     @staticmethod
-    def _wrap_optional(type_str):
-        return _cpp_template_fix("std::optional<%s>" % type_str)
-
-    def generate_context_parameters(self, name, procedure):
-        parameters = super().generate_context_parameters(name, procedure)
-        for i, parameter in enumerate(parameters):
-            # A nullable class parameter keeps its class type (null is the id-0 object);
-            # every other nullable parameter is wrapped in std::optional.
-            typ = as_type(self.types, procedure["parameters"][i]["type"])
-            if parameter["nullable"] and not isinstance(typ, ClassType):
-                parameter["type"] = self._wrap_optional(parameter["type"])
-        return parameters
-
-    def _wrap_nullable_return(self, info):
-        procedure = info["procedure"]
-        if procedure.get("return_is_nullable", False):
-            typ = self.get_return_type(procedure)
-            if not isinstance(typ, ClassType):
-                info["return_type"] = self._wrap_optional(info["return_type"])
-
-    def _property_return_type(self, info):
-        # info["type"] is the property's C++ type; wrap it in std::optional when the getter
-        # is a nullable non-class return (a nullable class stays the id-0 object type).
-        return_type = info["type"]
-        getter = info["getter"]
-        if getter and getter["procedure"].get("return_is_nullable", False):
-            typ = self.get_return_type(getter["procedure"])
-            if not isinstance(typ, ClassType):
-                return_type = self._wrap_optional(return_type)
-        return return_type
-
-    @staticmethod
     def parse_documentation(documentation):
         documentation = CppDocParser().parse(documentation)
         if documentation == "":
@@ -68,7 +35,6 @@ class CppGenerator(Generator):
     def parse_context(self, context):
         for info in context["procedures"].values():
             info["return_set_client"] = self.parse_set_client(info["procedure"])
-            self._wrap_nullable_return(info)
 
         properties = collections.OrderedDict()
         for name, info in context["properties"].items():
@@ -76,7 +42,7 @@ class CppGenerator(Generator):
                 properties[name] = {
                     "remote_name": info["getter"]["remote_name"],
                     "parameters": [],
-                    "return_type": self._property_return_type(info),
+                    "return_type": info["type"],
                     "return_set_client": self.parse_set_client(
                         info["getter"]["procedure"]
                     ),
@@ -100,11 +66,9 @@ class CppGenerator(Generator):
         for class_info in context["classes"].values():
             for info in class_info["methods"].values():
                 info["return_set_client"] = self.parse_set_client(info["procedure"])
-                self._wrap_nullable_return(info)
 
             for info in class_info["static_methods"].values():
                 info["return_set_client"] = self.parse_set_client(info["procedure"])
-                self._wrap_nullable_return(info)
 
             class_properties = collections.OrderedDict()
             for name, info in class_info["properties"].items():
@@ -112,7 +76,7 @@ class CppGenerator(Generator):
                     class_properties[name] = {
                         "remote_name": info["getter"]["remote_name"],
                         "parameters": [],
-                        "return_type": self._property_return_type(info),
+                        "return_type": info["type"],
                         "return_set_client_fn": self.parse_set_client(
                             info["getter"]["procedure"]
                         ),

--- a/tools/krpctools/krpctools/clientgen/cpp.tmpl
+++ b/tools/krpctools/krpctools/clientgen/cpp.tmpl
@@ -361,59 +361,17 @@ inline std::size_t hash_value(const services::{{ service_name }}::{{ struct_name
 
 {% endfor %}
 {% endif %}
-// The encoder and decoder for a collection call encode and decode on the type it
-// contains without qualifying them, so the ones above, which are declared after those
-// templates, are only reachable through argument dependent lookup. That searches the
-// namespace enclosing the enumeration, which is this one, so the collection encoder and
-// decoder find an enumeration through these.
+// A collection encoder or decoder calls encode and decode on the type it contains
+// without qualifying them. The ones above are declared after those templates, so
+// argument dependent lookup is what reaches them. It searches the namespace that
+// encloses the type, which is this one. These name the same functions here, as a
+// second function with the same signature is ambiguous to a compiler that finds both.
 namespace services {
-  {% for enum_name,enm in enumerations.items() %}
-
-  {% if enm.deprecated %}
-#if defined(__GNUC__)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-#endif
+  using krpc::encoder::encode;
+  using krpc::decoder::decode;
+  {% if structs | length > 0 %}
+  using krpc::hash_value;
   {% endif %}
-  inline std::string encode(const {{ service_name }}::{{ enum_name }}& value) {
-    return encoder::encode(value);
-  }
-
-  inline void decode({{ service_name }}::{{ enum_name }}& value, const std::string& data, Client* client) {
-    decoder::decode(value, data, client);
-  }
-  {% if enm.deprecated %}
-#if defined(__GNUC__)
-#pragma GCC diagnostic pop
-#endif
-  {% endif %}
-  {% endfor %}
-  {% for struct_name,struct in structs.items() %}
-
-  {% if struct.deprecated %}
-#if defined(__GNUC__)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-#endif
-  {% endif %}
-  inline std::string encode(const {{ service_name }}::{{ struct_name }}& value) {
-    return encoder::encode(value);
-  }
-
-  inline void decode({{ service_name }}::{{ struct_name }}& value, const std::string& data, Client* client) {
-    decoder::decode(value, data, client);
-  }
-
-  inline std::size_t hash_value(const {{ service_name }}::{{ struct_name }}& value) {
-    return krpc::hash_value(value);
-  }
-  {% if struct.deprecated %}
-#if defined(__GNUC__)
-#pragma GCC diagnostic pop
-#endif
-  {% endif %}
-  {% endfor %}
-
 }  // namespace services
 {% endif %}
 

--- a/tools/krpctools/krpctools/clientgen/cpp.tmpl
+++ b/tools/krpctools/krpctools/clientgen/cpp.tmpl
@@ -3,7 +3,7 @@
 std::vector<krpc::encoder::Value> _args;
 _args.reserve({{ parameters | length }});
 {% for x in parameters %}
-_args.push_back({% if x.nullable is defined and x.nullable %}encoder::encode_nullable({{x.name}}){% else %}encoder::encode({{x.name}}){% endif %});
+_args.push_back(encoder::encode_arg({{x.name}}));
 {% endfor %}
 {% endmacro %}
 {% macro call(service, procedure, has_return, has_args, is_static=False) %}
@@ -277,7 +277,7 @@ namespace encoder {
     static thread_local krpc::schema::Tuple structMessage;
     structMessage.Clear();
     {% for field in struct['fields'] %}
-    structMessage.add_items(encode(value.{{ field.name }}));
+    structMessage.add_items(encode_item(value.{{ field.name }}));
     {% endfor %}
     return krpc::encoder::encode(structMessage);
   }
@@ -326,7 +326,7 @@ namespace decoder {
     if (structMessage.items_size() < {{ struct['fields'] | length }})
       throw EncodingError("Value for {{ struct_name }} does not have all of its fields");
     {% for field in struct['fields'] %}
-    decode(value.{{ field.name }}, structMessage.items({{ loop.index0 }}), client);
+    decode_item(value.{{ field.name }}, structMessage.items({{ loop.index0 }}), client);
     {% endfor %}
   }
   {% if struct.deprecated %}

--- a/tools/krpctools/krpctools/clientgen/csharp.py
+++ b/tools/krpctools/krpctools/clientgen/csharp.py
@@ -1,6 +1,11 @@
 # pylint: disable=no-name-in-module
-from krpc.schema.KRPC_pb2 import Type
-from krpc.types import ValueType, EnumerationType, StructType
+from krpc.types import (
+    StructType,
+    ListType,
+    SetType,
+    DictionaryType,
+    TupleType,
+)
 from .generator import Generator
 from ..lang.csharp import CsharpLanguage
 from ..utils import as_type
@@ -10,15 +15,10 @@ class CsharpGenerator(Generator):
 
     language = CsharpLanguage()
 
-    @staticmethod
-    def _is_nullable_value_type(typ):
-        # C# reference types (string, byte[], classes and collections) carry null
-        # naturally; only genuine value types need the nullable form T?.
-        if isinstance(typ, (EnumerationType, StructType)):
-            return True
-        if isinstance(typ, ValueType):
-            return typ.protobuf_type.code not in (Type.STRING, Type.BYTES)
-        return False
+    def __init__(self, macro_template, service, definitions):
+        super().__init__(macro_template, service, definitions)
+        # The specs the generated stubs name, each held in a static field of its own
+        self._type_specs = {}
 
     @staticmethod
     def parse_documentation(documentation):
@@ -36,7 +36,8 @@ class CsharpGenerator(Generator):
         parameters = super().generate_context_parameters(name, procedure)
         for i, parameter in enumerate(parameters):
             typ = as_type(self.types, procedure["parameters"][i]["type"])
-            if parameter["nullable"] and self._is_nullable_value_type(typ):
+            parameter["spec"] = self.parse_type_specification(typ)
+            if parameter["nullable"] and self.language.takes_the_nullable_form(typ):
                 parameter["type"] += "?"
             if "default_value" not in parameter:
                 parameter["name_value"] = parameter["name"]
@@ -72,40 +73,157 @@ class CsharpGenerator(Generator):
         return parameters
 
     def _apply_return_nullable(self, info):
-        procedure = info["procedure"]
-        nullable = procedure.get("return_is_nullable", False)
-        info["return_is_nullable"] = nullable
-        if nullable and self._is_nullable_value_type(self.get_return_type(procedure)):
+        typ = self.get_return_type(info["procedure"])
+        info["return_spec"] = self.parse_type_specification(typ)
+        if info["return_is_nullable"] and self.language.takes_the_nullable_form(typ):
             info["return_type"] += "?"
 
     def _apply_property_nullable(self, info):
-        # A property's nullability spans its getter and setter; the value type is the
-        # same on both, so read the flag from whichever accessor exists.
-        nullable = False
+        # A property's value type is the same on its getter and its setter, so read it
+        # from whichever accessor exists.
         typ = None
         if info["getter"]:
-            procedure = info["getter"]["procedure"]
-            nullable = procedure.get("return_is_nullable", False)
-            typ = self.get_return_type(procedure)
+            typ = self.get_return_type(info["getter"]["procedure"])
         elif info["setter"]:
-            procedure = info["setter"]["procedure"]
-            param = procedure["parameters"][-1]
-            nullable = param.get("nullable", False)
+            param = info["setter"]["procedure"]["parameters"][-1]
             typ = as_type(self.types, param["type"])
-        info["return_is_nullable"] = nullable
-        if nullable and typ is not None and self._is_nullable_value_type(typ):
+        info["return_spec"] = self.parse_type_specification(typ)
+        if info["return_is_nullable"] and self.language.takes_the_nullable_form(typ):
             info["type"] += "?"
+
+    def parse_type_specification(self, typ):
+        """The expression a generated stub names in place of the type of a slot. A slot
+        carries a null out of band, so its type is named without its nullability.
+
+        Each spec is built once and held in a static field, as building one on every call
+        would allocate where naming a type does not."""
+        if typ is None:
+            return "null"
+        expression = (
+            self._named_specification(typ)
+            if self._names_a_position(typ)
+            else self._plain_specification(typ)
+        )
+        if expression not in self._type_specs:
+            self._type_specs[expression] = "TypeSpecs.Spec%d" % len(self._type_specs)
+        return self._type_specs[expression]
+
+    def _specification_at_position(self, typ):
+        """The expression that builds the spec of a value at a position inside another value.
+        A position carries a null in the value, so a nullable type is named as one."""
+        if typ.nullable:
+            return self._named_specification(typ, nullable=True)
+        if self._names_a_position(typ):
+            return self._named_specification(typ)
+        return self._plain_specification(typ)
+
+    def _named_specification(self, typ, nullable=False):
+        # A spec names the values a type contains by their position, so one that says nothing
+        # is kept in place and only trailing ones are dropped
+        contained = self._contained_positions(typ)
+        args = [self._specification_at_position(t) for t in contained]
+        while args and args[-1] == self._plain_specification(contained[len(args) - 1]):
+            args.pop()
+        return "%s (typeof(%s)%s)" % (
+            (
+                "global::KRPC.Client.TypeSpec.Null"
+                if nullable
+                else "new global::KRPC.Client.TypeSpec"
+            ),
+            self.parse_type(typ),
+            "".join(", " + arg for arg in args),
+        )
+
+    def _plain_specification(self, typ):
+        """The spec of a type that names no position of its own, which the C# type gives"""
+        return "global::KRPC.Client.TypeSpec.For (typeof(%s))" % self.parse_type(typ)
+
+    @staticmethod
+    def _contained_positions(typ):
+        """The values the type contains, in the order the encoding holds them"""
+        if isinstance(typ, (ListType, SetType)):
+            return [typ.value_type]
+        if isinstance(typ, DictionaryType):
+            return [typ.key_type, typ.value_type]
+        if isinstance(typ, TupleType):
+            return list(typ.value_types)
+        if isinstance(typ, StructType):
+            return list(typ.field_types)
+        return []
+
+    def _names_a_position(self, typ):
+        """Whether a position inside the type can hold null and cannot say so through its C#
+        type, which is every reference-typed position. A structure field says so on the
+        generated field, so only the positions nested inside one count."""
+        declared = not isinstance(typ, StructType)
+        return any(
+            (declared and t.nullable and not self.language.takes_the_nullable_form(t))
+            or self._names_a_position(t)
+            for t in self._contained_positions(typ)
+        )
+
+    def _procedure_specs(self):
+        """The specs of the procedures whose values a call built from an expression cannot
+        read off the C# types it has. Such a call names a nullable reference-typed position
+        inside a value nowhere else, so the stub's spec is looked up by procedure name.
+        """
+        specs = []
+        for name, procedure in self._get_defs("procedures"):
+            return_type = self.get_return_type(procedure)
+            parameter_types = [
+                as_type(self.types, x["type"]) for x in procedure["parameters"]
+            ]
+            types = parameter_types + ([] if return_type is None else [return_type])
+            if not any(self._names_a_position(typ) for typ in types):
+                continue
+            specs.append(
+                {
+                    "name": name,
+                    "return_spec": (
+                        None
+                        if return_type is None
+                        else self.parse_type_specification(return_type)
+                    ),
+                    "parameter_specs": [
+                        self.parse_type_specification(typ) for typ in parameter_types
+                    ],
+                }
+            )
+        return specs
+
+    def add_struct_field_nullability(self, context):
+        """Give every nullable field of a structure the C# type that holds a null. A value
+        type takes the nullable form T?, and a reference type is marked with an attribute, as
+        it is nullable in C# whether the service declares it so or not."""
+        for struct_info in context["structs"].values():
+            for field in struct_info["fields"]:
+                if not field["krpc_type"].nullable:
+                    continue
+                if self.language.takes_the_nullable_form(field["krpc_type"]):
+                    field["type"] += "?"
+                else:
+                    field["attribute"] = "global::KRPC.Client.Attributes.KRPCNullable"
 
     def parse_context(self, context):
         for info in context["procedures"].values():
             self._apply_return_nullable(info)
         for info in context["properties"].values():
             self._apply_property_nullable(info)
-        for cls in context["classes"].values():
+        for class_name, cls in context["classes"].items():
+            # A class method passes the object it is called on as its first argument
+            cls["spec"] = self.parse_type_specification(
+                self.types.class_type(self.service_name, class_name)
+            )
             for info in cls["methods"].values():
                 self._apply_return_nullable(info)
             for info in cls["static_methods"].values():
                 self._apply_return_nullable(info)
             for info in cls["properties"].values():
                 self._apply_property_nullable(info)
+        self.add_struct_field_nullability(context)
+        context["procedure_specs"] = self._procedure_specs()
+        context["type_specs"] = [
+            {"name": name.split(".")[-1], "spec": expression}
+            for expression, name in self._type_specs.items()
+        ]
         return context

--- a/tools/krpctools/krpctools/clientgen/csharp.tmpl
+++ b/tools/krpctools/krpctools/clientgen/csharp.tmpl
@@ -5,7 +5,7 @@ using System.Runtime.Serialization;
 {% macro args(parameters) %}
 var _args = new ByteString[] {
 {% for x in parameters %}
-    global::KRPC.Client.Encoder.Encode ({{x.name_value}}, typeof({{x.type}})){% if not loop.last %},{% endif %}
+    global::KRPC.Client.Encoder.Encode ({{x.name_value}}, {{x.spec}}){% if not loop.last %},{% endif %}
 
 {% endfor %}
 };
@@ -13,12 +13,12 @@ var _args = new ByteString[] {
 {% macro call(service, procedure, has_return, has_args, is_static=False) %}
 {% if has_return %}var _result = {% endif %}connection.Invoke ("{{service}}", "{{procedure}}"{% if has_args %}, _args{% endif %});
 {% endmacro %}
-{% macro return(type, is_nullable=False) %}
+{% macro return(type, spec, is_nullable=False) %}
 {% if is_nullable %}
 if (_result.IsNull)
     return null;
 {% endif %}
-return ({{type}})global::KRPC.Client.Encoder.Decode (_result.Value, typeof({{type}}), connection);
+return ({{type}})global::KRPC.Client.Encoder.Decode (_result.Value, {{spec}}, connection);
 {% endmacro %}
 {% macro sig_parameters(parameters) %}
 {% for x in parameters %}{{x.type}} {{x.name}}{% if 'default_value' in x %} = {{x.default_value}}{%- endif %}{% if not loop.last %}, {% endif %}{% endfor %}
@@ -49,6 +49,49 @@ namespace KRPC.Client.Services.{{ service_name }}
         public static global::KRPC.Client.Services.{{ service_name }}.Service {{ service_name }} (this global::KRPC.Client.IConnection connection)
         {
             return new global::KRPC.Client.Services.{{ service_name }}.Service (connection);
+        }
+    }
+
+    // The types the stubs encode and decode values of, built once each. A spec names the
+    // positions inside a value that can hold null, which a C# type cannot always say.
+    static class TypeSpecs
+    {
+        {% if type_specs | length > 0 %}
+        {% for typ in type_specs %}
+        internal static readonly global::KRPC.Client.TypeSpec {{ typ.name }} = {{ typ.spec }};
+        {% endfor %}
+
+        {% endif %}
+        // The procedures whose values a C# type cannot describe on its own, which a call
+        // built from an expression looks up by name
+        static readonly global::System.Collections.Generic.Dictionary<string, global::KRPC.Client.TypeSpec> returnSpecs =
+            new global::System.Collections.Generic.Dictionary<string, global::KRPC.Client.TypeSpec> {
+            {% for procedure in procedure_specs %}
+            {% if procedure.return_spec %}
+                { "{{ procedure.name }}", {{ procedure.return_spec }} },
+            {% endif %}
+            {% endfor %}
+            };
+
+        static readonly global::System.Collections.Generic.Dictionary<string, global::KRPC.Client.TypeSpec[]> parameterSpecs =
+            new global::System.Collections.Generic.Dictionary<string, global::KRPC.Client.TypeSpec[]> {
+            {% for procedure in procedure_specs %}
+            {% if procedure.parameter_specs | length > 0 %}
+                { "{{ procedure.name }}", new global::KRPC.Client.TypeSpec[] { {{ procedure.parameter_specs | join(', ') }} } },
+            {% endif %}
+            {% endfor %}
+            };
+
+        public static global::KRPC.Client.TypeSpec ReturnSpec (string procedure)
+        {
+            global::KRPC.Client.TypeSpec spec;
+            return returnSpecs.TryGetValue (procedure, out spec) ? spec : null;
+        }
+
+        public static global::KRPC.Client.TypeSpec[] ParameterSpecs (string procedure)
+        {
+            global::KRPC.Client.TypeSpec[] specs;
+            return parameterSpecs.TryGetValue (procedure, out specs) ? specs : null;
         }
     }
 
@@ -90,13 +133,13 @@ namespace KRPC.Client.Services.{{ service_name }}
 {% endif %}
 {% if procedure.deprecated %}        [global::System.Obsolete{% if procedure.deprecated_reason %} ("{{ procedure.deprecated_reason }}"){% endif %}]
 {% endif %}
-        [global::KRPC.Client.Attributes.RPCAttribute ("{{ service_name }}", "{{ procedure_name }}")]
+        [global::KRPC.Client.Attributes.RPCAttribute ("{{ service_name }}", "{{ procedure_name }}", typeof(TypeSpecs))]
         public {{ procedure.return_type }} {{ procedure_name }} ({{ sig_parameters(procedure.parameters) }})
         {
 {% if procedure.parameters | length > 0 %}{{ args(procedure.parameters) | indent(width=12) }}
 {% endif %}
 {{ call(service_name, procedure.remote_name, procedure.return_type != 'void', procedure.parameters | length > 0) | indent(width=12) }}
-{% if procedure.return_type != 'void' %}{{ return(procedure.return_type, procedure.return_is_nullable) | indent(width=12) }}
+{% if procedure.return_type != 'void' %}{{ return(procedure.return_type, procedure.return_spec, procedure.return_is_nullable) | indent(width=12) }}
 {% endif %}
         }
         {% endfor %}
@@ -107,18 +150,18 @@ namespace KRPC.Client.Services.{{ service_name }}
 {% if property.deprecated %}        [global::System.Obsolete{% if property.deprecated_reason %} ("{{ property.deprecated_reason }}"){% endif %}]
 {% endif %}
         {% if property.getter %}
-        [global::KRPC.Client.Attributes.RPCAttribute ("{{ service_name }}", "{{ property.getter.remote_name }}")]
+        [global::KRPC.Client.Attributes.RPCAttribute ("{{ service_name }}", "{{ property.getter.remote_name }}", typeof(TypeSpecs))]
         {% endif %}
         public {{ property.type }} {{ property_name }} {
         {% if property.getter %}
             get {
 {{ call(service_name, property.getter.remote_name, true, false) | indent(width=16) }}
-{{ return(property.type, property.return_is_nullable) | indent(width=16) }}
+{{ return(property.type, property.return_spec, property.return_is_nullable) | indent(width=16) }}
             }
         {% endif %}
         {% if property.setter %}
             set {
-{{ args([{'name': 'value', 'name_value': 'value', 'type': property.type}]) | indent(width=16) }}
+{{ args([{'name': 'value', 'name_value': 'value', 'type': property.type, 'spec': property.return_spec}]) | indent(width=16) }}
 {{ call(service_name, property.setter.remote_name, false, true) | indent(width=16) }}
             }
         {% endif %}
@@ -168,6 +211,8 @@ namespace KRPC.Client.Services.{{ service_name }}
 {% if field.documentation %}{{ field.documentation | indent(width=8) }}
 {% endif %}
 {% if field.deprecated %}        [global::System.Obsolete{% if field.deprecated_reason %} ("{{ field.deprecated_reason }}"){% endif %}]
+{% endif %}
+{% if field.attribute is defined %}        [{{ field.attribute }}]
 {% endif %}
         public {{ field.type }} {{ field.name }} { get; private set; }
         {% endfor %}
@@ -326,12 +371,12 @@ namespace KRPC.Client.Services.{{ service_name }}
 {% endif %}
 {% if method.deprecated %}        [global::System.Obsolete{% if method.deprecated_reason %} ("{{ method.deprecated_reason }}"){% endif %}]
 {% endif %}
-        [global::KRPC.Client.Attributes.RPCAttribute ("{{ service_name }}", "{{ method.remote_name }}")]
+        [global::KRPC.Client.Attributes.RPCAttribute ("{{ service_name }}", "{{ method.remote_name }}", typeof(TypeSpecs))]
         public {{ method.return_type }} {{ method_name }} ({{ sig_parameters(method.parameters) }})
         {
-{{ args([{'name': 'this', 'name_value': 'this', 'type': service_name+'.'+class_name}] + method.parameters) | indent(width=12) }}
+{{ args([{'name': 'this', 'name_value': 'this', 'type': service_name+'.'+class_name, 'spec': cls.spec}] + method.parameters) | indent(width=12) }}
 {{ call(service_name, method.remote_name, method.return_type != 'void', true) | indent(width=12) }}
-{% if method.return_type != 'void' %}{{ return(method.return_type, method.return_is_nullable) | indent(width=12) }}
+{% if method.return_type != 'void' %}{{ return(method.return_type, method.return_spec, method.return_is_nullable) | indent(width=12) }}
 {% endif %}
         }
         {% endfor %}
@@ -342,7 +387,7 @@ namespace KRPC.Client.Services.{{ service_name }}
         /// <param name="connection">A connection object.</param>
 {% if method.deprecated %}        [global::System.Obsolete{% if method.deprecated_reason %} ("{{ method.deprecated_reason }}"){% endif %}]
 {% endif %}
-        [global::KRPC.Client.Attributes.RPCAttribute ("{{ service_name }}", "{{ method.remote_name }}")]
+        [global::KRPC.Client.Attributes.RPCAttribute ("{{ service_name }}", "{{ method.remote_name }}", typeof(TypeSpecs))]
         public static {{ method.return_type }} {{ method_name }} ({{ sig_parameters([{'type': 'IConnection', 'name': 'connection'}] + method.parameters) }})
         {
             if (connection == null)
@@ -350,7 +395,7 @@ namespace KRPC.Client.Services.{{ service_name }}
 {% if method.parameters | length > 0 %}{{ args(method.parameters) | indent(width=12) }}
 {% endif %}
 {{ call(service_name, method.remote_name, method.return_type != 'void', method.parameters | length > 0, true) | indent(width=12) }}
-{% if method.return_type != 'void' %}{{ return(method.return_type, method.return_is_nullable) | indent(width=12) }}
+{% if method.return_type != 'void' %}{{ return(method.return_type, method.return_spec, method.return_is_nullable) | indent(width=12) }}
 {% endif %}
         }
         {% endfor %}
@@ -361,19 +406,19 @@ namespace KRPC.Client.Services.{{ service_name }}
 {% if property.deprecated %}        [global::System.Obsolete{% if property.deprecated_reason %} ("{{ property.deprecated_reason }}"){% endif %}]
 {% endif %}
         {% if property.getter %}
-        [global::KRPC.Client.Attributes.RPCAttribute ("{{ service_name }}", "{{ property.getter.remote_name }}")]
+        [global::KRPC.Client.Attributes.RPCAttribute ("{{ service_name }}", "{{ property.getter.remote_name }}", typeof(TypeSpecs))]
         {% endif %}
         public {{ property.type }} {{ property_name }} {
         {% if property.getter %}
             get {
-{{ args([{'name': 'this', 'name_value': 'this', 'type': service_name+'.'+class_name }]) | indent(width=16) }}
+{{ args([{'name': 'this', 'name_value': 'this', 'type': service_name+'.'+class_name, 'spec': cls.spec }]) | indent(width=16) }}
 {{ call(service_name, property.getter.remote_name, true, true) | indent(width=16) }}
-{{ return(property.type, property.return_is_nullable) | indent(width=16) }}
+{{ return(property.type, property.return_spec, property.return_is_nullable) | indent(width=16) }}
             }
         {% endif %}
         {% if property.setter %}
             set {
-{{ args([{'name': 'this', 'name_value': 'this', 'type': service_name+'.'+class_name }, {'name': 'value', 'name_value': 'value', 'type': property.type}]) | indent(width=16) }}
+{{ args([{'name': 'this', 'name_value': 'this', 'type': service_name+'.'+class_name, 'spec': cls.spec }, {'name': 'value', 'name_value': 'value', 'type': property.type, 'spec': property.return_spec}]) | indent(width=16) }}
 {{ call(service_name, property.setter.remote_name, false, true) | indent(width=16) }}
             }
         {% endif %}

--- a/tools/krpctools/krpctools/clientgen/generator.py
+++ b/tools/krpctools/krpctools/clientgen/generator.py
@@ -10,7 +10,14 @@ from krpc.types import (
     TupleType,
 )
 from krpc.utils import snake_case
-from ..utils import lower_camel_case, indent, single_line, as_type, decode_default_value
+from ..utils import (
+    lower_camel_case,
+    indent,
+    single_line,
+    as_type,
+    decode_default_value,
+    is_nullable,
+)
 from .docparser import flatten_deprecation_reason
 
 
@@ -93,7 +100,7 @@ class Generator:
                 )
                 value = decode_default_value(parameter["default_value"], typ, location)
                 info["default_value"] = self.parse_default_value(value, typ)
-            info["nullable"] = parameter.get("nullable", False)
+            info["nullable"] = is_nullable(parameter["type"])
             parameters.append(info)
         return parameters
 
@@ -156,6 +163,7 @@ class Generator:
                         "remote_name": x["name"],
                         "krpc_type": self.as_type(x["type"]),
                         "type": self.parse_type(self.as_type(x["type"])),
+                        "nullable": is_nullable(x["type"]),
                         "documentation": self.parse_documentation(x["documentation"]),
                         "deprecated": x.get("deprecated", False),
                         "deprecated_reason": self.parse_deprecation_reason(
@@ -190,6 +198,7 @@ class Generator:
                     "return_type": self.parse_return_type(
                         self.get_return_type(procedure)
                     ),
+                    "return_is_nullable": is_nullable(procedure.get("return_type")),
                     "documentation": self.parse_documentation(
                         procedure["documentation"]
                     ),
@@ -204,6 +213,7 @@ class Generator:
                 if property_name not in context["properties"]:
                     context["properties"][property_name] = {
                         "type": self.parse_return_type(self.get_return_type(procedure)),
+                        "return_is_nullable": is_nullable(procedure.get("return_type")),
                         "getter": None,
                         "setter": None,
                         "documentation": self.parse_documentation(
@@ -226,6 +236,7 @@ class Generator:
                 if property_name not in context["properties"]:
                     context["properties"][property_name] = {
                         "type": params[0]["type"],
+                        "return_is_nullable": params[0]["nullable"],
                         "getter": None,
                         "setter": None,
                         "documentation": self.parse_documentation(
@@ -254,6 +265,7 @@ class Generator:
                     "return_type": self.parse_return_type(
                         self.get_return_type(procedure)
                     ),
+                    "return_is_nullable": is_nullable(procedure.get("return_type")),
                     "documentation": self.parse_documentation(
                         procedure["documentation"]
                     ),
@@ -275,6 +287,7 @@ class Generator:
                     "return_type": self.parse_return_type(
                         self.get_return_type(procedure)
                     ),
+                    "return_is_nullable": is_nullable(procedure.get("return_type")),
                     "documentation": self.parse_documentation(
                         procedure["documentation"]
                     ),
@@ -291,6 +304,7 @@ class Generator:
                 if property_name not in cls["properties"]:
                     cls["properties"][property_name] = {
                         "type": self.parse_return_type(self.get_return_type(procedure)),
+                        "return_is_nullable": is_nullable(procedure.get("return_type")),
                         "getter": None,
                         "setter": None,
                         "documentation": self.parse_documentation(
@@ -315,6 +329,7 @@ class Generator:
                     params = self.generate_context_parameters(name, procedure)
                     cls["properties"][property_name] = {
                         "type": params[1]["type"],
+                        "return_is_nullable": params[1]["nullable"],
                         "getter": None,
                         "setter": None,
                         "documentation": self.parse_documentation(

--- a/tools/krpctools/krpctools/clientgen/generator.py
+++ b/tools/krpctools/krpctools/clientgen/generator.py
@@ -100,7 +100,7 @@ class Generator:
                 )
                 value = decode_default_value(parameter["default_value"], typ, location)
                 info["default_value"] = self.parse_default_value(value, typ)
-            info["nullable"] = is_nullable(parameter["type"])
+            info["nullable"] = typ.nullable
             parameters.append(info)
         return parameters
 
@@ -163,7 +163,6 @@ class Generator:
                         "remote_name": x["name"],
                         "krpc_type": self.as_type(x["type"]),
                         "type": self.parse_type(self.as_type(x["type"])),
-                        "nullable": is_nullable(x["type"]),
                         "documentation": self.parse_documentation(x["documentation"]),
                         "deprecated": x.get("deprecated", False),
                         "deprecated_reason": self.parse_deprecation_reason(
@@ -189,16 +188,15 @@ class Generator:
             }
 
         for name, procedure in self._get_defs("procedures"):
+            return_type = self.get_return_type(procedure)
             if Attributes.is_a_procedure(name):
                 context["procedures"][self.parse_name(name)] = {
                     "procedure": procedure,
                     "remote_name": name,
                     "remote_id": procedure["id"],
                     "parameters": self.generate_context_parameters(name, procedure),
-                    "return_type": self.parse_return_type(
-                        self.get_return_type(procedure)
-                    ),
-                    "return_is_nullable": is_nullable(procedure.get("return_type")),
+                    "return_type": self.parse_return_type(return_type),
+                    "return_is_nullable": is_nullable(return_type),
                     "documentation": self.parse_documentation(
                         procedure["documentation"]
                     ),
@@ -212,8 +210,8 @@ class Generator:
                 property_name = self.parse_name(Attributes.get_property_name(name))
                 if property_name not in context["properties"]:
                     context["properties"][property_name] = {
-                        "type": self.parse_return_type(self.get_return_type(procedure)),
-                        "return_is_nullable": is_nullable(procedure.get("return_type")),
+                        "type": self.parse_return_type(return_type),
+                        "return_is_nullable": is_nullable(return_type),
                         "getter": None,
                         "setter": None,
                         "documentation": self.parse_documentation(
@@ -262,10 +260,8 @@ class Generator:
                     "remote_name": name,
                     "remote_id": procedure["id"],
                     "parameters": params[1:],
-                    "return_type": self.parse_return_type(
-                        self.get_return_type(procedure)
-                    ),
-                    "return_is_nullable": is_nullable(procedure.get("return_type")),
+                    "return_type": self.parse_return_type(return_type),
+                    "return_is_nullable": is_nullable(return_type),
                     "documentation": self.parse_documentation(
                         procedure["documentation"]
                     ),
@@ -284,10 +280,8 @@ class Generator:
                     "remote_name": name,
                     "remote_id": procedure["id"],
                     "parameters": self.generate_context_parameters(name, procedure),
-                    "return_type": self.parse_return_type(
-                        self.get_return_type(procedure)
-                    ),
-                    "return_is_nullable": is_nullable(procedure.get("return_type")),
+                    "return_type": self.parse_return_type(return_type),
+                    "return_is_nullable": is_nullable(return_type),
                     "documentation": self.parse_documentation(
                         procedure["documentation"]
                     ),
@@ -303,8 +297,8 @@ class Generator:
                 property_name = self.parse_name(Attributes.get_class_member_name(name))
                 if property_name not in cls["properties"]:
                     cls["properties"][property_name] = {
-                        "type": self.parse_return_type(self.get_return_type(procedure)),
-                        "return_is_nullable": is_nullable(procedure.get("return_type")),
+                        "type": self.parse_return_type(return_type),
+                        "return_is_nullable": is_nullable(return_type),
                         "getter": None,
                         "setter": None,
                         "documentation": self.parse_documentation(

--- a/tools/krpctools/krpctools/clientgen/java.py
+++ b/tools/krpctools/krpctools/clientgen/java.py
@@ -17,7 +17,7 @@ from krpc.types import (
 )
 from .generator import Generator
 from .docparser import DocParser
-from ..utils import lower_camel_case, upper_camel_case, as_type
+from ..utils import lower_camel_case, upper_camel_case, as_type, is_nullable
 from ..lang.java import JavaLanguage
 
 
@@ -59,22 +59,26 @@ class JavaGenerator(Generator):
             )
         if isinstance(typ, TupleType):
             return "krpc.client.Types.createTuple(%s)" % ",".join(
-                self.parse_type_specification(t) for t in typ.value_types
+                self._at_position(t) for t in typ.value_types
             )
         if isinstance(typ, ListType):
-            return "krpc.client.Types.createList(%s)" % self.parse_type_specification(
+            return "krpc.client.Types.createList(%s)" % self._at_position(
                 typ.value_type
             )
         if isinstance(typ, SetType):
-            return "krpc.client.Types.createSet(%s)" % self.parse_type_specification(
-                typ.value_type
-            )
+            return "krpc.client.Types.createSet(%s)" % self._at_position(typ.value_type)
         if isinstance(typ, DictionaryType):
             return "krpc.client.Types.createDictionary(%s, %s)" % (
-                self.parse_type_specification(typ.key_type),
-                self.parse_type_specification(typ.value_type),
+                self._at_position(typ.key_type),
+                self._at_position(typ.value_type),
             )
         raise RuntimeError("Unknown type " + typ)
+
+    def _at_position(self, typ):
+        """The specification of a type at a position inside a value, named as the nullable
+        form where that position can hold null"""
+        spec = self.parse_type_specification(typ)
+        return "krpc.client.Types.nullable(%s)" % spec if typ.nullable else spec
 
     @staticmethod
     def parse_documentation(documentation):
@@ -84,37 +88,13 @@ class JavaGenerator(Generator):
         lines = ["/**"] + [" * " + line for line in documentation.split("\n")] + [" */"]
         return "\n".join(line.rstrip() for line in lines)
 
-    @staticmethod
-    def _needs_boxing(typ):
-        # Java reference types (String, byte[], classes, enums, collections) carry null
-        # naturally; only the primitive value types need the boxed form to hold null.
-        return isinstance(typ, ValueType) and typ.protobuf_type.code not in (
-            Type.STRING,
-            Type.BYTES,
-        )
-
-    def generate_context_parameters(self, name, procedure):
-        parameters = super().generate_context_parameters(name, procedure)
-        for i, parameter in enumerate(parameters):
-            typ = as_type(self.types, procedure["parameters"][i]["type"])
-            if parameter["nullable"] and self._needs_boxing(typ):
-                parameter["type"] = self.language.type_map_classes[
-                    typ.protobuf_type.code
-                ]
-        return parameters
-
     def _make_return_type(self, info):
-        procedure = info["procedure"]
-        name = info["return_type"]
-        nullable = procedure.get("return_is_nullable", False)
-        if nullable:
-            return_type = self.get_return_type(procedure)
-            if self._needs_boxing(return_type):
-                name = self.language.type_map_classes[return_type.protobuf_type.code]
+        return_type = self.get_return_type(info["procedure"])
         return {
-            "name": name,
-            "spec": self.parse_type_specification(self.get_return_type(procedure)),
-            "nullable": nullable,
+            "name": info["return_type"],
+            "spec": self.parse_type_specification(return_type),
+            # The stub reads is_null where the return type says the value can be null
+            "nullable": is_nullable(return_type),
         }
 
     def add_struct_field_specifications(self, context):
@@ -122,7 +102,7 @@ class JavaGenerator(Generator):
         generated declaration is written with"""
         for struct_info in context["structs"].values():
             for field in struct_info["fields"]:
-                field["spec"] = self.parse_type_specification(field["krpc_type"])
+                field["spec"] = self._at_position(field["krpc_type"])
                 field["accessor_name"] = upper_camel_case(field["name"])
 
     def parse_context(self, context):

--- a/tools/krpctools/krpctools/clientgen/python.py
+++ b/tools/krpctools/krpctools/clientgen/python.py
@@ -45,8 +45,20 @@ class PythonGenerator(Generator):
         self.language = StubLanguage(service)
 
     def parse_python_type(self, typ):
+        """The expression that builds the type of a slot. A slot carries a null out of band,
+        so its type is named without its nullability."""
         if typ is None:
             return "None"
+        return self._parse_python_type(typ)
+
+    def parse_python_type_at_position(self, typ):
+        """The expression that builds the type at a position inside a value. A position
+        carries a null in the value, so a nullable type is named as one."""
+        if typ.nullable:
+            return "self._client._types.nullable(%s)" % self._parse_python_type(typ)
+        return self._parse_python_type(typ)
+
+    def _parse_python_type(self, typ):
         if isinstance(typ, ValueType):
             mapping = {
                 KRPC.Type.DOUBLE: "double",
@@ -79,33 +91,35 @@ class PythonGenerator(Generator):
             )
         if isinstance(typ, TupleType):
             return "self._client._types.tuple_type(%s)" % ", ".join(
-                self.parse_python_type(x) for x in typ.value_types
+                self.parse_python_type_at_position(x) for x in typ.value_types
             )
         if isinstance(typ, ListType):
-            return "self._client._types.list_type(%s)" % self.parse_python_type(
-                typ.value_type
+            return (
+                "self._client._types.list_type(%s)"
+                % self.parse_python_type_at_position(typ.value_type)
             )
         if isinstance(typ, SetType):
-            return "self._client._types.set_type(%s)" % self.parse_python_type(
-                typ.value_type
+            return (
+                "self._client._types.set_type(%s)"
+                % self.parse_python_type_at_position(typ.value_type)
             )
         if isinstance(typ, DictionaryType):
             return "self._client._types.dictionary_type(%s, %s)" % (
-                self.parse_python_type(typ.key_type),
-                self.parse_python_type(typ.value_type),
+                self.parse_python_type_at_position(typ.key_type),
+                self.parse_python_type_at_position(typ.value_type),
             )
         raise RuntimeError("Unknown type " + typ)
 
-    def parse_type_specification(self, typ, is_nullable=False):
+    def parse_type_specification(self, typ):
         if typ is None:
-            spec = "None"
-        elif isinstance(typ, ValueType):
+            return "None"
+        if isinstance(typ, ValueType):
             spec = self.language.parse_type(typ)
         elif isinstance(typ, MessageType):
             if typ.python_type == KRPC.Event:
                 spec = "Event"
             else:
-                return "KRPC_pb2.%s" % typ.python_type.__name__
+                spec = "KRPC_pb2.%s" % typ.python_type.__name__
         elif isinstance(typ, (ClassType, EnumerationType, StructType)):
             spec = self.language.parse_type(typ)
         elif isinstance(typ, TupleType):
@@ -123,7 +137,7 @@ class PythonGenerator(Generator):
             )
         else:
             raise RuntimeError("Unknown type " + typ)
-        if is_nullable:
+        if typ.nullable:
             return "Optional[%s]" % spec
         return spec
 
@@ -269,18 +283,16 @@ class PythonGenerator(Generator):
                     self.get_return_type(info["procedure"])
                 ),
                 "spec": self.parse_type_specification(
-                    self.get_return_type(info["procedure"]),
-                    info["procedure"].get("return_is_nullable", False),
+                    self.get_return_type(info["procedure"])
                 ),
             }
             pos = 0
             for i, pinfo in enumerate(info["parameters"]):
                 ptype = as_type(self.types, info["procedure"]["parameters"][i]["type"])
-                nullable = info["procedure"]["parameters"][i].get("nullable", False)
                 pinfo["type"] = {
                     "name": pinfo["type"],
                     "python_type": self.parse_python_type(ptype),
-                    "spec": self.parse_type_specification(ptype, nullable),
+                    "spec": self.parse_type_specification(ptype),
                 }
                 pos += 1
 
@@ -297,8 +309,7 @@ class PythonGenerator(Generator):
                         self.get_return_type(info["procedure"])
                     ),
                     "spec": self.parse_type_specification(
-                        self.get_return_type(info["procedure"]),
-                        info["procedure"].get("return_is_nullable", False),
+                        self.get_return_type(info["procedure"])
                     ),
                 }
                 pos = 0
@@ -306,13 +317,10 @@ class PythonGenerator(Generator):
                     ptype = as_type(
                         self.types, info["procedure"]["parameters"][i + 1]["type"]
                     )
-                    nullable = info["procedure"]["parameters"][i + 1].get(
-                        "nullable", False
-                    )
                     pinfo["type"] = {
                         "name": pinfo["type"],
                         "python_type": self.parse_python_type(ptype),
-                        "spec": self.parse_type_specification(ptype, nullable),
+                        "spec": self.parse_type_specification(ptype),
                     }
                     pos += 1
 

--- a/tools/krpctools/krpctools/docgen/cnano.py
+++ b/tools/krpctools/krpctools/docgen/cnano.py
@@ -43,23 +43,42 @@ class CnanoDomain(Domain):
             return "%s_" % name
         return name
 
+    def type_name_at_position(self, typ):
+        name = self.parse_type_name(typ)
+        return "nullable_%s" % name if typ.nullable else name
+
+    def type_at_position(self, typ):
+        """The C type of a value at a position inside another value. A value is stored by
+        value, so there is nowhere to put a null: a position that can hold one takes a
+        generated type of its own, holding the value beside a bool saying whether it is
+        there."""
+        value_type = self.type(typ)
+        if not typ.nullable:
+            return value_type
+        name = "nullable_%s" % value_type["name"]
+        return {
+            "name": name,
+            "ctype": "krpc_%s_t" % name,
+            "cvtype": "krpc_%s_t *" % name,
+        }
+
     def parse_type_name(self, typ):
         if isinstance(typ, ValueType):
             return self.language.type_name_map[typ.protobuf_type.code]
         if isinstance(typ, MessageType):
             return "message_%s" % typ.python_type.__name__
         if isinstance(typ, ListType):
-            return "list_%s" % self.parse_type_name(typ.value_type)
+            return "list_%s" % self.type_name_at_position(typ.value_type)
         if isinstance(typ, SetType):
-            return "set_%s" % self.parse_type_name(typ.value_type)
+            return "set_%s" % self.type_name_at_position(typ.value_type)
         if isinstance(typ, DictionaryType):
             return "dictionary_%s_%s" % (
-                self.parse_type_name(typ.key_type),
-                self.parse_type_name(typ.value_type),
+                self.type_name_at_position(typ.key_type),
+                self.type_name_at_position(typ.value_type),
             )
         if isinstance(typ, TupleType):
             return "tuple_%s" % "_".join(
-                self.parse_type_name(t) for t in typ.value_types
+                self.type_name_at_position(t) for t in typ.value_types
             )
         if isinstance(typ, ClassType):
             return "object"
@@ -79,17 +98,17 @@ class CnanoDomain(Domain):
         elif isinstance(typ, MessageType):
             ctype = "krpc_schema_%s" % typ.python_type.__name__
         elif isinstance(typ, ListType):
-            ctype = "krpc_list_%s_t" % self.parse_type_name(typ.value_type)
+            ctype = "krpc_list_%s_t" % self.type_name_at_position(typ.value_type)
         elif isinstance(typ, SetType):
-            ctype = "krpc_set_%s_t" % self.parse_type_name(typ.value_type)
+            ctype = "krpc_set_%s_t" % self.type_name_at_position(typ.value_type)
         elif isinstance(typ, DictionaryType):
             ctype = "krpc_dictionary_%s_%s_t" % (
-                self.parse_type_name(typ.key_type),
-                self.parse_type_name(typ.value_type),
+                self.type_name_at_position(typ.key_type),
+                self.type_name_at_position(typ.value_type),
             )
         elif isinstance(typ, TupleType):
             ctype = "krpc_tuple_%s_t" % "_".join(
-                self.parse_type_name(t) for t in typ.value_types
+                self.type_name_at_position(t) for t in typ.value_types
             )
         elif isinstance(typ, (ClassType, EnumerationType)):
             ctype = "krpc_%s_%s_t" % (typ.protobuf_type.service, typ.protobuf_type.name)

--- a/tools/krpctools/krpctools/docgen/cnano.tmpl
+++ b/tools/krpctools/krpctools/docgen/cnano.tmpl
@@ -159,7 +159,7 @@
 
 {% if hasdoc(x.documentation, './remarks') %}{{ remarks(x.documentation) | indent }}{% endif %}
 {% for field in x.fields.values() %}{{ mark_documented(field) }}
-   .. member:: {{ domain.type(field.type).ctype }} {{ field.name | snakecase }}
+   .. member:: {{ domain.field_type(field).ctype }} {{ field.name | snakecase }}
 
 {% if field.deprecated %}{{ deprecated(field) | indent(width=6) }}
 

--- a/tools/krpctools/krpctools/docgen/cpp.tmpl
+++ b/tools/krpctools/krpctools/docgen/cpp.tmpl
@@ -168,7 +168,7 @@
 
 {% if hasdoc(x.documentation, './remarks') %}{{ remarks(x.documentation) | indent }}{% endif %}
 {% for field in x.fields.values() %}{{ mark_documented(field) }}
-   .. member:: {{ domain.return_type(field.type) }} {{ field.name | snakecase }}
+   .. member:: {{ domain.field_type(field) }} {{ field.name | snakecase }}
 
 {% if field.deprecated %}{{ deprecated(field) | indent(width=6) }}
 

--- a/tools/krpctools/krpctools/docgen/csharp.py
+++ b/tools/krpctools/krpctools/docgen/csharp.py
@@ -49,19 +49,29 @@ class CsharpDomain(Domain):
                 "%s.%s" % (typ.protobuf_type.service, typ.protobuf_type.name)
             )
         if isinstance(typ, ListType):
-            return "System.Collections.Generic.IList<%s>" % self.type(typ.value_type)
+            return "System.Collections.Generic.IList<%s>" % self.type_at_position(
+                typ.value_type
+            )
         if isinstance(typ, DictionaryType):
             return "System.Collections.Generic.IDictionary<%s,%s>" % (
                 self.type(typ.key_type),
-                self.type(typ.value_type),
+                self.type_at_position(typ.value_type),
             )
         if isinstance(typ, SetType):
             return "System.Collections.Generic.ISet<%s>" % self.type(typ.value_type)
         if isinstance(typ, TupleType):
             return "System.Tuple<%s>" % ",".join(
-                self.type(typ) for typ in typ.value_types
+                self.type_at_position(t) for t in typ.value_types
             )
         raise RuntimeError("Unknown type '%s'" % str(typ))
+
+    def type_at_position(self, typ):
+        # The docs name a type without its namespace alias, so the nullable form is built on
+        # the name this domain gives rather than the one the client is generated with
+        name = self.type(typ)
+        if typ.nullable and self.language.takes_the_nullable_form(typ):
+            return name + "?"
+        return name
 
     def default_value(self, value, typ):
         if isinstance(typ, StructType):

--- a/tools/krpctools/krpctools/docgen/csharp.tmpl
+++ b/tools/krpctools/krpctools/docgen/csharp.tmpl
@@ -164,7 +164,7 @@
 
 {% if hasdoc(x.documentation, './remarks') %}{{ remarks(x.documentation) | indent }}{% endif %}
 {% for field in x.fields.values() %}{{ mark_documented(field) }}
-   .. property:: {{ domain.return_type(field.type) }} {{ field.name }} {{'{'}} get; set; {{'}'}}
+   .. property:: {{ domain.field_type(field) }} {{ field.name }} {{'{'}} get; set; {{'}'}}
 
 {% if field.deprecated %}{{ deprecated(field) | indent(width=6) }}
 

--- a/tools/krpctools/krpctools/docgen/domain.py
+++ b/tools/krpctools/krpctools/docgen/domain.py
@@ -15,6 +15,15 @@ class Domain:
     def type(self, typ):
         return self.language.parse_type(typ)
 
+    def type_at_position(self, typ):
+        """The type at a position inside a value, as the client declares it. A language
+        with no separate spelling for a nullable type names the type itself."""
+        return self.type(typ)
+
+    def field_type(self, field):
+        """The type a structure field is declared with"""
+        return self.type_at_position(field.type)
+
     def return_type(self, typ):
         return self.type(typ)
 

--- a/tools/krpctools/krpctools/docgen/java.py
+++ b/tools/krpctools/krpctools/docgen/java.py
@@ -47,6 +47,11 @@ class JavaDomain(Domain):
     def type(self, typ):
         return self._type(typ)
 
+    def type_at_position(self, typ):
+        # A primitive takes its boxed form at a position that can hold null, which is the
+        # same form it takes inside a collection
+        return self._type(typ, generic=typ.nullable)
+
     def _type(self, typ, generic=False):
         if typ is None:
             return "void"

--- a/tools/krpctools/krpctools/docgen/java.tmpl
+++ b/tools/krpctools/krpctools/docgen/java.tmpl
@@ -171,7 +171,7 @@
 
 {% if hasdoc(x.documentation, './remarks') %}{{ remarks(x.documentation) | indent }}{% endif %}
 {% for field in x.fields.values() %}{{ mark_documented(field) }}
-   .. method:: {{ domain.return_type(field.type) }} get{{ domain.method_name(field.name) }}()
+   .. method:: {{ domain.field_type(field) }} get{{ domain.method_name(field.name) }}()
 
 {% if field.deprecated %}{{ deprecated(field) | indent(width=6) }}
 

--- a/tools/krpctools/krpctools/docgen/lua.tmpl
+++ b/tools/krpctools/krpctools/docgen/lua.tmpl
@@ -173,7 +173,7 @@
 
 {% if hasdoc(x.documentation, './remarks') %}{{ remarks(x.documentation) | indent }}{% endif %}
 {% for field in x.fields.values() %}{{ mark_documented(field) }}
-   .. attribute:: {{ field.name | snakecase }}: {{ domain.type(field.type) }}
+   .. attribute:: {{ field.name | snakecase }}: {{ domain.field_type(field) }}
 
 {% if field.deprecated %}{{ deprecated(field) | indent(width=6) }}
 

--- a/tools/krpctools/krpctools/docgen/nodes.py
+++ b/tools/krpctools/krpctools/docgen/nodes.py
@@ -172,7 +172,6 @@ class Parameter(Appendable):
         types,
         procedure,
         default_value=None,
-        nullable=False,
     ):
         super().__init__()
         self.types = types
@@ -183,7 +182,6 @@ class Parameter(Appendable):
             location = "%s parameter %s" % (procedure, name)
             default_value = decode_default_value(default_value, self.type, location)
         self.default_value = default_value
-        self.nullable = nullable
         self.documentation = documentation
 
 
@@ -198,7 +196,6 @@ class Procedure(Appendable):
         documentation,
         types,
         return_type=None,
-        return_is_nullable=False,
         game_scenes=None,
         deprecated=False,
         deprecated_reason="",
@@ -212,7 +209,6 @@ class Procedure(Appendable):
             self.return_type = as_type(self.types, return_type)
         else:
             self.return_type = None
-        self.return_is_nullable = return_is_nullable
         self.parameters = [
             Parameter(
                 documentation=documentation,
@@ -267,7 +263,6 @@ class ClassMethod(Appendable):
         documentation,
         types,
         return_type=None,
-        return_is_nullable=False,
         game_scenes=None,
         deprecated=False,
         deprecated_reason="",
@@ -283,7 +278,6 @@ class ClassMethod(Appendable):
             self.return_type = as_type(self.types, return_type)
         else:
             self.return_type = None
-        self.return_is_nullable = return_is_nullable
         self.parameters = [
             Parameter(
                 documentation=documentation,
@@ -313,7 +307,6 @@ class ClassStaticMethod(Appendable):
         documentation,
         types,
         return_type=None,
-        return_is_nullable=False,
         game_scenes=None,
         deprecated=False,
         deprecated_reason="",
@@ -329,7 +322,6 @@ class ClassStaticMethod(Appendable):
             self.return_type = as_type(self.types, return_type)
         else:
             self.return_type = None
-        self.return_is_nullable = return_is_nullable
         self.parameters = [
             Parameter(
                 documentation=documentation,

--- a/tools/krpctools/krpctools/docgen/python.py
+++ b/tools/krpctools/krpctools/docgen/python.py
@@ -42,6 +42,11 @@ class PythonDomain(Domain):
         return name
 
     def type_description(self, typ):
+        description = self._type_description(typ)
+        # Python writes a value that can be null as the type or None
+        return "%s or None" % description if typ.nullable else description
+
+    def _type_description(self, typ):
         if isinstance(typ, ValueType):
             return self.language.parse_type(typ)
         if isinstance(typ, MessageType):
@@ -63,7 +68,7 @@ class PythonDomain(Domain):
             return "set(%s)" % self.type_description(typ.value_type)
         if isinstance(typ, TupleType):
             return "tuple(%s)" % ", ".join(
-                self.type_description(typ) for typ in typ.value_types
+                self.type_description(t) for t in typ.value_types
             )
         raise RuntimeError("Unknown type '%s'" % str(typ))
 

--- a/tools/krpctools/krpctools/lang/cpp.py
+++ b/tools/krpctools/krpctools/lang/cpp.py
@@ -149,6 +149,15 @@ class CppLanguage(Language):
         return super().parse_name(snake_case(name))
 
     def parse_type(self, typ):
+        """The C++ type of a value. A value that can hold null is a std::optional, at a
+        slot and at a position inside another value alike, as the type is all the codec
+        has to read nullability from."""
+        if typ is not None and typ.nullable:
+            return "std::optional<%s>" % self._parse_type(typ)
+        return self._parse_type(typ)
+
+    def _parse_type(self, typ):
+        """The C++ type a value is spelled with, leaving aside whether it can hold null"""
         if typ is None:
             return "void"
         if isinstance(typ, ValueType):
@@ -185,15 +194,15 @@ class CppLanguage(Language):
             return "true" if value else "false"
         if isinstance(typ, ValueType) and typ.protobuf_type.code == Type.FLOAT:
             return float32_literal(value) + "f"
-        if isinstance(typ, ClassType) and value is None:
+        # A default of null is the default constructed value, which for a nullable position
+        # is the empty std::optional it is declared with
+        if value is None:
             return self.parse_type(typ) + "()"
         if isinstance(typ, EnumerationType):
             return "%s::%s" % (
-                self.parse_type(typ),
+                self._parse_type(typ),
                 self.parse_enum_value_name(value.name),
             )
-        if value is None:
-            return self.parse_type(typ) + "()"
         # A collection is written as a braced initializer list. Parentheses would name a
         # constructor instead, so std::vector<int32_t>(1, 2, 3) is not the vector of those
         # three values it appears to be.
@@ -202,19 +211,19 @@ class CppLanguage(Language):
                 self.parse_default_value(x, typ.field_types[i])
                 for i, x in enumerate(value)
             )
-            return "%s{%s}" % (self.parse_type(typ), ", ".join(values))
+            return "%s{%s}" % (self._parse_type(typ), ", ".join(values))
         if isinstance(typ, TupleType):
             values = (
                 self.parse_default_value(x, typ.value_types[i])
                 for i, x in enumerate(value)
             )
-            return "%s{%s}" % (self.parse_type(typ), ", ".join(values))
+            return "%s{%s}" % (self._parse_type(typ), ", ".join(values))
         if isinstance(typ, ListType):
             values = (self.parse_default_value(x, typ.value_type) for x in value)
-            return "%s{%s}" % (self.parse_type(typ), ", ".join(values))
+            return "%s{%s}" % (self._parse_type(typ), ", ".join(values))
         if isinstance(typ, SetType):
             values = (self.parse_default_value(x, typ.value_type) for x in value)
-            return "%s{%s}" % (self.parse_type(typ), ", ".join(values))
+            return "%s{%s}" % (self._parse_type(typ), ", ".join(values))
         if isinstance(typ, DictionaryType):
             entries = (
                 "{%s, %s}"
@@ -224,7 +233,7 @@ class CppLanguage(Language):
                 )
                 for k, v in value.items()
             )
-            return "%s{%s}" % (self.parse_type(typ), ", ".join(entries))
+            return "%s{%s}" % (self._parse_type(typ), ", ".join(entries))
         return str(value)
 
     def shorten_ref(self, name):

--- a/tools/krpctools/krpctools/lang/csharp.py
+++ b/tools/krpctools/krpctools/lang/csharp.py
@@ -145,7 +145,7 @@ class CsharpLanguage(Language):
             return "global::KRPC.Schema.KRPC.%s" % typ.python_type.__name__
         if isinstance(typ, TupleType):
             return "systemAlias::Tuple<%s>" % ",".join(
-                self._parse_type(t) for t in typ.value_types
+                self._at_position(t) for t in typ.value_types
             )
         if isinstance(typ, ListType):
             if interface:
@@ -154,7 +154,7 @@ class CsharpLanguage(Language):
                 name = "List"
             return "global::System.Collections.Generic.%s<%s>" % (
                 name,
-                self._parse_type(typ.value_type),
+                self._at_position(typ.value_type),
             )
         if isinstance(typ, SetType):
             if interface:
@@ -170,7 +170,7 @@ class CsharpLanguage(Language):
             return "global::System.Collections.Generic.%s<%s,%s>" % (
                 name,
                 self._parse_type(typ.key_type),
-                self._parse_type(typ.value_type),
+                self._at_position(typ.value_type),
             )
         if isinstance(typ, (ClassType, EnumerationType, StructType)):
             return "global::KRPC.Client.Services.%s.%s" % (
@@ -178,6 +178,26 @@ class CsharpLanguage(Language):
                 typ.protobuf_type.name,
             )
         raise RuntimeError("Unknown type '%s'" % str(typ))
+
+    def _at_position(self, typ):
+        """The C# type of a value at a position inside a collection. A value type takes the
+        nullable form T? where the position can hold null; a reference type is nullable in C#
+        already, and the generated stub names the position for the encoder instead."""
+        name = self._parse_type(typ)
+        if typ.nullable and self.takes_the_nullable_form(typ):
+            return name + "?"
+        return name
+
+    @staticmethod
+    def takes_the_nullable_form(typ):
+        """Whether a value at a nullable position is written T?, which a C# value type is
+        and a reference type is not."""
+        if isinstance(typ, (EnumerationType, StructType)):
+            return True
+        return isinstance(typ, ValueType) and typ.protobuf_type.code not in (
+            Type.STRING,
+            Type.BYTES,
+        )
 
     def parse_default_value(self, value, typ):
         special = self.parse_special_value(value, typ)

--- a/tools/krpctools/krpctools/lang/java.py
+++ b/tools/krpctools/krpctools/lang/java.py
@@ -125,15 +125,22 @@ class JavaLanguage(Language):
     def parse_type(self, typ):
         return self._parse_type(typ)
 
+    def _at_position(self, typ):
+        """The Java type of a value at a position inside a collection. A collection holds
+        its values as objects, so a primitive takes its boxed form there whether the
+        position can hold null or not."""
+        return self._parse_type(typ, True)
+
     def _parse_type(self, typ, in_collection=False):
         if typ is None:
             if in_collection:
                 raise RuntimeError("void type not allowed in collection type")
             return "void"
-        if not in_collection and isinstance(typ, ValueType):
-            return self.type_map[typ.protobuf_type.code]
         if isinstance(typ, ValueType):
-            return self.type_map_classes[typ.protobuf_type.code]
+            # A primitive takes its boxed form at a position that can hold null
+            if in_collection or typ.nullable:
+                return self.type_map_classes[typ.protobuf_type.code]
+            return self.type_map[typ.protobuf_type.code]
         if isinstance(typ, MessageType) and typ.protobuf_type.code == Type.EVENT:
             return "krpc.client.Event"
         if isinstance(typ, MessageType):
@@ -148,16 +155,15 @@ class JavaLanguage(Language):
             return (
                 "org.javatuples."
                 + name
-                + "<%s>"
-                % (",".join(self._parse_type(t, True) for t in typ.value_types))
+                + "<%s>" % (",".join(self._at_position(t) for t in typ.value_types))
             )
         if isinstance(typ, ListType):
-            return "java.util.List<%s>" % self._parse_type(typ.value_type, True)
+            return "java.util.List<%s>" % self._at_position(typ.value_type)
         if isinstance(typ, SetType):
-            return "java.util.Set<%s>" % self._parse_type(typ.value_type, True)
+            return "java.util.Set<%s>" % self._at_position(typ.value_type)
         if isinstance(typ, DictionaryType):
             return "java.util.Map<%s,%s>" % (
-                self._parse_type(typ.key_type, True),
-                self._parse_type(typ.value_type, True),
+                self._at_position(typ.key_type),
+                self._at_position(typ.value_type),
             )
         raise RuntimeError("Unknown type '%s'" % str(typ))

--- a/tools/krpctools/krpctools/test/clientgen-Empty-cnano.txt
+++ b/tools/krpctools/krpctools/test/clientgen-Empty-cnano.txt
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <string.h>
+
 #include <krpc_cnano/decoder.h>
 #include <krpc_cnano/deprecated.h>
 #include <krpc_cnano/encoder.h>

--- a/tools/krpctools/krpctools/test/clientgen-Empty-csharp.txt
+++ b/tools/krpctools/krpctools/test/clientgen-Empty-csharp.txt
@@ -31,6 +31,33 @@ namespace KRPC.Client.Services.EmptyService
         }
     }
 
+    // The types the stubs encode and decode values of, built once each. A spec names the
+    // positions inside a value that can hold null, which a C# type cannot always say.
+    static class TypeSpecs
+    {
+        // The procedures whose values a C# type cannot describe on its own, which a call
+        // built from an expression looks up by name
+        static readonly global::System.Collections.Generic.Dictionary<string, global::KRPC.Client.TypeSpec> returnSpecs =
+            new global::System.Collections.Generic.Dictionary<string, global::KRPC.Client.TypeSpec> {
+            };
+
+        static readonly global::System.Collections.Generic.Dictionary<string, global::KRPC.Client.TypeSpec[]> parameterSpecs =
+            new global::System.Collections.Generic.Dictionary<string, global::KRPC.Client.TypeSpec[]> {
+            };
+
+        public static global::KRPC.Client.TypeSpec ReturnSpec (string procedure)
+        {
+            global::KRPC.Client.TypeSpec spec;
+            return returnSpecs.TryGetValue (procedure, out spec) ? spec : null;
+        }
+
+        public static global::KRPC.Client.TypeSpec[] ParameterSpecs (string procedure)
+        {
+            global::KRPC.Client.TypeSpec[] specs;
+            return parameterSpecs.TryGetValue (procedure, out specs) ? specs : null;
+        }
+    }
+
     /// <summary>
     /// EmptyService service.
     /// </summary>

--- a/tools/krpctools/krpctools/test/clientgen-Ordering-cnano.txt
+++ b/tools/krpctools/krpctools/test/clientgen-Ordering-cnano.txt
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <string.h>
+
 #include <krpc_cnano/decoder.h>
 #include <krpc_cnano/deprecated.h>
 #include <krpc_cnano/encoder.h>

--- a/tools/krpctools/krpctools/test/clientgen-Ordering-cpp.txt
+++ b/tools/krpctools/krpctools/test/clientgen-Ordering-cpp.txt
@@ -51,28 +51,28 @@ inline ServiceA::ServiceA(Client* client):
 inline void ServiceA::frob(ServiceB::Mode mode = ServiceB::Mode::fast) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(1);
-  _args.push_back(encoder::encode(mode));
+  _args.push_back(encoder::encode_arg(mode));
   this->_client->invoke("ServiceA", "Frob", _args);
 }
 
 inline void ServiceA::frob_all(std::vector<ServiceB::Mode> modes = std::vector<ServiceB::Mode>{ServiceB::Mode::fast}) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(1);
-  _args.push_back(encoder::encode(modes));
+  _args.push_back(encoder::encode_arg(modes));
   this->_client->invoke("ServiceA", "FrobAll", _args);
 }
 
 inline ::krpc::schema::ProcedureCall ServiceA::frob_call(ServiceB::Mode mode = ServiceB::Mode::fast) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(1);
-  _args.push_back(encoder::encode(mode));
+  _args.push_back(encoder::encode_arg(mode));
   return this->_client->build_call("ServiceA", "Frob", _args);
 }
 
 inline ::krpc::schema::ProcedureCall ServiceA::frob_all_call(std::vector<ServiceB::Mode> modes = std::vector<ServiceB::Mode>{ServiceB::Mode::fast}) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(1);
-  _args.push_back(encoder::encode(modes));
+  _args.push_back(encoder::encode_arg(modes));
   return this->_client->build_call("ServiceA", "FrobAll", _args);
 }
 }  // namespace services

--- a/tools/krpctools/krpctools/test/clientgen-Ordering-csharp.txt
+++ b/tools/krpctools/krpctools/test/clientgen-Ordering-csharp.txt
@@ -31,6 +31,36 @@ namespace KRPC.Client.Services.ServiceA
         }
     }
 
+    // The types the stubs encode and decode values of, built once each. A spec names the
+    // positions inside a value that can hold null, which a C# type cannot always say.
+    static class TypeSpecs
+    {
+        internal static readonly global::KRPC.Client.TypeSpec Spec0 = global::KRPC.Client.TypeSpec.For (typeof(global::KRPC.Client.Services.ServiceB.Mode));
+        internal static readonly global::KRPC.Client.TypeSpec Spec1 = global::KRPC.Client.TypeSpec.For (typeof(global::System.Collections.Generic.IList<global::KRPC.Client.Services.ServiceB.Mode>));
+
+        // The procedures whose values a C# type cannot describe on its own, which a call
+        // built from an expression looks up by name
+        static readonly global::System.Collections.Generic.Dictionary<string, global::KRPC.Client.TypeSpec> returnSpecs =
+            new global::System.Collections.Generic.Dictionary<string, global::KRPC.Client.TypeSpec> {
+            };
+
+        static readonly global::System.Collections.Generic.Dictionary<string, global::KRPC.Client.TypeSpec[]> parameterSpecs =
+            new global::System.Collections.Generic.Dictionary<string, global::KRPC.Client.TypeSpec[]> {
+            };
+
+        public static global::KRPC.Client.TypeSpec ReturnSpec (string procedure)
+        {
+            global::KRPC.Client.TypeSpec spec;
+            return returnSpecs.TryGetValue (procedure, out spec) ? spec : null;
+        }
+
+        public static global::KRPC.Client.TypeSpec[] ParameterSpecs (string procedure)
+        {
+            global::KRPC.Client.TypeSpec[] specs;
+            return parameterSpecs.TryGetValue (procedure, out specs) ? specs : null;
+        }
+    }
+
     /// <summary>
     /// ServiceA service.
     /// </summary>
@@ -46,11 +76,11 @@ namespace KRPC.Client.Services.ServiceA
         /// <summary>
         /// Defaults to a member of another service's enumeration.
         /// </summary>
-        [global::KRPC.Client.Attributes.RPCAttribute ("ServiceA", "Frob")]
+        [global::KRPC.Client.Attributes.RPCAttribute ("ServiceA", "Frob", typeof(TypeSpecs))]
         public void Frob (global::KRPC.Client.Services.ServiceB.Mode mode = global::KRPC.Client.Services.ServiceB.Mode.Fast)
         {
             var _args = new ByteString[] {
-                global::KRPC.Client.Encoder.Encode (mode, typeof(global::KRPC.Client.Services.ServiceB.Mode))
+                global::KRPC.Client.Encoder.Encode (mode, TypeSpecs.Spec0)
             };
             connection.Invoke ("ServiceA", "Frob", _args);
         }
@@ -58,11 +88,11 @@ namespace KRPC.Client.Services.ServiceA
         /// <summary>
         /// Defaults to a collection containing a member of another service's enumeration.
         /// </summary>
-        [global::KRPC.Client.Attributes.RPCAttribute ("ServiceA", "FrobAll")]
+        [global::KRPC.Client.Attributes.RPCAttribute ("ServiceA", "FrobAll", typeof(TypeSpecs))]
         public void FrobAll (global::System.Collections.Generic.IList<global::KRPC.Client.Services.ServiceB.Mode> modes = null)
         {
             var _args = new ByteString[] {
-                global::KRPC.Client.Encoder.Encode (modes ?? new global::System.Collections.Generic.List<global::KRPC.Client.Services.ServiceB.Mode> { global::KRPC.Client.Services.ServiceB.Mode.Fast }, typeof(global::System.Collections.Generic.IList<global::KRPC.Client.Services.ServiceB.Mode>))
+                global::KRPC.Client.Encoder.Encode (modes ?? new global::System.Collections.Generic.List<global::KRPC.Client.Services.ServiceB.Mode> { global::KRPC.Client.Services.ServiceB.Mode.Fast }, TypeSpecs.Spec1)
             };
             connection.Invoke ("ServiceA", "FrobAll", _args);
         }

--- a/tools/krpctools/krpctools/test/clientgen-TestService-cnano.txt
+++ b/tools/krpctools/krpctools/test/clientgen-TestService-cnano.txt
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <string.h>
+
 #include <krpc_cnano/decoder.h>
 #include <krpc_cnano/deprecated.h>
 #include <krpc_cnano/encoder.h>
@@ -21,6 +23,66 @@ typedef krpc_object_t krpc_TestService_DeprecatedClass_t;
  * Class documentation string.
  */
 typedef krpc_object_t krpc_TestService_TestClass_t;
+
+#ifndef KRPC_TYPE_NULLABLE_OBJECT
+#define KRPC_TYPE_NULLABLE_OBJECT
+
+typedef struct krpc_nullable_object_s krpc_nullable_object_t;
+struct krpc_nullable_object_s {
+  krpc_object_t value;
+  bool has_value;
+};
+
+static inline krpc_error_t krpc_encode_nullable_object(
+  pb_ostream_t * stream, const krpc_nullable_object_t * value);
+static inline krpc_error_t krpc_encode_size_nullable_object(
+  size_t * size, const krpc_nullable_object_t * value);
+static inline bool krpc_encode_callback_nullable_object(
+  pb_ostream_t * stream, const pb_field_t * field, void * const * arg);
+static inline krpc_error_t krpc_decode_nullable_object(
+  pb_istream_t * stream, krpc_nullable_object_t * value);
+
+#endif  // KRPC_TYPE_NULLABLE_OBJECT
+
+#ifndef KRPC_TYPE_LIST_NULLABLE_OBJECT
+#define KRPC_TYPE_LIST_NULLABLE_OBJECT
+
+typedef struct krpc_list_nullable_object_s krpc_list_nullable_object_t;
+struct krpc_list_nullable_object_s {
+  size_t size;
+  krpc_nullable_object_t * items;
+};
+
+static inline krpc_error_t krpc_encode_list_nullable_object(
+  pb_ostream_t * stream, const krpc_list_nullable_object_t * value);
+static inline krpc_error_t krpc_encode_size_list_nullable_object(
+  size_t * size, const krpc_list_nullable_object_t * value);
+static inline bool krpc_encode_callback_list_nullable_object(
+  pb_ostream_t * stream, const pb_field_t * field, void * const * arg);
+static inline krpc_error_t krpc_decode_list_nullable_object(
+  pb_istream_t * stream, krpc_list_nullable_object_t * value);
+
+#endif  // KRPC_TYPE_LIST_NULLABLE_OBJECT
+
+#ifndef KRPC_TYPE_TESTSERVICE_TESTNESTEDNULLABLESTRUCT
+#define KRPC_TYPE_TESTSERVICE_TESTNESTEDNULLABLESTRUCT
+
+typedef struct krpc_TestService_TestNestedNullableStruct_s krpc_TestService_TestNestedNullableStruct_t;
+struct krpc_TestService_TestNestedNullableStruct_s {
+  krpc_list_nullable_object_t list_field;
+  char * string_field;
+};
+
+static inline krpc_error_t krpc_encode_TestService_TestNestedNullableStruct(
+  pb_ostream_t * stream, const krpc_TestService_TestNestedNullableStruct_t * value);
+static inline krpc_error_t krpc_encode_size_TestService_TestNestedNullableStruct(
+  size_t * size, const krpc_TestService_TestNestedNullableStruct_t * value);
+static inline bool krpc_encode_callback_TestService_TestNestedNullableStruct(
+  pb_ostream_t * stream, const pb_field_t * field, void * const * arg);
+static inline krpc_error_t krpc_decode_TestService_TestNestedNullableStruct(
+  pb_istream_t * stream, krpc_TestService_TestNestedNullableStruct_t * value);
+
+#endif  // KRPC_TYPE_TESTSERVICE_TESTNESTEDNULLABLESTRUCT
 
 #ifndef KRPC_TYPE_LIST_INT32
 #define KRPC_TYPE_LIST_INT32
@@ -84,6 +146,89 @@ static inline krpc_error_t krpc_decode_TestService_TestNestedStruct(
   pb_istream_t * stream, krpc_TestService_TestNestedStruct_t * value);
 
 #endif  // KRPC_TYPE_TESTSERVICE_TESTNESTEDSTRUCT
+
+#ifndef KRPC_TYPE_NULLABLE_INT32
+#define KRPC_TYPE_NULLABLE_INT32
+
+typedef struct krpc_nullable_int32_s krpc_nullable_int32_t;
+struct krpc_nullable_int32_s {
+  int32_t value;
+  bool has_value;
+};
+
+static inline krpc_error_t krpc_encode_nullable_int32(
+  pb_ostream_t * stream, const krpc_nullable_int32_t * value);
+static inline krpc_error_t krpc_encode_size_nullable_int32(
+  size_t * size, const krpc_nullable_int32_t * value);
+static inline bool krpc_encode_callback_nullable_int32(
+  pb_ostream_t * stream, const pb_field_t * field, void * const * arg);
+static inline krpc_error_t krpc_decode_nullable_int32(
+  pb_istream_t * stream, krpc_nullable_int32_t * value);
+
+#endif  // KRPC_TYPE_NULLABLE_INT32
+
+#ifndef KRPC_TYPE_NULLABLE_ENUM
+#define KRPC_TYPE_NULLABLE_ENUM
+
+typedef struct krpc_nullable_enum_s krpc_nullable_enum_t;
+struct krpc_nullable_enum_s {
+  krpc_enum_t value;
+  bool has_value;
+};
+
+static inline krpc_error_t krpc_encode_nullable_enum(
+  pb_ostream_t * stream, const krpc_nullable_enum_t * value);
+static inline krpc_error_t krpc_encode_size_nullable_enum(
+  size_t * size, const krpc_nullable_enum_t * value);
+static inline bool krpc_encode_callback_nullable_enum(
+  pb_ostream_t * stream, const pb_field_t * field, void * const * arg);
+static inline krpc_error_t krpc_decode_nullable_enum(
+  pb_istream_t * stream, krpc_nullable_enum_t * value);
+
+#endif  // KRPC_TYPE_NULLABLE_ENUM
+
+#ifndef KRPC_TYPE_NULLABLE_STRING
+#define KRPC_TYPE_NULLABLE_STRING
+
+typedef struct krpc_nullable_string_s krpc_nullable_string_t;
+struct krpc_nullable_string_s {
+  char * value;
+  bool has_value;
+};
+
+static inline krpc_error_t krpc_encode_nullable_string(
+  pb_ostream_t * stream, const krpc_nullable_string_t * value);
+static inline krpc_error_t krpc_encode_size_nullable_string(
+  size_t * size, const krpc_nullable_string_t * value);
+static inline bool krpc_encode_callback_nullable_string(
+  pb_ostream_t * stream, const pb_field_t * field, void * const * arg);
+static inline krpc_error_t krpc_decode_nullable_string(
+  pb_istream_t * stream, krpc_nullable_string_t * value);
+
+#endif  // KRPC_TYPE_NULLABLE_STRING
+
+#ifndef KRPC_TYPE_TESTSERVICE_TESTNULLABLESTRUCT
+#define KRPC_TYPE_TESTSERVICE_TESTNULLABLESTRUCT
+
+typedef struct krpc_TestService_TestNullableStruct_s krpc_TestService_TestNullableStruct_t;
+struct krpc_TestService_TestNullableStruct_s {
+  int32_t int_field;
+  krpc_nullable_int32_t nullable_int_field;
+  krpc_nullable_enum_t nullable_enum_field;
+  krpc_nullable_string_t nullable_string_field;
+  krpc_nullable_object_t nullable_object_field;
+};
+
+static inline krpc_error_t krpc_encode_TestService_TestNullableStruct(
+  pb_ostream_t * stream, const krpc_TestService_TestNullableStruct_t * value);
+static inline krpc_error_t krpc_encode_size_TestService_TestNullableStruct(
+  size_t * size, const krpc_TestService_TestNullableStruct_t * value);
+static inline bool krpc_encode_callback_TestService_TestNullableStruct(
+  pb_ostream_t * stream, const pb_field_t * field, void * const * arg);
+static inline krpc_error_t krpc_decode_TestService_TestNullableStruct(
+  pb_istream_t * stream, krpc_TestService_TestNullableStruct_t * value);
+
+#endif  // KRPC_TYPE_TESTSERVICE_TESTNULLABLESTRUCT
 
 #ifndef KRPC_TYPE_DICTIONARY_INT32_BOOL
 #define KRPC_TYPE_DICTIONARY_INT32_BOOL
@@ -162,6 +307,32 @@ static inline krpc_error_t krpc_decode_dictionary_string_list_int32(
   pb_istream_t * stream, krpc_dictionary_string_list_int32_t * value);
 
 #endif  // KRPC_TYPE_DICTIONARY_STRING_LIST_INT32
+
+#ifndef KRPC_TYPE_DICTIONARY_STRING_NULLABLE_OBJECT
+#define KRPC_TYPE_DICTIONARY_STRING_NULLABLE_OBJECT
+
+typedef struct krpc_dictionary_entry_string_nullable_object_s krpc_dictionary_entry_string_nullable_object_t;
+struct krpc_dictionary_entry_string_nullable_object_s {
+  char * key;
+  krpc_nullable_object_t value;
+};
+
+typedef struct krpc_dictionary_string_nullable_object_s krpc_dictionary_string_nullable_object_t;
+struct krpc_dictionary_string_nullable_object_s {
+  size_t size;
+  krpc_dictionary_entry_string_nullable_object_t * entries;
+};
+
+static inline krpc_error_t krpc_encode_dictionary_string_nullable_object(
+  pb_ostream_t * stream, const krpc_dictionary_string_nullable_object_t * value);
+static inline krpc_error_t krpc_encode_size_dictionary_string_nullable_object(
+  size_t * size, const krpc_dictionary_string_nullable_object_t * value);
+static inline bool krpc_encode_callback_dictionary_string_nullable_object(
+  pb_ostream_t * stream, const pb_field_t * field, void * const * arg);
+static inline krpc_error_t krpc_decode_dictionary_string_nullable_object(
+  pb_istream_t * stream, krpc_dictionary_string_nullable_object_t * value);
+
+#endif  // KRPC_TYPE_DICTIONARY_STRING_NULLABLE_OBJECT
 
 #ifndef KRPC_TYPE_LIST_TESTSERVICE_TESTSTRUCT
 #define KRPC_TYPE_LIST_TESTSERVICE_TESTSTRUCT
@@ -262,6 +433,46 @@ static inline krpc_error_t krpc_decode_list_int64(
   pb_istream_t * stream, krpc_list_int64_t * value);
 
 #endif  // KRPC_TYPE_LIST_INT64
+
+#ifndef KRPC_TYPE_LIST_LIST_NULLABLE_OBJECT
+#define KRPC_TYPE_LIST_LIST_NULLABLE_OBJECT
+
+typedef struct krpc_list_list_nullable_object_s krpc_list_list_nullable_object_t;
+struct krpc_list_list_nullable_object_s {
+  size_t size;
+  krpc_list_nullable_object_t * items;
+};
+
+static inline krpc_error_t krpc_encode_list_list_nullable_object(
+  pb_ostream_t * stream, const krpc_list_list_nullable_object_t * value);
+static inline krpc_error_t krpc_encode_size_list_list_nullable_object(
+  size_t * size, const krpc_list_list_nullable_object_t * value);
+static inline bool krpc_encode_callback_list_list_nullable_object(
+  pb_ostream_t * stream, const pb_field_t * field, void * const * arg);
+static inline krpc_error_t krpc_decode_list_list_nullable_object(
+  pb_istream_t * stream, krpc_list_list_nullable_object_t * value);
+
+#endif  // KRPC_TYPE_LIST_LIST_NULLABLE_OBJECT
+
+#ifndef KRPC_TYPE_LIST_NULLABLE_INT32
+#define KRPC_TYPE_LIST_NULLABLE_INT32
+
+typedef struct krpc_list_nullable_int32_s krpc_list_nullable_int32_t;
+struct krpc_list_nullable_int32_s {
+  size_t size;
+  krpc_nullable_int32_t * items;
+};
+
+static inline krpc_error_t krpc_encode_list_nullable_int32(
+  pb_ostream_t * stream, const krpc_list_nullable_int32_t * value);
+static inline krpc_error_t krpc_encode_size_list_nullable_int32(
+  size_t * size, const krpc_list_nullable_int32_t * value);
+static inline bool krpc_encode_callback_list_nullable_int32(
+  pb_ostream_t * stream, const pb_field_t * field, void * const * arg);
+static inline krpc_error_t krpc_decode_list_nullable_int32(
+  pb_istream_t * stream, krpc_list_nullable_int32_t * value);
+
+#endif  // KRPC_TYPE_LIST_NULLABLE_INT32
 
 #ifndef KRPC_TYPE_LIST_OBJECT
 #define KRPC_TYPE_LIST_OBJECT
@@ -403,6 +614,26 @@ static inline krpc_error_t krpc_decode_tuple_int32_int64(
 
 #endif  // KRPC_TYPE_TUPLE_INT32_INT64
 
+#ifndef KRPC_TYPE_TUPLE_INT32_NULLABLE_OBJECT
+#define KRPC_TYPE_TUPLE_INT32_NULLABLE_OBJECT
+
+typedef struct krpc_tuple_int32_nullable_object_s krpc_tuple_int32_nullable_object_t;
+struct krpc_tuple_int32_nullable_object_s {
+  int32_t e0;
+  krpc_nullable_object_t e1;
+};
+
+static inline krpc_error_t krpc_encode_tuple_int32_nullable_object(
+  pb_ostream_t * stream, const krpc_tuple_int32_nullable_object_t * value);
+static inline krpc_error_t krpc_encode_size_tuple_int32_nullable_object(
+  size_t * size, const krpc_tuple_int32_nullable_object_t * value);
+static inline bool krpc_encode_callback_tuple_int32_nullable_object(
+  pb_ostream_t * stream, const pb_field_t * field, void * const * arg);
+static inline krpc_error_t krpc_decode_tuple_int32_nullable_object(
+  pb_istream_t * stream, krpc_tuple_int32_nullable_object_t * value);
+
+#endif  // KRPC_TYPE_TUPLE_INT32_NULLABLE_OBJECT
+
 /**
  * Deprecated enum documentation string.
  */
@@ -476,6 +707,16 @@ static inline krpc_error_t krpc_TestService_DoubleSpecialDefaults(krpc_connectio
 
 static inline krpc_error_t krpc_TestService_DoubleToString(krpc_connection_t connection, char * * returnValue, double value);
 
+static inline krpc_error_t krpc_TestService_EchoDictionaryOfNullableObjects(krpc_connection_t connection, krpc_dictionary_string_nullable_object_t * returnValue, const krpc_dictionary_string_nullable_object_t * d);
+
+static inline krpc_error_t krpc_TestService_EchoListOfNullableInts(krpc_connection_t connection, krpc_list_nullable_int32_t * returnValue, const krpc_list_nullable_int32_t * l);
+
+static inline krpc_error_t krpc_TestService_EchoListOfNullableObjects(krpc_connection_t connection, krpc_list_nullable_object_t * returnValue, const krpc_list_nullable_object_t * l);
+
+static inline krpc_error_t krpc_TestService_EchoNestedListOfNullableObjects(krpc_connection_t connection, krpc_list_list_nullable_object_t * returnValue, const krpc_list_list_nullable_object_t * l);
+
+static inline krpc_error_t krpc_TestService_EchoNestedNullableStruct(krpc_connection_t connection, krpc_TestService_TestNestedNullableStruct_t * returnValue, const krpc_TestService_TestNestedNullableStruct_t * value);
+
 static inline krpc_error_t krpc_TestService_EchoNullableInt(krpc_connection_t connection, int32_t * returnValue, bool * returnValueIsNull, const int32_t * value);
 
 static inline krpc_error_t krpc_TestService_EchoNullableList(krpc_connection_t connection, krpc_list_int32_t * returnValue, bool * returnValueIsNull, const krpc_list_int32_t * l);
@@ -483,6 +724,8 @@ static inline krpc_error_t krpc_TestService_EchoNullableList(krpc_connection_t c
 static inline krpc_error_t krpc_TestService_EchoNullableString(krpc_connection_t connection, char * * returnValue, bool * returnValueIsNull, const char * value);
 
 static inline krpc_error_t krpc_TestService_EchoTestObject(krpc_connection_t connection, krpc_TestService_TestClass_t * returnValue, krpc_TestService_TestClass_t value);
+
+static inline krpc_error_t krpc_TestService_EchoTupleWithANullableObject(krpc_connection_t connection, krpc_tuple_int32_nullable_object_t * returnValue, const krpc_tuple_int32_nullable_object_t * t);
 
 static inline krpc_error_t krpc_TestService_EmptyListDefault(krpc_connection_t connection, krpc_list_string_t * returnValue, const krpc_list_string_t * x);
 
@@ -536,6 +779,8 @@ static inline krpc_error_t krpc_TestService_ListDefault(krpc_connection_t connec
 static inline krpc_error_t krpc_TestService_NestedStructEcho(krpc_connection_t connection, krpc_TestService_TestNestedStruct_t * returnValue, const krpc_TestService_TestNestedStruct_t * x);
 
 static inline krpc_error_t krpc_TestService_NotNullableObject(krpc_connection_t connection, krpc_TestService_TestClass_t * returnValue, krpc_TestService_TestClass_t value);
+
+static inline krpc_error_t krpc_TestService_NullableStructEcho(krpc_connection_t connection, krpc_TestService_TestNullableStruct_t * returnValue, const krpc_TestService_TestNullableStruct_t * x);
 
 static inline krpc_error_t krpc_TestService_OnTimer(krpc_connection_t connection, krpc_schema_Event * returnValue, uint32_t milliseconds, uint32_t repeats);
 
@@ -661,6 +906,230 @@ static inline krpc_error_t krpc_TestService_TestClass_set_StringPropertyPrivateG
 static inline krpc_error_t krpc_TestService_TestClass_StringPropertyPrivateSet(krpc_connection_t connection, char * * returnValue, krpc_TestService_TestClass_t instance);
 
 // Implementation
+
+#ifndef KRPC_IMPL_TYPE_NULLABLE_OBJECT
+#define KRPC_IMPL_TYPE_NULLABLE_OBJECT
+
+
+static inline krpc_error_t krpc_encode_nullable_object(
+  pb_ostream_t * stream, const krpc_nullable_object_t * value) {
+  // A nullable position carries a presence bool before its value, and holds nothing else
+  // when that bool is false
+  KRPC_RETURN_ON_ERROR(krpc_encode_bool(stream, value->has_value));
+  if (value->has_value)
+    KRPC_RETURN_ON_ERROR(krpc_encode_object(stream, value->value));
+  return KRPC_OK;
+}
+
+static inline krpc_error_t krpc_encode_size_nullable_object(
+  size_t * size, const krpc_nullable_object_t * value) {
+  pb_ostream_t stream = PB_OSTREAM_SIZING;
+  KRPC_RETURN_ON_ERROR(krpc_encode_nullable_object(&stream, value));
+  *size = stream.bytes_written;
+  return KRPC_OK;
+}
+
+static inline bool krpc_encode_callback_nullable_object(
+  pb_ostream_t * stream, const pb_field_t * field, void * const * arg) {
+  if (!pb_encode_tag_for_field(stream, field))
+    KRPC_CALLBACK_RETURN_ERROR("encoding tag for nullable_object");
+  krpc_nullable_object_t * value = (krpc_nullable_object_t*)(*arg);
+  size_t size;
+  KRPC_CALLBACK_RETURN_ON_ERROR(krpc_encode_size_nullable_object(&size, value));
+  if (!pb_encode_varint(stream, size))
+    KRPC_CALLBACK_RETURN_ERROR("encoding size for nullable_object");
+  KRPC_CALLBACK_RETURN_ON_ERROR(krpc_encode_nullable_object(stream, value));
+  return true;
+}
+
+
+static inline krpc_error_t krpc_decode_nullable_object(
+  pb_istream_t * stream, krpc_nullable_object_t * value) {
+  // An absent value is left zeroed, so the member is defined whatever the caller passed in
+  memset(&value->value, 0, sizeof(value->value));
+  KRPC_RETURN_ON_ERROR(krpc_decode_bool(stream, &value->has_value));
+  if (value->has_value)
+    KRPC_RETURN_ON_ERROR(krpc_decode_object(stream, &value->value));
+  return KRPC_OK;
+}
+
+#endif  // KRPC_IMPL_TYPE_NULLABLE_OBJECT
+
+#ifndef KRPC_IMPL_TYPE_LIST_NULLABLE_OBJECT
+#define KRPC_IMPL_TYPE_LIST_NULLABLE_OBJECT
+
+static inline bool krpc_encode_callback_items_list_nullable_object(
+  pb_ostream_t * stream, const pb_field_t * field, void * const * arg) {
+  const krpc_list_nullable_object_t * value = (const krpc_list_nullable_object_t*)(*arg);
+  size_t i = 0;
+  for (; i < value->size; i++) {
+    if (!pb_encode_tag_for_field(stream, field))
+      KRPC_CALLBACK_RETURN_ERROR("encoding tag for list item");
+    size_t size;
+    KRPC_CALLBACK_RETURN_ON_ERROR(krpc_encode_size_nullable_object(&size, &value->items[i]));
+    if (!pb_encode_varint(stream, size))
+      KRPC_CALLBACK_RETURN_ERROR("encoding size for list item");
+    KRPC_CALLBACK_RETURN_ON_ERROR(krpc_encode_nullable_object(stream, &value->items[i]));
+  }
+  return true;
+}
+
+static inline krpc_error_t krpc_encode_list_nullable_object(
+  pb_ostream_t * stream, const krpc_list_nullable_object_t * value) {
+  krpc_schema_List message = krpc_schema_List_init_default;
+  message.items.funcs.encode = &krpc_encode_callback_items_list_nullable_object;
+  message.items.arg = (krpc_list_nullable_object_t*)value;
+  KRPC_RETURN_ON_ERROR(krpc_encode_message_List(stream, &message));
+  return KRPC_OK;
+}
+
+static inline krpc_error_t krpc_encode_size_list_nullable_object(
+  size_t * size, const krpc_list_nullable_object_t * value) {
+  pb_ostream_t stream = PB_OSTREAM_SIZING;
+  KRPC_RETURN_ON_ERROR(krpc_encode_list_nullable_object(&stream, value));
+  *size = stream.bytes_written;
+  return KRPC_OK;
+}
+
+static inline bool krpc_encode_callback_list_nullable_object(
+  pb_ostream_t * stream, const pb_field_t * field, void * const * arg) {
+  if (!pb_encode_tag_for_field(stream, field))
+    KRPC_CALLBACK_RETURN_ERROR("encoding tag for list_nullable_object");
+  krpc_list_nullable_object_t * value = (krpc_list_nullable_object_t*)(*arg);
+  size_t size;
+  KRPC_CALLBACK_RETURN_ON_ERROR(krpc_encode_size_list_nullable_object(&size, value));
+  if (!pb_encode_varint(stream, size))
+    KRPC_CALLBACK_RETURN_ERROR("encoding size for list_nullable_object");
+  KRPC_CALLBACK_RETURN_ON_ERROR(krpc_encode_list_nullable_object(stream, value));
+  return true;
+}
+
+static inline bool krpc_decode_callback_item_list_nullable_object(
+  pb_istream_t * stream, const pb_field_t * field, void ** arg) {
+  typedef struct State { size_t capacity; krpc_list_nullable_object_t * value; } State;
+  State * state = (State*)(*arg);
+  size_t i = state->value->size;
+  state->value->size++;
+  if (state->capacity > 0 && state->value->size > state->capacity) {
+    state->value->items = (krpc_nullable_object_t*)krpc_recalloc(state->value->items, state->capacity, KRPC_ALLOC_BLOCK_SIZE, sizeof(krpc_nullable_object_t));
+    state->capacity += KRPC_ALLOC_BLOCK_SIZE;
+  }
+  KRPC_CALLBACK_RETURN_ON_ERROR(krpc_decode_nullable_object(stream, &state->value->items[i]));
+  return true;
+}
+
+static inline krpc_error_t krpc_decode_list_nullable_object(
+  pb_istream_t * stream, krpc_list_nullable_object_t * value) {
+  typedef struct State { size_t capacity; krpc_list_nullable_object_t * value; } State;
+  State state = { 0, value };
+  value->size = 0;
+  if (value->items == NULL) {
+    value->items = (krpc_nullable_object_t*)krpc_calloc(KRPC_ALLOC_BLOCK_SIZE, sizeof(krpc_nullable_object_t));
+    state.capacity = KRPC_ALLOC_BLOCK_SIZE;
+  }
+  krpc_schema_List message = krpc_schema_List_init_default;
+  message.items.funcs.decode = &krpc_decode_callback_item_list_nullable_object;
+  message.items.arg = &state;
+  KRPC_RETURN_ON_ERROR(krpc_decode_message_List(stream, &message));
+  return KRPC_OK;
+}
+
+#endif  // KRPC_IMPL_TYPE_LIST_NULLABLE_OBJECT
+
+#ifndef KRPC_IMPL_TYPE_TESTSERVICE_TESTNESTEDNULLABLESTRUCT
+#define KRPC_IMPL_TYPE_TESTSERVICE_TESTNESTEDNULLABLESTRUCT
+
+static inline bool krpc_encode_callback_items_TestService_TestNestedNullableStruct(
+  pb_ostream_t * stream, const pb_field_t * field, void * const * arg) {
+  const krpc_TestService_TestNestedNullableStruct_t * value = (const krpc_TestService_TestNestedNullableStruct_t*)(*arg);
+  {
+    if (!pb_encode_tag_for_field(stream, field))
+      KRPC_CALLBACK_RETURN_ERROR("encoding tag for tuple item");
+    size_t size;
+    KRPC_CALLBACK_RETURN_ON_ERROR(krpc_encode_size_list_nullable_object(&size, &value->list_field));
+    if (!pb_encode_varint(stream, size))
+      KRPC_CALLBACK_RETURN_ERROR("encoding size for tuple item");
+    KRPC_CALLBACK_RETURN_ON_ERROR(krpc_encode_list_nullable_object(stream, &value->list_field));
+  }
+  {
+    if (!pb_encode_tag_for_field(stream, field))
+      KRPC_CALLBACK_RETURN_ERROR("encoding tag for tuple item");
+    size_t size;
+    KRPC_CALLBACK_RETURN_ON_ERROR(krpc_encode_size_string(&size, value->string_field));
+    if (!pb_encode_varint(stream, size))
+      KRPC_CALLBACK_RETURN_ERROR("encoding size for tuple item");
+    KRPC_CALLBACK_RETURN_ON_ERROR(krpc_encode_string(stream, value->string_field));
+  }
+  return true;
+}
+
+static inline krpc_error_t krpc_encode_TestService_TestNestedNullableStruct(
+  pb_ostream_t * stream, const krpc_TestService_TestNestedNullableStruct_t * value) {
+  krpc_schema_Tuple message = krpc_schema_Tuple_init_default;
+  message.items.funcs.encode = &krpc_encode_callback_items_TestService_TestNestedNullableStruct;
+  message.items.arg = (krpc_TestService_TestNestedNullableStruct_t*)value;
+  KRPC_RETURN_ON_ERROR(krpc_encode_message_Tuple(stream, &message));
+  return KRPC_OK;
+}
+
+static inline krpc_error_t krpc_encode_size_TestService_TestNestedNullableStruct(
+  size_t * size, const krpc_TestService_TestNestedNullableStruct_t * value) {
+  pb_ostream_t stream = PB_OSTREAM_SIZING;
+  KRPC_RETURN_ON_ERROR(krpc_encode_TestService_TestNestedNullableStruct(&stream, value));
+  *size = stream.bytes_written;
+  return KRPC_OK;
+}
+
+static inline bool krpc_encode_callback_TestService_TestNestedNullableStruct(
+  pb_ostream_t * stream, const pb_field_t * field, void * const * arg) {
+  if (!pb_encode_tag_for_field(stream, field))
+    KRPC_CALLBACK_RETURN_ERROR("encoding tag for TestService_TestNestedNullableStruct");
+  krpc_TestService_TestNestedNullableStruct_t * value = (krpc_TestService_TestNestedNullableStruct_t*)(*arg);
+  size_t size;
+  KRPC_CALLBACK_RETURN_ON_ERROR(krpc_encode_size_TestService_TestNestedNullableStruct(&size, value));
+  if (!pb_encode_varint(stream, size))
+    KRPC_CALLBACK_RETURN_ERROR("encoding size for TestService_TestNestedNullableStruct");
+  KRPC_CALLBACK_RETURN_ON_ERROR(krpc_encode_TestService_TestNestedNullableStruct(stream, value));
+  return true;
+}
+
+static inline bool krpc_decode_callback_item_TestService_TestNestedNullableStruct(
+  pb_istream_t * stream, const pb_field_t * field, void ** arg) {
+  typedef struct State {size_t pos; krpc_TestService_TestNestedNullableStruct_t * value;} State;
+  State * state = (State*)(*arg);
+  krpc_TestService_TestNestedNullableStruct_t * value = state->value;
+  switch (state->pos) {
+  case 0:
+    KRPC_CALLBACK_RETURN_ON_ERROR(krpc_decode_list_nullable_object(stream, &value->list_field));
+    break;
+  case 1:
+    KRPC_CALLBACK_RETURN_ON_ERROR(krpc_decode_string(stream, &value->string_field));
+    break;
+  default:
+    // Fields are only ever appended to a structure, so a value from a newer server may
+    // carry more items than this client knows about, and those are skipped
+    if (!pb_read(stream, NULL, stream->bytes_left))
+      KRPC_CALLBACK_RETURN_ERROR("skipping an appended struct field");
+    break;
+  }
+  state->pos++;
+  return true;
+}
+
+static inline krpc_error_t krpc_decode_TestService_TestNestedNullableStruct(
+  pb_istream_t * stream, krpc_TestService_TestNestedNullableStruct_t * value) {
+  krpc_schema_Tuple message = krpc_schema_Tuple_init_default;
+  message.items.funcs.decode = &krpc_decode_callback_item_TestService_TestNestedNullableStruct;
+  typedef struct State { size_t pos; krpc_TestService_TestNestedNullableStruct_t * value; } State;
+  State state = { 0, value };
+  message.items.arg = &state;
+  KRPC_RETURN_ON_ERROR(krpc_decode_message_Tuple(stream, &message));
+  if (state.pos < 2)
+    KRPC_RETURN_ERROR(DECODING_FAILED, "too few fields for a TestService_TestNestedNullableStruct");
+  return KRPC_OK;
+}
+
+#endif  // KRPC_IMPL_TYPE_TESTSERVICE_TESTNESTEDNULLABLESTRUCT
 
 #ifndef KRPC_IMPL_TYPE_LIST_INT32
 #define KRPC_IMPL_TYPE_LIST_INT32
@@ -968,6 +1437,281 @@ static inline krpc_error_t krpc_decode_TestService_TestNestedStruct(
 }
 
 #endif  // KRPC_IMPL_TYPE_TESTSERVICE_TESTNESTEDSTRUCT
+
+#ifndef KRPC_IMPL_TYPE_NULLABLE_INT32
+#define KRPC_IMPL_TYPE_NULLABLE_INT32
+
+
+static inline krpc_error_t krpc_encode_nullable_int32(
+  pb_ostream_t * stream, const krpc_nullable_int32_t * value) {
+  // A nullable position carries a presence bool before its value, and holds nothing else
+  // when that bool is false
+  KRPC_RETURN_ON_ERROR(krpc_encode_bool(stream, value->has_value));
+  if (value->has_value)
+    KRPC_RETURN_ON_ERROR(krpc_encode_int32(stream, value->value));
+  return KRPC_OK;
+}
+
+static inline krpc_error_t krpc_encode_size_nullable_int32(
+  size_t * size, const krpc_nullable_int32_t * value) {
+  pb_ostream_t stream = PB_OSTREAM_SIZING;
+  KRPC_RETURN_ON_ERROR(krpc_encode_nullable_int32(&stream, value));
+  *size = stream.bytes_written;
+  return KRPC_OK;
+}
+
+static inline bool krpc_encode_callback_nullable_int32(
+  pb_ostream_t * stream, const pb_field_t * field, void * const * arg) {
+  if (!pb_encode_tag_for_field(stream, field))
+    KRPC_CALLBACK_RETURN_ERROR("encoding tag for nullable_int32");
+  krpc_nullable_int32_t * value = (krpc_nullable_int32_t*)(*arg);
+  size_t size;
+  KRPC_CALLBACK_RETURN_ON_ERROR(krpc_encode_size_nullable_int32(&size, value));
+  if (!pb_encode_varint(stream, size))
+    KRPC_CALLBACK_RETURN_ERROR("encoding size for nullable_int32");
+  KRPC_CALLBACK_RETURN_ON_ERROR(krpc_encode_nullable_int32(stream, value));
+  return true;
+}
+
+
+static inline krpc_error_t krpc_decode_nullable_int32(
+  pb_istream_t * stream, krpc_nullable_int32_t * value) {
+  // An absent value is left zeroed, so the member is defined whatever the caller passed in
+  memset(&value->value, 0, sizeof(value->value));
+  KRPC_RETURN_ON_ERROR(krpc_decode_bool(stream, &value->has_value));
+  if (value->has_value)
+    KRPC_RETURN_ON_ERROR(krpc_decode_int32(stream, &value->value));
+  return KRPC_OK;
+}
+
+#endif  // KRPC_IMPL_TYPE_NULLABLE_INT32
+
+#ifndef KRPC_IMPL_TYPE_NULLABLE_ENUM
+#define KRPC_IMPL_TYPE_NULLABLE_ENUM
+
+
+static inline krpc_error_t krpc_encode_nullable_enum(
+  pb_ostream_t * stream, const krpc_nullable_enum_t * value) {
+  // A nullable position carries a presence bool before its value, and holds nothing else
+  // when that bool is false
+  KRPC_RETURN_ON_ERROR(krpc_encode_bool(stream, value->has_value));
+  if (value->has_value)
+    KRPC_RETURN_ON_ERROR(krpc_encode_enum(stream, value->value));
+  return KRPC_OK;
+}
+
+static inline krpc_error_t krpc_encode_size_nullable_enum(
+  size_t * size, const krpc_nullable_enum_t * value) {
+  pb_ostream_t stream = PB_OSTREAM_SIZING;
+  KRPC_RETURN_ON_ERROR(krpc_encode_nullable_enum(&stream, value));
+  *size = stream.bytes_written;
+  return KRPC_OK;
+}
+
+static inline bool krpc_encode_callback_nullable_enum(
+  pb_ostream_t * stream, const pb_field_t * field, void * const * arg) {
+  if (!pb_encode_tag_for_field(stream, field))
+    KRPC_CALLBACK_RETURN_ERROR("encoding tag for nullable_enum");
+  krpc_nullable_enum_t * value = (krpc_nullable_enum_t*)(*arg);
+  size_t size;
+  KRPC_CALLBACK_RETURN_ON_ERROR(krpc_encode_size_nullable_enum(&size, value));
+  if (!pb_encode_varint(stream, size))
+    KRPC_CALLBACK_RETURN_ERROR("encoding size for nullable_enum");
+  KRPC_CALLBACK_RETURN_ON_ERROR(krpc_encode_nullable_enum(stream, value));
+  return true;
+}
+
+
+static inline krpc_error_t krpc_decode_nullable_enum(
+  pb_istream_t * stream, krpc_nullable_enum_t * value) {
+  // An absent value is left zeroed, so the member is defined whatever the caller passed in
+  memset(&value->value, 0, sizeof(value->value));
+  KRPC_RETURN_ON_ERROR(krpc_decode_bool(stream, &value->has_value));
+  if (value->has_value)
+    KRPC_RETURN_ON_ERROR(krpc_decode_enum(stream, &value->value));
+  return KRPC_OK;
+}
+
+#endif  // KRPC_IMPL_TYPE_NULLABLE_ENUM
+
+#ifndef KRPC_IMPL_TYPE_NULLABLE_STRING
+#define KRPC_IMPL_TYPE_NULLABLE_STRING
+
+
+static inline krpc_error_t krpc_encode_nullable_string(
+  pb_ostream_t * stream, const krpc_nullable_string_t * value) {
+  // A nullable position carries a presence bool before its value, and holds nothing else
+  // when that bool is false
+  KRPC_RETURN_ON_ERROR(krpc_encode_bool(stream, value->has_value));
+  if (value->has_value)
+    KRPC_RETURN_ON_ERROR(krpc_encode_string(stream, value->value));
+  return KRPC_OK;
+}
+
+static inline krpc_error_t krpc_encode_size_nullable_string(
+  size_t * size, const krpc_nullable_string_t * value) {
+  pb_ostream_t stream = PB_OSTREAM_SIZING;
+  KRPC_RETURN_ON_ERROR(krpc_encode_nullable_string(&stream, value));
+  *size = stream.bytes_written;
+  return KRPC_OK;
+}
+
+static inline bool krpc_encode_callback_nullable_string(
+  pb_ostream_t * stream, const pb_field_t * field, void * const * arg) {
+  if (!pb_encode_tag_for_field(stream, field))
+    KRPC_CALLBACK_RETURN_ERROR("encoding tag for nullable_string");
+  krpc_nullable_string_t * value = (krpc_nullable_string_t*)(*arg);
+  size_t size;
+  KRPC_CALLBACK_RETURN_ON_ERROR(krpc_encode_size_nullable_string(&size, value));
+  if (!pb_encode_varint(stream, size))
+    KRPC_CALLBACK_RETURN_ERROR("encoding size for nullable_string");
+  KRPC_CALLBACK_RETURN_ON_ERROR(krpc_encode_nullable_string(stream, value));
+  return true;
+}
+
+
+static inline krpc_error_t krpc_decode_nullable_string(
+  pb_istream_t * stream, krpc_nullable_string_t * value) {
+  // An absent value is left zeroed, so the member is defined whatever the caller passed in
+  memset(&value->value, 0, sizeof(value->value));
+  KRPC_RETURN_ON_ERROR(krpc_decode_bool(stream, &value->has_value));
+  if (value->has_value)
+    KRPC_RETURN_ON_ERROR(krpc_decode_string(stream, &value->value));
+  return KRPC_OK;
+}
+
+#endif  // KRPC_IMPL_TYPE_NULLABLE_STRING
+
+#ifndef KRPC_IMPL_TYPE_TESTSERVICE_TESTNULLABLESTRUCT
+#define KRPC_IMPL_TYPE_TESTSERVICE_TESTNULLABLESTRUCT
+
+static inline bool krpc_encode_callback_items_TestService_TestNullableStruct(
+  pb_ostream_t * stream, const pb_field_t * field, void * const * arg) {
+  const krpc_TestService_TestNullableStruct_t * value = (const krpc_TestService_TestNullableStruct_t*)(*arg);
+  {
+    if (!pb_encode_tag_for_field(stream, field))
+      KRPC_CALLBACK_RETURN_ERROR("encoding tag for tuple item");
+    size_t size;
+    KRPC_CALLBACK_RETURN_ON_ERROR(krpc_encode_size_int32(&size, value->int_field));
+    if (!pb_encode_varint(stream, size))
+      KRPC_CALLBACK_RETURN_ERROR("encoding size for tuple item");
+    KRPC_CALLBACK_RETURN_ON_ERROR(krpc_encode_int32(stream, value->int_field));
+  }
+  {
+    if (!pb_encode_tag_for_field(stream, field))
+      KRPC_CALLBACK_RETURN_ERROR("encoding tag for tuple item");
+    size_t size;
+    KRPC_CALLBACK_RETURN_ON_ERROR(krpc_encode_size_nullable_int32(&size, &value->nullable_int_field));
+    if (!pb_encode_varint(stream, size))
+      KRPC_CALLBACK_RETURN_ERROR("encoding size for tuple item");
+    KRPC_CALLBACK_RETURN_ON_ERROR(krpc_encode_nullable_int32(stream, &value->nullable_int_field));
+  }
+  {
+    if (!pb_encode_tag_for_field(stream, field))
+      KRPC_CALLBACK_RETURN_ERROR("encoding tag for tuple item");
+    size_t size;
+    KRPC_CALLBACK_RETURN_ON_ERROR(krpc_encode_size_nullable_enum(&size, &value->nullable_enum_field));
+    if (!pb_encode_varint(stream, size))
+      KRPC_CALLBACK_RETURN_ERROR("encoding size for tuple item");
+    KRPC_CALLBACK_RETURN_ON_ERROR(krpc_encode_nullable_enum(stream, &value->nullable_enum_field));
+  }
+  {
+    if (!pb_encode_tag_for_field(stream, field))
+      KRPC_CALLBACK_RETURN_ERROR("encoding tag for tuple item");
+    size_t size;
+    KRPC_CALLBACK_RETURN_ON_ERROR(krpc_encode_size_nullable_string(&size, &value->nullable_string_field));
+    if (!pb_encode_varint(stream, size))
+      KRPC_CALLBACK_RETURN_ERROR("encoding size for tuple item");
+    KRPC_CALLBACK_RETURN_ON_ERROR(krpc_encode_nullable_string(stream, &value->nullable_string_field));
+  }
+  {
+    if (!pb_encode_tag_for_field(stream, field))
+      KRPC_CALLBACK_RETURN_ERROR("encoding tag for tuple item");
+    size_t size;
+    KRPC_CALLBACK_RETURN_ON_ERROR(krpc_encode_size_nullable_object(&size, &value->nullable_object_field));
+    if (!pb_encode_varint(stream, size))
+      KRPC_CALLBACK_RETURN_ERROR("encoding size for tuple item");
+    KRPC_CALLBACK_RETURN_ON_ERROR(krpc_encode_nullable_object(stream, &value->nullable_object_field));
+  }
+  return true;
+}
+
+static inline krpc_error_t krpc_encode_TestService_TestNullableStruct(
+  pb_ostream_t * stream, const krpc_TestService_TestNullableStruct_t * value) {
+  krpc_schema_Tuple message = krpc_schema_Tuple_init_default;
+  message.items.funcs.encode = &krpc_encode_callback_items_TestService_TestNullableStruct;
+  message.items.arg = (krpc_TestService_TestNullableStruct_t*)value;
+  KRPC_RETURN_ON_ERROR(krpc_encode_message_Tuple(stream, &message));
+  return KRPC_OK;
+}
+
+static inline krpc_error_t krpc_encode_size_TestService_TestNullableStruct(
+  size_t * size, const krpc_TestService_TestNullableStruct_t * value) {
+  pb_ostream_t stream = PB_OSTREAM_SIZING;
+  KRPC_RETURN_ON_ERROR(krpc_encode_TestService_TestNullableStruct(&stream, value));
+  *size = stream.bytes_written;
+  return KRPC_OK;
+}
+
+static inline bool krpc_encode_callback_TestService_TestNullableStruct(
+  pb_ostream_t * stream, const pb_field_t * field, void * const * arg) {
+  if (!pb_encode_tag_for_field(stream, field))
+    KRPC_CALLBACK_RETURN_ERROR("encoding tag for TestService_TestNullableStruct");
+  krpc_TestService_TestNullableStruct_t * value = (krpc_TestService_TestNullableStruct_t*)(*arg);
+  size_t size;
+  KRPC_CALLBACK_RETURN_ON_ERROR(krpc_encode_size_TestService_TestNullableStruct(&size, value));
+  if (!pb_encode_varint(stream, size))
+    KRPC_CALLBACK_RETURN_ERROR("encoding size for TestService_TestNullableStruct");
+  KRPC_CALLBACK_RETURN_ON_ERROR(krpc_encode_TestService_TestNullableStruct(stream, value));
+  return true;
+}
+
+static inline bool krpc_decode_callback_item_TestService_TestNullableStruct(
+  pb_istream_t * stream, const pb_field_t * field, void ** arg) {
+  typedef struct State {size_t pos; krpc_TestService_TestNullableStruct_t * value;} State;
+  State * state = (State*)(*arg);
+  krpc_TestService_TestNullableStruct_t * value = state->value;
+  switch (state->pos) {
+  case 0:
+    KRPC_CALLBACK_RETURN_ON_ERROR(krpc_decode_int32(stream, &value->int_field));
+    break;
+  case 1:
+    KRPC_CALLBACK_RETURN_ON_ERROR(krpc_decode_nullable_int32(stream, &value->nullable_int_field));
+    break;
+  case 2:
+    KRPC_CALLBACK_RETURN_ON_ERROR(krpc_decode_nullable_enum(stream, &value->nullable_enum_field));
+    break;
+  case 3:
+    KRPC_CALLBACK_RETURN_ON_ERROR(krpc_decode_nullable_string(stream, &value->nullable_string_field));
+    break;
+  case 4:
+    KRPC_CALLBACK_RETURN_ON_ERROR(krpc_decode_nullable_object(stream, &value->nullable_object_field));
+    break;
+  default:
+    // Fields are only ever appended to a structure, so a value from a newer server may
+    // carry more items than this client knows about, and those are skipped
+    if (!pb_read(stream, NULL, stream->bytes_left))
+      KRPC_CALLBACK_RETURN_ERROR("skipping an appended struct field");
+    break;
+  }
+  state->pos++;
+  return true;
+}
+
+static inline krpc_error_t krpc_decode_TestService_TestNullableStruct(
+  pb_istream_t * stream, krpc_TestService_TestNullableStruct_t * value) {
+  krpc_schema_Tuple message = krpc_schema_Tuple_init_default;
+  message.items.funcs.decode = &krpc_decode_callback_item_TestService_TestNullableStruct;
+  typedef struct State { size_t pos; krpc_TestService_TestNullableStruct_t * value; } State;
+  State state = { 0, value };
+  message.items.arg = &state;
+  KRPC_RETURN_ON_ERROR(krpc_decode_message_Tuple(stream, &message));
+  if (state.pos < 5)
+    KRPC_RETURN_ERROR(DECODING_FAILED, "too few fields for a TestService_TestNullableStruct");
+  return KRPC_OK;
+}
+
+#endif  // KRPC_IMPL_TYPE_TESTSERVICE_TESTNULLABLESTRUCT
 
 #ifndef KRPC_IMPL_TYPE_DICTIONARY_INT32_BOOL
 #define KRPC_IMPL_TYPE_DICTIONARY_INT32_BOOL
@@ -1364,6 +2108,138 @@ static inline krpc_error_t krpc_decode_dictionary_string_list_int32(
 }
 
 #endif  // KRPC_IMPL_TYPE_DICTIONARY_STRING_LIST_INT32
+
+#ifndef KRPC_IMPL_TYPE_DICTIONARY_STRING_NULLABLE_OBJECT
+#define KRPC_IMPL_TYPE_DICTIONARY_STRING_NULLABLE_OBJECT
+
+static inline bool krpc_encode_callback_key_dictionary_string_nullable_object(
+  pb_ostream_t * stream, const pb_field_t * field, void * const * arg) {
+  if (!pb_encode_tag_for_field(stream, field))
+    KRPC_CALLBACK_RETURN_ERROR("encoding tag for dictionary entry key");
+  const char * * key = (const char **)(*arg);
+  size_t size = 0;
+  KRPC_CALLBACK_RETURN_ON_ERROR(krpc_encode_size_string(&size, *key));
+  if (!pb_encode_varint(stream, size))
+    KRPC_CALLBACK_RETURN_ERROR("encoding size for dictionary entry key");
+  KRPC_CALLBACK_RETURN_ON_ERROR(krpc_encode_string(stream, *key));
+  return true;
+}
+
+static inline bool krpc_encode_callback_value_dictionary_string_nullable_object(
+  pb_ostream_t * stream, const pb_field_t * field, void * const * arg) {
+  if (!pb_encode_tag_for_field(stream, field))
+    KRPC_CALLBACK_RETURN_ERROR("encoding tag for dictionary entry value");
+  const krpc_nullable_object_t * value = (const krpc_nullable_object_t*)(*arg);
+  size_t size = 0;
+  KRPC_CALLBACK_RETURN_ON_ERROR(krpc_encode_size_nullable_object(&size, value));
+  if (!pb_encode_varint(stream, size))
+    KRPC_CALLBACK_RETURN_ERROR("encoding size for dictionary entry value");
+  KRPC_CALLBACK_RETURN_ON_ERROR(krpc_encode_nullable_object(stream, value));
+  return true;
+}
+
+static inline bool krpc_encode_callback_entry_dictionary_string_nullable_object(
+  pb_ostream_t * stream, const pb_field_t * field, void * const * arg) {
+  const krpc_dictionary_string_nullable_object_t * value = (const krpc_dictionary_string_nullable_object_t*)(*arg);
+  krpc_schema_DictionaryEntry entry = krpc_schema_DictionaryEntry_init_default;
+  entry.key.funcs.encode = &krpc_encode_callback_key_dictionary_string_nullable_object;
+  entry.value.funcs.encode = &krpc_encode_callback_value_dictionary_string_nullable_object;
+  size_t i = 0;
+  for (; i < value->size; i++) {
+    entry.key.arg = &value->entries[i].key;
+    entry.value.arg = &value->entries[i].value;
+    if (!pb_encode_tag_for_field(stream, field))
+      KRPC_CALLBACK_RETURN_ERROR("encoding tag for dictionary entry");
+    size_t size;
+    KRPC_CALLBACK_RETURN_ON_ERROR(krpc_encode_size_message_DictionaryEntry(&size, &entry));
+    if (!pb_encode_varint(stream, size))
+      KRPC_CALLBACK_RETURN_ERROR("encoding size for dictionary item");
+    KRPC_CALLBACK_RETURN_ON_ERROR(krpc_encode_message_DictionaryEntry(stream, &entry));
+  }
+  return true;
+}
+
+static inline krpc_error_t krpc_encode_dictionary_string_nullable_object(
+  pb_ostream_t * stream, const krpc_dictionary_string_nullable_object_t * value) {
+  krpc_schema_Dictionary message = krpc_schema_Dictionary_init_default;
+  message.entries.funcs.encode = &krpc_encode_callback_entry_dictionary_string_nullable_object;
+  message.entries.arg = (krpc_dictionary_string_nullable_object_t*)value;
+  KRPC_RETURN_ON_ERROR(krpc_encode_message_Dictionary(stream, &message));
+  return KRPC_OK;
+}
+
+static inline krpc_error_t krpc_encode_size_dictionary_string_nullable_object(
+  size_t * size, const krpc_dictionary_string_nullable_object_t * value) {
+  pb_ostream_t stream = PB_OSTREAM_SIZING;
+  KRPC_RETURN_ON_ERROR(krpc_encode_dictionary_string_nullable_object(&stream, value));
+  *size = stream.bytes_written;
+  return KRPC_OK;
+}
+
+static inline bool krpc_encode_callback_dictionary_string_nullable_object(
+  pb_ostream_t * stream, const pb_field_t * field, void * const * arg) {
+  if (!pb_encode_tag_for_field(stream, field))
+    KRPC_CALLBACK_RETURN_ERROR("encoding tag for dictionary_string_nullable_object");
+  krpc_dictionary_string_nullable_object_t * value = (krpc_dictionary_string_nullable_object_t*)(*arg);
+  size_t size;
+  KRPC_CALLBACK_RETURN_ON_ERROR(krpc_encode_size_dictionary_string_nullable_object(&size, value));
+  if (!pb_encode_varint(stream, size))
+    KRPC_CALLBACK_RETURN_ERROR("encoding size for dictionary_string_nullable_object");
+  KRPC_CALLBACK_RETURN_ON_ERROR(krpc_encode_dictionary_string_nullable_object(stream, value));
+  return true;
+}
+
+static inline bool krpc_decode_callback_key_dictionary_string_nullable_object(
+  pb_istream_t * stream, const pb_field_t * field, void ** arg) {
+  char * * key = (char **)(*arg);
+  KRPC_CALLBACK_RETURN_ON_ERROR(krpc_decode_string(stream, key));
+  return true;
+}
+
+static inline bool krpc_decode_callback_value_dictionary_string_nullable_object(
+  pb_istream_t * stream, const pb_field_t * field, void ** arg) {
+  krpc_nullable_object_t * value = (krpc_nullable_object_t*)(*arg);
+  KRPC_CALLBACK_RETURN_ON_ERROR(krpc_decode_nullable_object(stream, value));
+  return true;
+}
+
+static inline bool krpc_decode_callback_entry_dictionary_string_nullable_object(
+  pb_istream_t * stream, const pb_field_t * field, void ** arg) {
+  typedef struct State { size_t capacity; krpc_dictionary_string_nullable_object_t * value; } State;
+  State * state = (State*)(*arg);
+  krpc_dictionary_string_nullable_object_t * value = state->value;
+  size_t i = value->size;
+  value->size++;
+  if (state->capacity > 0 && state->value->size > state->capacity) {
+    state->value->entries = (krpc_dictionary_entry_string_nullable_object_t*)krpc_recalloc(state->value->entries, state->capacity, KRPC_ALLOC_BLOCK_SIZE, sizeof(krpc_dictionary_entry_string_nullable_object_t));
+    state->capacity += KRPC_ALLOC_BLOCK_SIZE;
+  }
+  krpc_schema_DictionaryEntry message = krpc_schema_DictionaryEntry_init_default;
+  message.key.funcs.decode = &krpc_decode_callback_key_dictionary_string_nullable_object;
+  message.key.arg = &value->entries[i].key;
+  message.value.funcs.decode = &krpc_decode_callback_value_dictionary_string_nullable_object;
+  message.value.arg = &value->entries[i].value;
+  KRPC_CALLBACK_RETURN_ON_ERROR(krpc_decode_message_DictionaryEntry(stream, &message));
+  return true;
+}
+
+static inline krpc_error_t krpc_decode_dictionary_string_nullable_object(
+  pb_istream_t * stream, krpc_dictionary_string_nullable_object_t * value) {
+  typedef struct State { size_t capacity; krpc_dictionary_string_nullable_object_t * value; } State;
+  State state = { 0, value };
+  value->size = 0;
+  if (value->entries == NULL) {
+    value->entries = (krpc_dictionary_entry_string_nullable_object_t*)krpc_calloc(KRPC_ALLOC_BLOCK_SIZE, sizeof(krpc_dictionary_entry_string_nullable_object_t));
+    state.capacity = KRPC_ALLOC_BLOCK_SIZE;
+  }
+  krpc_schema_Dictionary message = krpc_schema_Dictionary_init_default;
+  message.entries.funcs.decode = &krpc_decode_callback_entry_dictionary_string_nullable_object;
+  message.entries.arg = &state;
+  KRPC_RETURN_ON_ERROR(krpc_decode_message_Dictionary(stream, &message));
+  return KRPC_OK;
+}
+
+#endif  // KRPC_IMPL_TYPE_DICTIONARY_STRING_NULLABLE_OBJECT
 
 #ifndef KRPC_IMPL_TYPE_LIST_TESTSERVICE_TESTSTRUCT
 #define KRPC_IMPL_TYPE_LIST_TESTSERVICE_TESTSTRUCT
@@ -1769,6 +2645,168 @@ static inline krpc_error_t krpc_decode_list_int64(
 }
 
 #endif  // KRPC_IMPL_TYPE_LIST_INT64
+
+#ifndef KRPC_IMPL_TYPE_LIST_LIST_NULLABLE_OBJECT
+#define KRPC_IMPL_TYPE_LIST_LIST_NULLABLE_OBJECT
+
+static inline bool krpc_encode_callback_items_list_list_nullable_object(
+  pb_ostream_t * stream, const pb_field_t * field, void * const * arg) {
+  const krpc_list_list_nullable_object_t * value = (const krpc_list_list_nullable_object_t*)(*arg);
+  size_t i = 0;
+  for (; i < value->size; i++) {
+    if (!pb_encode_tag_for_field(stream, field))
+      KRPC_CALLBACK_RETURN_ERROR("encoding tag for list item");
+    size_t size;
+    KRPC_CALLBACK_RETURN_ON_ERROR(krpc_encode_size_list_nullable_object(&size, &value->items[i]));
+    if (!pb_encode_varint(stream, size))
+      KRPC_CALLBACK_RETURN_ERROR("encoding size for list item");
+    KRPC_CALLBACK_RETURN_ON_ERROR(krpc_encode_list_nullable_object(stream, &value->items[i]));
+  }
+  return true;
+}
+
+static inline krpc_error_t krpc_encode_list_list_nullable_object(
+  pb_ostream_t * stream, const krpc_list_list_nullable_object_t * value) {
+  krpc_schema_List message = krpc_schema_List_init_default;
+  message.items.funcs.encode = &krpc_encode_callback_items_list_list_nullable_object;
+  message.items.arg = (krpc_list_list_nullable_object_t*)value;
+  KRPC_RETURN_ON_ERROR(krpc_encode_message_List(stream, &message));
+  return KRPC_OK;
+}
+
+static inline krpc_error_t krpc_encode_size_list_list_nullable_object(
+  size_t * size, const krpc_list_list_nullable_object_t * value) {
+  pb_ostream_t stream = PB_OSTREAM_SIZING;
+  KRPC_RETURN_ON_ERROR(krpc_encode_list_list_nullable_object(&stream, value));
+  *size = stream.bytes_written;
+  return KRPC_OK;
+}
+
+static inline bool krpc_encode_callback_list_list_nullable_object(
+  pb_ostream_t * stream, const pb_field_t * field, void * const * arg) {
+  if (!pb_encode_tag_for_field(stream, field))
+    KRPC_CALLBACK_RETURN_ERROR("encoding tag for list_list_nullable_object");
+  krpc_list_list_nullable_object_t * value = (krpc_list_list_nullable_object_t*)(*arg);
+  size_t size;
+  KRPC_CALLBACK_RETURN_ON_ERROR(krpc_encode_size_list_list_nullable_object(&size, value));
+  if (!pb_encode_varint(stream, size))
+    KRPC_CALLBACK_RETURN_ERROR("encoding size for list_list_nullable_object");
+  KRPC_CALLBACK_RETURN_ON_ERROR(krpc_encode_list_list_nullable_object(stream, value));
+  return true;
+}
+
+static inline bool krpc_decode_callback_item_list_list_nullable_object(
+  pb_istream_t * stream, const pb_field_t * field, void ** arg) {
+  typedef struct State { size_t capacity; krpc_list_list_nullable_object_t * value; } State;
+  State * state = (State*)(*arg);
+  size_t i = state->value->size;
+  state->value->size++;
+  if (state->capacity > 0 && state->value->size > state->capacity) {
+    state->value->items = (krpc_list_nullable_object_t*)krpc_recalloc(state->value->items, state->capacity, KRPC_ALLOC_BLOCK_SIZE, sizeof(krpc_list_nullable_object_t));
+    state->capacity += KRPC_ALLOC_BLOCK_SIZE;
+  }
+  KRPC_CALLBACK_RETURN_ON_ERROR(krpc_decode_list_nullable_object(stream, &state->value->items[i]));
+  return true;
+}
+
+static inline krpc_error_t krpc_decode_list_list_nullable_object(
+  pb_istream_t * stream, krpc_list_list_nullable_object_t * value) {
+  typedef struct State { size_t capacity; krpc_list_list_nullable_object_t * value; } State;
+  State state = { 0, value };
+  value->size = 0;
+  if (value->items == NULL) {
+    value->items = (krpc_list_nullable_object_t*)krpc_calloc(KRPC_ALLOC_BLOCK_SIZE, sizeof(krpc_list_nullable_object_t));
+    state.capacity = KRPC_ALLOC_BLOCK_SIZE;
+  }
+  krpc_schema_List message = krpc_schema_List_init_default;
+  message.items.funcs.decode = &krpc_decode_callback_item_list_list_nullable_object;
+  message.items.arg = &state;
+  KRPC_RETURN_ON_ERROR(krpc_decode_message_List(stream, &message));
+  return KRPC_OK;
+}
+
+#endif  // KRPC_IMPL_TYPE_LIST_LIST_NULLABLE_OBJECT
+
+#ifndef KRPC_IMPL_TYPE_LIST_NULLABLE_INT32
+#define KRPC_IMPL_TYPE_LIST_NULLABLE_INT32
+
+static inline bool krpc_encode_callback_items_list_nullable_int32(
+  pb_ostream_t * stream, const pb_field_t * field, void * const * arg) {
+  const krpc_list_nullable_int32_t * value = (const krpc_list_nullable_int32_t*)(*arg);
+  size_t i = 0;
+  for (; i < value->size; i++) {
+    if (!pb_encode_tag_for_field(stream, field))
+      KRPC_CALLBACK_RETURN_ERROR("encoding tag for list item");
+    size_t size;
+    KRPC_CALLBACK_RETURN_ON_ERROR(krpc_encode_size_nullable_int32(&size, &value->items[i]));
+    if (!pb_encode_varint(stream, size))
+      KRPC_CALLBACK_RETURN_ERROR("encoding size for list item");
+    KRPC_CALLBACK_RETURN_ON_ERROR(krpc_encode_nullable_int32(stream, &value->items[i]));
+  }
+  return true;
+}
+
+static inline krpc_error_t krpc_encode_list_nullable_int32(
+  pb_ostream_t * stream, const krpc_list_nullable_int32_t * value) {
+  krpc_schema_List message = krpc_schema_List_init_default;
+  message.items.funcs.encode = &krpc_encode_callback_items_list_nullable_int32;
+  message.items.arg = (krpc_list_nullable_int32_t*)value;
+  KRPC_RETURN_ON_ERROR(krpc_encode_message_List(stream, &message));
+  return KRPC_OK;
+}
+
+static inline krpc_error_t krpc_encode_size_list_nullable_int32(
+  size_t * size, const krpc_list_nullable_int32_t * value) {
+  pb_ostream_t stream = PB_OSTREAM_SIZING;
+  KRPC_RETURN_ON_ERROR(krpc_encode_list_nullable_int32(&stream, value));
+  *size = stream.bytes_written;
+  return KRPC_OK;
+}
+
+static inline bool krpc_encode_callback_list_nullable_int32(
+  pb_ostream_t * stream, const pb_field_t * field, void * const * arg) {
+  if (!pb_encode_tag_for_field(stream, field))
+    KRPC_CALLBACK_RETURN_ERROR("encoding tag for list_nullable_int32");
+  krpc_list_nullable_int32_t * value = (krpc_list_nullable_int32_t*)(*arg);
+  size_t size;
+  KRPC_CALLBACK_RETURN_ON_ERROR(krpc_encode_size_list_nullable_int32(&size, value));
+  if (!pb_encode_varint(stream, size))
+    KRPC_CALLBACK_RETURN_ERROR("encoding size for list_nullable_int32");
+  KRPC_CALLBACK_RETURN_ON_ERROR(krpc_encode_list_nullable_int32(stream, value));
+  return true;
+}
+
+static inline bool krpc_decode_callback_item_list_nullable_int32(
+  pb_istream_t * stream, const pb_field_t * field, void ** arg) {
+  typedef struct State { size_t capacity; krpc_list_nullable_int32_t * value; } State;
+  State * state = (State*)(*arg);
+  size_t i = state->value->size;
+  state->value->size++;
+  if (state->capacity > 0 && state->value->size > state->capacity) {
+    state->value->items = (krpc_nullable_int32_t*)krpc_recalloc(state->value->items, state->capacity, KRPC_ALLOC_BLOCK_SIZE, sizeof(krpc_nullable_int32_t));
+    state->capacity += KRPC_ALLOC_BLOCK_SIZE;
+  }
+  KRPC_CALLBACK_RETURN_ON_ERROR(krpc_decode_nullable_int32(stream, &state->value->items[i]));
+  return true;
+}
+
+static inline krpc_error_t krpc_decode_list_nullable_int32(
+  pb_istream_t * stream, krpc_list_nullable_int32_t * value) {
+  typedef struct State { size_t capacity; krpc_list_nullable_int32_t * value; } State;
+  State state = { 0, value };
+  value->size = 0;
+  if (value->items == NULL) {
+    value->items = (krpc_nullable_int32_t*)krpc_calloc(KRPC_ALLOC_BLOCK_SIZE, sizeof(krpc_nullable_int32_t));
+    state.capacity = KRPC_ALLOC_BLOCK_SIZE;
+  }
+  krpc_schema_List message = krpc_schema_List_init_default;
+  message.items.funcs.decode = &krpc_decode_callback_item_list_nullable_int32;
+  message.items.arg = &state;
+  KRPC_RETURN_ON_ERROR(krpc_decode_message_List(stream, &message));
+  return KRPC_OK;
+}
+
+#endif  // KRPC_IMPL_TYPE_LIST_NULLABLE_INT32
 
 #ifndef KRPC_IMPL_TYPE_LIST_OBJECT
 #define KRPC_IMPL_TYPE_LIST_OBJECT
@@ -2353,6 +3391,95 @@ static inline krpc_error_t krpc_decode_tuple_int32_int64(
 
 #endif  // KRPC_IMPL_TYPE_TUPLE_INT32_INT64
 
+#ifndef KRPC_IMPL_TYPE_TUPLE_INT32_NULLABLE_OBJECT
+#define KRPC_IMPL_TYPE_TUPLE_INT32_NULLABLE_OBJECT
+
+static inline bool krpc_encode_callback_items_tuple_int32_nullable_object(
+  pb_ostream_t * stream, const pb_field_t * field, void * const * arg) {
+  const krpc_tuple_int32_nullable_object_t * value = (const krpc_tuple_int32_nullable_object_t*)(*arg);
+  {
+    if (!pb_encode_tag_for_field(stream, field))
+      KRPC_CALLBACK_RETURN_ERROR("encoding tag for tuple item");
+    size_t size;
+    KRPC_CALLBACK_RETURN_ON_ERROR(krpc_encode_size_int32(&size, value->e0));
+    if (!pb_encode_varint(stream, size))
+      KRPC_CALLBACK_RETURN_ERROR("encoding size for tuple item");
+    KRPC_CALLBACK_RETURN_ON_ERROR(krpc_encode_int32(stream, value->e0));
+  }
+  {
+    if (!pb_encode_tag_for_field(stream, field))
+      KRPC_CALLBACK_RETURN_ERROR("encoding tag for tuple item");
+    size_t size;
+    KRPC_CALLBACK_RETURN_ON_ERROR(krpc_encode_size_nullable_object(&size, &value->e1));
+    if (!pb_encode_varint(stream, size))
+      KRPC_CALLBACK_RETURN_ERROR("encoding size for tuple item");
+    KRPC_CALLBACK_RETURN_ON_ERROR(krpc_encode_nullable_object(stream, &value->e1));
+  }
+  return true;
+}
+
+static inline krpc_error_t krpc_encode_tuple_int32_nullable_object(
+  pb_ostream_t * stream, const krpc_tuple_int32_nullable_object_t * value) {
+  krpc_schema_Tuple message = krpc_schema_Tuple_init_default;
+  message.items.funcs.encode = &krpc_encode_callback_items_tuple_int32_nullable_object;
+  message.items.arg = (krpc_tuple_int32_nullable_object_t*)value;
+  KRPC_RETURN_ON_ERROR(krpc_encode_message_Tuple(stream, &message));
+  return KRPC_OK;
+}
+
+static inline krpc_error_t krpc_encode_size_tuple_int32_nullable_object(
+  size_t * size, const krpc_tuple_int32_nullable_object_t * value) {
+  pb_ostream_t stream = PB_OSTREAM_SIZING;
+  KRPC_RETURN_ON_ERROR(krpc_encode_tuple_int32_nullable_object(&stream, value));
+  *size = stream.bytes_written;
+  return KRPC_OK;
+}
+
+static inline bool krpc_encode_callback_tuple_int32_nullable_object(
+  pb_ostream_t * stream, const pb_field_t * field, void * const * arg) {
+  if (!pb_encode_tag_for_field(stream, field))
+    KRPC_CALLBACK_RETURN_ERROR("encoding tag for tuple_int32_nullable_object");
+  krpc_tuple_int32_nullable_object_t * value = (krpc_tuple_int32_nullable_object_t*)(*arg);
+  size_t size;
+  KRPC_CALLBACK_RETURN_ON_ERROR(krpc_encode_size_tuple_int32_nullable_object(&size, value));
+  if (!pb_encode_varint(stream, size))
+    KRPC_CALLBACK_RETURN_ERROR("encoding size for tuple_int32_nullable_object");
+  KRPC_CALLBACK_RETURN_ON_ERROR(krpc_encode_tuple_int32_nullable_object(stream, value));
+  return true;
+}
+
+static inline bool krpc_decode_callback_item_tuple_int32_nullable_object(
+  pb_istream_t * stream, const pb_field_t * field, void ** arg) {
+  typedef struct State {size_t pos; krpc_tuple_int32_nullable_object_t * value;} State;
+  State * state = (State*)(*arg);
+  krpc_tuple_int32_nullable_object_t * value = state->value;
+  switch (state->pos) {
+  case 0:
+    KRPC_CALLBACK_RETURN_ON_ERROR(krpc_decode_int32(stream, &value->e0));
+    break;
+  case 1:
+    KRPC_CALLBACK_RETURN_ON_ERROR(krpc_decode_nullable_object(stream, &value->e1));
+    break;
+  default:
+    KRPC_CALLBACK_RETURN_ERROR("unexpected tuple item");
+  }
+  state->pos++;
+  return true;
+}
+
+static inline krpc_error_t krpc_decode_tuple_int32_nullable_object(
+  pb_istream_t * stream, krpc_tuple_int32_nullable_object_t * value) {
+  krpc_schema_Tuple message = krpc_schema_Tuple_init_default;
+  message.items.funcs.decode = &krpc_decode_callback_item_tuple_int32_nullable_object;
+  typedef struct State { size_t pos; krpc_tuple_int32_nullable_object_t * value; } State;
+  State state = { 0, value };
+  message.items.arg = &state;
+  KRPC_RETURN_ON_ERROR(krpc_decode_message_Tuple(stream, &message));
+  return KRPC_OK;
+}
+
+#endif  // KRPC_IMPL_TYPE_TUPLE_INT32_NULLABLE_OBJECT
+
 static inline krpc_error_t krpc_TestService_AddMultipleValues(krpc_connection_t connection, char * * returnValue, float x, int32_t y, int64_t z) {
   krpc_call_t _call;
   krpc_argument_t _arguments[3];
@@ -2375,7 +3502,7 @@ static inline krpc_error_t krpc_TestService_AddMultipleValues(krpc_connection_t 
 static inline krpc_error_t krpc_TestService_AddToObjectList(krpc_connection_t connection, krpc_list_object_t * returnValue, const krpc_list_object_t * l, const char * value) {
   krpc_call_t _call;
   krpc_argument_t _arguments[2];
-  KRPC_CHECK(krpc_call(&_call, 9999, 38, 2, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 45, 2, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_list_object, l));
   KRPC_CHECK(krpc_add_argument(&_call, 1, &krpc_encode_callback_string, &value));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
@@ -2393,7 +3520,7 @@ static inline krpc_error_t krpc_TestService_AddToObjectList(krpc_connection_t co
 static inline krpc_error_t krpc_TestService_BlockingProcedure(krpc_connection_t connection, int32_t * returnValue, int32_t n, int32_t sum) {
   krpc_call_t _call;
   krpc_argument_t _arguments[2];
-  KRPC_CHECK(krpc_call(&_call, 9999, 26, 2, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 33, 2, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_int32, &n));
   KRPC_CHECK(krpc_add_argument(&_call, 1, &krpc_encode_callback_int32, &sum));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
@@ -2445,7 +3572,7 @@ static inline krpc_error_t krpc_TestService_BytesToHexString(krpc_connection_t c
 static inline krpc_error_t krpc_TestService_Counter(krpc_connection_t connection, int32_t * returnValue, const char * id, int32_t divisor) {
   krpc_call_t _call;
   krpc_argument_t _arguments[2];
-  KRPC_CHECK(krpc_call(&_call, 9999, 39, 2, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 46, 2, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_string, &id));
   KRPC_CHECK(krpc_add_argument(&_call, 1, &krpc_encode_callback_int32, &divisor));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
@@ -2463,7 +3590,7 @@ static inline krpc_error_t krpc_TestService_Counter(krpc_connection_t connection
 static inline krpc_error_t krpc_TestService_CounterStruct(krpc_connection_t connection, krpc_TestService_TestStruct_t * returnValue, const char * id) {
   krpc_call_t _call;
   krpc_argument_t _arguments[1];
-  KRPC_CHECK(krpc_call(&_call, 9999, 25, 1, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 32, 1, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_string, &id));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
@@ -2497,7 +3624,7 @@ static inline krpc_error_t krpc_TestService_CreateTestObject(krpc_connection_t c
 static inline krpc_error_t krpc_TestService_DeprecatedProcedure(krpc_connection_t connection, char * * returnValue, float value) {
   krpc_call_t _call;
   krpc_argument_t _arguments[1];
-  KRPC_CHECK(krpc_call(&_call, 9999, 51, 1, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 58, 1, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_float, &value));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
@@ -2514,7 +3641,7 @@ static inline krpc_error_t krpc_TestService_DeprecatedProcedure(krpc_connection_
 static inline krpc_error_t krpc_TestService_DeprecatedProcedureNoMessage(krpc_connection_t connection, char * * returnValue, float value) {
   krpc_call_t _call;
   krpc_argument_t _arguments[1];
-  KRPC_CHECK(krpc_call(&_call, 9999, 52, 1, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 59, 1, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_float, &value));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
@@ -2531,7 +3658,7 @@ static inline krpc_error_t krpc_TestService_DeprecatedProcedureNoMessage(krpc_co
 static inline krpc_error_t krpc_TestService_DictionaryDefault(krpc_connection_t connection, krpc_dictionary_int32_bool_t * returnValue, const krpc_dictionary_int32_bool_t * x) {
   krpc_call_t _call;
   krpc_argument_t _arguments[1];
-  KRPC_CHECK(krpc_call(&_call, 9999, 35, 1, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 42, 1, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_dictionary_int32_bool, x));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
@@ -2548,7 +3675,7 @@ static inline krpc_error_t krpc_TestService_DictionaryDefault(krpc_connection_t 
 static inline krpc_error_t krpc_TestService_DoubleSpecialDefaults(krpc_connection_t connection, krpc_list_double_t * returnValue, double nan, double infinity, double negativeInfinity, double maximum, double lowest) {
   krpc_call_t _call;
   krpc_argument_t _arguments[5];
-  KRPC_CHECK(krpc_call(&_call, 9999, 53, 5, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 60, 5, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_double, &nan));
   KRPC_CHECK(krpc_add_argument(&_call, 1, &krpc_encode_callback_double, &infinity));
   KRPC_CHECK(krpc_add_argument(&_call, 2, &krpc_encode_callback_double, &negativeInfinity));
@@ -2578,6 +3705,91 @@ static inline krpc_error_t krpc_TestService_DoubleToString(krpc_connection_t con
     pb_istream_t _stream;
     KRPC_CHECK(krpc_get_return_value(&_result, &_stream));
     KRPC_CHECK(krpc_decode_string(&_stream, returnValue));
+  }
+  KRPC_CHECK(krpc_free_result(&_result));
+  return KRPC_OK;
+}
+
+static inline krpc_error_t krpc_TestService_EchoDictionaryOfNullableObjects(krpc_connection_t connection, krpc_dictionary_string_nullable_object_t * returnValue, const krpc_dictionary_string_nullable_object_t * d) {
+  krpc_call_t _call;
+  krpc_argument_t _arguments[1];
+  KRPC_CHECK(krpc_call(&_call, 9999, 23, 1, _arguments));
+  KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_dictionary_string_nullable_object, d));
+  krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
+  KRPC_CHECK(krpc_init_result(&_result));
+  KRPC_CHECK(krpc_invoke(connection, &_result.message, &_call.message));
+  if (returnValue) {
+    pb_istream_t _stream;
+    KRPC_CHECK(krpc_get_return_value(&_result, &_stream));
+    KRPC_CHECK(krpc_decode_dictionary_string_nullable_object(&_stream, returnValue));
+  }
+  KRPC_CHECK(krpc_free_result(&_result));
+  return KRPC_OK;
+}
+
+static inline krpc_error_t krpc_TestService_EchoListOfNullableInts(krpc_connection_t connection, krpc_list_nullable_int32_t * returnValue, const krpc_list_nullable_int32_t * l) {
+  krpc_call_t _call;
+  krpc_argument_t _arguments[1];
+  KRPC_CHECK(krpc_call(&_call, 9999, 21, 1, _arguments));
+  KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_list_nullable_int32, l));
+  krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
+  KRPC_CHECK(krpc_init_result(&_result));
+  KRPC_CHECK(krpc_invoke(connection, &_result.message, &_call.message));
+  if (returnValue) {
+    pb_istream_t _stream;
+    KRPC_CHECK(krpc_get_return_value(&_result, &_stream));
+    KRPC_CHECK(krpc_decode_list_nullable_int32(&_stream, returnValue));
+  }
+  KRPC_CHECK(krpc_free_result(&_result));
+  return KRPC_OK;
+}
+
+static inline krpc_error_t krpc_TestService_EchoListOfNullableObjects(krpc_connection_t connection, krpc_list_nullable_object_t * returnValue, const krpc_list_nullable_object_t * l) {
+  krpc_call_t _call;
+  krpc_argument_t _arguments[1];
+  KRPC_CHECK(krpc_call(&_call, 9999, 22, 1, _arguments));
+  KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_list_nullable_object, l));
+  krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
+  KRPC_CHECK(krpc_init_result(&_result));
+  KRPC_CHECK(krpc_invoke(connection, &_result.message, &_call.message));
+  if (returnValue) {
+    pb_istream_t _stream;
+    KRPC_CHECK(krpc_get_return_value(&_result, &_stream));
+    KRPC_CHECK(krpc_decode_list_nullable_object(&_stream, returnValue));
+  }
+  KRPC_CHECK(krpc_free_result(&_result));
+  return KRPC_OK;
+}
+
+static inline krpc_error_t krpc_TestService_EchoNestedListOfNullableObjects(krpc_connection_t connection, krpc_list_list_nullable_object_t * returnValue, const krpc_list_list_nullable_object_t * l) {
+  krpc_call_t _call;
+  krpc_argument_t _arguments[1];
+  KRPC_CHECK(krpc_call(&_call, 9999, 25, 1, _arguments));
+  KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_list_list_nullable_object, l));
+  krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
+  KRPC_CHECK(krpc_init_result(&_result));
+  KRPC_CHECK(krpc_invoke(connection, &_result.message, &_call.message));
+  if (returnValue) {
+    pb_istream_t _stream;
+    KRPC_CHECK(krpc_get_return_value(&_result, &_stream));
+    KRPC_CHECK(krpc_decode_list_list_nullable_object(&_stream, returnValue));
+  }
+  KRPC_CHECK(krpc_free_result(&_result));
+  return KRPC_OK;
+}
+
+static inline krpc_error_t krpc_TestService_EchoNestedNullableStruct(krpc_connection_t connection, krpc_TestService_TestNestedNullableStruct_t * returnValue, const krpc_TestService_TestNestedNullableStruct_t * value) {
+  krpc_call_t _call;
+  krpc_argument_t _arguments[1];
+  KRPC_CHECK(krpc_call(&_call, 9999, 20, 1, _arguments));
+  KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_TestService_TestNestedNullableStruct, value));
+  krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
+  KRPC_CHECK(krpc_init_result(&_result));
+  KRPC_CHECK(krpc_invoke(connection, &_result.message, &_call.message));
+  if (returnValue) {
+    pb_istream_t _stream;
+    KRPC_CHECK(krpc_get_return_value(&_result, &_stream));
+    KRPC_CHECK(krpc_decode_TestService_TestNestedNullableStruct(&_stream, returnValue));
   }
   KRPC_CHECK(krpc_free_result(&_result));
   return KRPC_OK;
@@ -2692,10 +3904,27 @@ static inline krpc_error_t krpc_TestService_EchoTestObject(krpc_connection_t con
   return KRPC_OK;
 }
 
+static inline krpc_error_t krpc_TestService_EchoTupleWithANullableObject(krpc_connection_t connection, krpc_tuple_int32_nullable_object_t * returnValue, const krpc_tuple_int32_nullable_object_t * t) {
+  krpc_call_t _call;
+  krpc_argument_t _arguments[1];
+  KRPC_CHECK(krpc_call(&_call, 9999, 24, 1, _arguments));
+  KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_tuple_int32_nullable_object, t));
+  krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
+  KRPC_CHECK(krpc_init_result(&_result));
+  KRPC_CHECK(krpc_invoke(connection, &_result.message, &_call.message));
+  if (returnValue) {
+    pb_istream_t _stream;
+    KRPC_CHECK(krpc_get_return_value(&_result, &_stream));
+    KRPC_CHECK(krpc_decode_tuple_int32_nullable_object(&_stream, returnValue));
+  }
+  KRPC_CHECK(krpc_free_result(&_result));
+  return KRPC_OK;
+}
+
 static inline krpc_error_t krpc_TestService_EmptyListDefault(krpc_connection_t connection, krpc_list_string_t * returnValue, const krpc_list_string_t * x) {
   krpc_call_t _call;
   krpc_argument_t _arguments[1];
-  KRPC_CHECK(krpc_call(&_call, 9999, 37, 1, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 44, 1, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_list_string, x));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
@@ -2746,7 +3975,7 @@ static inline krpc_error_t krpc_TestService_EnumEcho(krpc_connection_t connectio
 static inline krpc_error_t krpc_TestService_EnumListDefault(krpc_connection_t connection, krpc_list_enum_t * returnValue, const krpc_list_enum_t * x) {
   krpc_call_t _call;
   krpc_argument_t _arguments[1];
-  KRPC_CHECK(krpc_call(&_call, 9999, 36, 1, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 43, 1, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_list_enum, x));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
@@ -2778,7 +4007,7 @@ static inline krpc_error_t krpc_TestService_EnumReturn(krpc_connection_t connect
 static inline krpc_error_t krpc_TestService_FloatSpecialDefaults(krpc_connection_t connection, krpc_list_float_t * returnValue, float nan, float infinity, float negativeInfinity, float maximum, float lowest, float fraction) {
   krpc_call_t _call;
   krpc_argument_t _arguments[6];
-  KRPC_CHECK(krpc_call(&_call, 9999, 54, 6, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 61, 6, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_float, &nan));
   KRPC_CHECK(krpc_add_argument(&_call, 1, &krpc_encode_callback_float, &infinity));
   KRPC_CHECK(krpc_add_argument(&_call, 2, &krpc_encode_callback_float, &negativeInfinity));
@@ -2817,7 +4046,7 @@ static inline krpc_error_t krpc_TestService_FloatToString(krpc_connection_t conn
 static inline krpc_error_t krpc_TestService_IncrementDictionary(krpc_connection_t connection, krpc_dictionary_string_int32_t * returnValue, const krpc_dictionary_string_int32_t * d) {
   krpc_call_t _call;
   krpc_argument_t _arguments[1];
-  KRPC_CHECK(krpc_call(&_call, 9999, 28, 1, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 35, 1, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_dictionary_string_int32, d));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
@@ -2834,7 +4063,7 @@ static inline krpc_error_t krpc_TestService_IncrementDictionary(krpc_connection_
 static inline krpc_error_t krpc_TestService_IncrementList(krpc_connection_t connection, krpc_list_int32_t * returnValue, const krpc_list_int32_t * l) {
   krpc_call_t _call;
   krpc_argument_t _arguments[1];
-  KRPC_CHECK(krpc_call(&_call, 9999, 27, 1, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 34, 1, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_list_int32, l));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
@@ -2851,7 +4080,7 @@ static inline krpc_error_t krpc_TestService_IncrementList(krpc_connection_t conn
 static inline krpc_error_t krpc_TestService_IncrementListOfStructs(krpc_connection_t connection, krpc_list_TestService_TestStruct_t * returnValue, const krpc_list_TestService_TestStruct_t * l) {
   krpc_call_t _call;
   krpc_argument_t _arguments[1];
-  KRPC_CHECK(krpc_call(&_call, 9999, 22, 1, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 29, 1, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_list_TestService_TestStruct, l));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
@@ -2868,7 +4097,7 @@ static inline krpc_error_t krpc_TestService_IncrementListOfStructs(krpc_connecti
 static inline krpc_error_t krpc_TestService_IncrementNestedCollection(krpc_connection_t connection, krpc_dictionary_string_list_int32_t * returnValue, const krpc_dictionary_string_list_int32_t * d) {
   krpc_call_t _call;
   krpc_argument_t _arguments[1];
-  KRPC_CHECK(krpc_call(&_call, 9999, 31, 1, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 38, 1, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_dictionary_string_list_int32, d));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
@@ -2885,7 +4114,7 @@ static inline krpc_error_t krpc_TestService_IncrementNestedCollection(krpc_conne
 static inline krpc_error_t krpc_TestService_IncrementSet(krpc_connection_t connection, krpc_set_int32_t * returnValue, const krpc_set_int32_t * h) {
   krpc_call_t _call;
   krpc_argument_t _arguments[1];
-  KRPC_CHECK(krpc_call(&_call, 9999, 29, 1, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 36, 1, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_set_int32, h));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
@@ -2902,7 +4131,7 @@ static inline krpc_error_t krpc_TestService_IncrementSet(krpc_connection_t conne
 static inline krpc_error_t krpc_TestService_IncrementTuple(krpc_connection_t connection, krpc_tuple_int32_int64_t * returnValue, const krpc_tuple_int32_int64_t * t) {
   krpc_call_t _call;
   krpc_argument_t _arguments[1];
-  KRPC_CHECK(krpc_call(&_call, 9999, 30, 1, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 37, 1, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_tuple_int32_int64, t));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
@@ -2919,7 +4148,7 @@ static inline krpc_error_t krpc_TestService_IncrementTuple(krpc_connection_t con
 static inline krpc_error_t krpc_TestService_Int32SpecialDefaults(krpc_connection_t connection, krpc_list_int32_t * returnValue, int32_t maximum, int32_t minimum) {
   krpc_call_t _call;
   krpc_argument_t _arguments[2];
-  KRPC_CHECK(krpc_call(&_call, 9999, 55, 2, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 62, 2, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_int32, &maximum));
   KRPC_CHECK(krpc_add_argument(&_call, 1, &krpc_encode_callback_int32, &minimum));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
@@ -2954,7 +4183,7 @@ static inline krpc_error_t krpc_TestService_Int32ToString(krpc_connection_t conn
 static inline krpc_error_t krpc_TestService_Int64SpecialDefaults(krpc_connection_t connection, krpc_list_int64_t * returnValue, int64_t maximum, int64_t minimum) {
   krpc_call_t _call;
   krpc_argument_t _arguments[2];
-  KRPC_CHECK(krpc_call(&_call, 9999, 56, 2, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 63, 2, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_int64, &maximum));
   KRPC_CHECK(krpc_add_argument(&_call, 1, &krpc_encode_callback_int64, &minimum));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
@@ -2989,7 +4218,7 @@ static inline krpc_error_t krpc_TestService_Int64ToString(krpc_connection_t conn
 static inline krpc_error_t krpc_TestService_ListDefault(krpc_connection_t connection, krpc_list_int32_t * returnValue, const krpc_list_int32_t * x) {
   krpc_call_t _call;
   krpc_argument_t _arguments[1];
-  KRPC_CHECK(krpc_call(&_call, 9999, 33, 1, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 40, 1, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_list_int32, x));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
@@ -3006,7 +4235,7 @@ static inline krpc_error_t krpc_TestService_ListDefault(krpc_connection_t connec
 static inline krpc_error_t krpc_TestService_NestedStructEcho(krpc_connection_t connection, krpc_TestService_TestNestedStruct_t * returnValue, const krpc_TestService_TestNestedStruct_t * x) {
   krpc_call_t _call;
   krpc_argument_t _arguments[1];
-  KRPC_CHECK(krpc_call(&_call, 9999, 21, 1, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 28, 1, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_TestService_TestNestedStruct, x));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
@@ -3037,10 +4266,27 @@ static inline krpc_error_t krpc_TestService_NotNullableObject(krpc_connection_t 
   return KRPC_OK;
 }
 
+static inline krpc_error_t krpc_TestService_NullableStructEcho(krpc_connection_t connection, krpc_TestService_TestNullableStruct_t * returnValue, const krpc_TestService_TestNullableStruct_t * x) {
+  krpc_call_t _call;
+  krpc_argument_t _arguments[1];
+  KRPC_CHECK(krpc_call(&_call, 9999, 27, 1, _arguments));
+  KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_TestService_TestNullableStruct, x));
+  krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
+  KRPC_CHECK(krpc_init_result(&_result));
+  KRPC_CHECK(krpc_invoke(connection, &_result.message, &_call.message));
+  if (returnValue) {
+    pb_istream_t _stream;
+    KRPC_CHECK(krpc_get_return_value(&_result, &_stream));
+    KRPC_CHECK(krpc_decode_TestService_TestNullableStruct(&_stream, returnValue));
+  }
+  KRPC_CHECK(krpc_free_result(&_result));
+  return KRPC_OK;
+}
+
 static inline krpc_error_t krpc_TestService_OnTimer(krpc_connection_t connection, krpc_schema_Event * returnValue, uint32_t milliseconds, uint32_t repeats) {
   krpc_call_t _call;
   krpc_argument_t _arguments[2];
-  KRPC_CHECK(krpc_call(&_call, 9999, 49, 2, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 56, 2, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_uint32, &milliseconds));
   KRPC_CHECK(krpc_add_argument(&_call, 1, &krpc_encode_callback_uint32, &repeats));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
@@ -3058,7 +4304,7 @@ static inline krpc_error_t krpc_TestService_OnTimer(krpc_connection_t connection
 static inline krpc_error_t krpc_TestService_OnTimerUsingLambda(krpc_connection_t connection, krpc_schema_Event * returnValue, uint32_t milliseconds) {
   krpc_call_t _call;
   krpc_argument_t _arguments[1];
-  KRPC_CHECK(krpc_call(&_call, 9999, 50, 1, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 57, 1, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_uint32, &milliseconds));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
@@ -3098,7 +4344,7 @@ static inline krpc_error_t krpc_TestService_OptionalArguments(krpc_connection_t 
 
 static inline krpc_error_t krpc_TestService_ResetCustomExceptionLater(krpc_connection_t connection) {
   krpc_call_t _call;
-  KRPC_CHECK(krpc_call(&_call, 9999, 47, 0, NULL));
+  KRPC_CHECK(krpc_call(&_call, 9999, 54, 0, NULL));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
   KRPC_CHECK(krpc_invoke(connection, &_result.message, &_call.message));
@@ -3108,7 +4354,7 @@ static inline krpc_error_t krpc_TestService_ResetCustomExceptionLater(krpc_conne
 
 static inline krpc_error_t krpc_TestService_ResetInvalidOperationExceptionLater(krpc_connection_t connection) {
   krpc_call_t _call;
-  KRPC_CHECK(krpc_call(&_call, 9999, 41, 0, NULL));
+  KRPC_CHECK(krpc_call(&_call, 9999, 48, 0, NULL));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
   KRPC_CHECK(krpc_invoke(connection, &_result.message, &_call.message));
@@ -3134,7 +4380,7 @@ static inline krpc_error_t krpc_TestService_ReturnNullWhenNotAllowed(krpc_connec
 static inline krpc_error_t krpc_TestService_SetDefault(krpc_connection_t connection, krpc_set_int32_t * returnValue, const krpc_set_int32_t * x) {
   krpc_call_t _call;
   krpc_argument_t _arguments[1];
-  KRPC_CHECK(krpc_call(&_call, 9999, 34, 1, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 41, 1, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_set_int32, x));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
@@ -3168,7 +4414,7 @@ static inline krpc_error_t krpc_TestService_StringToInt32(krpc_connection_t conn
 static inline krpc_error_t krpc_TestService_StructDefault(krpc_connection_t connection, krpc_TestService_TestStruct_t * returnValue, const krpc_TestService_TestStruct_t * x) {
   krpc_call_t _call;
   krpc_argument_t _arguments[1];
-  KRPC_CHECK(krpc_call(&_call, 9999, 23, 1, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 30, 1, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_TestService_TestStruct, x));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
@@ -3185,7 +4431,7 @@ static inline krpc_error_t krpc_TestService_StructDefault(krpc_connection_t conn
 static inline krpc_error_t krpc_TestService_StructEcho(krpc_connection_t connection, krpc_TestService_TestStruct_t * returnValue, const krpc_TestService_TestStruct_t * x) {
   krpc_call_t _call;
   krpc_argument_t _arguments[1];
-  KRPC_CHECK(krpc_call(&_call, 9999, 20, 1, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 26, 1, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_TestService_TestStruct, x));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
@@ -3202,7 +4448,7 @@ static inline krpc_error_t krpc_TestService_StructEcho(krpc_connection_t connect
 static inline krpc_error_t krpc_TestService_StructEchoNullable(krpc_connection_t connection, krpc_TestService_TestStruct_t * returnValue, bool * returnValueIsNull, const krpc_TestService_TestStruct_t * x) {
   krpc_call_t _call;
   krpc_argument_t _arguments[1];
-  KRPC_CHECK(krpc_call(&_call, 9999, 24, 1, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 31, 1, _arguments));
   if (x == NULL) {
     KRPC_CHECK(krpc_add_null_argument(&_call, 0));
   } else {
@@ -3229,7 +4475,7 @@ static inline krpc_error_t krpc_TestService_StructEchoNullable(krpc_connection_t
 
 static inline krpc_error_t krpc_TestService_ThrowArgumentException(krpc_connection_t connection, int32_t * returnValue) {
   krpc_call_t _call;
-  KRPC_CHECK(krpc_call(&_call, 9999, 43, 0, NULL));
+  KRPC_CHECK(krpc_call(&_call, 9999, 50, 0, NULL));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
   KRPC_CHECK(krpc_invoke(connection, &_result.message, &_call.message));
@@ -3245,7 +4491,7 @@ static inline krpc_error_t krpc_TestService_ThrowArgumentException(krpc_connecti
 static inline krpc_error_t krpc_TestService_ThrowArgumentNullException(krpc_connection_t connection, int32_t * returnValue, const char * foo) {
   krpc_call_t _call;
   krpc_argument_t _arguments[1];
-  KRPC_CHECK(krpc_call(&_call, 9999, 44, 1, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 51, 1, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_string, &foo));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
@@ -3262,7 +4508,7 @@ static inline krpc_error_t krpc_TestService_ThrowArgumentNullException(krpc_conn
 static inline krpc_error_t krpc_TestService_ThrowArgumentOutOfRangeException(krpc_connection_t connection, int32_t * returnValue, int32_t foo) {
   krpc_call_t _call;
   krpc_argument_t _arguments[1];
-  KRPC_CHECK(krpc_call(&_call, 9999, 45, 1, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 52, 1, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_int32, &foo));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
@@ -3278,7 +4524,7 @@ static inline krpc_error_t krpc_TestService_ThrowArgumentOutOfRangeException(krp
 
 static inline krpc_error_t krpc_TestService_ThrowCustomException(krpc_connection_t connection, int32_t * returnValue) {
   krpc_call_t _call;
-  KRPC_CHECK(krpc_call(&_call, 9999, 46, 0, NULL));
+  KRPC_CHECK(krpc_call(&_call, 9999, 53, 0, NULL));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
   KRPC_CHECK(krpc_invoke(connection, &_result.message, &_call.message));
@@ -3293,7 +4539,7 @@ static inline krpc_error_t krpc_TestService_ThrowCustomException(krpc_connection
 
 static inline krpc_error_t krpc_TestService_ThrowCustomExceptionLater(krpc_connection_t connection, int32_t * returnValue) {
   krpc_call_t _call;
-  KRPC_CHECK(krpc_call(&_call, 9999, 48, 0, NULL));
+  KRPC_CHECK(krpc_call(&_call, 9999, 55, 0, NULL));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
   KRPC_CHECK(krpc_invoke(connection, &_result.message, &_call.message));
@@ -3308,7 +4554,7 @@ static inline krpc_error_t krpc_TestService_ThrowCustomExceptionLater(krpc_conne
 
 static inline krpc_error_t krpc_TestService_ThrowInvalidOperationException(krpc_connection_t connection, int32_t * returnValue) {
   krpc_call_t _call;
-  KRPC_CHECK(krpc_call(&_call, 9999, 40, 0, NULL));
+  KRPC_CHECK(krpc_call(&_call, 9999, 47, 0, NULL));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
   KRPC_CHECK(krpc_invoke(connection, &_result.message, &_call.message));
@@ -3323,7 +4569,7 @@ static inline krpc_error_t krpc_TestService_ThrowInvalidOperationException(krpc_
 
 static inline krpc_error_t krpc_TestService_ThrowInvalidOperationExceptionLater(krpc_connection_t connection, int32_t * returnValue) {
   krpc_call_t _call;
-  KRPC_CHECK(krpc_call(&_call, 9999, 42, 0, NULL));
+  KRPC_CHECK(krpc_call(&_call, 9999, 49, 0, NULL));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
   KRPC_CHECK(krpc_invoke(connection, &_result.message, &_call.message));
@@ -3339,7 +4585,7 @@ static inline krpc_error_t krpc_TestService_ThrowInvalidOperationExceptionLater(
 static inline krpc_error_t krpc_TestService_TupleDefault(krpc_connection_t connection, krpc_tuple_int32_bool_t * returnValue, const krpc_tuple_int32_bool_t * x) {
   krpc_call_t _call;
   krpc_argument_t _arguments[1];
-  KRPC_CHECK(krpc_call(&_call, 9999, 32, 1, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 39, 1, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_tuple_int32_bool, x));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
@@ -3356,7 +4602,7 @@ static inline krpc_error_t krpc_TestService_TupleDefault(krpc_connection_t conne
 static inline krpc_error_t krpc_TestService_Uint32SpecialDefaults(krpc_connection_t connection, krpc_list_uint32_t * returnValue, uint32_t maximum) {
   krpc_call_t _call;
   krpc_argument_t _arguments[1];
-  KRPC_CHECK(krpc_call(&_call, 9999, 57, 1, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 64, 1, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_uint32, &maximum));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
@@ -3373,7 +4619,7 @@ static inline krpc_error_t krpc_TestService_Uint32SpecialDefaults(krpc_connectio
 static inline krpc_error_t krpc_TestService_Uint64SpecialDefaults(krpc_connection_t connection, krpc_list_uint64_t * returnValue, uint64_t maximum) {
   krpc_call_t _call;
   krpc_argument_t _arguments[1];
-  KRPC_CHECK(krpc_call(&_call, 9999, 58, 1, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 65, 1, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_uint64, &maximum));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
@@ -3389,7 +4635,7 @@ static inline krpc_error_t krpc_TestService_Uint64SpecialDefaults(krpc_connectio
 
 static inline krpc_error_t krpc_TestService_DeprecatedProperty(krpc_connection_t connection, char * * returnValue) {
   krpc_call_t _call;
-  KRPC_CHECK(krpc_call(&_call, 9999, 67, 0, NULL));
+  KRPC_CHECK(krpc_call(&_call, 9999, 74, 0, NULL));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
   KRPC_CHECK(krpc_invoke(connection, &_result.message, &_call.message));
@@ -3405,7 +4651,7 @@ static inline krpc_error_t krpc_TestService_DeprecatedProperty(krpc_connection_t
 static inline krpc_error_t krpc_TestService_set_DeprecatedProperty(krpc_connection_t connection, const char * value) {
   krpc_call_t _call;
   krpc_argument_t _arguments[1];
-  KRPC_CHECK(krpc_call(&_call, 9999, 68, 1, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 75, 1, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_string, &value));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
@@ -3416,7 +4662,7 @@ static inline krpc_error_t krpc_TestService_set_DeprecatedProperty(krpc_connecti
 
 static inline krpc_error_t krpc_TestService_NullableObject(krpc_connection_t connection, krpc_TestService_TestClass_t * returnValue) {
   krpc_call_t _call;
-  KRPC_CHECK(krpc_call(&_call, 9999, 65, 0, NULL));
+  KRPC_CHECK(krpc_call(&_call, 9999, 72, 0, NULL));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
   KRPC_CHECK(krpc_invoke(connection, &_result.message, &_call.message));
@@ -3436,7 +4682,7 @@ static inline krpc_error_t krpc_TestService_NullableObject(krpc_connection_t con
 static inline krpc_error_t krpc_TestService_set_NullableObject(krpc_connection_t connection, krpc_TestService_TestClass_t value) {
   krpc_call_t _call;
   krpc_argument_t _arguments[1];
-  KRPC_CHECK(krpc_call(&_call, 9999, 66, 1, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 73, 1, _arguments));
   if (value == KRPC_NULL) {
     KRPC_CHECK(krpc_add_null_argument(&_call, 0));
   } else {
@@ -3451,7 +4697,7 @@ static inline krpc_error_t krpc_TestService_set_NullableObject(krpc_connection_t
 
 static inline krpc_error_t krpc_TestService_ObjectProperty(krpc_connection_t connection, krpc_TestService_TestClass_t * returnValue) {
   krpc_call_t _call;
-  KRPC_CHECK(krpc_call(&_call, 9999, 63, 0, NULL));
+  KRPC_CHECK(krpc_call(&_call, 9999, 70, 0, NULL));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
   KRPC_CHECK(krpc_invoke(connection, &_result.message, &_call.message));
@@ -3471,7 +4717,7 @@ static inline krpc_error_t krpc_TestService_ObjectProperty(krpc_connection_t con
 static inline krpc_error_t krpc_TestService_set_ObjectProperty(krpc_connection_t connection, krpc_TestService_TestClass_t value) {
   krpc_call_t _call;
   krpc_argument_t _arguments[1];
-  KRPC_CHECK(krpc_call(&_call, 9999, 64, 1, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 71, 1, _arguments));
   if (value == KRPC_NULL) {
     KRPC_CHECK(krpc_add_null_argument(&_call, 0));
   } else {
@@ -3486,7 +4732,7 @@ static inline krpc_error_t krpc_TestService_set_ObjectProperty(krpc_connection_t
 
 static inline krpc_error_t krpc_TestService_StringProperty(krpc_connection_t connection, char * * returnValue) {
   krpc_call_t _call;
-  KRPC_CHECK(krpc_call(&_call, 9999, 59, 0, NULL));
+  KRPC_CHECK(krpc_call(&_call, 9999, 66, 0, NULL));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
   KRPC_CHECK(krpc_invoke(connection, &_result.message, &_call.message));
@@ -3502,7 +4748,7 @@ static inline krpc_error_t krpc_TestService_StringProperty(krpc_connection_t con
 static inline krpc_error_t krpc_TestService_set_StringProperty(krpc_connection_t connection, const char * value) {
   krpc_call_t _call;
   krpc_argument_t _arguments[1];
-  KRPC_CHECK(krpc_call(&_call, 9999, 60, 1, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 67, 1, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_string, &value));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
@@ -3514,7 +4760,7 @@ static inline krpc_error_t krpc_TestService_set_StringProperty(krpc_connection_t
 static inline krpc_error_t krpc_TestService_set_StringPropertyPrivateGet(krpc_connection_t connection, const char * value) {
   krpc_call_t _call;
   krpc_argument_t _arguments[1];
-  KRPC_CHECK(krpc_call(&_call, 9999, 61, 1, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 68, 1, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_string, &value));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
@@ -3525,7 +4771,7 @@ static inline krpc_error_t krpc_TestService_set_StringPropertyPrivateGet(krpc_co
 
 static inline krpc_error_t krpc_TestService_StringPropertyPrivateSet(krpc_connection_t connection, char * * returnValue) {
   krpc_call_t _call;
-  KRPC_CHECK(krpc_call(&_call, 9999, 62, 0, NULL));
+  KRPC_CHECK(krpc_call(&_call, 9999, 69, 0, NULL));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
   KRPC_CHECK(krpc_invoke(connection, &_result.message, &_call.message));
@@ -3541,7 +4787,7 @@ static inline krpc_error_t krpc_TestService_StringPropertyPrivateSet(krpc_connec
 static inline krpc_error_t krpc_TestService_DeprecatedClass_DeprecatedMethod(krpc_connection_t connection, char * * returnValue, krpc_TestService_DeprecatedClass_t instance) {
   krpc_call_t _call;
   krpc_argument_t _arguments[1];
-  KRPC_CHECK(krpc_call(&_call, 9999, 82, 1, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 89, 1, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_uint64, &instance));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
@@ -3558,7 +4804,7 @@ static inline krpc_error_t krpc_TestService_DeprecatedClass_DeprecatedMethod(krp
 static inline krpc_error_t krpc_TestService_TestClass_EchoNullableObject(krpc_connection_t connection, krpc_TestService_TestClass_t * returnValue, krpc_TestService_TestClass_t instance, krpc_TestService_TestClass_t value) {
   krpc_call_t _call;
   krpc_argument_t _arguments[2];
-  KRPC_CHECK(krpc_call(&_call, 9999, 72, 2, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 79, 2, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_uint64, &instance));
   if (value == KRPC_NULL) {
     KRPC_CHECK(krpc_add_null_argument(&_call, 1));
@@ -3584,7 +4830,7 @@ static inline krpc_error_t krpc_TestService_TestClass_EchoNullableObject(krpc_co
 static inline krpc_error_t krpc_TestService_TestClass_FloatToString(krpc_connection_t connection, char * * returnValue, krpc_TestService_TestClass_t instance, float x) {
   krpc_call_t _call;
   krpc_argument_t _arguments[2];
-  KRPC_CHECK(krpc_call(&_call, 9999, 70, 2, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 77, 2, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_uint64, &instance));
   KRPC_CHECK(krpc_add_argument(&_call, 1, &krpc_encode_callback_float, &x));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
@@ -3602,7 +4848,7 @@ static inline krpc_error_t krpc_TestService_TestClass_FloatToString(krpc_connect
 static inline krpc_error_t krpc_TestService_TestClass_GetValue(krpc_connection_t connection, char * * returnValue, krpc_TestService_TestClass_t instance) {
   krpc_call_t _call;
   krpc_argument_t _arguments[1];
-  KRPC_CHECK(krpc_call(&_call, 9999, 69, 1, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 76, 1, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_uint64, &instance));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
@@ -3619,7 +4865,7 @@ static inline krpc_error_t krpc_TestService_TestClass_GetValue(krpc_connection_t
 static inline krpc_error_t krpc_TestService_TestClass_ObjectToString(krpc_connection_t connection, char * * returnValue, krpc_TestService_TestClass_t instance, krpc_TestService_TestClass_t other) {
   krpc_call_t _call;
   krpc_argument_t _arguments[2];
-  KRPC_CHECK(krpc_call(&_call, 9999, 71, 2, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 78, 2, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_uint64, &instance));
   if (other == KRPC_NULL) {
     KRPC_CHECK(krpc_add_null_argument(&_call, 1));
@@ -3641,7 +4887,7 @@ static inline krpc_error_t krpc_TestService_TestClass_ObjectToString(krpc_connec
 static inline krpc_error_t krpc_TestService_TestClass_OptionalArguments(krpc_connection_t connection, char * * returnValue, krpc_TestService_TestClass_t instance, const char * x, const char * y, const char * z, krpc_TestService_TestClass_t obj) {
   krpc_call_t _call;
   krpc_argument_t _arguments[5];
-  KRPC_CHECK(krpc_call(&_call, 9999, 73, 5, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 80, 5, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_uint64, &instance));
   KRPC_CHECK(krpc_add_argument(&_call, 1, &krpc_encode_callback_string, &x));
   KRPC_CHECK(krpc_add_argument(&_call, 2, &krpc_encode_callback_string, &y));
@@ -3666,7 +4912,7 @@ static inline krpc_error_t krpc_TestService_TestClass_OptionalArguments(krpc_con
 static inline krpc_error_t krpc_TestService_TestClass_IntProperty(krpc_connection_t connection, int32_t * returnValue, krpc_TestService_TestClass_t instance) {
   krpc_call_t _call;
   krpc_argument_t _arguments[1];
-  KRPC_CHECK(krpc_call(&_call, 9999, 76, 1, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 83, 1, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_uint64, &instance));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
@@ -3683,7 +4929,7 @@ static inline krpc_error_t krpc_TestService_TestClass_IntProperty(krpc_connectio
 static inline krpc_error_t krpc_TestService_TestClass_set_IntProperty(krpc_connection_t connection, krpc_TestService_TestClass_t instance, int32_t value) {
   krpc_call_t _call;
   krpc_argument_t _arguments[2];
-  KRPC_CHECK(krpc_call(&_call, 9999, 77, 2, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 84, 2, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_uint64, &instance));
   KRPC_CHECK(krpc_add_argument(&_call, 1, &krpc_encode_callback_int32, &value));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
@@ -3696,7 +4942,7 @@ static inline krpc_error_t krpc_TestService_TestClass_set_IntProperty(krpc_conne
 static inline krpc_error_t krpc_TestService_TestClass_ObjectProperty(krpc_connection_t connection, krpc_TestService_TestClass_t * returnValue, krpc_TestService_TestClass_t instance) {
   krpc_call_t _call;
   krpc_argument_t _arguments[1];
-  KRPC_CHECK(krpc_call(&_call, 9999, 78, 1, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 85, 1, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_uint64, &instance));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
@@ -3717,7 +4963,7 @@ static inline krpc_error_t krpc_TestService_TestClass_ObjectProperty(krpc_connec
 static inline krpc_error_t krpc_TestService_TestClass_set_ObjectProperty(krpc_connection_t connection, krpc_TestService_TestClass_t instance, krpc_TestService_TestClass_t value) {
   krpc_call_t _call;
   krpc_argument_t _arguments[2];
-  KRPC_CHECK(krpc_call(&_call, 9999, 79, 2, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 86, 2, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_uint64, &instance));
   if (value == KRPC_NULL) {
     KRPC_CHECK(krpc_add_null_argument(&_call, 1));
@@ -3734,7 +4980,7 @@ static inline krpc_error_t krpc_TestService_TestClass_set_ObjectProperty(krpc_co
 static inline krpc_error_t krpc_TestService_TestClass_set_StringPropertyPrivateGet(krpc_connection_t connection, krpc_TestService_TestClass_t instance, const char * value) {
   krpc_call_t _call;
   krpc_argument_t _arguments[2];
-  KRPC_CHECK(krpc_call(&_call, 9999, 80, 2, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 87, 2, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_uint64, &instance));
   KRPC_CHECK(krpc_add_argument(&_call, 1, &krpc_encode_callback_string, &value));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
@@ -3747,7 +4993,7 @@ static inline krpc_error_t krpc_TestService_TestClass_set_StringPropertyPrivateG
 static inline krpc_error_t krpc_TestService_TestClass_StringPropertyPrivateSet(krpc_connection_t connection, char * * returnValue, krpc_TestService_TestClass_t instance) {
   krpc_call_t _call;
   krpc_argument_t _arguments[1];
-  KRPC_CHECK(krpc_call(&_call, 9999, 81, 1, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 88, 1, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_uint64, &instance));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
   KRPC_CHECK(krpc_init_result(&_result));
@@ -3764,7 +5010,7 @@ static inline krpc_error_t krpc_TestService_TestClass_StringPropertyPrivateSet(k
 static inline krpc_error_t krpc_TestService_TestClass_StaticMethod(krpc_connection_t connection, char * * returnValue, const char * a, const char * b) {
   krpc_call_t _call;
   krpc_argument_t _arguments[2];
-  KRPC_CHECK(krpc_call(&_call, 9999, 74, 2, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 81, 2, _arguments));
   KRPC_CHECK(krpc_add_argument(&_call, 0, &krpc_encode_callback_string, &a));
   KRPC_CHECK(krpc_add_argument(&_call, 1, &krpc_encode_callback_string, &b));
   krpc_result_t _result = KRPC_RESULT_INIT_DEFAULT;
@@ -3782,7 +5028,7 @@ static inline krpc_error_t krpc_TestService_TestClass_StaticMethod(krpc_connecti
 static inline krpc_error_t krpc_TestService_TestClass_StaticNullableObject(krpc_connection_t connection, krpc_TestService_TestClass_t * returnValue, krpc_TestService_TestClass_t value) {
   krpc_call_t _call;
   krpc_argument_t _arguments[1];
-  KRPC_CHECK(krpc_call(&_call, 9999, 75, 1, _arguments));
+  KRPC_CHECK(krpc_call(&_call, 9999, 82, 1, _arguments));
   if (value == KRPC_NULL) {
     KRPC_CHECK(krpc_add_null_argument(&_call, 0));
   } else {

--- a/tools/krpctools/krpctools/test/clientgen-TestService-cpp.txt
+++ b/tools/krpctools/krpctools/test/clientgen-TestService-cpp.txt
@@ -31,8 +31,10 @@ class TestService : public Service {
 
   // Structure forward declarations
   struct DeprecatedStruct;
+  struct TestNestedNullableStruct;
   struct TestStruct;
   struct TestNestedStruct;
+  struct TestNullableStruct;
 
   class CustomException : public ::krpc::RPCError {
    public:
@@ -128,13 +130,25 @@ class TestService : public Service {
 
   std::string double_to_string(double value);
 
+  std::map<std::string, std::optional<TestService::TestClass> > echo_dictionary_of_nullable_objects(std::map<std::string, std::optional<TestService::TestClass> > d);
+
+  std::vector<std::optional<int32_t> > echo_list_of_nullable_ints(std::vector<std::optional<int32_t> > l);
+
+  std::vector<std::optional<TestService::TestClass> > echo_list_of_nullable_objects(std::vector<std::optional<TestService::TestClass> > l);
+
+  std::vector<std::vector<std::optional<TestService::TestClass>> > echo_nested_list_of_nullable_objects(std::vector<std::vector<std::optional<TestService::TestClass>> > l);
+
+  TestService::TestNestedNullableStruct echo_nested_nullable_struct(TestService::TestNestedNullableStruct value);
+
   std::optional<int32_t> echo_nullable_int(std::optional<int32_t> value);
 
   std::optional<std::vector<int32_t> > echo_nullable_list(std::optional<std::vector<int32_t> > l);
 
   std::optional<std::string> echo_nullable_string(std::optional<std::string> value);
 
-  TestService::TestClass echo_test_object(TestService::TestClass value);
+  std::optional<TestService::TestClass> echo_test_object(std::optional<TestService::TestClass> value);
+
+  std::tuple<int32_t, std::optional<TestService::TestClass> > echo_tuple_with_a_nullable_object(std::tuple<int32_t, std::optional<TestService::TestClass> > t);
 
   std::vector<std::string> empty_list_default(std::vector<std::string> x);
 
@@ -189,11 +203,13 @@ class TestService : public Service {
 
   TestService::TestClass not_nullable_object(TestService::TestClass value);
 
+  TestService::TestNullableStruct nullable_struct_echo(TestService::TestNullableStruct x);
+
   ::krpc::Event on_timer(uint32_t milliseconds, uint32_t repeats);
 
   ::krpc::Event on_timer_using_lambda(uint32_t milliseconds);
 
-  std::string optional_arguments(std::string x, std::string y, std::string z, TestService::TestClass obj);
+  std::string optional_arguments(std::string x, std::string y, std::string z, std::optional<TestService::TestClass> obj);
 
   void reset_custom_exception_later();
 
@@ -253,13 +269,13 @@ class TestService : public Service {
   [[deprecated("Use string_property instead.")]]
   void set_deprecated_property(std::string value);
 
-  TestService::TestClass nullable_object();
+  std::optional<TestService::TestClass> nullable_object();
 
-  void set_nullable_object(TestService::TestClass value);
+  void set_nullable_object(std::optional<TestService::TestClass> value);
 
-  TestService::TestClass object_property();
+  std::optional<TestService::TestClass> object_property();
 
-  void set_object_property(TestService::TestClass value);
+  void set_object_property(std::optional<TestService::TestClass> value);
 
   /**
    * Property documentation string.
@@ -301,13 +317,25 @@ class TestService : public Service {
 
   ::krpc::Stream<std::string> double_to_string_stream(double value);
 
+  ::krpc::Stream<std::map<std::string, std::optional<TestService::TestClass> >> echo_dictionary_of_nullable_objects_stream(std::map<std::string, std::optional<TestService::TestClass> > d);
+
+  ::krpc::Stream<std::vector<std::optional<int32_t> >> echo_list_of_nullable_ints_stream(std::vector<std::optional<int32_t> > l);
+
+  ::krpc::Stream<std::vector<std::optional<TestService::TestClass> >> echo_list_of_nullable_objects_stream(std::vector<std::optional<TestService::TestClass> > l);
+
+  ::krpc::Stream<std::vector<std::vector<std::optional<TestService::TestClass>> >> echo_nested_list_of_nullable_objects_stream(std::vector<std::vector<std::optional<TestService::TestClass>> > l);
+
+  ::krpc::Stream<TestService::TestNestedNullableStruct> echo_nested_nullable_struct_stream(TestService::TestNestedNullableStruct value);
+
   ::krpc::Stream<std::optional<int32_t>> echo_nullable_int_stream(std::optional<int32_t> value);
 
   ::krpc::Stream<std::optional<std::vector<int32_t> >> echo_nullable_list_stream(std::optional<std::vector<int32_t> > l);
 
   ::krpc::Stream<std::optional<std::string>> echo_nullable_string_stream(std::optional<std::string> value);
 
-  ::krpc::Stream<TestService::TestClass> echo_test_object_stream(TestService::TestClass value);
+  ::krpc::Stream<std::optional<TestService::TestClass>> echo_test_object_stream(std::optional<TestService::TestClass> value);
+
+  ::krpc::Stream<std::tuple<int32_t, std::optional<TestService::TestClass> >> echo_tuple_with_a_nullable_object_stream(std::tuple<int32_t, std::optional<TestService::TestClass> > t);
 
   ::krpc::Stream<std::vector<std::string>> empty_list_default_stream(std::vector<std::string> x);
 
@@ -349,11 +377,13 @@ class TestService : public Service {
 
   ::krpc::Stream<TestService::TestClass> not_nullable_object_stream(TestService::TestClass value);
 
+  ::krpc::Stream<TestService::TestNullableStruct> nullable_struct_echo_stream(TestService::TestNullableStruct x);
+
   ::krpc::Stream<::krpc::Event> on_timer_stream(uint32_t milliseconds, uint32_t repeats);
 
   ::krpc::Stream<::krpc::Event> on_timer_using_lambda_stream(uint32_t milliseconds);
 
-  ::krpc::Stream<std::string> optional_arguments_stream(std::string x, std::string y, std::string z, TestService::TestClass obj);
+  ::krpc::Stream<std::string> optional_arguments_stream(std::string x, std::string y, std::string z, std::optional<TestService::TestClass> obj);
 
   ::krpc::Stream<TestService::TestClass> return_null_when_not_allowed_stream();
 
@@ -389,9 +419,9 @@ class TestService : public Service {
 
   ::krpc::Stream<std::string> deprecated_property_stream();
 
-  ::krpc::Stream<TestService::TestClass> nullable_object_stream();
+  ::krpc::Stream<std::optional<TestService::TestClass>> nullable_object_stream();
 
-  ::krpc::Stream<TestService::TestClass> object_property_stream();
+  ::krpc::Stream<std::optional<TestService::TestClass>> object_property_stream();
 
   ::krpc::Stream<std::string> string_property_stream();
 
@@ -423,13 +453,25 @@ class TestService : public Service {
 
   ::krpc::schema::ProcedureCall double_to_string_call(double value);
 
+  ::krpc::schema::ProcedureCall echo_dictionary_of_nullable_objects_call(std::map<std::string, std::optional<TestService::TestClass> > d);
+
+  ::krpc::schema::ProcedureCall echo_list_of_nullable_ints_call(std::vector<std::optional<int32_t> > l);
+
+  ::krpc::schema::ProcedureCall echo_list_of_nullable_objects_call(std::vector<std::optional<TestService::TestClass> > l);
+
+  ::krpc::schema::ProcedureCall echo_nested_list_of_nullable_objects_call(std::vector<std::vector<std::optional<TestService::TestClass>> > l);
+
+  ::krpc::schema::ProcedureCall echo_nested_nullable_struct_call(TestService::TestNestedNullableStruct value);
+
   ::krpc::schema::ProcedureCall echo_nullable_int_call(std::optional<int32_t> value);
 
   ::krpc::schema::ProcedureCall echo_nullable_list_call(std::optional<std::vector<int32_t> > l);
 
   ::krpc::schema::ProcedureCall echo_nullable_string_call(std::optional<std::string> value);
 
-  ::krpc::schema::ProcedureCall echo_test_object_call(TestService::TestClass value);
+  ::krpc::schema::ProcedureCall echo_test_object_call(std::optional<TestService::TestClass> value);
+
+  ::krpc::schema::ProcedureCall echo_tuple_with_a_nullable_object_call(std::tuple<int32_t, std::optional<TestService::TestClass> > t);
 
   ::krpc::schema::ProcedureCall empty_list_default_call(std::vector<std::string> x);
 
@@ -471,11 +513,13 @@ class TestService : public Service {
 
   ::krpc::schema::ProcedureCall not_nullable_object_call(TestService::TestClass value);
 
+  ::krpc::schema::ProcedureCall nullable_struct_echo_call(TestService::TestNullableStruct x);
+
   ::krpc::schema::ProcedureCall on_timer_call(uint32_t milliseconds, uint32_t repeats);
 
   ::krpc::schema::ProcedureCall on_timer_using_lambda_call(uint32_t milliseconds);
 
-  ::krpc::schema::ProcedureCall optional_arguments_call(std::string x, std::string y, std::string z, TestService::TestClass obj);
+  ::krpc::schema::ProcedureCall optional_arguments_call(std::string x, std::string y, std::string z, std::optional<TestService::TestClass> obj);
 
   ::krpc::schema::ProcedureCall reset_custom_exception_later_call();
 
@@ -519,11 +563,11 @@ class TestService : public Service {
 
   ::krpc::schema::ProcedureCall nullable_object_call();
 
-  ::krpc::schema::ProcedureCall set_nullable_object_call(TestService::TestClass value);
+  ::krpc::schema::ProcedureCall set_nullable_object_call(std::optional<TestService::TestClass> value);
 
   ::krpc::schema::ProcedureCall object_property_call();
 
-  ::krpc::schema::ProcedureCall set_object_property_call(TestService::TestClass value);
+  ::krpc::schema::ProcedureCall set_object_property_call(std::optional<TestService::TestClass> value);
 
   ::krpc::schema::ProcedureCall string_property_call();
 
@@ -562,7 +606,7 @@ class TestService : public Service {
    public:
     explicit TestClass(Client* client = nullptr, uint64_t id = 0);
 
-    TestService::TestClass echo_nullable_object(TestService::TestClass value);
+    std::optional<TestService::TestClass> echo_nullable_object(std::optional<TestService::TestClass> value);
 
     std::string float_to_string(float x);
 
@@ -571,13 +615,13 @@ class TestService : public Service {
      */
     std::string get_value();
 
-    std::string object_to_string(TestService::TestClass other);
+    std::string object_to_string(std::optional<TestService::TestClass> other);
 
-    std::string optional_arguments(std::string x, std::string y, std::string z, TestService::TestClass obj);
+    std::string optional_arguments(std::string x, std::string y, std::string z, std::optional<TestService::TestClass> obj);
 
     static std::string static_method(Client& client, std::string a, std::string b);
 
-    static TestService::TestClass static_nullable_object(Client& client, TestService::TestClass value);
+    static std::optional<TestService::TestClass> static_nullable_object(Client& client, std::optional<TestService::TestClass> value);
 
     /**
      * Property documentation string.
@@ -589,47 +633,47 @@ class TestService : public Service {
      */
     void set_int_property(int32_t value);
 
-    TestService::TestClass object_property();
+    std::optional<TestService::TestClass> object_property();
 
-    void set_object_property(TestService::TestClass value);
+    void set_object_property(std::optional<TestService::TestClass> value);
 
     void set_string_property_private_get(std::string value);
 
     std::string string_property_private_set();
 
-    ::krpc::Stream<TestService::TestClass> echo_nullable_object_stream(TestService::TestClass value);
+    ::krpc::Stream<std::optional<TestService::TestClass>> echo_nullable_object_stream(std::optional<TestService::TestClass> value);
 
     ::krpc::Stream<std::string> float_to_string_stream(float x);
 
     ::krpc::Stream<std::string> get_value_stream();
 
-    ::krpc::Stream<std::string> object_to_string_stream(TestService::TestClass other);
+    ::krpc::Stream<std::string> object_to_string_stream(std::optional<TestService::TestClass> other);
 
-    ::krpc::Stream<std::string> optional_arguments_stream(std::string x, std::string y, std::string z, TestService::TestClass obj);
+    ::krpc::Stream<std::string> optional_arguments_stream(std::string x, std::string y, std::string z, std::optional<TestService::TestClass> obj);
 
     static ::krpc::Stream<std::string> static_method_stream(Client& client, std::string a, std::string b);
 
-    static ::krpc::Stream<TestService::TestClass> static_nullable_object_stream(Client& client, TestService::TestClass value);
+    static ::krpc::Stream<std::optional<TestService::TestClass>> static_nullable_object_stream(Client& client, std::optional<TestService::TestClass> value);
 
     ::krpc::Stream<int32_t> int_property_stream();
 
-    ::krpc::Stream<TestService::TestClass> object_property_stream();
+    ::krpc::Stream<std::optional<TestService::TestClass>> object_property_stream();
 
     ::krpc::Stream<std::string> string_property_private_set_stream();
 
-    ::krpc::schema::ProcedureCall echo_nullable_object_call(TestService::TestClass value);
+    ::krpc::schema::ProcedureCall echo_nullable_object_call(std::optional<TestService::TestClass> value);
 
     ::krpc::schema::ProcedureCall float_to_string_call(float x);
 
     ::krpc::schema::ProcedureCall get_value_call();
 
-    ::krpc::schema::ProcedureCall object_to_string_call(TestService::TestClass other);
+    ::krpc::schema::ProcedureCall object_to_string_call(std::optional<TestService::TestClass> other);
 
-    ::krpc::schema::ProcedureCall optional_arguments_call(std::string x, std::string y, std::string z, TestService::TestClass obj);
+    ::krpc::schema::ProcedureCall optional_arguments_call(std::string x, std::string y, std::string z, std::optional<TestService::TestClass> obj);
 
     static ::krpc::schema::ProcedureCall static_method_call(Client& client, std::string a, std::string b);
 
-    static ::krpc::schema::ProcedureCall static_nullable_object_call(Client& client, TestService::TestClass value);
+    static ::krpc::schema::ProcedureCall static_nullable_object_call(Client& client, std::optional<TestService::TestClass> value);
 
     ::krpc::schema::ProcedureCall int_property_call();
 
@@ -637,7 +681,7 @@ class TestService : public Service {
 
     ::krpc::schema::ProcedureCall object_property_call();
 
-    ::krpc::schema::ProcedureCall set_object_property_call(TestService::TestClass value);
+    ::krpc::schema::ProcedureCall set_object_property_call(std::optional<TestService::TestClass> value);
 
     ::krpc::schema::ProcedureCall set_string_property_private_get_call(std::string value);
 
@@ -694,6 +738,50 @@ value(value), old_value(old_value) {}
     }
 
     bool operator>=(const DeprecatedStruct& other) const {
+      return !(*this < other);
+    }
+  };
+
+  /**
+   * Nested nullable struct documentation string.
+   */
+  struct TestNestedNullableStruct {
+    std::vector<std::optional<TestService::TestClass> > list_field;
+    std::string string_field;
+
+    TestNestedNullableStruct() : list_field(), string_field() {}
+
+    TestNestedNullableStruct(std::vector<std::optional<TestService::TestClass> > list_field, std::string string_field) :
+list_field(list_field), string_field(string_field) {}
+
+    bool operator==(const TestNestedNullableStruct& other) const {
+      return this->list_field == other.list_field && this->string_field == other.string_field;
+    }
+
+    bool operator!=(const TestNestedNullableStruct& other) const {
+      return !(*this == other);
+    }
+
+    // Ordered by the fields in turn, which is how a tuple of the same values orders
+    bool operator<(const TestNestedNullableStruct& other) const {
+      if (list_field < other.list_field)
+        return true;
+      if (other.list_field < list_field)
+        return false;
+      if (string_field < other.string_field)
+        return true;
+      return false;
+    }
+
+    bool operator>(const TestNestedNullableStruct& other) const {
+      return other < *this;
+    }
+
+    bool operator<=(const TestNestedNullableStruct& other) const {
+      return !(other < *this);
+    }
+
+    bool operator>=(const TestNestedNullableStruct& other) const {
       return !(*this < other);
     }
   };
@@ -803,6 +891,65 @@ struct_field(struct_field), object_field(object_field), string_field(string_fiel
       return !(*this < other);
     }
   };
+
+  /**
+   * Nullable struct documentation string.
+   */
+  struct TestNullableStruct {
+    int32_t int_field;
+    std::optional<int32_t> nullable_int_field;
+    std::optional<TestService::TestEnum> nullable_enum_field;
+    std::optional<std::string> nullable_string_field;
+    std::optional<TestService::TestClass> nullable_object_field;
+
+    TestNullableStruct() : int_field(), nullable_int_field(), nullable_enum_field(), nullable_string_field(), nullable_object_field() {}
+
+    TestNullableStruct(int32_t int_field, std::optional<int32_t> nullable_int_field, std::optional<TestService::TestEnum> nullable_enum_field, std::optional<std::string> nullable_string_field, std::optional<TestService::TestClass> nullable_object_field) :
+int_field(int_field), nullable_int_field(nullable_int_field), nullable_enum_field(nullable_enum_field), nullable_string_field(nullable_string_field), nullable_object_field(nullable_object_field) {}
+
+    bool operator==(const TestNullableStruct& other) const {
+      return this->int_field == other.int_field && this->nullable_int_field == other.nullable_int_field && this->nullable_enum_field == other.nullable_enum_field && this->nullable_string_field == other.nullable_string_field && this->nullable_object_field == other.nullable_object_field;
+    }
+
+    bool operator!=(const TestNullableStruct& other) const {
+      return !(*this == other);
+    }
+
+    // Ordered by the fields in turn, which is how a tuple of the same values orders
+    bool operator<(const TestNullableStruct& other) const {
+      if (int_field < other.int_field)
+        return true;
+      if (other.int_field < int_field)
+        return false;
+      if (nullable_int_field < other.nullable_int_field)
+        return true;
+      if (other.nullable_int_field < nullable_int_field)
+        return false;
+      if (nullable_enum_field < other.nullable_enum_field)
+        return true;
+      if (other.nullable_enum_field < nullable_enum_field)
+        return false;
+      if (nullable_string_field < other.nullable_string_field)
+        return true;
+      if (other.nullable_string_field < nullable_string_field)
+        return false;
+      if (nullable_object_field < other.nullable_object_field)
+        return true;
+      return false;
+    }
+
+    bool operator>(const TestNullableStruct& other) const {
+      return other < *this;
+    }
+
+    bool operator<=(const TestNullableStruct& other) const {
+      return !(other < *this);
+    }
+
+    bool operator>=(const TestNullableStruct& other) const {
+      return !(*this < other);
+    }
+  };
 };
 
 }  // namespace services
@@ -834,8 +981,8 @@ namespace encoder {
   inline std::string encode(const services::TestService::DeprecatedStruct& value) {
     static thread_local krpc::schema::Tuple structMessage;
     structMessage.Clear();
-    structMessage.add_items(encode(value.value));
-    structMessage.add_items(encode(value.old_value));
+    structMessage.add_items(encode_item(value.value));
+    structMessage.add_items(encode_item(value.old_value));
     return krpc::encoder::encode(structMessage);
   }
 #if defined(__GNUC__)
@@ -845,13 +992,24 @@ namespace encoder {
   // A structure is sent as the values of its fields in order, which is the same encoding as
   // a tuple of those values. See the note on the collection encoders for why the message it
   // is sent in is kept between calls.
+  inline std::string encode(const services::TestService::TestNestedNullableStruct& value) {
+    static thread_local krpc::schema::Tuple structMessage;
+    structMessage.Clear();
+    structMessage.add_items(encode_item(value.list_field));
+    structMessage.add_items(encode_item(value.string_field));
+    return krpc::encoder::encode(structMessage);
+  }
+
+  // A structure is sent as the values of its fields in order, which is the same encoding as
+  // a tuple of those values. See the note on the collection encoders for why the message it
+  // is sent in is kept between calls.
   inline std::string encode(const services::TestService::TestStruct& value) {
     static thread_local krpc::schema::Tuple structMessage;
     structMessage.Clear();
-    structMessage.add_items(encode(value.int_field));
-    structMessage.add_items(encode(value.string_field));
-    structMessage.add_items(encode(value.enum_field));
-    structMessage.add_items(encode(value.list_field));
+    structMessage.add_items(encode_item(value.int_field));
+    structMessage.add_items(encode_item(value.string_field));
+    structMessage.add_items(encode_item(value.enum_field));
+    structMessage.add_items(encode_item(value.list_field));
     return krpc::encoder::encode(structMessage);
   }
 
@@ -861,9 +1019,23 @@ namespace encoder {
   inline std::string encode(const services::TestService::TestNestedStruct& value) {
     static thread_local krpc::schema::Tuple structMessage;
     structMessage.Clear();
-    structMessage.add_items(encode(value.struct_field));
-    structMessage.add_items(encode(value.object_field));
-    structMessage.add_items(encode(value.string_field));
+    structMessage.add_items(encode_item(value.struct_field));
+    structMessage.add_items(encode_item(value.object_field));
+    structMessage.add_items(encode_item(value.string_field));
+    return krpc::encoder::encode(structMessage);
+  }
+
+  // A structure is sent as the values of its fields in order, which is the same encoding as
+  // a tuple of those values. See the note on the collection encoders for why the message it
+  // is sent in is kept between calls.
+  inline std::string encode(const services::TestService::TestNullableStruct& value) {
+    static thread_local krpc::schema::Tuple structMessage;
+    structMessage.Clear();
+    structMessage.add_items(encode_item(value.int_field));
+    structMessage.add_items(encode_item(value.nullable_int_field));
+    structMessage.add_items(encode_item(value.nullable_enum_field));
+    structMessage.add_items(encode_item(value.nullable_string_field));
+    structMessage.add_items(encode_item(value.nullable_object_field));
     return krpc::encoder::encode(structMessage);
   }
 
@@ -901,12 +1073,23 @@ namespace decoder {
     if (!structMessage.ParseFromString(data)) throw EncodingError("Failed to decode message");
     if (structMessage.items_size() < 2)
       throw EncodingError("Value for DeprecatedStruct does not have all of its fields");
-    decode(value.value, structMessage.items(0), client);
-    decode(value.old_value, structMessage.items(1), client);
+    decode_item(value.value, structMessage.items(0), client);
+    decode_item(value.old_value, structMessage.items(1), client);
   }
 #if defined(__GNUC__)
 #pragma GCC diagnostic pop
 #endif
+
+  // Fields are only ever appended to a structure, so a value from a newer server may carry
+  // more items than this client knows about, and those are ignored.
+  inline void decode(services::TestService::TestNestedNullableStruct& value, const std::string& data, Client* client) {
+    static thread_local krpc::schema::Tuple structMessage;
+    if (!structMessage.ParseFromString(data)) throw EncodingError("Failed to decode message");
+    if (structMessage.items_size() < 2)
+      throw EncodingError("Value for TestNestedNullableStruct does not have all of its fields");
+    decode_item(value.list_field, structMessage.items(0), client);
+    decode_item(value.string_field, structMessage.items(1), client);
+  }
 
   // Fields are only ever appended to a structure, so a value from a newer server may carry
   // more items than this client knows about, and those are ignored.
@@ -915,10 +1098,10 @@ namespace decoder {
     if (!structMessage.ParseFromString(data)) throw EncodingError("Failed to decode message");
     if (structMessage.items_size() < 4)
       throw EncodingError("Value for TestStruct does not have all of its fields");
-    decode(value.int_field, structMessage.items(0), client);
-    decode(value.string_field, structMessage.items(1), client);
-    decode(value.enum_field, structMessage.items(2), client);
-    decode(value.list_field, structMessage.items(3), client);
+    decode_item(value.int_field, structMessage.items(0), client);
+    decode_item(value.string_field, structMessage.items(1), client);
+    decode_item(value.enum_field, structMessage.items(2), client);
+    decode_item(value.list_field, structMessage.items(3), client);
   }
 
   // Fields are only ever appended to a structure, so a value from a newer server may carry
@@ -928,9 +1111,23 @@ namespace decoder {
     if (!structMessage.ParseFromString(data)) throw EncodingError("Failed to decode message");
     if (structMessage.items_size() < 3)
       throw EncodingError("Value for TestNestedStruct does not have all of its fields");
-    decode(value.struct_field, structMessage.items(0), client);
-    decode(value.object_field, structMessage.items(1), client);
-    decode(value.string_field, structMessage.items(2), client);
+    decode_item(value.struct_field, structMessage.items(0), client);
+    decode_item(value.object_field, structMessage.items(1), client);
+    decode_item(value.string_field, structMessage.items(2), client);
+  }
+
+  // Fields are only ever appended to a structure, so a value from a newer server may carry
+  // more items than this client knows about, and those are ignored.
+  inline void decode(services::TestService::TestNullableStruct& value, const std::string& data, Client* client) {
+    static thread_local krpc::schema::Tuple structMessage;
+    if (!structMessage.ParseFromString(data)) throw EncodingError("Failed to decode message");
+    if (structMessage.items_size() < 5)
+      throw EncodingError("Value for TestNullableStruct does not have all of its fields");
+    decode_item(value.int_field, structMessage.items(0), client);
+    decode_item(value.nullable_int_field, structMessage.items(1), client);
+    decode_item(value.nullable_enum_field, structMessage.items(2), client);
+    decode_item(value.nullable_string_field, structMessage.items(3), client);
+    decode_item(value.nullable_object_field, structMessage.items(4), client);
   }
 
 }  // namespace decoder
@@ -949,6 +1146,13 @@ inline std::size_t hash_value(const services::TestService::DeprecatedStruct& val
 #pragma GCC diagnostic pop
 #endif
 
+inline std::size_t hash_value(const services::TestService::TestNestedNullableStruct& value) {
+  std::size_t seed = 0;
+  hash_combine(&seed, hash_value(value.list_field));
+  hash_combine(&seed, hash_value(value.string_field));
+  return seed;
+}
+
 inline std::size_t hash_value(const services::TestService::TestStruct& value) {
   std::size_t seed = 0;
   hash_combine(&seed, hash_value(value.int_field));
@@ -963,6 +1167,16 @@ inline std::size_t hash_value(const services::TestService::TestNestedStruct& val
   hash_combine(&seed, hash_value(value.struct_field));
   hash_combine(&seed, hash_value(value.object_field));
   hash_combine(&seed, hash_value(value.string_field));
+  return seed;
+}
+
+inline std::size_t hash_value(const services::TestService::TestNullableStruct& value) {
+  std::size_t seed = 0;
+  hash_combine(&seed, hash_value(value.int_field));
+  hash_combine(&seed, hash_value(value.nullable_int_field));
+  hash_combine(&seed, hash_value(value.nullable_enum_field));
+  hash_combine(&seed, hash_value(value.nullable_string_field));
+  hash_combine(&seed, hash_value(value.nullable_object_field));
   return seed;
 }
 
@@ -1015,6 +1229,18 @@ namespace services {
 #pragma GCC diagnostic pop
 #endif
 
+  inline std::string encode(const TestService::TestNestedNullableStruct& value) {
+    return encoder::encode(value);
+  }
+
+  inline void decode(TestService::TestNestedNullableStruct& value, const std::string& data, Client* client) {
+    decoder::decode(value, data, client);
+  }
+
+  inline std::size_t hash_value(const TestService::TestNestedNullableStruct& value) {
+    return krpc::hash_value(value);
+  }
+
   inline std::string encode(const TestService::TestStruct& value) {
     return encoder::encode(value);
   }
@@ -1036,6 +1262,18 @@ namespace services {
   }
 
   inline std::size_t hash_value(const TestService::TestNestedStruct& value) {
+    return krpc::hash_value(value);
+  }
+
+  inline std::string encode(const TestService::TestNullableStruct& value) {
+    return encoder::encode(value);
+  }
+
+  inline void decode(TestService::TestNullableStruct& value, const std::string& data, Client* client) {
+    decoder::decode(value, data, client);
+  }
+
+  inline std::size_t hash_value(const TestService::TestNullableStruct& value) {
     return krpc::hash_value(value);
   }
 
@@ -1063,9 +1301,9 @@ inline TestService::TestService(Client* client):
 inline std::string TestService::add_multiple_values(float x, int32_t y, int64_t z) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(3);
-  _args.push_back(encoder::encode(x));
-  _args.push_back(encoder::encode(y));
-  _args.push_back(encoder::encode(z));
+  _args.push_back(encoder::encode_arg(x));
+  _args.push_back(encoder::encode_arg(y));
+  _args.push_back(encoder::encode_arg(z));
   auto _data = this->_client->invoke("TestService", "AddMultipleValues", _args);
   std::string _result{};
   if (!_data.is_null())
@@ -1076,8 +1314,8 @@ inline std::string TestService::add_multiple_values(float x, int32_t y, int64_t 
 inline std::vector<TestService::TestClass> TestService::add_to_object_list(std::vector<TestService::TestClass> l, std::string value) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(2);
-  _args.push_back(encoder::encode(l));
-  _args.push_back(encoder::encode(value));
+  _args.push_back(encoder::encode_arg(l));
+  _args.push_back(encoder::encode_arg(value));
   auto _data = this->_client->invoke("TestService", "AddToObjectList", _args);
   std::vector<TestService::TestClass> _result{};
   if (!_data.is_null())
@@ -1088,8 +1326,8 @@ inline std::vector<TestService::TestClass> TestService::add_to_object_list(std::
 inline int32_t TestService::blocking_procedure(int32_t n, int32_t sum = 0) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(2);
-  _args.push_back(encoder::encode(n));
-  _args.push_back(encoder::encode(sum));
+  _args.push_back(encoder::encode_arg(n));
+  _args.push_back(encoder::encode_arg(sum));
   auto _data = this->_client->invoke("TestService", "BlockingProcedure", _args);
   int32_t _result{};
   if (!_data.is_null())
@@ -1100,7 +1338,7 @@ inline int32_t TestService::blocking_procedure(int32_t n, int32_t sum = 0) {
 inline std::string TestService::bool_to_string(bool value) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(1);
-  _args.push_back(encoder::encode(value));
+  _args.push_back(encoder::encode_arg(value));
   auto _data = this->_client->invoke("TestService", "BoolToString", _args);
   std::string _result{};
   if (!_data.is_null())
@@ -1111,7 +1349,7 @@ inline std::string TestService::bool_to_string(bool value) {
 inline std::string TestService::bytes_to_hex_string(std::string value) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(1);
-  _args.push_back(encoder::encode(value));
+  _args.push_back(encoder::encode_arg(value));
   auto _data = this->_client->invoke("TestService", "BytesToHexString", _args);
   std::string _result{};
   if (!_data.is_null())
@@ -1122,8 +1360,8 @@ inline std::string TestService::bytes_to_hex_string(std::string value) {
 inline int32_t TestService::counter(std::string id = "", int32_t divisor = 1) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(2);
-  _args.push_back(encoder::encode(id));
-  _args.push_back(encoder::encode(divisor));
+  _args.push_back(encoder::encode_arg(id));
+  _args.push_back(encoder::encode_arg(divisor));
   auto _data = this->_client->invoke("TestService", "Counter", _args);
   int32_t _result{};
   if (!_data.is_null())
@@ -1134,7 +1372,7 @@ inline int32_t TestService::counter(std::string id = "", int32_t divisor = 1) {
 inline TestService::TestStruct TestService::counter_struct(std::string id = "") {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(1);
-  _args.push_back(encoder::encode(id));
+  _args.push_back(encoder::encode_arg(id));
   auto _data = this->_client->invoke("TestService", "CounterStruct", _args);
   TestService::TestStruct _result{};
   if (!_data.is_null())
@@ -1145,7 +1383,7 @@ inline TestService::TestStruct TestService::counter_struct(std::string id = "") 
 inline TestService::TestClass TestService::create_test_object(std::string value) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(1);
-  _args.push_back(encoder::encode(value));
+  _args.push_back(encoder::encode_arg(value));
   auto _data = this->_client->invoke("TestService", "CreateTestObject", _args);
   TestService::TestClass _result{};
   if (!_data.is_null())
@@ -1156,7 +1394,7 @@ inline TestService::TestClass TestService::create_test_object(std::string value)
 inline std::string TestService::deprecated_procedure(float value) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(1);
-  _args.push_back(encoder::encode(value));
+  _args.push_back(encoder::encode_arg(value));
   auto _data = this->_client->invoke("TestService", "DeprecatedProcedure", _args);
   std::string _result{};
   if (!_data.is_null())
@@ -1167,7 +1405,7 @@ inline std::string TestService::deprecated_procedure(float value) {
 inline std::string TestService::deprecated_procedure_no_message(float value) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(1);
-  _args.push_back(encoder::encode(value));
+  _args.push_back(encoder::encode_arg(value));
   auto _data = this->_client->invoke("TestService", "DeprecatedProcedureNoMessage", _args);
   std::string _result{};
   if (!_data.is_null())
@@ -1178,7 +1416,7 @@ inline std::string TestService::deprecated_procedure_no_message(float value) {
 inline std::map<int32_t, bool> TestService::dictionary_default(std::map<int32_t, bool> x = std::map<int32_t, bool>{{1, false}, {2, true}}) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(1);
-  _args.push_back(encoder::encode(x));
+  _args.push_back(encoder::encode_arg(x));
   auto _data = this->_client->invoke("TestService", "DictionaryDefault", _args);
   std::map<int32_t, bool> _result{};
   if (!_data.is_null())
@@ -1189,11 +1427,11 @@ inline std::map<int32_t, bool> TestService::dictionary_default(std::map<int32_t,
 inline std::vector<double> TestService::double_special_defaults(double nan = std::numeric_limits<double>::quiet_NaN(), double infinity = std::numeric_limits<double>::infinity(), double negative_infinity = -std::numeric_limits<double>::infinity(), double maximum = (std::numeric_limits<double>::max)(), double lowest = std::numeric_limits<double>::lowest()) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(5);
-  _args.push_back(encoder::encode(nan));
-  _args.push_back(encoder::encode(infinity));
-  _args.push_back(encoder::encode(negative_infinity));
-  _args.push_back(encoder::encode(maximum));
-  _args.push_back(encoder::encode(lowest));
+  _args.push_back(encoder::encode_arg(nan));
+  _args.push_back(encoder::encode_arg(infinity));
+  _args.push_back(encoder::encode_arg(negative_infinity));
+  _args.push_back(encoder::encode_arg(maximum));
+  _args.push_back(encoder::encode_arg(lowest));
   auto _data = this->_client->invoke("TestService", "DoubleSpecialDefaults", _args);
   std::vector<double> _result{};
   if (!_data.is_null())
@@ -1204,9 +1442,64 @@ inline std::vector<double> TestService::double_special_defaults(double nan = std
 inline std::string TestService::double_to_string(double value) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(1);
-  _args.push_back(encoder::encode(value));
+  _args.push_back(encoder::encode_arg(value));
   auto _data = this->_client->invoke("TestService", "DoubleToString", _args);
   std::string _result{};
+  if (!_data.is_null())
+    decoder::decode(_result, _data.value(), this->_client);
+  return _result;
+}
+
+inline std::map<std::string, std::optional<TestService::TestClass> > TestService::echo_dictionary_of_nullable_objects(std::map<std::string, std::optional<TestService::TestClass> > d) {
+  std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
+  _args.push_back(encoder::encode_arg(d));
+  auto _data = this->_client->invoke("TestService", "EchoDictionaryOfNullableObjects", _args);
+  std::map<std::string, std::optional<TestService::TestClass> > _result{};
+  if (!_data.is_null())
+    decoder::decode(_result, _data.value(), this->_client);
+  return _result;
+}
+
+inline std::vector<std::optional<int32_t> > TestService::echo_list_of_nullable_ints(std::vector<std::optional<int32_t> > l) {
+  std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
+  _args.push_back(encoder::encode_arg(l));
+  auto _data = this->_client->invoke("TestService", "EchoListOfNullableInts", _args);
+  std::vector<std::optional<int32_t> > _result{};
+  if (!_data.is_null())
+    decoder::decode(_result, _data.value(), this->_client);
+  return _result;
+}
+
+inline std::vector<std::optional<TestService::TestClass> > TestService::echo_list_of_nullable_objects(std::vector<std::optional<TestService::TestClass> > l) {
+  std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
+  _args.push_back(encoder::encode_arg(l));
+  auto _data = this->_client->invoke("TestService", "EchoListOfNullableObjects", _args);
+  std::vector<std::optional<TestService::TestClass> > _result{};
+  if (!_data.is_null())
+    decoder::decode(_result, _data.value(), this->_client);
+  return _result;
+}
+
+inline std::vector<std::vector<std::optional<TestService::TestClass>> > TestService::echo_nested_list_of_nullable_objects(std::vector<std::vector<std::optional<TestService::TestClass>> > l) {
+  std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
+  _args.push_back(encoder::encode_arg(l));
+  auto _data = this->_client->invoke("TestService", "EchoNestedListOfNullableObjects", _args);
+  std::vector<std::vector<std::optional<TestService::TestClass>> > _result{};
+  if (!_data.is_null())
+    decoder::decode(_result, _data.value(), this->_client);
+  return _result;
+}
+
+inline TestService::TestNestedNullableStruct TestService::echo_nested_nullable_struct(TestService::TestNestedNullableStruct value) {
+  std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
+  _args.push_back(encoder::encode_arg(value));
+  auto _data = this->_client->invoke("TestService", "EchoNestedNullableStruct", _args);
+  TestService::TestNestedNullableStruct _result{};
   if (!_data.is_null())
     decoder::decode(_result, _data.value(), this->_client);
   return _result;
@@ -1215,7 +1508,7 @@ inline std::string TestService::double_to_string(double value) {
 inline std::optional<int32_t> TestService::echo_nullable_int(std::optional<int32_t> value) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(1);
-  _args.push_back(encoder::encode_nullable(value));
+  _args.push_back(encoder::encode_arg(value));
   auto _data = this->_client->invoke("TestService", "EchoNullableInt", _args);
   std::optional<int32_t> _result{};
   if (!_data.is_null())
@@ -1226,7 +1519,7 @@ inline std::optional<int32_t> TestService::echo_nullable_int(std::optional<int32
 inline std::optional<std::vector<int32_t> > TestService::echo_nullable_list(std::optional<std::vector<int32_t> > l) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(1);
-  _args.push_back(encoder::encode_nullable(l));
+  _args.push_back(encoder::encode_arg(l));
   auto _data = this->_client->invoke("TestService", "EchoNullableList", _args);
   std::optional<std::vector<int32_t> > _result{};
   if (!_data.is_null())
@@ -1237,7 +1530,7 @@ inline std::optional<std::vector<int32_t> > TestService::echo_nullable_list(std:
 inline std::optional<std::string> TestService::echo_nullable_string(std::optional<std::string> value) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(1);
-  _args.push_back(encoder::encode_nullable(value));
+  _args.push_back(encoder::encode_arg(value));
   auto _data = this->_client->invoke("TestService", "EchoNullableString", _args);
   std::optional<std::string> _result{};
   if (!_data.is_null())
@@ -1245,12 +1538,23 @@ inline std::optional<std::string> TestService::echo_nullable_string(std::optiona
   return _result;
 }
 
-inline TestService::TestClass TestService::echo_test_object(TestService::TestClass value) {
+inline std::optional<TestService::TestClass> TestService::echo_test_object(std::optional<TestService::TestClass> value) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(1);
-  _args.push_back(encoder::encode_nullable(value));
+  _args.push_back(encoder::encode_arg(value));
   auto _data = this->_client->invoke("TestService", "EchoTestObject", _args);
-  TestService::TestClass _result{};
+  std::optional<TestService::TestClass> _result{};
+  if (!_data.is_null())
+    decoder::decode(_result, _data.value(), this->_client);
+  return _result;
+}
+
+inline std::tuple<int32_t, std::optional<TestService::TestClass> > TestService::echo_tuple_with_a_nullable_object(std::tuple<int32_t, std::optional<TestService::TestClass> > t) {
+  std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
+  _args.push_back(encoder::encode_arg(t));
+  auto _data = this->_client->invoke("TestService", "EchoTupleWithANullableObject", _args);
+  std::tuple<int32_t, std::optional<TestService::TestClass> > _result{};
   if (!_data.is_null())
     decoder::decode(_result, _data.value(), this->_client);
   return _result;
@@ -1259,7 +1563,7 @@ inline TestService::TestClass TestService::echo_test_object(TestService::TestCla
 inline std::vector<std::string> TestService::empty_list_default(std::vector<std::string> x = std::vector<std::string>{}) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(1);
-  _args.push_back(encoder::encode(x));
+  _args.push_back(encoder::encode_arg(x));
   auto _data = this->_client->invoke("TestService", "EmptyListDefault", _args);
   std::vector<std::string> _result{};
   if (!_data.is_null())
@@ -1270,7 +1574,7 @@ inline std::vector<std::string> TestService::empty_list_default(std::vector<std:
 inline TestService::TestEnum TestService::enum_default_arg(TestService::TestEnum x = TestService::TestEnum::value_c) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(1);
-  _args.push_back(encoder::encode(x));
+  _args.push_back(encoder::encode_arg(x));
   auto _data = this->_client->invoke("TestService", "EnumDefaultArg", _args);
   TestService::TestEnum _result{};
   if (!_data.is_null())
@@ -1281,7 +1585,7 @@ inline TestService::TestEnum TestService::enum_default_arg(TestService::TestEnum
 inline TestService::TestEnum TestService::enum_echo(TestService::TestEnum x) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(1);
-  _args.push_back(encoder::encode(x));
+  _args.push_back(encoder::encode_arg(x));
   auto _data = this->_client->invoke("TestService", "EnumEcho", _args);
   TestService::TestEnum _result{};
   if (!_data.is_null())
@@ -1292,7 +1596,7 @@ inline TestService::TestEnum TestService::enum_echo(TestService::TestEnum x) {
 inline std::vector<TestService::TestEnum> TestService::enum_list_default(std::vector<TestService::TestEnum> x = std::vector<TestService::TestEnum>{TestService::TestEnum::value_b, TestService::TestEnum::value_c}) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(1);
-  _args.push_back(encoder::encode(x));
+  _args.push_back(encoder::encode_arg(x));
   auto _data = this->_client->invoke("TestService", "EnumListDefault", _args);
   std::vector<TestService::TestEnum> _result{};
   if (!_data.is_null())
@@ -1311,12 +1615,12 @@ inline TestService::TestEnum TestService::enum_return() {
 inline std::vector<float> TestService::float_special_defaults(float nan = std::numeric_limits<float>::quiet_NaN(), float infinity = std::numeric_limits<float>::infinity(), float negative_infinity = -std::numeric_limits<float>::infinity(), float maximum = (std::numeric_limits<float>::max)(), float lowest = std::numeric_limits<float>::lowest(), float fraction = 0.1f) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(6);
-  _args.push_back(encoder::encode(nan));
-  _args.push_back(encoder::encode(infinity));
-  _args.push_back(encoder::encode(negative_infinity));
-  _args.push_back(encoder::encode(maximum));
-  _args.push_back(encoder::encode(lowest));
-  _args.push_back(encoder::encode(fraction));
+  _args.push_back(encoder::encode_arg(nan));
+  _args.push_back(encoder::encode_arg(infinity));
+  _args.push_back(encoder::encode_arg(negative_infinity));
+  _args.push_back(encoder::encode_arg(maximum));
+  _args.push_back(encoder::encode_arg(lowest));
+  _args.push_back(encoder::encode_arg(fraction));
   auto _data = this->_client->invoke("TestService", "FloatSpecialDefaults", _args);
   std::vector<float> _result{};
   if (!_data.is_null())
@@ -1327,7 +1631,7 @@ inline std::vector<float> TestService::float_special_defaults(float nan = std::n
 inline std::string TestService::float_to_string(float value) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(1);
-  _args.push_back(encoder::encode(value));
+  _args.push_back(encoder::encode_arg(value));
   auto _data = this->_client->invoke("TestService", "FloatToString", _args);
   std::string _result{};
   if (!_data.is_null())
@@ -1338,7 +1642,7 @@ inline std::string TestService::float_to_string(float value) {
 inline std::map<std::string, int32_t> TestService::increment_dictionary(std::map<std::string, int32_t> d) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(1);
-  _args.push_back(encoder::encode(d));
+  _args.push_back(encoder::encode_arg(d));
   auto _data = this->_client->invoke("TestService", "IncrementDictionary", _args);
   std::map<std::string, int32_t> _result{};
   if (!_data.is_null())
@@ -1349,7 +1653,7 @@ inline std::map<std::string, int32_t> TestService::increment_dictionary(std::map
 inline std::vector<int32_t> TestService::increment_list(std::vector<int32_t> l) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(1);
-  _args.push_back(encoder::encode(l));
+  _args.push_back(encoder::encode_arg(l));
   auto _data = this->_client->invoke("TestService", "IncrementList", _args);
   std::vector<int32_t> _result{};
   if (!_data.is_null())
@@ -1360,7 +1664,7 @@ inline std::vector<int32_t> TestService::increment_list(std::vector<int32_t> l) 
 inline std::vector<TestService::TestStruct> TestService::increment_list_of_structs(std::vector<TestService::TestStruct> l) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(1);
-  _args.push_back(encoder::encode(l));
+  _args.push_back(encoder::encode_arg(l));
   auto _data = this->_client->invoke("TestService", "IncrementListOfStructs", _args);
   std::vector<TestService::TestStruct> _result{};
   if (!_data.is_null())
@@ -1371,7 +1675,7 @@ inline std::vector<TestService::TestStruct> TestService::increment_list_of_struc
 inline std::map<std::string, std::vector<int32_t> > TestService::increment_nested_collection(std::map<std::string, std::vector<int32_t> > d) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(1);
-  _args.push_back(encoder::encode(d));
+  _args.push_back(encoder::encode_arg(d));
   auto _data = this->_client->invoke("TestService", "IncrementNestedCollection", _args);
   std::map<std::string, std::vector<int32_t> > _result{};
   if (!_data.is_null())
@@ -1382,7 +1686,7 @@ inline std::map<std::string, std::vector<int32_t> > TestService::increment_neste
 inline std::set<int32_t> TestService::increment_set(std::set<int32_t> h) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(1);
-  _args.push_back(encoder::encode(h));
+  _args.push_back(encoder::encode_arg(h));
   auto _data = this->_client->invoke("TestService", "IncrementSet", _args);
   std::set<int32_t> _result{};
   if (!_data.is_null())
@@ -1393,7 +1697,7 @@ inline std::set<int32_t> TestService::increment_set(std::set<int32_t> h) {
 inline std::tuple<int32_t, int64_t> TestService::increment_tuple(std::tuple<int32_t, int64_t> t) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(1);
-  _args.push_back(encoder::encode(t));
+  _args.push_back(encoder::encode_arg(t));
   auto _data = this->_client->invoke("TestService", "IncrementTuple", _args);
   std::tuple<int32_t, int64_t> _result{};
   if (!_data.is_null())
@@ -1404,8 +1708,8 @@ inline std::tuple<int32_t, int64_t> TestService::increment_tuple(std::tuple<int3
 inline std::vector<int32_t> TestService::int32_special_defaults(int32_t maximum = (std::numeric_limits<int32_t>::max)(), int32_t minimum = (std::numeric_limits<int32_t>::min)()) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(2);
-  _args.push_back(encoder::encode(maximum));
-  _args.push_back(encoder::encode(minimum));
+  _args.push_back(encoder::encode_arg(maximum));
+  _args.push_back(encoder::encode_arg(minimum));
   auto _data = this->_client->invoke("TestService", "Int32SpecialDefaults", _args);
   std::vector<int32_t> _result{};
   if (!_data.is_null())
@@ -1416,7 +1720,7 @@ inline std::vector<int32_t> TestService::int32_special_defaults(int32_t maximum 
 inline std::string TestService::int32_to_string(int32_t value) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(1);
-  _args.push_back(encoder::encode(value));
+  _args.push_back(encoder::encode_arg(value));
   auto _data = this->_client->invoke("TestService", "Int32ToString", _args);
   std::string _result{};
   if (!_data.is_null())
@@ -1427,8 +1731,8 @@ inline std::string TestService::int32_to_string(int32_t value) {
 inline std::vector<int64_t> TestService::int64_special_defaults(int64_t maximum = (std::numeric_limits<int64_t>::max)(), int64_t minimum = (std::numeric_limits<int64_t>::min)()) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(2);
-  _args.push_back(encoder::encode(maximum));
-  _args.push_back(encoder::encode(minimum));
+  _args.push_back(encoder::encode_arg(maximum));
+  _args.push_back(encoder::encode_arg(minimum));
   auto _data = this->_client->invoke("TestService", "Int64SpecialDefaults", _args);
   std::vector<int64_t> _result{};
   if (!_data.is_null())
@@ -1439,7 +1743,7 @@ inline std::vector<int64_t> TestService::int64_special_defaults(int64_t maximum 
 inline std::string TestService::int64_to_string(int64_t value) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(1);
-  _args.push_back(encoder::encode(value));
+  _args.push_back(encoder::encode_arg(value));
   auto _data = this->_client->invoke("TestService", "Int64ToString", _args);
   std::string _result{};
   if (!_data.is_null())
@@ -1450,7 +1754,7 @@ inline std::string TestService::int64_to_string(int64_t value) {
 inline std::vector<int32_t> TestService::list_default(std::vector<int32_t> x = std::vector<int32_t>{1, 2, 3}) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(1);
-  _args.push_back(encoder::encode(x));
+  _args.push_back(encoder::encode_arg(x));
   auto _data = this->_client->invoke("TestService", "ListDefault", _args);
   std::vector<int32_t> _result{};
   if (!_data.is_null())
@@ -1461,7 +1765,7 @@ inline std::vector<int32_t> TestService::list_default(std::vector<int32_t> x = s
 inline TestService::TestNestedStruct TestService::nested_struct_echo(TestService::TestNestedStruct x) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(1);
-  _args.push_back(encoder::encode(x));
+  _args.push_back(encoder::encode_arg(x));
   auto _data = this->_client->invoke("TestService", "NestedStructEcho", _args);
   TestService::TestNestedStruct _result{};
   if (!_data.is_null())
@@ -1472,9 +1776,20 @@ inline TestService::TestNestedStruct TestService::nested_struct_echo(TestService
 inline TestService::TestClass TestService::not_nullable_object(TestService::TestClass value) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(1);
-  _args.push_back(encoder::encode(value));
+  _args.push_back(encoder::encode_arg(value));
   auto _data = this->_client->invoke("TestService", "NotNullableObject", _args);
   TestService::TestClass _result{};
+  if (!_data.is_null())
+    decoder::decode(_result, _data.value(), this->_client);
+  return _result;
+}
+
+inline TestService::TestNullableStruct TestService::nullable_struct_echo(TestService::TestNullableStruct x) {
+  std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
+  _args.push_back(encoder::encode_arg(x));
+  auto _data = this->_client->invoke("TestService", "NullableStructEcho", _args);
+  TestService::TestNullableStruct _result{};
   if (!_data.is_null())
     decoder::decode(_result, _data.value(), this->_client);
   return _result;
@@ -1483,8 +1798,8 @@ inline TestService::TestClass TestService::not_nullable_object(TestService::Test
 inline ::krpc::Event TestService::on_timer(uint32_t milliseconds, uint32_t repeats = 1) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(2);
-  _args.push_back(encoder::encode(milliseconds));
-  _args.push_back(encoder::encode(repeats));
+  _args.push_back(encoder::encode_arg(milliseconds));
+  _args.push_back(encoder::encode_arg(repeats));
   auto _data = this->_client->invoke("TestService", "OnTimer", _args);
   ::krpc::Event _result{};
   if (!_data.is_null())
@@ -1495,7 +1810,7 @@ inline ::krpc::Event TestService::on_timer(uint32_t milliseconds, uint32_t repea
 inline ::krpc::Event TestService::on_timer_using_lambda(uint32_t milliseconds) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(1);
-  _args.push_back(encoder::encode(milliseconds));
+  _args.push_back(encoder::encode_arg(milliseconds));
   auto _data = this->_client->invoke("TestService", "OnTimerUsingLambda", _args);
   ::krpc::Event _result{};
   if (!_data.is_null())
@@ -1503,13 +1818,13 @@ inline ::krpc::Event TestService::on_timer_using_lambda(uint32_t milliseconds) {
   return _result;
 }
 
-inline std::string TestService::optional_arguments(std::string x, std::string y = "foo", std::string z = "bar", TestService::TestClass obj = TestService::TestClass()) {
+inline std::string TestService::optional_arguments(std::string x, std::string y = "foo", std::string z = "bar", std::optional<TestService::TestClass> obj = std::optional<TestService::TestClass>()) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(4);
-  _args.push_back(encoder::encode(x));
-  _args.push_back(encoder::encode(y));
-  _args.push_back(encoder::encode(z));
-  _args.push_back(encoder::encode_nullable(obj));
+  _args.push_back(encoder::encode_arg(x));
+  _args.push_back(encoder::encode_arg(y));
+  _args.push_back(encoder::encode_arg(z));
+  _args.push_back(encoder::encode_arg(obj));
   auto _data = this->_client->invoke("TestService", "OptionalArguments", _args);
   std::string _result{};
   if (!_data.is_null())
@@ -1536,7 +1851,7 @@ inline TestService::TestClass TestService::return_null_when_not_allowed() {
 inline std::set<int32_t> TestService::set_default(std::set<int32_t> x = std::set<int32_t>{1, 2, 3}) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(1);
-  _args.push_back(encoder::encode(x));
+  _args.push_back(encoder::encode_arg(x));
   auto _data = this->_client->invoke("TestService", "SetDefault", _args);
   std::set<int32_t> _result{};
   if (!_data.is_null())
@@ -1547,7 +1862,7 @@ inline std::set<int32_t> TestService::set_default(std::set<int32_t> x = std::set
 inline int32_t TestService::string_to_int32(std::string value) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(1);
-  _args.push_back(encoder::encode(value));
+  _args.push_back(encoder::encode_arg(value));
   auto _data = this->_client->invoke("TestService", "StringToInt32", _args);
   int32_t _result{};
   if (!_data.is_null())
@@ -1558,7 +1873,7 @@ inline int32_t TestService::string_to_int32(std::string value) {
 inline TestService::TestStruct TestService::struct_default(TestService::TestStruct x = TestService::TestStruct{42, "jeb", TestService::TestEnum::value_b, std::vector<int32_t>{1, 2, 3}}) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(1);
-  _args.push_back(encoder::encode(x));
+  _args.push_back(encoder::encode_arg(x));
   auto _data = this->_client->invoke("TestService", "StructDefault", _args);
   TestService::TestStruct _result{};
   if (!_data.is_null())
@@ -1569,7 +1884,7 @@ inline TestService::TestStruct TestService::struct_default(TestService::TestStru
 inline TestService::TestStruct TestService::struct_echo(TestService::TestStruct x) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(1);
-  _args.push_back(encoder::encode(x));
+  _args.push_back(encoder::encode_arg(x));
   auto _data = this->_client->invoke("TestService", "StructEcho", _args);
   TestService::TestStruct _result{};
   if (!_data.is_null())
@@ -1580,7 +1895,7 @@ inline TestService::TestStruct TestService::struct_echo(TestService::TestStruct 
 inline std::optional<TestService::TestStruct> TestService::struct_echo_nullable(std::optional<TestService::TestStruct> x) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(1);
-  _args.push_back(encoder::encode_nullable(x));
+  _args.push_back(encoder::encode_arg(x));
   auto _data = this->_client->invoke("TestService", "StructEchoNullable", _args);
   std::optional<TestService::TestStruct> _result{};
   if (!_data.is_null())
@@ -1599,7 +1914,7 @@ inline int32_t TestService::throw_argument_exception() {
 inline int32_t TestService::throw_argument_null_exception(std::string foo) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(1);
-  _args.push_back(encoder::encode(foo));
+  _args.push_back(encoder::encode_arg(foo));
   auto _data = this->_client->invoke("TestService", "ThrowArgumentNullException", _args);
   int32_t _result{};
   if (!_data.is_null())
@@ -1610,7 +1925,7 @@ inline int32_t TestService::throw_argument_null_exception(std::string foo) {
 inline int32_t TestService::throw_argument_out_of_range_exception(int32_t foo) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(1);
-  _args.push_back(encoder::encode(foo));
+  _args.push_back(encoder::encode_arg(foo));
   auto _data = this->_client->invoke("TestService", "ThrowArgumentOutOfRangeException", _args);
   int32_t _result{};
   if (!_data.is_null())
@@ -1653,7 +1968,7 @@ inline int32_t TestService::throw_invalid_operation_exception_later() {
 inline std::tuple<int32_t, bool> TestService::tuple_default(std::tuple<int32_t, bool> x = std::tuple<int32_t, bool>{1, false}) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(1);
-  _args.push_back(encoder::encode(x));
+  _args.push_back(encoder::encode_arg(x));
   auto _data = this->_client->invoke("TestService", "TupleDefault", _args);
   std::tuple<int32_t, bool> _result{};
   if (!_data.is_null())
@@ -1664,7 +1979,7 @@ inline std::tuple<int32_t, bool> TestService::tuple_default(std::tuple<int32_t, 
 inline std::vector<uint32_t> TestService::uint32_special_defaults(uint32_t maximum = (std::numeric_limits<uint32_t>::max)()) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(1);
-  _args.push_back(encoder::encode(maximum));
+  _args.push_back(encoder::encode_arg(maximum));
   auto _data = this->_client->invoke("TestService", "Uint32SpecialDefaults", _args);
   std::vector<uint32_t> _result{};
   if (!_data.is_null())
@@ -1675,7 +1990,7 @@ inline std::vector<uint32_t> TestService::uint32_special_defaults(uint32_t maxim
 inline std::vector<uint64_t> TestService::uint64_special_defaults(uint64_t maximum = (std::numeric_limits<uint64_t>::max)()) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(1);
-  _args.push_back(encoder::encode(maximum));
+  _args.push_back(encoder::encode_arg(maximum));
   auto _data = this->_client->invoke("TestService", "Uint64SpecialDefaults", _args);
   std::vector<uint64_t> _result{};
   if (!_data.is_null())
@@ -1694,37 +2009,37 @@ inline std::string TestService::deprecated_property() {
 inline void TestService::set_deprecated_property(std::string value) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(1);
-  _args.push_back(encoder::encode(value));
+  _args.push_back(encoder::encode_arg(value));
   this->_client->invoke("TestService", "set_DeprecatedProperty", _args);
 }
 
-inline TestService::TestClass TestService::nullable_object() {
+inline std::optional<TestService::TestClass> TestService::nullable_object() {
   auto _data = this->_client->invoke("TestService", "get_NullableObject");
-  TestService::TestClass _result{};
+  std::optional<TestService::TestClass> _result{};
   if (!_data.is_null())
     decoder::decode(_result, _data.value(), this->_client);
   return _result;
 }
 
-inline void TestService::set_nullable_object(TestService::TestClass value) {
+inline void TestService::set_nullable_object(std::optional<TestService::TestClass> value) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(1);
-  _args.push_back(encoder::encode_nullable(value));
+  _args.push_back(encoder::encode_arg(value));
   this->_client->invoke("TestService", "set_NullableObject", _args);
 }
 
-inline TestService::TestClass TestService::object_property() {
+inline std::optional<TestService::TestClass> TestService::object_property() {
   auto _data = this->_client->invoke("TestService", "get_ObjectProperty");
-  TestService::TestClass _result{};
+  std::optional<TestService::TestClass> _result{};
   if (!_data.is_null())
     decoder::decode(_result, _data.value(), this->_client);
   return _result;
 }
 
-inline void TestService::set_object_property(TestService::TestClass value) {
+inline void TestService::set_object_property(std::optional<TestService::TestClass> value) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(1);
-  _args.push_back(encoder::encode_nullable(value));
+  _args.push_back(encoder::encode_arg(value));
   this->_client->invoke("TestService", "set_ObjectProperty", _args);
 }
 
@@ -1739,14 +2054,14 @@ inline std::string TestService::string_property() {
 inline void TestService::set_string_property(std::string value) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(1);
-  _args.push_back(encoder::encode(value));
+  _args.push_back(encoder::encode_arg(value));
   this->_client->invoke("TestService", "set_StringProperty", _args);
 }
 
 inline void TestService::set_string_property_private_get(std::string value) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(1);
-  _args.push_back(encoder::encode(value));
+  _args.push_back(encoder::encode_arg(value));
   this->_client->invoke("TestService", "set_StringPropertyPrivateGet", _args);
 }
 
@@ -1761,156 +2076,198 @@ inline std::string TestService::string_property_private_set() {
 inline ::krpc::Stream<std::string> TestService::add_multiple_values_stream(float x, int32_t y, int64_t z) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(3);
-  _args.push_back(encoder::encode(x));
-  _args.push_back(encoder::encode(y));
-  _args.push_back(encoder::encode(z));
+  _args.push_back(encoder::encode_arg(x));
+  _args.push_back(encoder::encode_arg(y));
+  _args.push_back(encoder::encode_arg(z));
   return ::krpc::Stream<std::string>(this->_client, this->_client->build_call("TestService", "AddMultipleValues", _args));
 }
 
 inline ::krpc::Stream<std::vector<TestService::TestClass>> TestService::add_to_object_list_stream(std::vector<TestService::TestClass> l, std::string value) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(2);
-  _args.push_back(encoder::encode(l));
-  _args.push_back(encoder::encode(value));
+  _args.push_back(encoder::encode_arg(l));
+  _args.push_back(encoder::encode_arg(value));
   return ::krpc::Stream<std::vector<TestService::TestClass>>(this->_client, this->_client->build_call("TestService", "AddToObjectList", _args));
 }
 
 inline ::krpc::Stream<int32_t> TestService::blocking_procedure_stream(int32_t n, int32_t sum = 0) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(2);
-  _args.push_back(encoder::encode(n));
-  _args.push_back(encoder::encode(sum));
+  _args.push_back(encoder::encode_arg(n));
+  _args.push_back(encoder::encode_arg(sum));
   return ::krpc::Stream<int32_t>(this->_client, this->_client->build_call("TestService", "BlockingProcedure", _args));
 }
 
 inline ::krpc::Stream<std::string> TestService::bool_to_string_stream(bool value) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(1);
-  _args.push_back(encoder::encode(value));
+  _args.push_back(encoder::encode_arg(value));
   return ::krpc::Stream<std::string>(this->_client, this->_client->build_call("TestService", "BoolToString", _args));
 }
 
 inline ::krpc::Stream<std::string> TestService::bytes_to_hex_string_stream(std::string value) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(1);
-  _args.push_back(encoder::encode(value));
+  _args.push_back(encoder::encode_arg(value));
   return ::krpc::Stream<std::string>(this->_client, this->_client->build_call("TestService", "BytesToHexString", _args));
 }
 
 inline ::krpc::Stream<int32_t> TestService::counter_stream(std::string id = "", int32_t divisor = 1) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(2);
-  _args.push_back(encoder::encode(id));
-  _args.push_back(encoder::encode(divisor));
+  _args.push_back(encoder::encode_arg(id));
+  _args.push_back(encoder::encode_arg(divisor));
   return ::krpc::Stream<int32_t>(this->_client, this->_client->build_call("TestService", "Counter", _args));
 }
 
 inline ::krpc::Stream<TestService::TestStruct> TestService::counter_struct_stream(std::string id = "") {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(1);
-  _args.push_back(encoder::encode(id));
+  _args.push_back(encoder::encode_arg(id));
   return ::krpc::Stream<TestService::TestStruct>(this->_client, this->_client->build_call("TestService", "CounterStruct", _args));
 }
 
 inline ::krpc::Stream<TestService::TestClass> TestService::create_test_object_stream(std::string value) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(1);
-  _args.push_back(encoder::encode(value));
+  _args.push_back(encoder::encode_arg(value));
   return ::krpc::Stream<TestService::TestClass>(this->_client, this->_client->build_call("TestService", "CreateTestObject", _args));
 }
 
 inline ::krpc::Stream<std::string> TestService::deprecated_procedure_stream(float value) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(1);
-  _args.push_back(encoder::encode(value));
+  _args.push_back(encoder::encode_arg(value));
   return ::krpc::Stream<std::string>(this->_client, this->_client->build_call("TestService", "DeprecatedProcedure", _args));
 }
 
 inline ::krpc::Stream<std::string> TestService::deprecated_procedure_no_message_stream(float value) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(1);
-  _args.push_back(encoder::encode(value));
+  _args.push_back(encoder::encode_arg(value));
   return ::krpc::Stream<std::string>(this->_client, this->_client->build_call("TestService", "DeprecatedProcedureNoMessage", _args));
 }
 
 inline ::krpc::Stream<std::map<int32_t, bool>> TestService::dictionary_default_stream(std::map<int32_t, bool> x = std::map<int32_t, bool>{{1, false}, {2, true}}) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(1);
-  _args.push_back(encoder::encode(x));
+  _args.push_back(encoder::encode_arg(x));
   return ::krpc::Stream<std::map<int32_t, bool>>(this->_client, this->_client->build_call("TestService", "DictionaryDefault", _args));
 }
 
 inline ::krpc::Stream<std::vector<double>> TestService::double_special_defaults_stream(double nan = std::numeric_limits<double>::quiet_NaN(), double infinity = std::numeric_limits<double>::infinity(), double negative_infinity = -std::numeric_limits<double>::infinity(), double maximum = (std::numeric_limits<double>::max)(), double lowest = std::numeric_limits<double>::lowest()) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(5);
-  _args.push_back(encoder::encode(nan));
-  _args.push_back(encoder::encode(infinity));
-  _args.push_back(encoder::encode(negative_infinity));
-  _args.push_back(encoder::encode(maximum));
-  _args.push_back(encoder::encode(lowest));
+  _args.push_back(encoder::encode_arg(nan));
+  _args.push_back(encoder::encode_arg(infinity));
+  _args.push_back(encoder::encode_arg(negative_infinity));
+  _args.push_back(encoder::encode_arg(maximum));
+  _args.push_back(encoder::encode_arg(lowest));
   return ::krpc::Stream<std::vector<double>>(this->_client, this->_client->build_call("TestService", "DoubleSpecialDefaults", _args));
 }
 
 inline ::krpc::Stream<std::string> TestService::double_to_string_stream(double value) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(1);
-  _args.push_back(encoder::encode(value));
+  _args.push_back(encoder::encode_arg(value));
   return ::krpc::Stream<std::string>(this->_client, this->_client->build_call("TestService", "DoubleToString", _args));
+}
+
+inline ::krpc::Stream<std::map<std::string, std::optional<TestService::TestClass> >> TestService::echo_dictionary_of_nullable_objects_stream(std::map<std::string, std::optional<TestService::TestClass> > d) {
+  std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
+  _args.push_back(encoder::encode_arg(d));
+  return ::krpc::Stream<std::map<std::string, std::optional<TestService::TestClass> >>(this->_client, this->_client->build_call("TestService", "EchoDictionaryOfNullableObjects", _args));
+}
+
+inline ::krpc::Stream<std::vector<std::optional<int32_t> >> TestService::echo_list_of_nullable_ints_stream(std::vector<std::optional<int32_t> > l) {
+  std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
+  _args.push_back(encoder::encode_arg(l));
+  return ::krpc::Stream<std::vector<std::optional<int32_t> >>(this->_client, this->_client->build_call("TestService", "EchoListOfNullableInts", _args));
+}
+
+inline ::krpc::Stream<std::vector<std::optional<TestService::TestClass> >> TestService::echo_list_of_nullable_objects_stream(std::vector<std::optional<TestService::TestClass> > l) {
+  std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
+  _args.push_back(encoder::encode_arg(l));
+  return ::krpc::Stream<std::vector<std::optional<TestService::TestClass> >>(this->_client, this->_client->build_call("TestService", "EchoListOfNullableObjects", _args));
+}
+
+inline ::krpc::Stream<std::vector<std::vector<std::optional<TestService::TestClass>> >> TestService::echo_nested_list_of_nullable_objects_stream(std::vector<std::vector<std::optional<TestService::TestClass>> > l) {
+  std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
+  _args.push_back(encoder::encode_arg(l));
+  return ::krpc::Stream<std::vector<std::vector<std::optional<TestService::TestClass>> >>(this->_client, this->_client->build_call("TestService", "EchoNestedListOfNullableObjects", _args));
+}
+
+inline ::krpc::Stream<TestService::TestNestedNullableStruct> TestService::echo_nested_nullable_struct_stream(TestService::TestNestedNullableStruct value) {
+  std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
+  _args.push_back(encoder::encode_arg(value));
+  return ::krpc::Stream<TestService::TestNestedNullableStruct>(this->_client, this->_client->build_call("TestService", "EchoNestedNullableStruct", _args));
 }
 
 inline ::krpc::Stream<std::optional<int32_t>> TestService::echo_nullable_int_stream(std::optional<int32_t> value) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(1);
-  _args.push_back(encoder::encode_nullable(value));
+  _args.push_back(encoder::encode_arg(value));
   return ::krpc::Stream<std::optional<int32_t>>(this->_client, this->_client->build_call("TestService", "EchoNullableInt", _args));
 }
 
 inline ::krpc::Stream<std::optional<std::vector<int32_t> >> TestService::echo_nullable_list_stream(std::optional<std::vector<int32_t> > l) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(1);
-  _args.push_back(encoder::encode_nullable(l));
+  _args.push_back(encoder::encode_arg(l));
   return ::krpc::Stream<std::optional<std::vector<int32_t> >>(this->_client, this->_client->build_call("TestService", "EchoNullableList", _args));
 }
 
 inline ::krpc::Stream<std::optional<std::string>> TestService::echo_nullable_string_stream(std::optional<std::string> value) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(1);
-  _args.push_back(encoder::encode_nullable(value));
+  _args.push_back(encoder::encode_arg(value));
   return ::krpc::Stream<std::optional<std::string>>(this->_client, this->_client->build_call("TestService", "EchoNullableString", _args));
 }
 
-inline ::krpc::Stream<TestService::TestClass> TestService::echo_test_object_stream(TestService::TestClass value) {
+inline ::krpc::Stream<std::optional<TestService::TestClass>> TestService::echo_test_object_stream(std::optional<TestService::TestClass> value) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(1);
-  _args.push_back(encoder::encode_nullable(value));
-  return ::krpc::Stream<TestService::TestClass>(this->_client, this->_client->build_call("TestService", "EchoTestObject", _args));
+  _args.push_back(encoder::encode_arg(value));
+  return ::krpc::Stream<std::optional<TestService::TestClass>>(this->_client, this->_client->build_call("TestService", "EchoTestObject", _args));
+}
+
+inline ::krpc::Stream<std::tuple<int32_t, std::optional<TestService::TestClass> >> TestService::echo_tuple_with_a_nullable_object_stream(std::tuple<int32_t, std::optional<TestService::TestClass> > t) {
+  std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
+  _args.push_back(encoder::encode_arg(t));
+  return ::krpc::Stream<std::tuple<int32_t, std::optional<TestService::TestClass> >>(this->_client, this->_client->build_call("TestService", "EchoTupleWithANullableObject", _args));
 }
 
 inline ::krpc::Stream<std::vector<std::string>> TestService::empty_list_default_stream(std::vector<std::string> x = std::vector<std::string>{}) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(1);
-  _args.push_back(encoder::encode(x));
+  _args.push_back(encoder::encode_arg(x));
   return ::krpc::Stream<std::vector<std::string>>(this->_client, this->_client->build_call("TestService", "EmptyListDefault", _args));
 }
 
 inline ::krpc::Stream<TestService::TestEnum> TestService::enum_default_arg_stream(TestService::TestEnum x = TestService::TestEnum::value_c) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(1);
-  _args.push_back(encoder::encode(x));
+  _args.push_back(encoder::encode_arg(x));
   return ::krpc::Stream<TestService::TestEnum>(this->_client, this->_client->build_call("TestService", "EnumDefaultArg", _args));
 }
 
 inline ::krpc::Stream<TestService::TestEnum> TestService::enum_echo_stream(TestService::TestEnum x) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(1);
-  _args.push_back(encoder::encode(x));
+  _args.push_back(encoder::encode_arg(x));
   return ::krpc::Stream<TestService::TestEnum>(this->_client, this->_client->build_call("TestService", "EnumEcho", _args));
 }
 
 inline ::krpc::Stream<std::vector<TestService::TestEnum>> TestService::enum_list_default_stream(std::vector<TestService::TestEnum> x = std::vector<TestService::TestEnum>{TestService::TestEnum::value_b, TestService::TestEnum::value_c}) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(1);
-  _args.push_back(encoder::encode(x));
+  _args.push_back(encoder::encode_arg(x));
   return ::krpc::Stream<std::vector<TestService::TestEnum>>(this->_client, this->_client->build_call("TestService", "EnumListDefault", _args));
 }
 
@@ -1921,137 +2278,144 @@ inline ::krpc::Stream<TestService::TestEnum> TestService::enum_return_stream() {
 inline ::krpc::Stream<std::vector<float>> TestService::float_special_defaults_stream(float nan = std::numeric_limits<float>::quiet_NaN(), float infinity = std::numeric_limits<float>::infinity(), float negative_infinity = -std::numeric_limits<float>::infinity(), float maximum = (std::numeric_limits<float>::max)(), float lowest = std::numeric_limits<float>::lowest(), float fraction = 0.1f) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(6);
-  _args.push_back(encoder::encode(nan));
-  _args.push_back(encoder::encode(infinity));
-  _args.push_back(encoder::encode(negative_infinity));
-  _args.push_back(encoder::encode(maximum));
-  _args.push_back(encoder::encode(lowest));
-  _args.push_back(encoder::encode(fraction));
+  _args.push_back(encoder::encode_arg(nan));
+  _args.push_back(encoder::encode_arg(infinity));
+  _args.push_back(encoder::encode_arg(negative_infinity));
+  _args.push_back(encoder::encode_arg(maximum));
+  _args.push_back(encoder::encode_arg(lowest));
+  _args.push_back(encoder::encode_arg(fraction));
   return ::krpc::Stream<std::vector<float>>(this->_client, this->_client->build_call("TestService", "FloatSpecialDefaults", _args));
 }
 
 inline ::krpc::Stream<std::string> TestService::float_to_string_stream(float value) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(1);
-  _args.push_back(encoder::encode(value));
+  _args.push_back(encoder::encode_arg(value));
   return ::krpc::Stream<std::string>(this->_client, this->_client->build_call("TestService", "FloatToString", _args));
 }
 
 inline ::krpc::Stream<std::map<std::string, int32_t>> TestService::increment_dictionary_stream(std::map<std::string, int32_t> d) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(1);
-  _args.push_back(encoder::encode(d));
+  _args.push_back(encoder::encode_arg(d));
   return ::krpc::Stream<std::map<std::string, int32_t>>(this->_client, this->_client->build_call("TestService", "IncrementDictionary", _args));
 }
 
 inline ::krpc::Stream<std::vector<int32_t>> TestService::increment_list_stream(std::vector<int32_t> l) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(1);
-  _args.push_back(encoder::encode(l));
+  _args.push_back(encoder::encode_arg(l));
   return ::krpc::Stream<std::vector<int32_t>>(this->_client, this->_client->build_call("TestService", "IncrementList", _args));
 }
 
 inline ::krpc::Stream<std::vector<TestService::TestStruct>> TestService::increment_list_of_structs_stream(std::vector<TestService::TestStruct> l) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(1);
-  _args.push_back(encoder::encode(l));
+  _args.push_back(encoder::encode_arg(l));
   return ::krpc::Stream<std::vector<TestService::TestStruct>>(this->_client, this->_client->build_call("TestService", "IncrementListOfStructs", _args));
 }
 
 inline ::krpc::Stream<std::map<std::string, std::vector<int32_t> >> TestService::increment_nested_collection_stream(std::map<std::string, std::vector<int32_t> > d) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(1);
-  _args.push_back(encoder::encode(d));
+  _args.push_back(encoder::encode_arg(d));
   return ::krpc::Stream<std::map<std::string, std::vector<int32_t> >>(this->_client, this->_client->build_call("TestService", "IncrementNestedCollection", _args));
 }
 
 inline ::krpc::Stream<std::set<int32_t>> TestService::increment_set_stream(std::set<int32_t> h) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(1);
-  _args.push_back(encoder::encode(h));
+  _args.push_back(encoder::encode_arg(h));
   return ::krpc::Stream<std::set<int32_t>>(this->_client, this->_client->build_call("TestService", "IncrementSet", _args));
 }
 
 inline ::krpc::Stream<std::tuple<int32_t, int64_t>> TestService::increment_tuple_stream(std::tuple<int32_t, int64_t> t) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(1);
-  _args.push_back(encoder::encode(t));
+  _args.push_back(encoder::encode_arg(t));
   return ::krpc::Stream<std::tuple<int32_t, int64_t>>(this->_client, this->_client->build_call("TestService", "IncrementTuple", _args));
 }
 
 inline ::krpc::Stream<std::vector<int32_t>> TestService::int32_special_defaults_stream(int32_t maximum = (std::numeric_limits<int32_t>::max)(), int32_t minimum = (std::numeric_limits<int32_t>::min)()) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(2);
-  _args.push_back(encoder::encode(maximum));
-  _args.push_back(encoder::encode(minimum));
+  _args.push_back(encoder::encode_arg(maximum));
+  _args.push_back(encoder::encode_arg(minimum));
   return ::krpc::Stream<std::vector<int32_t>>(this->_client, this->_client->build_call("TestService", "Int32SpecialDefaults", _args));
 }
 
 inline ::krpc::Stream<std::string> TestService::int32_to_string_stream(int32_t value) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(1);
-  _args.push_back(encoder::encode(value));
+  _args.push_back(encoder::encode_arg(value));
   return ::krpc::Stream<std::string>(this->_client, this->_client->build_call("TestService", "Int32ToString", _args));
 }
 
 inline ::krpc::Stream<std::vector<int64_t>> TestService::int64_special_defaults_stream(int64_t maximum = (std::numeric_limits<int64_t>::max)(), int64_t minimum = (std::numeric_limits<int64_t>::min)()) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(2);
-  _args.push_back(encoder::encode(maximum));
-  _args.push_back(encoder::encode(minimum));
+  _args.push_back(encoder::encode_arg(maximum));
+  _args.push_back(encoder::encode_arg(minimum));
   return ::krpc::Stream<std::vector<int64_t>>(this->_client, this->_client->build_call("TestService", "Int64SpecialDefaults", _args));
 }
 
 inline ::krpc::Stream<std::string> TestService::int64_to_string_stream(int64_t value) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(1);
-  _args.push_back(encoder::encode(value));
+  _args.push_back(encoder::encode_arg(value));
   return ::krpc::Stream<std::string>(this->_client, this->_client->build_call("TestService", "Int64ToString", _args));
 }
 
 inline ::krpc::Stream<std::vector<int32_t>> TestService::list_default_stream(std::vector<int32_t> x = std::vector<int32_t>{1, 2, 3}) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(1);
-  _args.push_back(encoder::encode(x));
+  _args.push_back(encoder::encode_arg(x));
   return ::krpc::Stream<std::vector<int32_t>>(this->_client, this->_client->build_call("TestService", "ListDefault", _args));
 }
 
 inline ::krpc::Stream<TestService::TestNestedStruct> TestService::nested_struct_echo_stream(TestService::TestNestedStruct x) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(1);
-  _args.push_back(encoder::encode(x));
+  _args.push_back(encoder::encode_arg(x));
   return ::krpc::Stream<TestService::TestNestedStruct>(this->_client, this->_client->build_call("TestService", "NestedStructEcho", _args));
 }
 
 inline ::krpc::Stream<TestService::TestClass> TestService::not_nullable_object_stream(TestService::TestClass value) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(1);
-  _args.push_back(encoder::encode(value));
+  _args.push_back(encoder::encode_arg(value));
   return ::krpc::Stream<TestService::TestClass>(this->_client, this->_client->build_call("TestService", "NotNullableObject", _args));
+}
+
+inline ::krpc::Stream<TestService::TestNullableStruct> TestService::nullable_struct_echo_stream(TestService::TestNullableStruct x) {
+  std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
+  _args.push_back(encoder::encode_arg(x));
+  return ::krpc::Stream<TestService::TestNullableStruct>(this->_client, this->_client->build_call("TestService", "NullableStructEcho", _args));
 }
 
 inline ::krpc::Stream<::krpc::Event> TestService::on_timer_stream(uint32_t milliseconds, uint32_t repeats = 1) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(2);
-  _args.push_back(encoder::encode(milliseconds));
-  _args.push_back(encoder::encode(repeats));
+  _args.push_back(encoder::encode_arg(milliseconds));
+  _args.push_back(encoder::encode_arg(repeats));
   return ::krpc::Stream<::krpc::Event>(this->_client, this->_client->build_call("TestService", "OnTimer", _args));
 }
 
 inline ::krpc::Stream<::krpc::Event> TestService::on_timer_using_lambda_stream(uint32_t milliseconds) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(1);
-  _args.push_back(encoder::encode(milliseconds));
+  _args.push_back(encoder::encode_arg(milliseconds));
   return ::krpc::Stream<::krpc::Event>(this->_client, this->_client->build_call("TestService", "OnTimerUsingLambda", _args));
 }
 
-inline ::krpc::Stream<std::string> TestService::optional_arguments_stream(std::string x, std::string y = "foo", std::string z = "bar", TestService::TestClass obj = TestService::TestClass()) {
+inline ::krpc::Stream<std::string> TestService::optional_arguments_stream(std::string x, std::string y = "foo", std::string z = "bar", std::optional<TestService::TestClass> obj = std::optional<TestService::TestClass>()) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(4);
-  _args.push_back(encoder::encode(x));
-  _args.push_back(encoder::encode(y));
-  _args.push_back(encoder::encode(z));
-  _args.push_back(encoder::encode_nullable(obj));
+  _args.push_back(encoder::encode_arg(x));
+  _args.push_back(encoder::encode_arg(y));
+  _args.push_back(encoder::encode_arg(z));
+  _args.push_back(encoder::encode_arg(obj));
   return ::krpc::Stream<std::string>(this->_client, this->_client->build_call("TestService", "OptionalArguments", _args));
 }
 
@@ -2062,35 +2426,35 @@ inline ::krpc::Stream<TestService::TestClass> TestService::return_null_when_not_
 inline ::krpc::Stream<std::set<int32_t>> TestService::set_default_stream(std::set<int32_t> x = std::set<int32_t>{1, 2, 3}) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(1);
-  _args.push_back(encoder::encode(x));
+  _args.push_back(encoder::encode_arg(x));
   return ::krpc::Stream<std::set<int32_t>>(this->_client, this->_client->build_call("TestService", "SetDefault", _args));
 }
 
 inline ::krpc::Stream<int32_t> TestService::string_to_int32_stream(std::string value) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(1);
-  _args.push_back(encoder::encode(value));
+  _args.push_back(encoder::encode_arg(value));
   return ::krpc::Stream<int32_t>(this->_client, this->_client->build_call("TestService", "StringToInt32", _args));
 }
 
 inline ::krpc::Stream<TestService::TestStruct> TestService::struct_default_stream(TestService::TestStruct x = TestService::TestStruct{42, "jeb", TestService::TestEnum::value_b, std::vector<int32_t>{1, 2, 3}}) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(1);
-  _args.push_back(encoder::encode(x));
+  _args.push_back(encoder::encode_arg(x));
   return ::krpc::Stream<TestService::TestStruct>(this->_client, this->_client->build_call("TestService", "StructDefault", _args));
 }
 
 inline ::krpc::Stream<TestService::TestStruct> TestService::struct_echo_stream(TestService::TestStruct x) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(1);
-  _args.push_back(encoder::encode(x));
+  _args.push_back(encoder::encode_arg(x));
   return ::krpc::Stream<TestService::TestStruct>(this->_client, this->_client->build_call("TestService", "StructEcho", _args));
 }
 
 inline ::krpc::Stream<std::optional<TestService::TestStruct>> TestService::struct_echo_nullable_stream(std::optional<TestService::TestStruct> x) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(1);
-  _args.push_back(encoder::encode_nullable(x));
+  _args.push_back(encoder::encode_arg(x));
   return ::krpc::Stream<std::optional<TestService::TestStruct>>(this->_client, this->_client->build_call("TestService", "StructEchoNullable", _args));
 }
 
@@ -2101,14 +2465,14 @@ inline ::krpc::Stream<int32_t> TestService::throw_argument_exception_stream() {
 inline ::krpc::Stream<int32_t> TestService::throw_argument_null_exception_stream(std::string foo) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(1);
-  _args.push_back(encoder::encode(foo));
+  _args.push_back(encoder::encode_arg(foo));
   return ::krpc::Stream<int32_t>(this->_client, this->_client->build_call("TestService", "ThrowArgumentNullException", _args));
 }
 
 inline ::krpc::Stream<int32_t> TestService::throw_argument_out_of_range_exception_stream(int32_t foo) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(1);
-  _args.push_back(encoder::encode(foo));
+  _args.push_back(encoder::encode_arg(foo));
   return ::krpc::Stream<int32_t>(this->_client, this->_client->build_call("TestService", "ThrowArgumentOutOfRangeException", _args));
 }
 
@@ -2131,21 +2495,21 @@ inline ::krpc::Stream<int32_t> TestService::throw_invalid_operation_exception_la
 inline ::krpc::Stream<std::tuple<int32_t, bool>> TestService::tuple_default_stream(std::tuple<int32_t, bool> x = std::tuple<int32_t, bool>{1, false}) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(1);
-  _args.push_back(encoder::encode(x));
+  _args.push_back(encoder::encode_arg(x));
   return ::krpc::Stream<std::tuple<int32_t, bool>>(this->_client, this->_client->build_call("TestService", "TupleDefault", _args));
 }
 
 inline ::krpc::Stream<std::vector<uint32_t>> TestService::uint32_special_defaults_stream(uint32_t maximum = (std::numeric_limits<uint32_t>::max)()) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(1);
-  _args.push_back(encoder::encode(maximum));
+  _args.push_back(encoder::encode_arg(maximum));
   return ::krpc::Stream<std::vector<uint32_t>>(this->_client, this->_client->build_call("TestService", "Uint32SpecialDefaults", _args));
 }
 
 inline ::krpc::Stream<std::vector<uint64_t>> TestService::uint64_special_defaults_stream(uint64_t maximum = (std::numeric_limits<uint64_t>::max)()) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(1);
-  _args.push_back(encoder::encode(maximum));
+  _args.push_back(encoder::encode_arg(maximum));
   return ::krpc::Stream<std::vector<uint64_t>>(this->_client, this->_client->build_call("TestService", "Uint64SpecialDefaults", _args));
 }
 
@@ -2153,12 +2517,12 @@ inline ::krpc::Stream<std::string> TestService::deprecated_property_stream() {
   return ::krpc::Stream<std::string>(this->_client, this->_client->build_call("TestService", "get_DeprecatedProperty"));
 }
 
-inline ::krpc::Stream<TestService::TestClass> TestService::nullable_object_stream() {
-  return ::krpc::Stream<TestService::TestClass>(this->_client, this->_client->build_call("TestService", "get_NullableObject"));
+inline ::krpc::Stream<std::optional<TestService::TestClass>> TestService::nullable_object_stream() {
+  return ::krpc::Stream<std::optional<TestService::TestClass>>(this->_client, this->_client->build_call("TestService", "get_NullableObject"));
 }
 
-inline ::krpc::Stream<TestService::TestClass> TestService::object_property_stream() {
-  return ::krpc::Stream<TestService::TestClass>(this->_client, this->_client->build_call("TestService", "get_ObjectProperty"));
+inline ::krpc::Stream<std::optional<TestService::TestClass>> TestService::object_property_stream() {
+  return ::krpc::Stream<std::optional<TestService::TestClass>>(this->_client, this->_client->build_call("TestService", "get_ObjectProperty"));
 }
 
 inline ::krpc::Stream<std::string> TestService::string_property_stream() {
@@ -2172,156 +2536,198 @@ inline ::krpc::Stream<std::string> TestService::string_property_private_set_stre
 inline ::krpc::schema::ProcedureCall TestService::add_multiple_values_call(float x, int32_t y, int64_t z) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(3);
-  _args.push_back(encoder::encode(x));
-  _args.push_back(encoder::encode(y));
-  _args.push_back(encoder::encode(z));
+  _args.push_back(encoder::encode_arg(x));
+  _args.push_back(encoder::encode_arg(y));
+  _args.push_back(encoder::encode_arg(z));
   return this->_client->build_call("TestService", "AddMultipleValues", _args);
 }
 
 inline ::krpc::schema::ProcedureCall TestService::add_to_object_list_call(std::vector<TestService::TestClass> l, std::string value) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(2);
-  _args.push_back(encoder::encode(l));
-  _args.push_back(encoder::encode(value));
+  _args.push_back(encoder::encode_arg(l));
+  _args.push_back(encoder::encode_arg(value));
   return this->_client->build_call("TestService", "AddToObjectList", _args);
 }
 
 inline ::krpc::schema::ProcedureCall TestService::blocking_procedure_call(int32_t n, int32_t sum = 0) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(2);
-  _args.push_back(encoder::encode(n));
-  _args.push_back(encoder::encode(sum));
+  _args.push_back(encoder::encode_arg(n));
+  _args.push_back(encoder::encode_arg(sum));
   return this->_client->build_call("TestService", "BlockingProcedure", _args);
 }
 
 inline ::krpc::schema::ProcedureCall TestService::bool_to_string_call(bool value) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(1);
-  _args.push_back(encoder::encode(value));
+  _args.push_back(encoder::encode_arg(value));
   return this->_client->build_call("TestService", "BoolToString", _args);
 }
 
 inline ::krpc::schema::ProcedureCall TestService::bytes_to_hex_string_call(std::string value) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(1);
-  _args.push_back(encoder::encode(value));
+  _args.push_back(encoder::encode_arg(value));
   return this->_client->build_call("TestService", "BytesToHexString", _args);
 }
 
 inline ::krpc::schema::ProcedureCall TestService::counter_call(std::string id = "", int32_t divisor = 1) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(2);
-  _args.push_back(encoder::encode(id));
-  _args.push_back(encoder::encode(divisor));
+  _args.push_back(encoder::encode_arg(id));
+  _args.push_back(encoder::encode_arg(divisor));
   return this->_client->build_call("TestService", "Counter", _args);
 }
 
 inline ::krpc::schema::ProcedureCall TestService::counter_struct_call(std::string id = "") {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(1);
-  _args.push_back(encoder::encode(id));
+  _args.push_back(encoder::encode_arg(id));
   return this->_client->build_call("TestService", "CounterStruct", _args);
 }
 
 inline ::krpc::schema::ProcedureCall TestService::create_test_object_call(std::string value) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(1);
-  _args.push_back(encoder::encode(value));
+  _args.push_back(encoder::encode_arg(value));
   return this->_client->build_call("TestService", "CreateTestObject", _args);
 }
 
 inline ::krpc::schema::ProcedureCall TestService::deprecated_procedure_call(float value) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(1);
-  _args.push_back(encoder::encode(value));
+  _args.push_back(encoder::encode_arg(value));
   return this->_client->build_call("TestService", "DeprecatedProcedure", _args);
 }
 
 inline ::krpc::schema::ProcedureCall TestService::deprecated_procedure_no_message_call(float value) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(1);
-  _args.push_back(encoder::encode(value));
+  _args.push_back(encoder::encode_arg(value));
   return this->_client->build_call("TestService", "DeprecatedProcedureNoMessage", _args);
 }
 
 inline ::krpc::schema::ProcedureCall TestService::dictionary_default_call(std::map<int32_t, bool> x = std::map<int32_t, bool>{{1, false}, {2, true}}) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(1);
-  _args.push_back(encoder::encode(x));
+  _args.push_back(encoder::encode_arg(x));
   return this->_client->build_call("TestService", "DictionaryDefault", _args);
 }
 
 inline ::krpc::schema::ProcedureCall TestService::double_special_defaults_call(double nan = std::numeric_limits<double>::quiet_NaN(), double infinity = std::numeric_limits<double>::infinity(), double negative_infinity = -std::numeric_limits<double>::infinity(), double maximum = (std::numeric_limits<double>::max)(), double lowest = std::numeric_limits<double>::lowest()) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(5);
-  _args.push_back(encoder::encode(nan));
-  _args.push_back(encoder::encode(infinity));
-  _args.push_back(encoder::encode(negative_infinity));
-  _args.push_back(encoder::encode(maximum));
-  _args.push_back(encoder::encode(lowest));
+  _args.push_back(encoder::encode_arg(nan));
+  _args.push_back(encoder::encode_arg(infinity));
+  _args.push_back(encoder::encode_arg(negative_infinity));
+  _args.push_back(encoder::encode_arg(maximum));
+  _args.push_back(encoder::encode_arg(lowest));
   return this->_client->build_call("TestService", "DoubleSpecialDefaults", _args);
 }
 
 inline ::krpc::schema::ProcedureCall TestService::double_to_string_call(double value) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(1);
-  _args.push_back(encoder::encode(value));
+  _args.push_back(encoder::encode_arg(value));
   return this->_client->build_call("TestService", "DoubleToString", _args);
+}
+
+inline ::krpc::schema::ProcedureCall TestService::echo_dictionary_of_nullable_objects_call(std::map<std::string, std::optional<TestService::TestClass> > d) {
+  std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
+  _args.push_back(encoder::encode_arg(d));
+  return this->_client->build_call("TestService", "EchoDictionaryOfNullableObjects", _args);
+}
+
+inline ::krpc::schema::ProcedureCall TestService::echo_list_of_nullable_ints_call(std::vector<std::optional<int32_t> > l) {
+  std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
+  _args.push_back(encoder::encode_arg(l));
+  return this->_client->build_call("TestService", "EchoListOfNullableInts", _args);
+}
+
+inline ::krpc::schema::ProcedureCall TestService::echo_list_of_nullable_objects_call(std::vector<std::optional<TestService::TestClass> > l) {
+  std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
+  _args.push_back(encoder::encode_arg(l));
+  return this->_client->build_call("TestService", "EchoListOfNullableObjects", _args);
+}
+
+inline ::krpc::schema::ProcedureCall TestService::echo_nested_list_of_nullable_objects_call(std::vector<std::vector<std::optional<TestService::TestClass>> > l) {
+  std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
+  _args.push_back(encoder::encode_arg(l));
+  return this->_client->build_call("TestService", "EchoNestedListOfNullableObjects", _args);
+}
+
+inline ::krpc::schema::ProcedureCall TestService::echo_nested_nullable_struct_call(TestService::TestNestedNullableStruct value) {
+  std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
+  _args.push_back(encoder::encode_arg(value));
+  return this->_client->build_call("TestService", "EchoNestedNullableStruct", _args);
 }
 
 inline ::krpc::schema::ProcedureCall TestService::echo_nullable_int_call(std::optional<int32_t> value) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(1);
-  _args.push_back(encoder::encode_nullable(value));
+  _args.push_back(encoder::encode_arg(value));
   return this->_client->build_call("TestService", "EchoNullableInt", _args);
 }
 
 inline ::krpc::schema::ProcedureCall TestService::echo_nullable_list_call(std::optional<std::vector<int32_t> > l) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(1);
-  _args.push_back(encoder::encode_nullable(l));
+  _args.push_back(encoder::encode_arg(l));
   return this->_client->build_call("TestService", "EchoNullableList", _args);
 }
 
 inline ::krpc::schema::ProcedureCall TestService::echo_nullable_string_call(std::optional<std::string> value) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(1);
-  _args.push_back(encoder::encode_nullable(value));
+  _args.push_back(encoder::encode_arg(value));
   return this->_client->build_call("TestService", "EchoNullableString", _args);
 }
 
-inline ::krpc::schema::ProcedureCall TestService::echo_test_object_call(TestService::TestClass value) {
+inline ::krpc::schema::ProcedureCall TestService::echo_test_object_call(std::optional<TestService::TestClass> value) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(1);
-  _args.push_back(encoder::encode_nullable(value));
+  _args.push_back(encoder::encode_arg(value));
   return this->_client->build_call("TestService", "EchoTestObject", _args);
+}
+
+inline ::krpc::schema::ProcedureCall TestService::echo_tuple_with_a_nullable_object_call(std::tuple<int32_t, std::optional<TestService::TestClass> > t) {
+  std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
+  _args.push_back(encoder::encode_arg(t));
+  return this->_client->build_call("TestService", "EchoTupleWithANullableObject", _args);
 }
 
 inline ::krpc::schema::ProcedureCall TestService::empty_list_default_call(std::vector<std::string> x = std::vector<std::string>{}) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(1);
-  _args.push_back(encoder::encode(x));
+  _args.push_back(encoder::encode_arg(x));
   return this->_client->build_call("TestService", "EmptyListDefault", _args);
 }
 
 inline ::krpc::schema::ProcedureCall TestService::enum_default_arg_call(TestService::TestEnum x = TestService::TestEnum::value_c) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(1);
-  _args.push_back(encoder::encode(x));
+  _args.push_back(encoder::encode_arg(x));
   return this->_client->build_call("TestService", "EnumDefaultArg", _args);
 }
 
 inline ::krpc::schema::ProcedureCall TestService::enum_echo_call(TestService::TestEnum x) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(1);
-  _args.push_back(encoder::encode(x));
+  _args.push_back(encoder::encode_arg(x));
   return this->_client->build_call("TestService", "EnumEcho", _args);
 }
 
 inline ::krpc::schema::ProcedureCall TestService::enum_list_default_call(std::vector<TestService::TestEnum> x = std::vector<TestService::TestEnum>{TestService::TestEnum::value_b, TestService::TestEnum::value_c}) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(1);
-  _args.push_back(encoder::encode(x));
+  _args.push_back(encoder::encode_arg(x));
   return this->_client->build_call("TestService", "EnumListDefault", _args);
 }
 
@@ -2332,137 +2738,144 @@ inline ::krpc::schema::ProcedureCall TestService::enum_return_call() {
 inline ::krpc::schema::ProcedureCall TestService::float_special_defaults_call(float nan = std::numeric_limits<float>::quiet_NaN(), float infinity = std::numeric_limits<float>::infinity(), float negative_infinity = -std::numeric_limits<float>::infinity(), float maximum = (std::numeric_limits<float>::max)(), float lowest = std::numeric_limits<float>::lowest(), float fraction = 0.1f) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(6);
-  _args.push_back(encoder::encode(nan));
-  _args.push_back(encoder::encode(infinity));
-  _args.push_back(encoder::encode(negative_infinity));
-  _args.push_back(encoder::encode(maximum));
-  _args.push_back(encoder::encode(lowest));
-  _args.push_back(encoder::encode(fraction));
+  _args.push_back(encoder::encode_arg(nan));
+  _args.push_back(encoder::encode_arg(infinity));
+  _args.push_back(encoder::encode_arg(negative_infinity));
+  _args.push_back(encoder::encode_arg(maximum));
+  _args.push_back(encoder::encode_arg(lowest));
+  _args.push_back(encoder::encode_arg(fraction));
   return this->_client->build_call("TestService", "FloatSpecialDefaults", _args);
 }
 
 inline ::krpc::schema::ProcedureCall TestService::float_to_string_call(float value) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(1);
-  _args.push_back(encoder::encode(value));
+  _args.push_back(encoder::encode_arg(value));
   return this->_client->build_call("TestService", "FloatToString", _args);
 }
 
 inline ::krpc::schema::ProcedureCall TestService::increment_dictionary_call(std::map<std::string, int32_t> d) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(1);
-  _args.push_back(encoder::encode(d));
+  _args.push_back(encoder::encode_arg(d));
   return this->_client->build_call("TestService", "IncrementDictionary", _args);
 }
 
 inline ::krpc::schema::ProcedureCall TestService::increment_list_call(std::vector<int32_t> l) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(1);
-  _args.push_back(encoder::encode(l));
+  _args.push_back(encoder::encode_arg(l));
   return this->_client->build_call("TestService", "IncrementList", _args);
 }
 
 inline ::krpc::schema::ProcedureCall TestService::increment_list_of_structs_call(std::vector<TestService::TestStruct> l) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(1);
-  _args.push_back(encoder::encode(l));
+  _args.push_back(encoder::encode_arg(l));
   return this->_client->build_call("TestService", "IncrementListOfStructs", _args);
 }
 
 inline ::krpc::schema::ProcedureCall TestService::increment_nested_collection_call(std::map<std::string, std::vector<int32_t> > d) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(1);
-  _args.push_back(encoder::encode(d));
+  _args.push_back(encoder::encode_arg(d));
   return this->_client->build_call("TestService", "IncrementNestedCollection", _args);
 }
 
 inline ::krpc::schema::ProcedureCall TestService::increment_set_call(std::set<int32_t> h) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(1);
-  _args.push_back(encoder::encode(h));
+  _args.push_back(encoder::encode_arg(h));
   return this->_client->build_call("TestService", "IncrementSet", _args);
 }
 
 inline ::krpc::schema::ProcedureCall TestService::increment_tuple_call(std::tuple<int32_t, int64_t> t) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(1);
-  _args.push_back(encoder::encode(t));
+  _args.push_back(encoder::encode_arg(t));
   return this->_client->build_call("TestService", "IncrementTuple", _args);
 }
 
 inline ::krpc::schema::ProcedureCall TestService::int32_special_defaults_call(int32_t maximum = (std::numeric_limits<int32_t>::max)(), int32_t minimum = (std::numeric_limits<int32_t>::min)()) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(2);
-  _args.push_back(encoder::encode(maximum));
-  _args.push_back(encoder::encode(minimum));
+  _args.push_back(encoder::encode_arg(maximum));
+  _args.push_back(encoder::encode_arg(minimum));
   return this->_client->build_call("TestService", "Int32SpecialDefaults", _args);
 }
 
 inline ::krpc::schema::ProcedureCall TestService::int32_to_string_call(int32_t value) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(1);
-  _args.push_back(encoder::encode(value));
+  _args.push_back(encoder::encode_arg(value));
   return this->_client->build_call("TestService", "Int32ToString", _args);
 }
 
 inline ::krpc::schema::ProcedureCall TestService::int64_special_defaults_call(int64_t maximum = (std::numeric_limits<int64_t>::max)(), int64_t minimum = (std::numeric_limits<int64_t>::min)()) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(2);
-  _args.push_back(encoder::encode(maximum));
-  _args.push_back(encoder::encode(minimum));
+  _args.push_back(encoder::encode_arg(maximum));
+  _args.push_back(encoder::encode_arg(minimum));
   return this->_client->build_call("TestService", "Int64SpecialDefaults", _args);
 }
 
 inline ::krpc::schema::ProcedureCall TestService::int64_to_string_call(int64_t value) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(1);
-  _args.push_back(encoder::encode(value));
+  _args.push_back(encoder::encode_arg(value));
   return this->_client->build_call("TestService", "Int64ToString", _args);
 }
 
 inline ::krpc::schema::ProcedureCall TestService::list_default_call(std::vector<int32_t> x = std::vector<int32_t>{1, 2, 3}) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(1);
-  _args.push_back(encoder::encode(x));
+  _args.push_back(encoder::encode_arg(x));
   return this->_client->build_call("TestService", "ListDefault", _args);
 }
 
 inline ::krpc::schema::ProcedureCall TestService::nested_struct_echo_call(TestService::TestNestedStruct x) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(1);
-  _args.push_back(encoder::encode(x));
+  _args.push_back(encoder::encode_arg(x));
   return this->_client->build_call("TestService", "NestedStructEcho", _args);
 }
 
 inline ::krpc::schema::ProcedureCall TestService::not_nullable_object_call(TestService::TestClass value) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(1);
-  _args.push_back(encoder::encode(value));
+  _args.push_back(encoder::encode_arg(value));
   return this->_client->build_call("TestService", "NotNullableObject", _args);
+}
+
+inline ::krpc::schema::ProcedureCall TestService::nullable_struct_echo_call(TestService::TestNullableStruct x) {
+  std::vector<krpc::encoder::Value> _args;
+  _args.reserve(1);
+  _args.push_back(encoder::encode_arg(x));
+  return this->_client->build_call("TestService", "NullableStructEcho", _args);
 }
 
 inline ::krpc::schema::ProcedureCall TestService::on_timer_call(uint32_t milliseconds, uint32_t repeats = 1) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(2);
-  _args.push_back(encoder::encode(milliseconds));
-  _args.push_back(encoder::encode(repeats));
+  _args.push_back(encoder::encode_arg(milliseconds));
+  _args.push_back(encoder::encode_arg(repeats));
   return this->_client->build_call("TestService", "OnTimer", _args);
 }
 
 inline ::krpc::schema::ProcedureCall TestService::on_timer_using_lambda_call(uint32_t milliseconds) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(1);
-  _args.push_back(encoder::encode(milliseconds));
+  _args.push_back(encoder::encode_arg(milliseconds));
   return this->_client->build_call("TestService", "OnTimerUsingLambda", _args);
 }
 
-inline ::krpc::schema::ProcedureCall TestService::optional_arguments_call(std::string x, std::string y = "foo", std::string z = "bar", TestService::TestClass obj = TestService::TestClass()) {
+inline ::krpc::schema::ProcedureCall TestService::optional_arguments_call(std::string x, std::string y = "foo", std::string z = "bar", std::optional<TestService::TestClass> obj = std::optional<TestService::TestClass>()) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(4);
-  _args.push_back(encoder::encode(x));
-  _args.push_back(encoder::encode(y));
-  _args.push_back(encoder::encode(z));
-  _args.push_back(encoder::encode_nullable(obj));
+  _args.push_back(encoder::encode_arg(x));
+  _args.push_back(encoder::encode_arg(y));
+  _args.push_back(encoder::encode_arg(z));
+  _args.push_back(encoder::encode_arg(obj));
   return this->_client->build_call("TestService", "OptionalArguments", _args);
 }
 
@@ -2481,35 +2894,35 @@ inline ::krpc::schema::ProcedureCall TestService::return_null_when_not_allowed_c
 inline ::krpc::schema::ProcedureCall TestService::set_default_call(std::set<int32_t> x = std::set<int32_t>{1, 2, 3}) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(1);
-  _args.push_back(encoder::encode(x));
+  _args.push_back(encoder::encode_arg(x));
   return this->_client->build_call("TestService", "SetDefault", _args);
 }
 
 inline ::krpc::schema::ProcedureCall TestService::string_to_int32_call(std::string value) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(1);
-  _args.push_back(encoder::encode(value));
+  _args.push_back(encoder::encode_arg(value));
   return this->_client->build_call("TestService", "StringToInt32", _args);
 }
 
 inline ::krpc::schema::ProcedureCall TestService::struct_default_call(TestService::TestStruct x = TestService::TestStruct{42, "jeb", TestService::TestEnum::value_b, std::vector<int32_t>{1, 2, 3}}) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(1);
-  _args.push_back(encoder::encode(x));
+  _args.push_back(encoder::encode_arg(x));
   return this->_client->build_call("TestService", "StructDefault", _args);
 }
 
 inline ::krpc::schema::ProcedureCall TestService::struct_echo_call(TestService::TestStruct x) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(1);
-  _args.push_back(encoder::encode(x));
+  _args.push_back(encoder::encode_arg(x));
   return this->_client->build_call("TestService", "StructEcho", _args);
 }
 
 inline ::krpc::schema::ProcedureCall TestService::struct_echo_nullable_call(std::optional<TestService::TestStruct> x) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(1);
-  _args.push_back(encoder::encode_nullable(x));
+  _args.push_back(encoder::encode_arg(x));
   return this->_client->build_call("TestService", "StructEchoNullable", _args);
 }
 
@@ -2520,14 +2933,14 @@ inline ::krpc::schema::ProcedureCall TestService::throw_argument_exception_call(
 inline ::krpc::schema::ProcedureCall TestService::throw_argument_null_exception_call(std::string foo) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(1);
-  _args.push_back(encoder::encode(foo));
+  _args.push_back(encoder::encode_arg(foo));
   return this->_client->build_call("TestService", "ThrowArgumentNullException", _args);
 }
 
 inline ::krpc::schema::ProcedureCall TestService::throw_argument_out_of_range_exception_call(int32_t foo) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(1);
-  _args.push_back(encoder::encode(foo));
+  _args.push_back(encoder::encode_arg(foo));
   return this->_client->build_call("TestService", "ThrowArgumentOutOfRangeException", _args);
 }
 
@@ -2550,21 +2963,21 @@ inline ::krpc::schema::ProcedureCall TestService::throw_invalid_operation_except
 inline ::krpc::schema::ProcedureCall TestService::tuple_default_call(std::tuple<int32_t, bool> x = std::tuple<int32_t, bool>{1, false}) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(1);
-  _args.push_back(encoder::encode(x));
+  _args.push_back(encoder::encode_arg(x));
   return this->_client->build_call("TestService", "TupleDefault", _args);
 }
 
 inline ::krpc::schema::ProcedureCall TestService::uint32_special_defaults_call(uint32_t maximum = (std::numeric_limits<uint32_t>::max)()) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(1);
-  _args.push_back(encoder::encode(maximum));
+  _args.push_back(encoder::encode_arg(maximum));
   return this->_client->build_call("TestService", "Uint32SpecialDefaults", _args);
 }
 
 inline ::krpc::schema::ProcedureCall TestService::uint64_special_defaults_call(uint64_t maximum = (std::numeric_limits<uint64_t>::max)()) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(1);
-  _args.push_back(encoder::encode(maximum));
+  _args.push_back(encoder::encode_arg(maximum));
   return this->_client->build_call("TestService", "Uint64SpecialDefaults", _args);
 }
 
@@ -2575,7 +2988,7 @@ inline ::krpc::schema::ProcedureCall TestService::deprecated_property_call() {
 inline ::krpc::schema::ProcedureCall TestService::set_deprecated_property_call(std::string value) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(1);
-  _args.push_back(encoder::encode(value));
+  _args.push_back(encoder::encode_arg(value));
   return this->_client->build_call("TestService", "set_DeprecatedProperty", _args);
 }
 
@@ -2583,10 +2996,10 @@ inline ::krpc::schema::ProcedureCall TestService::nullable_object_call() {
   return this->_client->build_call("TestService", "get_NullableObject");
 }
 
-inline ::krpc::schema::ProcedureCall TestService::set_nullable_object_call(TestService::TestClass value) {
+inline ::krpc::schema::ProcedureCall TestService::set_nullable_object_call(std::optional<TestService::TestClass> value) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(1);
-  _args.push_back(encoder::encode_nullable(value));
+  _args.push_back(encoder::encode_arg(value));
   return this->_client->build_call("TestService", "set_NullableObject", _args);
 }
 
@@ -2594,10 +3007,10 @@ inline ::krpc::schema::ProcedureCall TestService::object_property_call() {
   return this->_client->build_call("TestService", "get_ObjectProperty");
 }
 
-inline ::krpc::schema::ProcedureCall TestService::set_object_property_call(TestService::TestClass value) {
+inline ::krpc::schema::ProcedureCall TestService::set_object_property_call(std::optional<TestService::TestClass> value) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(1);
-  _args.push_back(encoder::encode_nullable(value));
+  _args.push_back(encoder::encode_arg(value));
   return this->_client->build_call("TestService", "set_ObjectProperty", _args);
 }
 
@@ -2608,14 +3021,14 @@ inline ::krpc::schema::ProcedureCall TestService::string_property_call() {
 inline ::krpc::schema::ProcedureCall TestService::set_string_property_call(std::string value) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(1);
-  _args.push_back(encoder::encode(value));
+  _args.push_back(encoder::encode_arg(value));
   return this->_client->build_call("TestService", "set_StringProperty", _args);
 }
 
 inline ::krpc::schema::ProcedureCall TestService::set_string_property_private_get_call(std::string value) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(1);
-  _args.push_back(encoder::encode(value));
+  _args.push_back(encoder::encode_arg(value));
   return this->_client->build_call("TestService", "set_StringPropertyPrivateGet", _args);
 }
 
@@ -2629,7 +3042,7 @@ inline TestService::DeprecatedClass::DeprecatedClass(Client* client, uint64_t id
 inline std::string TestService::DeprecatedClass::deprecated_method() {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(1);
-  _args.push_back(encoder::encode(*this));
+  _args.push_back(encoder::encode_arg(*this));
   auto _data = this->_client->invoke("TestService", "DeprecatedClass_DeprecatedMethod", _args);
   std::string _result{};
   if (!_data.is_null())
@@ -2640,27 +3053,27 @@ inline std::string TestService::DeprecatedClass::deprecated_method() {
 inline ::krpc::Stream<std::string> TestService::DeprecatedClass::deprecated_method_stream() {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(1);
-  _args.push_back(encoder::encode(*this));
+  _args.push_back(encoder::encode_arg(*this));
   return ::krpc::Stream<std::string>(this->_client, this->_client->build_call("TestService", "DeprecatedClass_DeprecatedMethod", _args));
 }
 
 inline ::krpc::schema::ProcedureCall TestService::DeprecatedClass::deprecated_method_call() {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(1);
-  _args.push_back(encoder::encode(*this));
+  _args.push_back(encoder::encode_arg(*this));
   return this->_client->build_call("TestService", "DeprecatedClass_DeprecatedMethod", _args);
 }
 
 inline TestService::TestClass::TestClass(Client* client, uint64_t id):
   Object(client, "TestService::TestClass", id) {}
 
-inline TestService::TestClass TestService::TestClass::echo_nullable_object(TestService::TestClass value) {
+inline std::optional<TestService::TestClass> TestService::TestClass::echo_nullable_object(std::optional<TestService::TestClass> value) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(2);
-  _args.push_back(encoder::encode(*this));
-  _args.push_back(encoder::encode_nullable(value));
+  _args.push_back(encoder::encode_arg(*this));
+  _args.push_back(encoder::encode_arg(value));
   auto _data = this->_client->invoke("TestService", "TestClass_EchoNullableObject", _args);
-  TestService::TestClass _result{};
+  std::optional<TestService::TestClass> _result{};
   if (!_data.is_null())
     decoder::decode(_result, _data.value(), this->_client);
   return _result;
@@ -2669,8 +3082,8 @@ inline TestService::TestClass TestService::TestClass::echo_nullable_object(TestS
 inline std::string TestService::TestClass::float_to_string(float x) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(2);
-  _args.push_back(encoder::encode(*this));
-  _args.push_back(encoder::encode(x));
+  _args.push_back(encoder::encode_arg(*this));
+  _args.push_back(encoder::encode_arg(x));
   auto _data = this->_client->invoke("TestService", "TestClass_FloatToString", _args);
   std::string _result{};
   if (!_data.is_null())
@@ -2681,7 +3094,7 @@ inline std::string TestService::TestClass::float_to_string(float x) {
 inline std::string TestService::TestClass::get_value() {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(1);
-  _args.push_back(encoder::encode(*this));
+  _args.push_back(encoder::encode_arg(*this));
   auto _data = this->_client->invoke("TestService", "TestClass_GetValue", _args);
   std::string _result{};
   if (!_data.is_null())
@@ -2689,11 +3102,11 @@ inline std::string TestService::TestClass::get_value() {
   return _result;
 }
 
-inline std::string TestService::TestClass::object_to_string(TestService::TestClass other) {
+inline std::string TestService::TestClass::object_to_string(std::optional<TestService::TestClass> other) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(2);
-  _args.push_back(encoder::encode(*this));
-  _args.push_back(encoder::encode_nullable(other));
+  _args.push_back(encoder::encode_arg(*this));
+  _args.push_back(encoder::encode_arg(other));
   auto _data = this->_client->invoke("TestService", "TestClass_ObjectToString", _args);
   std::string _result{};
   if (!_data.is_null())
@@ -2701,14 +3114,14 @@ inline std::string TestService::TestClass::object_to_string(TestService::TestCla
   return _result;
 }
 
-inline std::string TestService::TestClass::optional_arguments(std::string x, std::string y = "foo", std::string z = "bar", TestService::TestClass obj = TestService::TestClass()) {
+inline std::string TestService::TestClass::optional_arguments(std::string x, std::string y = "foo", std::string z = "bar", std::optional<TestService::TestClass> obj = std::optional<TestService::TestClass>()) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(5);
-  _args.push_back(encoder::encode(*this));
-  _args.push_back(encoder::encode(x));
-  _args.push_back(encoder::encode(y));
-  _args.push_back(encoder::encode(z));
-  _args.push_back(encoder::encode_nullable(obj));
+  _args.push_back(encoder::encode_arg(*this));
+  _args.push_back(encoder::encode_arg(x));
+  _args.push_back(encoder::encode_arg(y));
+  _args.push_back(encoder::encode_arg(z));
+  _args.push_back(encoder::encode_arg(obj));
   auto _data = this->_client->invoke("TestService", "TestClass_OptionalArguments", _args);
   std::string _result{};
   if (!_data.is_null())
@@ -2719,7 +3132,7 @@ inline std::string TestService::TestClass::optional_arguments(std::string x, std
 inline int32_t TestService::TestClass::int_property() {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(1);
-  _args.push_back(encoder::encode(*this));
+  _args.push_back(encoder::encode_arg(*this));
   auto _data = this->_client->invoke("TestService", "TestClass_get_IntProperty", _args);
   int32_t _result{};
   if (!_data.is_null())
@@ -2730,42 +3143,42 @@ inline int32_t TestService::TestClass::int_property() {
 inline void TestService::TestClass::set_int_property(int32_t value) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(2);
-  _args.push_back(encoder::encode(*this));
-  _args.push_back(encoder::encode(value));
+  _args.push_back(encoder::encode_arg(*this));
+  _args.push_back(encoder::encode_arg(value));
   this->_client->invoke("TestService", "TestClass_set_IntProperty", _args);
 }
 
-inline TestService::TestClass TestService::TestClass::object_property() {
+inline std::optional<TestService::TestClass> TestService::TestClass::object_property() {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(1);
-  _args.push_back(encoder::encode(*this));
+  _args.push_back(encoder::encode_arg(*this));
   auto _data = this->_client->invoke("TestService", "TestClass_get_ObjectProperty", _args);
-  TestService::TestClass _result{};
+  std::optional<TestService::TestClass> _result{};
   if (!_data.is_null())
     decoder::decode(_result, _data.value(), this->_client);
   return _result;
 }
 
-inline void TestService::TestClass::set_object_property(TestService::TestClass value) {
+inline void TestService::TestClass::set_object_property(std::optional<TestService::TestClass> value) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(2);
-  _args.push_back(encoder::encode(*this));
-  _args.push_back(encoder::encode_nullable(value));
+  _args.push_back(encoder::encode_arg(*this));
+  _args.push_back(encoder::encode_arg(value));
   this->_client->invoke("TestService", "TestClass_set_ObjectProperty", _args);
 }
 
 inline void TestService::TestClass::set_string_property_private_get(std::string value) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(2);
-  _args.push_back(encoder::encode(*this));
-  _args.push_back(encoder::encode(value));
+  _args.push_back(encoder::encode_arg(*this));
+  _args.push_back(encoder::encode_arg(value));
   this->_client->invoke("TestService", "TestClass_set_StringPropertyPrivateGet", _args);
 }
 
 inline std::string TestService::TestClass::string_property_private_set() {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(1);
-  _args.push_back(encoder::encode(*this));
+  _args.push_back(encoder::encode_arg(*this));
   auto _data = this->_client->invoke("TestService", "TestClass_get_StringPropertyPrivateSet", _args);
   std::string _result{};
   if (!_data.is_null())
@@ -2776,8 +3189,8 @@ inline std::string TestService::TestClass::string_property_private_set() {
 inline std::string TestService::TestClass::static_method(Client& _client, std::string a = "", std::string b = "") {
     std::vector<krpc::encoder::Value> _args;
   _args.reserve(2);
-  _args.push_back(encoder::encode(a));
-  _args.push_back(encoder::encode(b));
+  _args.push_back(encoder::encode_arg(a));
+  _args.push_back(encoder::encode_arg(b));
   auto _data = _client.invoke("TestService", "TestClass_static_StaticMethod", _args);
     std::string _result{};
   if (!_data.is_null())
@@ -2785,194 +3198,194 @@ inline std::string TestService::TestClass::static_method(Client& _client, std::s
   return _result;
 }
 
-inline TestService::TestClass TestService::TestClass::static_nullable_object(Client& _client, TestService::TestClass value) {
+inline std::optional<TestService::TestClass> TestService::TestClass::static_nullable_object(Client& _client, std::optional<TestService::TestClass> value) {
     std::vector<krpc::encoder::Value> _args;
   _args.reserve(1);
-  _args.push_back(encoder::encode_nullable(value));
+  _args.push_back(encoder::encode_arg(value));
   auto _data = _client.invoke("TestService", "TestClass_static_StaticNullableObject", _args);
-    TestService::TestClass _result{};
+    std::optional<TestService::TestClass> _result{};
   if (!_data.is_null())
     decoder::decode(_result, _data.value(), &_client);
   return _result;
 }
 
-inline ::krpc::Stream<TestService::TestClass> TestService::TestClass::echo_nullable_object_stream(TestService::TestClass value) {
+inline ::krpc::Stream<std::optional<TestService::TestClass>> TestService::TestClass::echo_nullable_object_stream(std::optional<TestService::TestClass> value) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(2);
-  _args.push_back(encoder::encode(*this));
-  _args.push_back(encoder::encode_nullable(value));
-  return ::krpc::Stream<TestService::TestClass>(this->_client, this->_client->build_call("TestService", "TestClass_EchoNullableObject", _args));
+  _args.push_back(encoder::encode_arg(*this));
+  _args.push_back(encoder::encode_arg(value));
+  return ::krpc::Stream<std::optional<TestService::TestClass>>(this->_client, this->_client->build_call("TestService", "TestClass_EchoNullableObject", _args));
 }
 
 inline ::krpc::Stream<std::string> TestService::TestClass::float_to_string_stream(float x) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(2);
-  _args.push_back(encoder::encode(*this));
-  _args.push_back(encoder::encode(x));
+  _args.push_back(encoder::encode_arg(*this));
+  _args.push_back(encoder::encode_arg(x));
   return ::krpc::Stream<std::string>(this->_client, this->_client->build_call("TestService", "TestClass_FloatToString", _args));
 }
 
 inline ::krpc::Stream<std::string> TestService::TestClass::get_value_stream() {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(1);
-  _args.push_back(encoder::encode(*this));
+  _args.push_back(encoder::encode_arg(*this));
   return ::krpc::Stream<std::string>(this->_client, this->_client->build_call("TestService", "TestClass_GetValue", _args));
 }
 
-inline ::krpc::Stream<std::string> TestService::TestClass::object_to_string_stream(TestService::TestClass other) {
+inline ::krpc::Stream<std::string> TestService::TestClass::object_to_string_stream(std::optional<TestService::TestClass> other) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(2);
-  _args.push_back(encoder::encode(*this));
-  _args.push_back(encoder::encode_nullable(other));
+  _args.push_back(encoder::encode_arg(*this));
+  _args.push_back(encoder::encode_arg(other));
   return ::krpc::Stream<std::string>(this->_client, this->_client->build_call("TestService", "TestClass_ObjectToString", _args));
 }
 
-inline ::krpc::Stream<std::string> TestService::TestClass::optional_arguments_stream(std::string x, std::string y = "foo", std::string z = "bar", TestService::TestClass obj = TestService::TestClass()) {
+inline ::krpc::Stream<std::string> TestService::TestClass::optional_arguments_stream(std::string x, std::string y = "foo", std::string z = "bar", std::optional<TestService::TestClass> obj = std::optional<TestService::TestClass>()) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(5);
-  _args.push_back(encoder::encode(*this));
-  _args.push_back(encoder::encode(x));
-  _args.push_back(encoder::encode(y));
-  _args.push_back(encoder::encode(z));
-  _args.push_back(encoder::encode_nullable(obj));
+  _args.push_back(encoder::encode_arg(*this));
+  _args.push_back(encoder::encode_arg(x));
+  _args.push_back(encoder::encode_arg(y));
+  _args.push_back(encoder::encode_arg(z));
+  _args.push_back(encoder::encode_arg(obj));
   return ::krpc::Stream<std::string>(this->_client, this->_client->build_call("TestService", "TestClass_OptionalArguments", _args));
 }
 
 inline ::krpc::Stream<int32_t> TestService::TestClass::int_property_stream() {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(1);
-  _args.push_back(encoder::encode(*this));
+  _args.push_back(encoder::encode_arg(*this));
   return ::krpc::Stream<int32_t>(this->_client, this->_client->build_call("TestService", "TestClass_get_IntProperty", _args));
 }
 
-inline ::krpc::Stream<TestService::TestClass> TestService::TestClass::object_property_stream() {
+inline ::krpc::Stream<std::optional<TestService::TestClass>> TestService::TestClass::object_property_stream() {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(1);
-  _args.push_back(encoder::encode(*this));
-  return ::krpc::Stream<TestService::TestClass>(this->_client, this->_client->build_call("TestService", "TestClass_get_ObjectProperty", _args));
+  _args.push_back(encoder::encode_arg(*this));
+  return ::krpc::Stream<std::optional<TestService::TestClass>>(this->_client, this->_client->build_call("TestService", "TestClass_get_ObjectProperty", _args));
 }
 
 inline ::krpc::Stream<std::string> TestService::TestClass::string_property_private_set_stream() {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(1);
-  _args.push_back(encoder::encode(*this));
+  _args.push_back(encoder::encode_arg(*this));
   return ::krpc::Stream<std::string>(this->_client, this->_client->build_call("TestService", "TestClass_get_StringPropertyPrivateSet", _args));
 }
 
 inline ::krpc::Stream<std::string> TestService::TestClass::static_method_stream(Client& _client, std::string a = "", std::string b = "") {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(2);
-  _args.push_back(encoder::encode(a));
-  _args.push_back(encoder::encode(b));
+  _args.push_back(encoder::encode_arg(a));
+  _args.push_back(encoder::encode_arg(b));
   return ::krpc::Stream<std::string>(&_client, _client.build_call("TestService", "TestClass_static_StaticMethod", _args));
 }
 
-inline ::krpc::Stream<TestService::TestClass> TestService::TestClass::static_nullable_object_stream(Client& _client, TestService::TestClass value) {
+inline ::krpc::Stream<std::optional<TestService::TestClass>> TestService::TestClass::static_nullable_object_stream(Client& _client, std::optional<TestService::TestClass> value) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(1);
-  _args.push_back(encoder::encode_nullable(value));
-  return ::krpc::Stream<TestService::TestClass>(&_client, _client.build_call("TestService", "TestClass_static_StaticNullableObject", _args));
+  _args.push_back(encoder::encode_arg(value));
+  return ::krpc::Stream<std::optional<TestService::TestClass>>(&_client, _client.build_call("TestService", "TestClass_static_StaticNullableObject", _args));
 }
 
-inline ::krpc::schema::ProcedureCall TestService::TestClass::echo_nullable_object_call(TestService::TestClass value) {
+inline ::krpc::schema::ProcedureCall TestService::TestClass::echo_nullable_object_call(std::optional<TestService::TestClass> value) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(2);
-  _args.push_back(encoder::encode(*this));
-  _args.push_back(encoder::encode_nullable(value));
+  _args.push_back(encoder::encode_arg(*this));
+  _args.push_back(encoder::encode_arg(value));
   return this->_client->build_call("TestService", "TestClass_EchoNullableObject", _args);
 }
 
 inline ::krpc::schema::ProcedureCall TestService::TestClass::float_to_string_call(float x) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(2);
-  _args.push_back(encoder::encode(*this));
-  _args.push_back(encoder::encode(x));
+  _args.push_back(encoder::encode_arg(*this));
+  _args.push_back(encoder::encode_arg(x));
   return this->_client->build_call("TestService", "TestClass_FloatToString", _args);
 }
 
 inline ::krpc::schema::ProcedureCall TestService::TestClass::get_value_call() {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(1);
-  _args.push_back(encoder::encode(*this));
+  _args.push_back(encoder::encode_arg(*this));
   return this->_client->build_call("TestService", "TestClass_GetValue", _args);
 }
 
-inline ::krpc::schema::ProcedureCall TestService::TestClass::object_to_string_call(TestService::TestClass other) {
+inline ::krpc::schema::ProcedureCall TestService::TestClass::object_to_string_call(std::optional<TestService::TestClass> other) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(2);
-  _args.push_back(encoder::encode(*this));
-  _args.push_back(encoder::encode_nullable(other));
+  _args.push_back(encoder::encode_arg(*this));
+  _args.push_back(encoder::encode_arg(other));
   return this->_client->build_call("TestService", "TestClass_ObjectToString", _args);
 }
 
-inline ::krpc::schema::ProcedureCall TestService::TestClass::optional_arguments_call(std::string x, std::string y = "foo", std::string z = "bar", TestService::TestClass obj = TestService::TestClass()) {
+inline ::krpc::schema::ProcedureCall TestService::TestClass::optional_arguments_call(std::string x, std::string y = "foo", std::string z = "bar", std::optional<TestService::TestClass> obj = std::optional<TestService::TestClass>()) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(5);
-  _args.push_back(encoder::encode(*this));
-  _args.push_back(encoder::encode(x));
-  _args.push_back(encoder::encode(y));
-  _args.push_back(encoder::encode(z));
-  _args.push_back(encoder::encode_nullable(obj));
+  _args.push_back(encoder::encode_arg(*this));
+  _args.push_back(encoder::encode_arg(x));
+  _args.push_back(encoder::encode_arg(y));
+  _args.push_back(encoder::encode_arg(z));
+  _args.push_back(encoder::encode_arg(obj));
   return this->_client->build_call("TestService", "TestClass_OptionalArguments", _args);
 }
 
 inline ::krpc::schema::ProcedureCall TestService::TestClass::int_property_call() {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(1);
-  _args.push_back(encoder::encode(*this));
+  _args.push_back(encoder::encode_arg(*this));
   return this->_client->build_call("TestService", "TestClass_get_IntProperty", _args);
 }
 
 inline ::krpc::schema::ProcedureCall TestService::TestClass::set_int_property_call(int32_t value) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(2);
-  _args.push_back(encoder::encode(*this));
-  _args.push_back(encoder::encode(value));
+  _args.push_back(encoder::encode_arg(*this));
+  _args.push_back(encoder::encode_arg(value));
   return this->_client->build_call("TestService", "TestClass_set_IntProperty", _args);
 }
 
 inline ::krpc::schema::ProcedureCall TestService::TestClass::object_property_call() {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(1);
-  _args.push_back(encoder::encode(*this));
+  _args.push_back(encoder::encode_arg(*this));
   return this->_client->build_call("TestService", "TestClass_get_ObjectProperty", _args);
 }
 
-inline ::krpc::schema::ProcedureCall TestService::TestClass::set_object_property_call(TestService::TestClass value) {
+inline ::krpc::schema::ProcedureCall TestService::TestClass::set_object_property_call(std::optional<TestService::TestClass> value) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(2);
-  _args.push_back(encoder::encode(*this));
-  _args.push_back(encoder::encode_nullable(value));
+  _args.push_back(encoder::encode_arg(*this));
+  _args.push_back(encoder::encode_arg(value));
   return this->_client->build_call("TestService", "TestClass_set_ObjectProperty", _args);
 }
 
 inline ::krpc::schema::ProcedureCall TestService::TestClass::set_string_property_private_get_call(std::string value) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(2);
-  _args.push_back(encoder::encode(*this));
-  _args.push_back(encoder::encode(value));
+  _args.push_back(encoder::encode_arg(*this));
+  _args.push_back(encoder::encode_arg(value));
   return this->_client->build_call("TestService", "TestClass_set_StringPropertyPrivateGet", _args);
 }
 
 inline ::krpc::schema::ProcedureCall TestService::TestClass::string_property_private_set_call() {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(1);
-  _args.push_back(encoder::encode(*this));
+  _args.push_back(encoder::encode_arg(*this));
   return this->_client->build_call("TestService", "TestClass_get_StringPropertyPrivateSet", _args);
 }
 
 inline ::krpc::schema::ProcedureCall TestService::TestClass::static_method_call(Client& _client, std::string a = "", std::string b = "") {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(2);
-  _args.push_back(encoder::encode(a));
-  _args.push_back(encoder::encode(b));
+  _args.push_back(encoder::encode_arg(a));
+  _args.push_back(encoder::encode_arg(b));
   return _client.build_call("TestService", "TestClass_static_StaticMethod", _args);
 }
 
-inline ::krpc::schema::ProcedureCall TestService::TestClass::static_nullable_object_call(Client& _client, TestService::TestClass value) {
+inline ::krpc::schema::ProcedureCall TestService::TestClass::static_nullable_object_call(Client& _client, std::optional<TestService::TestClass> value) {
   std::vector<krpc::encoder::Value> _args;
   _args.reserve(1);
-  _args.push_back(encoder::encode_nullable(value));
+  _args.push_back(encoder::encode_arg(value));
   return _client.build_call("TestService", "TestClass_static_StaticNullableObject", _args);
 }
 }  // namespace services
@@ -2998,6 +3411,13 @@ struct hash<krpc::services::TestService::DeprecatedStruct> {
 #endif
 
 template <>
+struct hash<krpc::services::TestService::TestNestedNullableStruct> {
+  std::size_t operator()(const krpc::services::TestService::TestNestedNullableStruct& value) const {
+    return krpc::hash_value(value);
+  }
+};
+
+template <>
 struct hash<krpc::services::TestService::TestStruct> {
   std::size_t operator()(const krpc::services::TestService::TestStruct& value) const {
     return krpc::hash_value(value);
@@ -3007,6 +3427,13 @@ struct hash<krpc::services::TestService::TestStruct> {
 template <>
 struct hash<krpc::services::TestService::TestNestedStruct> {
   std::size_t operator()(const krpc::services::TestService::TestNestedStruct& value) const {
+    return krpc::hash_value(value);
+  }
+};
+
+template <>
+struct hash<krpc::services::TestService::TestNullableStruct> {
+  std::size_t operator()(const krpc::services::TestService::TestNullableStruct& value) const {
     return krpc::hash_value(value);
   }
 };

--- a/tools/krpctools/krpctools/test/clientgen-TestService-cpp.txt
+++ b/tools/krpctools/krpctools/test/clientgen-TestService-cpp.txt
@@ -1180,103 +1180,15 @@ inline std::size_t hash_value(const services::TestService::TestNullableStruct& v
   return seed;
 }
 
-// The encoder and decoder for a collection call encode and decode on the type it
-// contains without qualifying them, so the ones above, which are declared after those
-// templates, are only reachable through argument dependent lookup. That searches the
-// namespace enclosing the enumeration, which is this one, so the collection encoder and
-// decoder find an enumeration through these.
+// A collection encoder or decoder calls encode and decode on the type it contains
+// without qualifying them. The ones above are declared after those templates, so
+// argument dependent lookup is what reaches them. It searches the namespace that
+// encloses the type, which is this one. These name the same functions here, as a
+// second function with the same signature is ambiguous to a compiler that finds both.
 namespace services {
-
-#if defined(__GNUC__)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-#endif
-  inline std::string encode(const TestService::DeprecatedEnum& value) {
-    return encoder::encode(value);
-  }
-
-  inline void decode(TestService::DeprecatedEnum& value, const std::string& data, Client* client) {
-    decoder::decode(value, data, client);
-  }
-#if defined(__GNUC__)
-#pragma GCC diagnostic pop
-#endif
-
-  inline std::string encode(const TestService::TestEnum& value) {
-    return encoder::encode(value);
-  }
-
-  inline void decode(TestService::TestEnum& value, const std::string& data, Client* client) {
-    decoder::decode(value, data, client);
-  }
-
-#if defined(__GNUC__)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-#endif
-  inline std::string encode(const TestService::DeprecatedStruct& value) {
-    return encoder::encode(value);
-  }
-
-  inline void decode(TestService::DeprecatedStruct& value, const std::string& data, Client* client) {
-    decoder::decode(value, data, client);
-  }
-
-  inline std::size_t hash_value(const TestService::DeprecatedStruct& value) {
-    return krpc::hash_value(value);
-  }
-#if defined(__GNUC__)
-#pragma GCC diagnostic pop
-#endif
-
-  inline std::string encode(const TestService::TestNestedNullableStruct& value) {
-    return encoder::encode(value);
-  }
-
-  inline void decode(TestService::TestNestedNullableStruct& value, const std::string& data, Client* client) {
-    decoder::decode(value, data, client);
-  }
-
-  inline std::size_t hash_value(const TestService::TestNestedNullableStruct& value) {
-    return krpc::hash_value(value);
-  }
-
-  inline std::string encode(const TestService::TestStruct& value) {
-    return encoder::encode(value);
-  }
-
-  inline void decode(TestService::TestStruct& value, const std::string& data, Client* client) {
-    decoder::decode(value, data, client);
-  }
-
-  inline std::size_t hash_value(const TestService::TestStruct& value) {
-    return krpc::hash_value(value);
-  }
-
-  inline std::string encode(const TestService::TestNestedStruct& value) {
-    return encoder::encode(value);
-  }
-
-  inline void decode(TestService::TestNestedStruct& value, const std::string& data, Client* client) {
-    decoder::decode(value, data, client);
-  }
-
-  inline std::size_t hash_value(const TestService::TestNestedStruct& value) {
-    return krpc::hash_value(value);
-  }
-
-  inline std::string encode(const TestService::TestNullableStruct& value) {
-    return encoder::encode(value);
-  }
-
-  inline void decode(TestService::TestNullableStruct& value, const std::string& data, Client* client) {
-    decoder::decode(value, data, client);
-  }
-
-  inline std::size_t hash_value(const TestService::TestNullableStruct& value) {
-    return krpc::hash_value(value);
-  }
-
+  using krpc::encoder::encode;
+  using krpc::decoder::decode;
+  using krpc::hash_value;
 }  // namespace services
 
 namespace services {

--- a/tools/krpctools/krpctools/test/clientgen-TestService-csharp.txt
+++ b/tools/krpctools/krpctools/test/clientgen-TestService-csharp.txt
@@ -31,6 +31,82 @@ namespace KRPC.Client.Services.TestService
         }
     }
 
+    // The types the stubs encode and decode values of, built once each. A spec names the
+    // positions inside a value that can hold null, which a C# type cannot always say.
+    static class TypeSpecs
+    {
+        internal static readonly global::KRPC.Client.TypeSpec Spec0 = global::KRPC.Client.TypeSpec.For (typeof(float));
+        internal static readonly global::KRPC.Client.TypeSpec Spec1 = global::KRPC.Client.TypeSpec.For (typeof(double));
+        internal static readonly global::KRPC.Client.TypeSpec Spec2 = global::KRPC.Client.TypeSpec.For (typeof(int));
+        internal static readonly global::KRPC.Client.TypeSpec Spec3 = global::KRPC.Client.TypeSpec.For (typeof(long));
+        internal static readonly global::KRPC.Client.TypeSpec Spec4 = global::KRPC.Client.TypeSpec.For (typeof(bool));
+        internal static readonly global::KRPC.Client.TypeSpec Spec5 = global::KRPC.Client.TypeSpec.For (typeof(string));
+        internal static readonly global::KRPC.Client.TypeSpec Spec6 = global::KRPC.Client.TypeSpec.For (typeof(byte[]));
+        internal static readonly global::KRPC.Client.TypeSpec Spec7 = global::KRPC.Client.TypeSpec.For (typeof(global::KRPC.Client.Services.TestService.TestClass));
+        internal static readonly global::KRPC.Client.TypeSpec Spec8 = global::KRPC.Client.TypeSpec.For (typeof(global::System.Collections.Generic.IList<int>));
+        internal static readonly global::KRPC.Client.TypeSpec Spec9 = global::KRPC.Client.TypeSpec.For (typeof(global::KRPC.Client.Services.TestService.TestEnum));
+        internal static readonly global::KRPC.Client.TypeSpec Spec10 = new global::KRPC.Client.TypeSpec (typeof(global::KRPC.Client.Services.TestService.TestNestedNullableStruct), new global::KRPC.Client.TypeSpec (typeof(global::System.Collections.Generic.IList<global::KRPC.Client.Services.TestService.TestClass>), global::KRPC.Client.TypeSpec.Null (typeof(global::KRPC.Client.Services.TestService.TestClass))));
+        internal static readonly global::KRPC.Client.TypeSpec Spec11 = global::KRPC.Client.TypeSpec.For (typeof(global::System.Collections.Generic.IList<int?>));
+        internal static readonly global::KRPC.Client.TypeSpec Spec12 = new global::KRPC.Client.TypeSpec (typeof(global::System.Collections.Generic.IList<global::KRPC.Client.Services.TestService.TestClass>), global::KRPC.Client.TypeSpec.Null (typeof(global::KRPC.Client.Services.TestService.TestClass)));
+        internal static readonly global::KRPC.Client.TypeSpec Spec13 = new global::KRPC.Client.TypeSpec (typeof(global::System.Collections.Generic.IDictionary<string,global::KRPC.Client.Services.TestService.TestClass>), global::KRPC.Client.TypeSpec.For (typeof(string)), global::KRPC.Client.TypeSpec.Null (typeof(global::KRPC.Client.Services.TestService.TestClass)));
+        internal static readonly global::KRPC.Client.TypeSpec Spec14 = new global::KRPC.Client.TypeSpec (typeof(systemAlias::Tuple<int,global::KRPC.Client.Services.TestService.TestClass>), global::KRPC.Client.TypeSpec.For (typeof(int)), global::KRPC.Client.TypeSpec.Null (typeof(global::KRPC.Client.Services.TestService.TestClass)));
+        internal static readonly global::KRPC.Client.TypeSpec Spec15 = new global::KRPC.Client.TypeSpec (typeof(global::System.Collections.Generic.IList<global::System.Collections.Generic.IList<global::KRPC.Client.Services.TestService.TestClass>>), new global::KRPC.Client.TypeSpec (typeof(global::System.Collections.Generic.IList<global::KRPC.Client.Services.TestService.TestClass>), global::KRPC.Client.TypeSpec.Null (typeof(global::KRPC.Client.Services.TestService.TestClass))));
+        internal static readonly global::KRPC.Client.TypeSpec Spec16 = global::KRPC.Client.TypeSpec.For (typeof(global::KRPC.Client.Services.TestService.TestStruct));
+        internal static readonly global::KRPC.Client.TypeSpec Spec17 = global::KRPC.Client.TypeSpec.For (typeof(global::KRPC.Client.Services.TestService.TestNullableStruct));
+        internal static readonly global::KRPC.Client.TypeSpec Spec18 = global::KRPC.Client.TypeSpec.For (typeof(global::KRPC.Client.Services.TestService.TestNestedStruct));
+        internal static readonly global::KRPC.Client.TypeSpec Spec19 = global::KRPC.Client.TypeSpec.For (typeof(global::System.Collections.Generic.IList<global::KRPC.Client.Services.TestService.TestStruct>));
+        internal static readonly global::KRPC.Client.TypeSpec Spec20 = global::KRPC.Client.TypeSpec.For (typeof(global::System.Collections.Generic.IDictionary<string,int>));
+        internal static readonly global::KRPC.Client.TypeSpec Spec21 = global::KRPC.Client.TypeSpec.For (typeof(genericCollectionsAlias::ISet<int>));
+        internal static readonly global::KRPC.Client.TypeSpec Spec22 = global::KRPC.Client.TypeSpec.For (typeof(systemAlias::Tuple<int,long>));
+        internal static readonly global::KRPC.Client.TypeSpec Spec23 = global::KRPC.Client.TypeSpec.For (typeof(global::System.Collections.Generic.IDictionary<string,global::System.Collections.Generic.IList<int>>));
+        internal static readonly global::KRPC.Client.TypeSpec Spec24 = global::KRPC.Client.TypeSpec.For (typeof(systemAlias::Tuple<int,bool>));
+        internal static readonly global::KRPC.Client.TypeSpec Spec25 = global::KRPC.Client.TypeSpec.For (typeof(global::System.Collections.Generic.IDictionary<int,bool>));
+        internal static readonly global::KRPC.Client.TypeSpec Spec26 = global::KRPC.Client.TypeSpec.For (typeof(global::System.Collections.Generic.IList<global::KRPC.Client.Services.TestService.TestEnum>));
+        internal static readonly global::KRPC.Client.TypeSpec Spec27 = global::KRPC.Client.TypeSpec.For (typeof(global::System.Collections.Generic.IList<string>));
+        internal static readonly global::KRPC.Client.TypeSpec Spec28 = global::KRPC.Client.TypeSpec.For (typeof(global::System.Collections.Generic.IList<global::KRPC.Client.Services.TestService.TestClass>));
+        internal static readonly global::KRPC.Client.TypeSpec Spec29 = global::KRPC.Client.TypeSpec.For (typeof(uint));
+        internal static readonly global::KRPC.Client.TypeSpec Spec30 = global::KRPC.Client.TypeSpec.For (typeof(ulong));
+        internal static readonly global::KRPC.Client.TypeSpec Spec31 = global::KRPC.Client.TypeSpec.For (typeof(global::KRPC.Client.Services.TestService.DeprecatedClass));
+        internal static readonly global::KRPC.Client.TypeSpec Spec32 = global::KRPC.Client.TypeSpec.For (typeof(global::System.Collections.Generic.IList<double>));
+        internal static readonly global::KRPC.Client.TypeSpec Spec33 = global::KRPC.Client.TypeSpec.For (typeof(global::System.Collections.Generic.IList<float>));
+        internal static readonly global::KRPC.Client.TypeSpec Spec34 = global::KRPC.Client.TypeSpec.For (typeof(global::System.Collections.Generic.IList<long>));
+        internal static readonly global::KRPC.Client.TypeSpec Spec35 = global::KRPC.Client.TypeSpec.For (typeof(global::KRPC.Client.Event));
+        internal static readonly global::KRPC.Client.TypeSpec Spec36 = global::KRPC.Client.TypeSpec.For (typeof(global::System.Collections.Generic.IList<uint>));
+        internal static readonly global::KRPC.Client.TypeSpec Spec37 = global::KRPC.Client.TypeSpec.For (typeof(global::System.Collections.Generic.IList<ulong>));
+
+        // The procedures whose values a C# type cannot describe on its own, which a call
+        // built from an expression looks up by name
+        static readonly global::System.Collections.Generic.Dictionary<string, global::KRPC.Client.TypeSpec> returnSpecs =
+            new global::System.Collections.Generic.Dictionary<string, global::KRPC.Client.TypeSpec> {
+                { "EchoNestedNullableStruct", TypeSpecs.Spec10 },
+                { "EchoListOfNullableObjects", TypeSpecs.Spec12 },
+                { "EchoDictionaryOfNullableObjects", TypeSpecs.Spec13 },
+                { "EchoTupleWithANullableObject", TypeSpecs.Spec14 },
+                { "EchoNestedListOfNullableObjects", TypeSpecs.Spec15 },
+            };
+
+        static readonly global::System.Collections.Generic.Dictionary<string, global::KRPC.Client.TypeSpec[]> parameterSpecs =
+            new global::System.Collections.Generic.Dictionary<string, global::KRPC.Client.TypeSpec[]> {
+                { "EchoNestedNullableStruct", new global::KRPC.Client.TypeSpec[] { TypeSpecs.Spec10 } },
+                { "EchoListOfNullableObjects", new global::KRPC.Client.TypeSpec[] { TypeSpecs.Spec12 } },
+                { "EchoDictionaryOfNullableObjects", new global::KRPC.Client.TypeSpec[] { TypeSpecs.Spec13 } },
+                { "EchoTupleWithANullableObject", new global::KRPC.Client.TypeSpec[] { TypeSpecs.Spec14 } },
+                { "EchoNestedListOfNullableObjects", new global::KRPC.Client.TypeSpec[] { TypeSpecs.Spec15 } },
+            };
+
+        public static global::KRPC.Client.TypeSpec ReturnSpec (string procedure)
+        {
+            global::KRPC.Client.TypeSpec spec;
+            return returnSpecs.TryGetValue (procedure, out spec) ? spec : null;
+        }
+
+        public static global::KRPC.Client.TypeSpec[] ParameterSpecs (string procedure)
+        {
+            global::KRPC.Client.TypeSpec[] specs;
+            return parameterSpecs.TryGetValue (procedure, out specs) ? specs : null;
+        }
+    }
+
     /// <summary>
     /// TestService service.
     /// </summary>
@@ -50,666 +126,736 @@ namespace KRPC.Client.Services.TestService
             serverConnection.AddExceptionType ("TestService", "DeprecatedException", typeof (DeprecatedException));
         }
 
-        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "AddMultipleValues")]
+        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "AddMultipleValues", typeof(TypeSpecs))]
         public string AddMultipleValues (float x, int y, long z)
         {
             var _args = new ByteString[] {
-                global::KRPC.Client.Encoder.Encode (x, typeof(float)),
-                global::KRPC.Client.Encoder.Encode (y, typeof(int)),
-                global::KRPC.Client.Encoder.Encode (z, typeof(long))
+                global::KRPC.Client.Encoder.Encode (x, TypeSpecs.Spec0),
+                global::KRPC.Client.Encoder.Encode (y, TypeSpecs.Spec2),
+                global::KRPC.Client.Encoder.Encode (z, TypeSpecs.Spec3)
             };
             var _result = connection.Invoke ("TestService", "AddMultipleValues", _args);
-            return (string)global::KRPC.Client.Encoder.Decode (_result.Value, typeof(string), connection);
+            return (string)global::KRPC.Client.Encoder.Decode (_result.Value, TypeSpecs.Spec5, connection);
         }
 
-        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "AddToObjectList")]
+        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "AddToObjectList", typeof(TypeSpecs))]
         public global::System.Collections.Generic.IList<global::KRPC.Client.Services.TestService.TestClass> AddToObjectList (global::System.Collections.Generic.IList<global::KRPC.Client.Services.TestService.TestClass> l, string value)
         {
             var _args = new ByteString[] {
-                global::KRPC.Client.Encoder.Encode (l, typeof(global::System.Collections.Generic.IList<global::KRPC.Client.Services.TestService.TestClass>)),
-                global::KRPC.Client.Encoder.Encode (value, typeof(string))
+                global::KRPC.Client.Encoder.Encode (l, TypeSpecs.Spec28),
+                global::KRPC.Client.Encoder.Encode (value, TypeSpecs.Spec5)
             };
             var _result = connection.Invoke ("TestService", "AddToObjectList", _args);
-            return (global::System.Collections.Generic.IList<global::KRPC.Client.Services.TestService.TestClass>)global::KRPC.Client.Encoder.Decode (_result.Value, typeof(global::System.Collections.Generic.IList<global::KRPC.Client.Services.TestService.TestClass>), connection);
+            return (global::System.Collections.Generic.IList<global::KRPC.Client.Services.TestService.TestClass>)global::KRPC.Client.Encoder.Decode (_result.Value, TypeSpecs.Spec28, connection);
         }
 
-        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "BlockingProcedure")]
+        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "BlockingProcedure", typeof(TypeSpecs))]
         public int BlockingProcedure (int n, int sum = 0)
         {
             var _args = new ByteString[] {
-                global::KRPC.Client.Encoder.Encode (n, typeof(int)),
-                global::KRPC.Client.Encoder.Encode (sum, typeof(int))
+                global::KRPC.Client.Encoder.Encode (n, TypeSpecs.Spec2),
+                global::KRPC.Client.Encoder.Encode (sum, TypeSpecs.Spec2)
             };
             var _result = connection.Invoke ("TestService", "BlockingProcedure", _args);
-            return (int)global::KRPC.Client.Encoder.Decode (_result.Value, typeof(int), connection);
+            return (int)global::KRPC.Client.Encoder.Decode (_result.Value, TypeSpecs.Spec2, connection);
         }
 
-        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "BoolToString")]
+        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "BoolToString", typeof(TypeSpecs))]
         public string BoolToString (bool value)
         {
             var _args = new ByteString[] {
-                global::KRPC.Client.Encoder.Encode (value, typeof(bool))
+                global::KRPC.Client.Encoder.Encode (value, TypeSpecs.Spec4)
             };
             var _result = connection.Invoke ("TestService", "BoolToString", _args);
-            return (string)global::KRPC.Client.Encoder.Decode (_result.Value, typeof(string), connection);
+            return (string)global::KRPC.Client.Encoder.Decode (_result.Value, TypeSpecs.Spec5, connection);
         }
 
-        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "BytesToHexString")]
+        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "BytesToHexString", typeof(TypeSpecs))]
         public string BytesToHexString (byte[] value)
         {
             var _args = new ByteString[] {
-                global::KRPC.Client.Encoder.Encode (value, typeof(byte[]))
+                global::KRPC.Client.Encoder.Encode (value, TypeSpecs.Spec6)
             };
             var _result = connection.Invoke ("TestService", "BytesToHexString", _args);
-            return (string)global::KRPC.Client.Encoder.Decode (_result.Value, typeof(string), connection);
+            return (string)global::KRPC.Client.Encoder.Decode (_result.Value, TypeSpecs.Spec5, connection);
         }
 
-        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "Counter")]
+        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "Counter", typeof(TypeSpecs))]
         public int Counter (string id = "", int divisor = 1)
         {
             var _args = new ByteString[] {
-                global::KRPC.Client.Encoder.Encode (id, typeof(string)),
-                global::KRPC.Client.Encoder.Encode (divisor, typeof(int))
+                global::KRPC.Client.Encoder.Encode (id, TypeSpecs.Spec5),
+                global::KRPC.Client.Encoder.Encode (divisor, TypeSpecs.Spec2)
             };
             var _result = connection.Invoke ("TestService", "Counter", _args);
-            return (int)global::KRPC.Client.Encoder.Decode (_result.Value, typeof(int), connection);
+            return (int)global::KRPC.Client.Encoder.Decode (_result.Value, TypeSpecs.Spec2, connection);
         }
 
         /// <summary>
         /// Returns a struct whose IntField counts the number of times it has been called,
         /// so that a stream on it changes on every update.
         /// </summary>
-        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "CounterStruct")]
+        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "CounterStruct", typeof(TypeSpecs))]
         public global::KRPC.Client.Services.TestService.TestStruct CounterStruct (string id = "")
         {
             var _args = new ByteString[] {
-                global::KRPC.Client.Encoder.Encode (id, typeof(string))
+                global::KRPC.Client.Encoder.Encode (id, TypeSpecs.Spec5)
             };
             var _result = connection.Invoke ("TestService", "CounterStruct", _args);
-            return (global::KRPC.Client.Services.TestService.TestStruct)global::KRPC.Client.Encoder.Decode (_result.Value, typeof(global::KRPC.Client.Services.TestService.TestStruct), connection);
+            return (global::KRPC.Client.Services.TestService.TestStruct)global::KRPC.Client.Encoder.Decode (_result.Value, TypeSpecs.Spec16, connection);
         }
 
-        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "CreateTestObject")]
+        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "CreateTestObject", typeof(TypeSpecs))]
         public global::KRPC.Client.Services.TestService.TestClass CreateTestObject (string value)
         {
             var _args = new ByteString[] {
-                global::KRPC.Client.Encoder.Encode (value, typeof(string))
+                global::KRPC.Client.Encoder.Encode (value, TypeSpecs.Spec5)
             };
             var _result = connection.Invoke ("TestService", "CreateTestObject", _args);
-            return (global::KRPC.Client.Services.TestService.TestClass)global::KRPC.Client.Encoder.Decode (_result.Value, typeof(global::KRPC.Client.Services.TestService.TestClass), connection);
+            return (global::KRPC.Client.Services.TestService.TestClass)global::KRPC.Client.Encoder.Decode (_result.Value, TypeSpecs.Spec7, connection);
         }
 
         /// <summary>
         /// Deprecated procedure documentation string.
         /// </summary>
         [global::System.Obsolete ("Use FloatToString instead.")]
-        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "DeprecatedProcedure")]
+        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "DeprecatedProcedure", typeof(TypeSpecs))]
         public string DeprecatedProcedure (float value)
         {
             var _args = new ByteString[] {
-                global::KRPC.Client.Encoder.Encode (value, typeof(float))
+                global::KRPC.Client.Encoder.Encode (value, TypeSpecs.Spec0)
             };
             var _result = connection.Invoke ("TestService", "DeprecatedProcedure", _args);
-            return (string)global::KRPC.Client.Encoder.Decode (_result.Value, typeof(string), connection);
+            return (string)global::KRPC.Client.Encoder.Decode (_result.Value, TypeSpecs.Spec5, connection);
         }
 
         /// <summary>
         /// Deprecated procedure with no reason documentation string.
         /// </summary>
         [global::System.Obsolete]
-        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "DeprecatedProcedureNoMessage")]
+        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "DeprecatedProcedureNoMessage", typeof(TypeSpecs))]
         public string DeprecatedProcedureNoMessage (float value)
         {
             var _args = new ByteString[] {
-                global::KRPC.Client.Encoder.Encode (value, typeof(float))
+                global::KRPC.Client.Encoder.Encode (value, TypeSpecs.Spec0)
             };
             var _result = connection.Invoke ("TestService", "DeprecatedProcedureNoMessage", _args);
-            return (string)global::KRPC.Client.Encoder.Decode (_result.Value, typeof(string), connection);
+            return (string)global::KRPC.Client.Encoder.Decode (_result.Value, TypeSpecs.Spec5, connection);
         }
 
-        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "DictionaryDefault")]
+        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "DictionaryDefault", typeof(TypeSpecs))]
         public global::System.Collections.Generic.IDictionary<int,bool> DictionaryDefault (global::System.Collections.Generic.IDictionary<int,bool> x = null)
         {
             var _args = new ByteString[] {
-                global::KRPC.Client.Encoder.Encode (x ?? new global::System.Collections.Generic.Dictionary<int,bool> {{ 1, false }, { 2, true }}, typeof(global::System.Collections.Generic.IDictionary<int,bool>))
+                global::KRPC.Client.Encoder.Encode (x ?? new global::System.Collections.Generic.Dictionary<int,bool> {{ 1, false }, { 2, true }}, TypeSpecs.Spec25)
             };
             var _result = connection.Invoke ("TestService", "DictionaryDefault", _args);
-            return (global::System.Collections.Generic.IDictionary<int,bool>)global::KRPC.Client.Encoder.Decode (_result.Value, typeof(global::System.Collections.Generic.IDictionary<int,bool>), connection);
+            return (global::System.Collections.Generic.IDictionary<int,bool>)global::KRPC.Client.Encoder.Decode (_result.Value, TypeSpecs.Spec25, connection);
         }
 
         /// <summary>
         /// Procedure whose defaults are the special values of double.
         /// </summary>
-        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "DoubleSpecialDefaults")]
+        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "DoubleSpecialDefaults", typeof(TypeSpecs))]
         public global::System.Collections.Generic.IList<double> DoubleSpecialDefaults (double nan = double.NaN, double infinity = double.PositiveInfinity, double negativeInfinity = double.NegativeInfinity, double maximum = double.MaxValue, double lowest = double.MinValue)
         {
             var _args = new ByteString[] {
-                global::KRPC.Client.Encoder.Encode (nan, typeof(double)),
-                global::KRPC.Client.Encoder.Encode (infinity, typeof(double)),
-                global::KRPC.Client.Encoder.Encode (negativeInfinity, typeof(double)),
-                global::KRPC.Client.Encoder.Encode (maximum, typeof(double)),
-                global::KRPC.Client.Encoder.Encode (lowest, typeof(double))
+                global::KRPC.Client.Encoder.Encode (nan, TypeSpecs.Spec1),
+                global::KRPC.Client.Encoder.Encode (infinity, TypeSpecs.Spec1),
+                global::KRPC.Client.Encoder.Encode (negativeInfinity, TypeSpecs.Spec1),
+                global::KRPC.Client.Encoder.Encode (maximum, TypeSpecs.Spec1),
+                global::KRPC.Client.Encoder.Encode (lowest, TypeSpecs.Spec1)
             };
             var _result = connection.Invoke ("TestService", "DoubleSpecialDefaults", _args);
-            return (global::System.Collections.Generic.IList<double>)global::KRPC.Client.Encoder.Decode (_result.Value, typeof(global::System.Collections.Generic.IList<double>), connection);
+            return (global::System.Collections.Generic.IList<double>)global::KRPC.Client.Encoder.Decode (_result.Value, TypeSpecs.Spec32, connection);
         }
 
-        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "DoubleToString")]
+        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "DoubleToString", typeof(TypeSpecs))]
         public string DoubleToString (double value)
         {
             var _args = new ByteString[] {
-                global::KRPC.Client.Encoder.Encode (value, typeof(double))
+                global::KRPC.Client.Encoder.Encode (value, TypeSpecs.Spec1)
             };
             var _result = connection.Invoke ("TestService", "DoubleToString", _args);
-            return (string)global::KRPC.Client.Encoder.Decode (_result.Value, typeof(string), connection);
+            return (string)global::KRPC.Client.Encoder.Decode (_result.Value, TypeSpecs.Spec5, connection);
         }
 
-        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "EchoNullableInt")]
+        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "EchoDictionaryOfNullableObjects", typeof(TypeSpecs))]
+        public global::System.Collections.Generic.IDictionary<string,global::KRPC.Client.Services.TestService.TestClass> EchoDictionaryOfNullableObjects (global::System.Collections.Generic.IDictionary<string,global::KRPC.Client.Services.TestService.TestClass> d)
+        {
+            var _args = new ByteString[] {
+                global::KRPC.Client.Encoder.Encode (d, TypeSpecs.Spec13)
+            };
+            var _result = connection.Invoke ("TestService", "EchoDictionaryOfNullableObjects", _args);
+            return (global::System.Collections.Generic.IDictionary<string,global::KRPC.Client.Services.TestService.TestClass>)global::KRPC.Client.Encoder.Decode (_result.Value, TypeSpecs.Spec13, connection);
+        }
+
+        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "EchoListOfNullableInts", typeof(TypeSpecs))]
+        public global::System.Collections.Generic.IList<int?> EchoListOfNullableInts (global::System.Collections.Generic.IList<int?> l)
+        {
+            var _args = new ByteString[] {
+                global::KRPC.Client.Encoder.Encode (l, TypeSpecs.Spec11)
+            };
+            var _result = connection.Invoke ("TestService", "EchoListOfNullableInts", _args);
+            return (global::System.Collections.Generic.IList<int?>)global::KRPC.Client.Encoder.Decode (_result.Value, TypeSpecs.Spec11, connection);
+        }
+
+        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "EchoListOfNullableObjects", typeof(TypeSpecs))]
+        public global::System.Collections.Generic.IList<global::KRPC.Client.Services.TestService.TestClass> EchoListOfNullableObjects (global::System.Collections.Generic.IList<global::KRPC.Client.Services.TestService.TestClass> l)
+        {
+            var _args = new ByteString[] {
+                global::KRPC.Client.Encoder.Encode (l, TypeSpecs.Spec12)
+            };
+            var _result = connection.Invoke ("TestService", "EchoListOfNullableObjects", _args);
+            return (global::System.Collections.Generic.IList<global::KRPC.Client.Services.TestService.TestClass>)global::KRPC.Client.Encoder.Decode (_result.Value, TypeSpecs.Spec12, connection);
+        }
+
+        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "EchoNestedListOfNullableObjects", typeof(TypeSpecs))]
+        public global::System.Collections.Generic.IList<global::System.Collections.Generic.IList<global::KRPC.Client.Services.TestService.TestClass>> EchoNestedListOfNullableObjects (global::System.Collections.Generic.IList<global::System.Collections.Generic.IList<global::KRPC.Client.Services.TestService.TestClass>> l)
+        {
+            var _args = new ByteString[] {
+                global::KRPC.Client.Encoder.Encode (l, TypeSpecs.Spec15)
+            };
+            var _result = connection.Invoke ("TestService", "EchoNestedListOfNullableObjects", _args);
+            return (global::System.Collections.Generic.IList<global::System.Collections.Generic.IList<global::KRPC.Client.Services.TestService.TestClass>>)global::KRPC.Client.Encoder.Decode (_result.Value, TypeSpecs.Spec15, connection);
+        }
+
+        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "EchoNestedNullableStruct", typeof(TypeSpecs))]
+        public global::KRPC.Client.Services.TestService.TestNestedNullableStruct EchoNestedNullableStruct (global::KRPC.Client.Services.TestService.TestNestedNullableStruct value)
+        {
+            var _args = new ByteString[] {
+                global::KRPC.Client.Encoder.Encode (value, TypeSpecs.Spec10)
+            };
+            var _result = connection.Invoke ("TestService", "EchoNestedNullableStruct", _args);
+            return (global::KRPC.Client.Services.TestService.TestNestedNullableStruct)global::KRPC.Client.Encoder.Decode (_result.Value, TypeSpecs.Spec10, connection);
+        }
+
+        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "EchoNullableInt", typeof(TypeSpecs))]
         public int? EchoNullableInt (int? value)
         {
             var _args = new ByteString[] {
-                global::KRPC.Client.Encoder.Encode (value, typeof(int?))
+                global::KRPC.Client.Encoder.Encode (value, TypeSpecs.Spec2)
             };
             var _result = connection.Invoke ("TestService", "EchoNullableInt", _args);
             if (_result.IsNull)
                 return null;
-            return (int?)global::KRPC.Client.Encoder.Decode (_result.Value, typeof(int?), connection);
+            return (int?)global::KRPC.Client.Encoder.Decode (_result.Value, TypeSpecs.Spec2, connection);
         }
 
-        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "EchoNullableList")]
+        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "EchoNullableList", typeof(TypeSpecs))]
         public global::System.Collections.Generic.IList<int> EchoNullableList (global::System.Collections.Generic.IList<int> l)
         {
             var _args = new ByteString[] {
-                global::KRPC.Client.Encoder.Encode (l, typeof(global::System.Collections.Generic.IList<int>))
+                global::KRPC.Client.Encoder.Encode (l, TypeSpecs.Spec8)
             };
             var _result = connection.Invoke ("TestService", "EchoNullableList", _args);
             if (_result.IsNull)
                 return null;
-            return (global::System.Collections.Generic.IList<int>)global::KRPC.Client.Encoder.Decode (_result.Value, typeof(global::System.Collections.Generic.IList<int>), connection);
+            return (global::System.Collections.Generic.IList<int>)global::KRPC.Client.Encoder.Decode (_result.Value, TypeSpecs.Spec8, connection);
         }
 
-        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "EchoNullableString")]
+        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "EchoNullableString", typeof(TypeSpecs))]
         public string EchoNullableString (string value)
         {
             var _args = new ByteString[] {
-                global::KRPC.Client.Encoder.Encode (value, typeof(string))
+                global::KRPC.Client.Encoder.Encode (value, TypeSpecs.Spec5)
             };
             var _result = connection.Invoke ("TestService", "EchoNullableString", _args);
             if (_result.IsNull)
                 return null;
-            return (string)global::KRPC.Client.Encoder.Decode (_result.Value, typeof(string), connection);
+            return (string)global::KRPC.Client.Encoder.Decode (_result.Value, TypeSpecs.Spec5, connection);
         }
 
-        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "EchoTestObject")]
+        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "EchoTestObject", typeof(TypeSpecs))]
         public global::KRPC.Client.Services.TestService.TestClass EchoTestObject (global::KRPC.Client.Services.TestService.TestClass value)
         {
             var _args = new ByteString[] {
-                global::KRPC.Client.Encoder.Encode (value, typeof(global::KRPC.Client.Services.TestService.TestClass))
+                global::KRPC.Client.Encoder.Encode (value, TypeSpecs.Spec7)
             };
             var _result = connection.Invoke ("TestService", "EchoTestObject", _args);
             if (_result.IsNull)
                 return null;
-            return (global::KRPC.Client.Services.TestService.TestClass)global::KRPC.Client.Encoder.Decode (_result.Value, typeof(global::KRPC.Client.Services.TestService.TestClass), connection);
+            return (global::KRPC.Client.Services.TestService.TestClass)global::KRPC.Client.Encoder.Decode (_result.Value, TypeSpecs.Spec7, connection);
         }
 
-        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "EmptyListDefault")]
+        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "EchoTupleWithANullableObject", typeof(TypeSpecs))]
+        public systemAlias::Tuple<int,global::KRPC.Client.Services.TestService.TestClass> EchoTupleWithANullableObject (systemAlias::Tuple<int,global::KRPC.Client.Services.TestService.TestClass> t)
+        {
+            var _args = new ByteString[] {
+                global::KRPC.Client.Encoder.Encode (t, TypeSpecs.Spec14)
+            };
+            var _result = connection.Invoke ("TestService", "EchoTupleWithANullableObject", _args);
+            return (systemAlias::Tuple<int,global::KRPC.Client.Services.TestService.TestClass>)global::KRPC.Client.Encoder.Decode (_result.Value, TypeSpecs.Spec14, connection);
+        }
+
+        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "EmptyListDefault", typeof(TypeSpecs))]
         public global::System.Collections.Generic.IList<string> EmptyListDefault (global::System.Collections.Generic.IList<string> x = null)
         {
             var _args = new ByteString[] {
-                global::KRPC.Client.Encoder.Encode (x ?? new global::System.Collections.Generic.List<string> {  }, typeof(global::System.Collections.Generic.IList<string>))
+                global::KRPC.Client.Encoder.Encode (x ?? new global::System.Collections.Generic.List<string> {  }, TypeSpecs.Spec27)
             };
             var _result = connection.Invoke ("TestService", "EmptyListDefault", _args);
-            return (global::System.Collections.Generic.IList<string>)global::KRPC.Client.Encoder.Decode (_result.Value, typeof(global::System.Collections.Generic.IList<string>), connection);
+            return (global::System.Collections.Generic.IList<string>)global::KRPC.Client.Encoder.Decode (_result.Value, TypeSpecs.Spec27, connection);
         }
 
-        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "EnumDefaultArg")]
+        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "EnumDefaultArg", typeof(TypeSpecs))]
         public global::KRPC.Client.Services.TestService.TestEnum EnumDefaultArg (global::KRPC.Client.Services.TestService.TestEnum x = global::KRPC.Client.Services.TestService.TestEnum.ValueC)
         {
             var _args = new ByteString[] {
-                global::KRPC.Client.Encoder.Encode (x, typeof(global::KRPC.Client.Services.TestService.TestEnum))
+                global::KRPC.Client.Encoder.Encode (x, TypeSpecs.Spec9)
             };
             var _result = connection.Invoke ("TestService", "EnumDefaultArg", _args);
-            return (global::KRPC.Client.Services.TestService.TestEnum)global::KRPC.Client.Encoder.Decode (_result.Value, typeof(global::KRPC.Client.Services.TestService.TestEnum), connection);
+            return (global::KRPC.Client.Services.TestService.TestEnum)global::KRPC.Client.Encoder.Decode (_result.Value, TypeSpecs.Spec9, connection);
         }
 
-        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "EnumEcho")]
+        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "EnumEcho", typeof(TypeSpecs))]
         public global::KRPC.Client.Services.TestService.TestEnum EnumEcho (global::KRPC.Client.Services.TestService.TestEnum x)
         {
             var _args = new ByteString[] {
-                global::KRPC.Client.Encoder.Encode (x, typeof(global::KRPC.Client.Services.TestService.TestEnum))
+                global::KRPC.Client.Encoder.Encode (x, TypeSpecs.Spec9)
             };
             var _result = connection.Invoke ("TestService", "EnumEcho", _args);
-            return (global::KRPC.Client.Services.TestService.TestEnum)global::KRPC.Client.Encoder.Decode (_result.Value, typeof(global::KRPC.Client.Services.TestService.TestEnum), connection);
+            return (global::KRPC.Client.Services.TestService.TestEnum)global::KRPC.Client.Encoder.Decode (_result.Value, TypeSpecs.Spec9, connection);
         }
 
-        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "EnumListDefault")]
+        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "EnumListDefault", typeof(TypeSpecs))]
         public global::System.Collections.Generic.IList<global::KRPC.Client.Services.TestService.TestEnum> EnumListDefault (global::System.Collections.Generic.IList<global::KRPC.Client.Services.TestService.TestEnum> x = null)
         {
             var _args = new ByteString[] {
-                global::KRPC.Client.Encoder.Encode (x ?? new global::System.Collections.Generic.List<global::KRPC.Client.Services.TestService.TestEnum> { global::KRPC.Client.Services.TestService.TestEnum.ValueB, global::KRPC.Client.Services.TestService.TestEnum.ValueC }, typeof(global::System.Collections.Generic.IList<global::KRPC.Client.Services.TestService.TestEnum>))
+                global::KRPC.Client.Encoder.Encode (x ?? new global::System.Collections.Generic.List<global::KRPC.Client.Services.TestService.TestEnum> { global::KRPC.Client.Services.TestService.TestEnum.ValueB, global::KRPC.Client.Services.TestService.TestEnum.ValueC }, TypeSpecs.Spec26)
             };
             var _result = connection.Invoke ("TestService", "EnumListDefault", _args);
-            return (global::System.Collections.Generic.IList<global::KRPC.Client.Services.TestService.TestEnum>)global::KRPC.Client.Encoder.Decode (_result.Value, typeof(global::System.Collections.Generic.IList<global::KRPC.Client.Services.TestService.TestEnum>), connection);
+            return (global::System.Collections.Generic.IList<global::KRPC.Client.Services.TestService.TestEnum>)global::KRPC.Client.Encoder.Decode (_result.Value, TypeSpecs.Spec26, connection);
         }
 
-        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "EnumReturn")]
+        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "EnumReturn", typeof(TypeSpecs))]
         public global::KRPC.Client.Services.TestService.TestEnum EnumReturn ()
         {
             var _result = connection.Invoke ("TestService", "EnumReturn");
-            return (global::KRPC.Client.Services.TestService.TestEnum)global::KRPC.Client.Encoder.Decode (_result.Value, typeof(global::KRPC.Client.Services.TestService.TestEnum), connection);
+            return (global::KRPC.Client.Services.TestService.TestEnum)global::KRPC.Client.Encoder.Decode (_result.Value, TypeSpecs.Spec9, connection);
         }
 
         /// <summary>
         /// Procedure whose defaults are the special values of float, plus a finite fraction
         /// that no float can hold exactly.
         /// </summary>
-        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "FloatSpecialDefaults")]
+        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "FloatSpecialDefaults", typeof(TypeSpecs))]
         public global::System.Collections.Generic.IList<float> FloatSpecialDefaults (float nan = float.NaN, float infinity = float.PositiveInfinity, float negativeInfinity = float.NegativeInfinity, float maximum = float.MaxValue, float lowest = float.MinValue, float fraction = 0.1f)
         {
             var _args = new ByteString[] {
-                global::KRPC.Client.Encoder.Encode (nan, typeof(float)),
-                global::KRPC.Client.Encoder.Encode (infinity, typeof(float)),
-                global::KRPC.Client.Encoder.Encode (negativeInfinity, typeof(float)),
-                global::KRPC.Client.Encoder.Encode (maximum, typeof(float)),
-                global::KRPC.Client.Encoder.Encode (lowest, typeof(float)),
-                global::KRPC.Client.Encoder.Encode (fraction, typeof(float))
+                global::KRPC.Client.Encoder.Encode (nan, TypeSpecs.Spec0),
+                global::KRPC.Client.Encoder.Encode (infinity, TypeSpecs.Spec0),
+                global::KRPC.Client.Encoder.Encode (negativeInfinity, TypeSpecs.Spec0),
+                global::KRPC.Client.Encoder.Encode (maximum, TypeSpecs.Spec0),
+                global::KRPC.Client.Encoder.Encode (lowest, TypeSpecs.Spec0),
+                global::KRPC.Client.Encoder.Encode (fraction, TypeSpecs.Spec0)
             };
             var _result = connection.Invoke ("TestService", "FloatSpecialDefaults", _args);
-            return (global::System.Collections.Generic.IList<float>)global::KRPC.Client.Encoder.Decode (_result.Value, typeof(global::System.Collections.Generic.IList<float>), connection);
+            return (global::System.Collections.Generic.IList<float>)global::KRPC.Client.Encoder.Decode (_result.Value, TypeSpecs.Spec33, connection);
         }
 
         /// <summary>
         /// Procedure documentation string.
         /// </summary>
-        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "FloatToString")]
+        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "FloatToString", typeof(TypeSpecs))]
         public string FloatToString (float value)
         {
             var _args = new ByteString[] {
-                global::KRPC.Client.Encoder.Encode (value, typeof(float))
+                global::KRPC.Client.Encoder.Encode (value, TypeSpecs.Spec0)
             };
             var _result = connection.Invoke ("TestService", "FloatToString", _args);
-            return (string)global::KRPC.Client.Encoder.Decode (_result.Value, typeof(string), connection);
+            return (string)global::KRPC.Client.Encoder.Decode (_result.Value, TypeSpecs.Spec5, connection);
         }
 
-        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "IncrementDictionary")]
+        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "IncrementDictionary", typeof(TypeSpecs))]
         public global::System.Collections.Generic.IDictionary<string,int> IncrementDictionary (global::System.Collections.Generic.IDictionary<string,int> d)
         {
             var _args = new ByteString[] {
-                global::KRPC.Client.Encoder.Encode (d, typeof(global::System.Collections.Generic.IDictionary<string,int>))
+                global::KRPC.Client.Encoder.Encode (d, TypeSpecs.Spec20)
             };
             var _result = connection.Invoke ("TestService", "IncrementDictionary", _args);
-            return (global::System.Collections.Generic.IDictionary<string,int>)global::KRPC.Client.Encoder.Decode (_result.Value, typeof(global::System.Collections.Generic.IDictionary<string,int>), connection);
+            return (global::System.Collections.Generic.IDictionary<string,int>)global::KRPC.Client.Encoder.Decode (_result.Value, TypeSpecs.Spec20, connection);
         }
 
-        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "IncrementList")]
+        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "IncrementList", typeof(TypeSpecs))]
         public global::System.Collections.Generic.IList<int> IncrementList (global::System.Collections.Generic.IList<int> l)
         {
             var _args = new ByteString[] {
-                global::KRPC.Client.Encoder.Encode (l, typeof(global::System.Collections.Generic.IList<int>))
+                global::KRPC.Client.Encoder.Encode (l, TypeSpecs.Spec8)
             };
             var _result = connection.Invoke ("TestService", "IncrementList", _args);
-            return (global::System.Collections.Generic.IList<int>)global::KRPC.Client.Encoder.Decode (_result.Value, typeof(global::System.Collections.Generic.IList<int>), connection);
+            return (global::System.Collections.Generic.IList<int>)global::KRPC.Client.Encoder.Decode (_result.Value, TypeSpecs.Spec8, connection);
         }
 
-        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "IncrementListOfStructs")]
+        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "IncrementListOfStructs", typeof(TypeSpecs))]
         public global::System.Collections.Generic.IList<global::KRPC.Client.Services.TestService.TestStruct> IncrementListOfStructs (global::System.Collections.Generic.IList<global::KRPC.Client.Services.TestService.TestStruct> l)
         {
             var _args = new ByteString[] {
-                global::KRPC.Client.Encoder.Encode (l, typeof(global::System.Collections.Generic.IList<global::KRPC.Client.Services.TestService.TestStruct>))
+                global::KRPC.Client.Encoder.Encode (l, TypeSpecs.Spec19)
             };
             var _result = connection.Invoke ("TestService", "IncrementListOfStructs", _args);
-            return (global::System.Collections.Generic.IList<global::KRPC.Client.Services.TestService.TestStruct>)global::KRPC.Client.Encoder.Decode (_result.Value, typeof(global::System.Collections.Generic.IList<global::KRPC.Client.Services.TestService.TestStruct>), connection);
+            return (global::System.Collections.Generic.IList<global::KRPC.Client.Services.TestService.TestStruct>)global::KRPC.Client.Encoder.Decode (_result.Value, TypeSpecs.Spec19, connection);
         }
 
-        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "IncrementNestedCollection")]
+        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "IncrementNestedCollection", typeof(TypeSpecs))]
         public global::System.Collections.Generic.IDictionary<string,global::System.Collections.Generic.IList<int>> IncrementNestedCollection (global::System.Collections.Generic.IDictionary<string,global::System.Collections.Generic.IList<int>> d)
         {
             var _args = new ByteString[] {
-                global::KRPC.Client.Encoder.Encode (d, typeof(global::System.Collections.Generic.IDictionary<string,global::System.Collections.Generic.IList<int>>))
+                global::KRPC.Client.Encoder.Encode (d, TypeSpecs.Spec23)
             };
             var _result = connection.Invoke ("TestService", "IncrementNestedCollection", _args);
-            return (global::System.Collections.Generic.IDictionary<string,global::System.Collections.Generic.IList<int>>)global::KRPC.Client.Encoder.Decode (_result.Value, typeof(global::System.Collections.Generic.IDictionary<string,global::System.Collections.Generic.IList<int>>), connection);
+            return (global::System.Collections.Generic.IDictionary<string,global::System.Collections.Generic.IList<int>>)global::KRPC.Client.Encoder.Decode (_result.Value, TypeSpecs.Spec23, connection);
         }
 
-        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "IncrementSet")]
+        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "IncrementSet", typeof(TypeSpecs))]
         public genericCollectionsAlias::ISet<int> IncrementSet (genericCollectionsAlias::ISet<int> h)
         {
             var _args = new ByteString[] {
-                global::KRPC.Client.Encoder.Encode (h, typeof(genericCollectionsAlias::ISet<int>))
+                global::KRPC.Client.Encoder.Encode (h, TypeSpecs.Spec21)
             };
             var _result = connection.Invoke ("TestService", "IncrementSet", _args);
-            return (genericCollectionsAlias::ISet<int>)global::KRPC.Client.Encoder.Decode (_result.Value, typeof(genericCollectionsAlias::ISet<int>), connection);
+            return (genericCollectionsAlias::ISet<int>)global::KRPC.Client.Encoder.Decode (_result.Value, TypeSpecs.Spec21, connection);
         }
 
-        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "IncrementTuple")]
+        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "IncrementTuple", typeof(TypeSpecs))]
         public systemAlias::Tuple<int,long> IncrementTuple (systemAlias::Tuple<int,long> t)
         {
             var _args = new ByteString[] {
-                global::KRPC.Client.Encoder.Encode (t, typeof(systemAlias::Tuple<int,long>))
+                global::KRPC.Client.Encoder.Encode (t, TypeSpecs.Spec22)
             };
             var _result = connection.Invoke ("TestService", "IncrementTuple", _args);
-            return (systemAlias::Tuple<int,long>)global::KRPC.Client.Encoder.Decode (_result.Value, typeof(systemAlias::Tuple<int,long>), connection);
+            return (systemAlias::Tuple<int,long>)global::KRPC.Client.Encoder.Decode (_result.Value, TypeSpecs.Spec22, connection);
         }
 
         /// <summary>
         /// Procedure whose defaults are the extremes of int.
         /// </summary>
-        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "Int32SpecialDefaults")]
+        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "Int32SpecialDefaults", typeof(TypeSpecs))]
         public global::System.Collections.Generic.IList<int> Int32SpecialDefaults (int maximum = int.MaxValue, int minimum = int.MinValue)
         {
             var _args = new ByteString[] {
-                global::KRPC.Client.Encoder.Encode (maximum, typeof(int)),
-                global::KRPC.Client.Encoder.Encode (minimum, typeof(int))
+                global::KRPC.Client.Encoder.Encode (maximum, TypeSpecs.Spec2),
+                global::KRPC.Client.Encoder.Encode (minimum, TypeSpecs.Spec2)
             };
             var _result = connection.Invoke ("TestService", "Int32SpecialDefaults", _args);
-            return (global::System.Collections.Generic.IList<int>)global::KRPC.Client.Encoder.Decode (_result.Value, typeof(global::System.Collections.Generic.IList<int>), connection);
+            return (global::System.Collections.Generic.IList<int>)global::KRPC.Client.Encoder.Decode (_result.Value, TypeSpecs.Spec8, connection);
         }
 
-        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "Int32ToString")]
+        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "Int32ToString", typeof(TypeSpecs))]
         public string Int32ToString (int value)
         {
             var _args = new ByteString[] {
-                global::KRPC.Client.Encoder.Encode (value, typeof(int))
+                global::KRPC.Client.Encoder.Encode (value, TypeSpecs.Spec2)
             };
             var _result = connection.Invoke ("TestService", "Int32ToString", _args);
-            return (string)global::KRPC.Client.Encoder.Decode (_result.Value, typeof(string), connection);
+            return (string)global::KRPC.Client.Encoder.Decode (_result.Value, TypeSpecs.Spec5, connection);
         }
 
         /// <summary>
         /// Procedure whose defaults are the extremes of long.
         /// </summary>
-        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "Int64SpecialDefaults")]
+        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "Int64SpecialDefaults", typeof(TypeSpecs))]
         public global::System.Collections.Generic.IList<long> Int64SpecialDefaults (long maximum = long.MaxValue, long minimum = long.MinValue)
         {
             var _args = new ByteString[] {
-                global::KRPC.Client.Encoder.Encode (maximum, typeof(long)),
-                global::KRPC.Client.Encoder.Encode (minimum, typeof(long))
+                global::KRPC.Client.Encoder.Encode (maximum, TypeSpecs.Spec3),
+                global::KRPC.Client.Encoder.Encode (minimum, TypeSpecs.Spec3)
             };
             var _result = connection.Invoke ("TestService", "Int64SpecialDefaults", _args);
-            return (global::System.Collections.Generic.IList<long>)global::KRPC.Client.Encoder.Decode (_result.Value, typeof(global::System.Collections.Generic.IList<long>), connection);
+            return (global::System.Collections.Generic.IList<long>)global::KRPC.Client.Encoder.Decode (_result.Value, TypeSpecs.Spec34, connection);
         }
 
-        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "Int64ToString")]
+        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "Int64ToString", typeof(TypeSpecs))]
         public string Int64ToString (long value)
         {
             var _args = new ByteString[] {
-                global::KRPC.Client.Encoder.Encode (value, typeof(long))
+                global::KRPC.Client.Encoder.Encode (value, TypeSpecs.Spec3)
             };
             var _result = connection.Invoke ("TestService", "Int64ToString", _args);
-            return (string)global::KRPC.Client.Encoder.Decode (_result.Value, typeof(string), connection);
+            return (string)global::KRPC.Client.Encoder.Decode (_result.Value, TypeSpecs.Spec5, connection);
         }
 
-        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "ListDefault")]
+        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "ListDefault", typeof(TypeSpecs))]
         public global::System.Collections.Generic.IList<int> ListDefault (global::System.Collections.Generic.IList<int> x = null)
         {
             var _args = new ByteString[] {
-                global::KRPC.Client.Encoder.Encode (x ?? new global::System.Collections.Generic.List<int> { 1, 2, 3 }, typeof(global::System.Collections.Generic.IList<int>))
+                global::KRPC.Client.Encoder.Encode (x ?? new global::System.Collections.Generic.List<int> { 1, 2, 3 }, TypeSpecs.Spec8)
             };
             var _result = connection.Invoke ("TestService", "ListDefault", _args);
-            return (global::System.Collections.Generic.IList<int>)global::KRPC.Client.Encoder.Decode (_result.Value, typeof(global::System.Collections.Generic.IList<int>), connection);
+            return (global::System.Collections.Generic.IList<int>)global::KRPC.Client.Encoder.Decode (_result.Value, TypeSpecs.Spec8, connection);
         }
 
-        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "NestedStructEcho")]
+        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "NestedStructEcho", typeof(TypeSpecs))]
         public global::KRPC.Client.Services.TestService.TestNestedStruct NestedStructEcho (global::KRPC.Client.Services.TestService.TestNestedStruct x)
         {
             var _args = new ByteString[] {
-                global::KRPC.Client.Encoder.Encode (x, typeof(global::KRPC.Client.Services.TestService.TestNestedStruct))
+                global::KRPC.Client.Encoder.Encode (x, TypeSpecs.Spec18)
             };
             var _result = connection.Invoke ("TestService", "NestedStructEcho", _args);
-            return (global::KRPC.Client.Services.TestService.TestNestedStruct)global::KRPC.Client.Encoder.Decode (_result.Value, typeof(global::KRPC.Client.Services.TestService.TestNestedStruct), connection);
+            return (global::KRPC.Client.Services.TestService.TestNestedStruct)global::KRPC.Client.Encoder.Decode (_result.Value, TypeSpecs.Spec18, connection);
         }
 
-        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "NotNullableObject")]
+        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "NotNullableObject", typeof(TypeSpecs))]
         public global::KRPC.Client.Services.TestService.TestClass NotNullableObject (global::KRPC.Client.Services.TestService.TestClass value)
         {
             var _args = new ByteString[] {
-                global::KRPC.Client.Encoder.Encode (value, typeof(global::KRPC.Client.Services.TestService.TestClass))
+                global::KRPC.Client.Encoder.Encode (value, TypeSpecs.Spec7)
             };
             var _result = connection.Invoke ("TestService", "NotNullableObject", _args);
-            return (global::KRPC.Client.Services.TestService.TestClass)global::KRPC.Client.Encoder.Decode (_result.Value, typeof(global::KRPC.Client.Services.TestService.TestClass), connection);
+            return (global::KRPC.Client.Services.TestService.TestClass)global::KRPC.Client.Encoder.Decode (_result.Value, TypeSpecs.Spec7, connection);
         }
 
-        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "OnTimer")]
+        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "NullableStructEcho", typeof(TypeSpecs))]
+        public global::KRPC.Client.Services.TestService.TestNullableStruct NullableStructEcho (global::KRPC.Client.Services.TestService.TestNullableStruct x)
+        {
+            var _args = new ByteString[] {
+                global::KRPC.Client.Encoder.Encode (x, TypeSpecs.Spec17)
+            };
+            var _result = connection.Invoke ("TestService", "NullableStructEcho", _args);
+            return (global::KRPC.Client.Services.TestService.TestNullableStruct)global::KRPC.Client.Encoder.Decode (_result.Value, TypeSpecs.Spec17, connection);
+        }
+
+        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "OnTimer", typeof(TypeSpecs))]
         public global::KRPC.Client.Event OnTimer (uint milliseconds, uint repeats = 1)
         {
             var _args = new ByteString[] {
-                global::KRPC.Client.Encoder.Encode (milliseconds, typeof(uint)),
-                global::KRPC.Client.Encoder.Encode (repeats, typeof(uint))
+                global::KRPC.Client.Encoder.Encode (milliseconds, TypeSpecs.Spec29),
+                global::KRPC.Client.Encoder.Encode (repeats, TypeSpecs.Spec29)
             };
             var _result = connection.Invoke ("TestService", "OnTimer", _args);
-            return (global::KRPC.Client.Event)global::KRPC.Client.Encoder.Decode (_result.Value, typeof(global::KRPC.Client.Event), connection);
+            return (global::KRPC.Client.Event)global::KRPC.Client.Encoder.Decode (_result.Value, TypeSpecs.Spec35, connection);
         }
 
-        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "OnTimerUsingLambda")]
+        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "OnTimerUsingLambda", typeof(TypeSpecs))]
         public global::KRPC.Client.Event OnTimerUsingLambda (uint milliseconds)
         {
             var _args = new ByteString[] {
-                global::KRPC.Client.Encoder.Encode (milliseconds, typeof(uint))
+                global::KRPC.Client.Encoder.Encode (milliseconds, TypeSpecs.Spec29)
             };
             var _result = connection.Invoke ("TestService", "OnTimerUsingLambda", _args);
-            return (global::KRPC.Client.Event)global::KRPC.Client.Encoder.Decode (_result.Value, typeof(global::KRPC.Client.Event), connection);
+            return (global::KRPC.Client.Event)global::KRPC.Client.Encoder.Decode (_result.Value, TypeSpecs.Spec35, connection);
         }
 
-        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "OptionalArguments")]
+        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "OptionalArguments", typeof(TypeSpecs))]
         public string OptionalArguments (string x, string y = "foo", string z = "bar", global::KRPC.Client.Services.TestService.TestClass obj = null)
         {
             var _args = new ByteString[] {
-                global::KRPC.Client.Encoder.Encode (x, typeof(string)),
-                global::KRPC.Client.Encoder.Encode (y, typeof(string)),
-                global::KRPC.Client.Encoder.Encode (z, typeof(string)),
-                global::KRPC.Client.Encoder.Encode (obj, typeof(global::KRPC.Client.Services.TestService.TestClass))
+                global::KRPC.Client.Encoder.Encode (x, TypeSpecs.Spec5),
+                global::KRPC.Client.Encoder.Encode (y, TypeSpecs.Spec5),
+                global::KRPC.Client.Encoder.Encode (z, TypeSpecs.Spec5),
+                global::KRPC.Client.Encoder.Encode (obj, TypeSpecs.Spec7)
             };
             var _result = connection.Invoke ("TestService", "OptionalArguments", _args);
-            return (string)global::KRPC.Client.Encoder.Decode (_result.Value, typeof(string), connection);
+            return (string)global::KRPC.Client.Encoder.Decode (_result.Value, TypeSpecs.Spec5, connection);
         }
 
-        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "ResetCustomExceptionLater")]
+        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "ResetCustomExceptionLater", typeof(TypeSpecs))]
         public void ResetCustomExceptionLater ()
         {
             connection.Invoke ("TestService", "ResetCustomExceptionLater");
         }
 
-        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "ResetInvalidOperationExceptionLater")]
+        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "ResetInvalidOperationExceptionLater", typeof(TypeSpecs))]
         public void ResetInvalidOperationExceptionLater ()
         {
             connection.Invoke ("TestService", "ResetInvalidOperationExceptionLater");
         }
 
-        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "ReturnNullWhenNotAllowed")]
+        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "ReturnNullWhenNotAllowed", typeof(TypeSpecs))]
         public global::KRPC.Client.Services.TestService.TestClass ReturnNullWhenNotAllowed ()
         {
             var _result = connection.Invoke ("TestService", "ReturnNullWhenNotAllowed");
-            return (global::KRPC.Client.Services.TestService.TestClass)global::KRPC.Client.Encoder.Decode (_result.Value, typeof(global::KRPC.Client.Services.TestService.TestClass), connection);
+            return (global::KRPC.Client.Services.TestService.TestClass)global::KRPC.Client.Encoder.Decode (_result.Value, TypeSpecs.Spec7, connection);
         }
 
-        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "SetDefault")]
+        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "SetDefault", typeof(TypeSpecs))]
         public genericCollectionsAlias::ISet<int> SetDefault (genericCollectionsAlias::ISet<int> x = null)
         {
             var _args = new ByteString[] {
-                global::KRPC.Client.Encoder.Encode (x ?? new global::System.Collections.Generic.HashSet<int> { 1, 2, 3 }, typeof(genericCollectionsAlias::ISet<int>))
+                global::KRPC.Client.Encoder.Encode (x ?? new global::System.Collections.Generic.HashSet<int> { 1, 2, 3 }, TypeSpecs.Spec21)
             };
             var _result = connection.Invoke ("TestService", "SetDefault", _args);
-            return (genericCollectionsAlias::ISet<int>)global::KRPC.Client.Encoder.Decode (_result.Value, typeof(genericCollectionsAlias::ISet<int>), connection);
+            return (genericCollectionsAlias::ISet<int>)global::KRPC.Client.Encoder.Decode (_result.Value, TypeSpecs.Spec21, connection);
         }
 
-        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "StringToInt32")]
+        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "StringToInt32", typeof(TypeSpecs))]
         public int StringToInt32 (string value)
         {
             var _args = new ByteString[] {
-                global::KRPC.Client.Encoder.Encode (value, typeof(string))
+                global::KRPC.Client.Encoder.Encode (value, TypeSpecs.Spec5)
             };
             var _result = connection.Invoke ("TestService", "StringToInt32", _args);
-            return (int)global::KRPC.Client.Encoder.Decode (_result.Value, typeof(int), connection);
+            return (int)global::KRPC.Client.Encoder.Decode (_result.Value, TypeSpecs.Spec2, connection);
         }
 
-        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "StructDefault")]
+        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "StructDefault", typeof(TypeSpecs))]
         public global::KRPC.Client.Services.TestService.TestStruct StructDefault (global::KRPC.Client.Services.TestService.TestStruct? x = null)
         {
             var _args = new ByteString[] {
-                global::KRPC.Client.Encoder.Encode (x ?? new global::KRPC.Client.Services.TestService.TestStruct (42, "jeb", global::KRPC.Client.Services.TestService.TestEnum.ValueB, new global::System.Collections.Generic.List<int> { 1, 2, 3 }), typeof(global::KRPC.Client.Services.TestService.TestStruct?))
+                global::KRPC.Client.Encoder.Encode (x ?? new global::KRPC.Client.Services.TestService.TestStruct (42, "jeb", global::KRPC.Client.Services.TestService.TestEnum.ValueB, new global::System.Collections.Generic.List<int> { 1, 2, 3 }), TypeSpecs.Spec16)
             };
             var _result = connection.Invoke ("TestService", "StructDefault", _args);
-            return (global::KRPC.Client.Services.TestService.TestStruct)global::KRPC.Client.Encoder.Decode (_result.Value, typeof(global::KRPC.Client.Services.TestService.TestStruct), connection);
+            return (global::KRPC.Client.Services.TestService.TestStruct)global::KRPC.Client.Encoder.Decode (_result.Value, TypeSpecs.Spec16, connection);
         }
 
-        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "StructEcho")]
+        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "StructEcho", typeof(TypeSpecs))]
         public global::KRPC.Client.Services.TestService.TestStruct StructEcho (global::KRPC.Client.Services.TestService.TestStruct x)
         {
             var _args = new ByteString[] {
-                global::KRPC.Client.Encoder.Encode (x, typeof(global::KRPC.Client.Services.TestService.TestStruct))
+                global::KRPC.Client.Encoder.Encode (x, TypeSpecs.Spec16)
             };
             var _result = connection.Invoke ("TestService", "StructEcho", _args);
-            return (global::KRPC.Client.Services.TestService.TestStruct)global::KRPC.Client.Encoder.Decode (_result.Value, typeof(global::KRPC.Client.Services.TestService.TestStruct), connection);
+            return (global::KRPC.Client.Services.TestService.TestStruct)global::KRPC.Client.Encoder.Decode (_result.Value, TypeSpecs.Spec16, connection);
         }
 
-        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "StructEchoNullable")]
+        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "StructEchoNullable", typeof(TypeSpecs))]
         public global::KRPC.Client.Services.TestService.TestStruct? StructEchoNullable (global::KRPC.Client.Services.TestService.TestStruct? x)
         {
             var _args = new ByteString[] {
-                global::KRPC.Client.Encoder.Encode (x, typeof(global::KRPC.Client.Services.TestService.TestStruct?))
+                global::KRPC.Client.Encoder.Encode (x, TypeSpecs.Spec16)
             };
             var _result = connection.Invoke ("TestService", "StructEchoNullable", _args);
             if (_result.IsNull)
                 return null;
-            return (global::KRPC.Client.Services.TestService.TestStruct?)global::KRPC.Client.Encoder.Decode (_result.Value, typeof(global::KRPC.Client.Services.TestService.TestStruct?), connection);
+            return (global::KRPC.Client.Services.TestService.TestStruct?)global::KRPC.Client.Encoder.Decode (_result.Value, TypeSpecs.Spec16, connection);
         }
 
-        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "ThrowArgumentException")]
+        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "ThrowArgumentException", typeof(TypeSpecs))]
         public int ThrowArgumentException ()
         {
             var _result = connection.Invoke ("TestService", "ThrowArgumentException");
-            return (int)global::KRPC.Client.Encoder.Decode (_result.Value, typeof(int), connection);
+            return (int)global::KRPC.Client.Encoder.Decode (_result.Value, TypeSpecs.Spec2, connection);
         }
 
-        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "ThrowArgumentNullException")]
+        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "ThrowArgumentNullException", typeof(TypeSpecs))]
         public int ThrowArgumentNullException (string foo)
         {
             var _args = new ByteString[] {
-                global::KRPC.Client.Encoder.Encode (foo, typeof(string))
+                global::KRPC.Client.Encoder.Encode (foo, TypeSpecs.Spec5)
             };
             var _result = connection.Invoke ("TestService", "ThrowArgumentNullException", _args);
-            return (int)global::KRPC.Client.Encoder.Decode (_result.Value, typeof(int), connection);
+            return (int)global::KRPC.Client.Encoder.Decode (_result.Value, TypeSpecs.Spec2, connection);
         }
 
-        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "ThrowArgumentOutOfRangeException")]
+        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "ThrowArgumentOutOfRangeException", typeof(TypeSpecs))]
         public int ThrowArgumentOutOfRangeException (int foo)
         {
             var _args = new ByteString[] {
-                global::KRPC.Client.Encoder.Encode (foo, typeof(int))
+                global::KRPC.Client.Encoder.Encode (foo, TypeSpecs.Spec2)
             };
             var _result = connection.Invoke ("TestService", "ThrowArgumentOutOfRangeException", _args);
-            return (int)global::KRPC.Client.Encoder.Decode (_result.Value, typeof(int), connection);
+            return (int)global::KRPC.Client.Encoder.Decode (_result.Value, TypeSpecs.Spec2, connection);
         }
 
-        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "ThrowCustomException")]
+        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "ThrowCustomException", typeof(TypeSpecs))]
         public int ThrowCustomException ()
         {
             var _result = connection.Invoke ("TestService", "ThrowCustomException");
-            return (int)global::KRPC.Client.Encoder.Decode (_result.Value, typeof(int), connection);
+            return (int)global::KRPC.Client.Encoder.Decode (_result.Value, TypeSpecs.Spec2, connection);
         }
 
-        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "ThrowCustomExceptionLater")]
+        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "ThrowCustomExceptionLater", typeof(TypeSpecs))]
         public int ThrowCustomExceptionLater ()
         {
             var _result = connection.Invoke ("TestService", "ThrowCustomExceptionLater");
-            return (int)global::KRPC.Client.Encoder.Decode (_result.Value, typeof(int), connection);
+            return (int)global::KRPC.Client.Encoder.Decode (_result.Value, TypeSpecs.Spec2, connection);
         }
 
-        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "ThrowInvalidOperationException")]
+        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "ThrowInvalidOperationException", typeof(TypeSpecs))]
         public int ThrowInvalidOperationException ()
         {
             var _result = connection.Invoke ("TestService", "ThrowInvalidOperationException");
-            return (int)global::KRPC.Client.Encoder.Decode (_result.Value, typeof(int), connection);
+            return (int)global::KRPC.Client.Encoder.Decode (_result.Value, TypeSpecs.Spec2, connection);
         }
 
-        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "ThrowInvalidOperationExceptionLater")]
+        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "ThrowInvalidOperationExceptionLater", typeof(TypeSpecs))]
         public int ThrowInvalidOperationExceptionLater ()
         {
             var _result = connection.Invoke ("TestService", "ThrowInvalidOperationExceptionLater");
-            return (int)global::KRPC.Client.Encoder.Decode (_result.Value, typeof(int), connection);
+            return (int)global::KRPC.Client.Encoder.Decode (_result.Value, TypeSpecs.Spec2, connection);
         }
 
-        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "TupleDefault")]
+        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "TupleDefault", typeof(TypeSpecs))]
         public systemAlias::Tuple<int,bool> TupleDefault (systemAlias::Tuple<int,bool> x = null)
         {
             var _args = new ByteString[] {
-                global::KRPC.Client.Encoder.Encode (x ?? new systemAlias::Tuple<int,bool> (1, false), typeof(systemAlias::Tuple<int,bool>))
+                global::KRPC.Client.Encoder.Encode (x ?? new systemAlias::Tuple<int,bool> (1, false), TypeSpecs.Spec24)
             };
             var _result = connection.Invoke ("TestService", "TupleDefault", _args);
-            return (systemAlias::Tuple<int,bool>)global::KRPC.Client.Encoder.Decode (_result.Value, typeof(systemAlias::Tuple<int,bool>), connection);
+            return (systemAlias::Tuple<int,bool>)global::KRPC.Client.Encoder.Decode (_result.Value, TypeSpecs.Spec24, connection);
         }
 
         /// <summary>
         /// Procedure whose default is the largest uint.
         /// </summary>
-        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "Uint32SpecialDefaults")]
+        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "Uint32SpecialDefaults", typeof(TypeSpecs))]
         public global::System.Collections.Generic.IList<uint> Uint32SpecialDefaults (uint maximum = uint.MaxValue)
         {
             var _args = new ByteString[] {
-                global::KRPC.Client.Encoder.Encode (maximum, typeof(uint))
+                global::KRPC.Client.Encoder.Encode (maximum, TypeSpecs.Spec29)
             };
             var _result = connection.Invoke ("TestService", "Uint32SpecialDefaults", _args);
-            return (global::System.Collections.Generic.IList<uint>)global::KRPC.Client.Encoder.Decode (_result.Value, typeof(global::System.Collections.Generic.IList<uint>), connection);
+            return (global::System.Collections.Generic.IList<uint>)global::KRPC.Client.Encoder.Decode (_result.Value, TypeSpecs.Spec36, connection);
         }
 
         /// <summary>
         /// Procedure whose default is the largest ulong.
         /// </summary>
-        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "Uint64SpecialDefaults")]
+        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "Uint64SpecialDefaults", typeof(TypeSpecs))]
         public global::System.Collections.Generic.IList<ulong> Uint64SpecialDefaults (ulong maximum = ulong.MaxValue)
         {
             var _args = new ByteString[] {
-                global::KRPC.Client.Encoder.Encode (maximum, typeof(ulong))
+                global::KRPC.Client.Encoder.Encode (maximum, TypeSpecs.Spec30)
             };
             var _result = connection.Invoke ("TestService", "Uint64SpecialDefaults", _args);
-            return (global::System.Collections.Generic.IList<ulong>)global::KRPC.Client.Encoder.Decode (_result.Value, typeof(global::System.Collections.Generic.IList<ulong>), connection);
+            return (global::System.Collections.Generic.IList<ulong>)global::KRPC.Client.Encoder.Decode (_result.Value, TypeSpecs.Spec37, connection);
         }
 
         /// <summary>
         /// Deprecated property documentation string.
         /// </summary>
         [global::System.Obsolete ("Use StringProperty instead.")]
-        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "get_DeprecatedProperty")]
+        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "get_DeprecatedProperty", typeof(TypeSpecs))]
         public string DeprecatedProperty {
             get {
                 var _result = connection.Invoke ("TestService", "get_DeprecatedProperty");
-                return (string)global::KRPC.Client.Encoder.Decode (_result.Value, typeof(string), connection);
+                return (string)global::KRPC.Client.Encoder.Decode (_result.Value, TypeSpecs.Spec5, connection);
             }
             set {
                 var _args = new ByteString[] {
-                    global::KRPC.Client.Encoder.Encode (value, typeof(string))
+                    global::KRPC.Client.Encoder.Encode (value, TypeSpecs.Spec5)
                 };
                 connection.Invoke ("TestService", "set_DeprecatedProperty", _args);
             }
         }
 
-        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "get_NullableObject")]
+        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "get_NullableObject", typeof(TypeSpecs))]
         public global::KRPC.Client.Services.TestService.TestClass NullableObject {
             get {
                 var _result = connection.Invoke ("TestService", "get_NullableObject");
                 if (_result.IsNull)
                     return null;
-                return (global::KRPC.Client.Services.TestService.TestClass)global::KRPC.Client.Encoder.Decode (_result.Value, typeof(global::KRPC.Client.Services.TestService.TestClass), connection);
+                return (global::KRPC.Client.Services.TestService.TestClass)global::KRPC.Client.Encoder.Decode (_result.Value, TypeSpecs.Spec7, connection);
             }
             set {
                 var _args = new ByteString[] {
-                    global::KRPC.Client.Encoder.Encode (value, typeof(global::KRPC.Client.Services.TestService.TestClass))
+                    global::KRPC.Client.Encoder.Encode (value, TypeSpecs.Spec7)
                 };
                 connection.Invoke ("TestService", "set_NullableObject", _args);
             }
         }
 
-        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "get_ObjectProperty")]
+        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "get_ObjectProperty", typeof(TypeSpecs))]
         public global::KRPC.Client.Services.TestService.TestClass ObjectProperty {
             get {
                 var _result = connection.Invoke ("TestService", "get_ObjectProperty");
                 if (_result.IsNull)
                     return null;
-                return (global::KRPC.Client.Services.TestService.TestClass)global::KRPC.Client.Encoder.Decode (_result.Value, typeof(global::KRPC.Client.Services.TestService.TestClass), connection);
+                return (global::KRPC.Client.Services.TestService.TestClass)global::KRPC.Client.Encoder.Decode (_result.Value, TypeSpecs.Spec7, connection);
             }
             set {
                 var _args = new ByteString[] {
-                    global::KRPC.Client.Encoder.Encode (value, typeof(global::KRPC.Client.Services.TestService.TestClass))
+                    global::KRPC.Client.Encoder.Encode (value, TypeSpecs.Spec7)
                 };
                 connection.Invoke ("TestService", "set_ObjectProperty", _args);
             }
@@ -718,15 +864,15 @@ namespace KRPC.Client.Services.TestService
         /// <summary>
         /// Property documentation string.
         /// </summary>
-        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "get_StringProperty")]
+        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "get_StringProperty", typeof(TypeSpecs))]
         public string StringProperty {
             get {
                 var _result = connection.Invoke ("TestService", "get_StringProperty");
-                return (string)global::KRPC.Client.Encoder.Decode (_result.Value, typeof(string), connection);
+                return (string)global::KRPC.Client.Encoder.Decode (_result.Value, TypeSpecs.Spec5, connection);
             }
             set {
                 var _args = new ByteString[] {
-                    global::KRPC.Client.Encoder.Encode (value, typeof(string))
+                    global::KRPC.Client.Encoder.Encode (value, TypeSpecs.Spec5)
                 };
                 connection.Invoke ("TestService", "set_StringProperty", _args);
             }
@@ -735,17 +881,17 @@ namespace KRPC.Client.Services.TestService
         public string StringPropertyPrivateGet {
             set {
                 var _args = new ByteString[] {
-                    global::KRPC.Client.Encoder.Encode (value, typeof(string))
+                    global::KRPC.Client.Encoder.Encode (value, TypeSpecs.Spec5)
                 };
                 connection.Invoke ("TestService", "set_StringPropertyPrivateGet", _args);
             }
         }
 
-        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "get_StringPropertyPrivateSet")]
+        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "get_StringPropertyPrivateSet", typeof(TypeSpecs))]
         public string StringPropertyPrivateSet {
             get {
                 var _result = connection.Invoke ("TestService", "get_StringPropertyPrivateSet");
-                return (string)global::KRPC.Client.Encoder.Decode (_result.Value, typeof(string), connection);
+                return (string)global::KRPC.Client.Encoder.Decode (_result.Value, TypeSpecs.Spec5, connection);
             }
         }
     }
@@ -905,6 +1051,120 @@ namespace KRPC.Client.Services.TestService
         /// Returns true if the first DeprecatedStruct does not order before the second.
         /// </summary>
         public static bool operator >= (DeprecatedStruct lhs, DeprecatedStruct rhs)
+        {
+            return lhs.CompareTo (rhs) >= 0;
+        }
+    }
+
+    /// <summary>
+    /// Nested nullable struct documentation string.
+    /// </summary>
+    [Serializable]
+    [global::KRPC.Client.Attributes.KRPCStruct]
+    public struct TestNestedNullableStruct : IEquatable<TestNestedNullableStruct>, IComparable<TestNestedNullableStruct>
+    {
+        /// <summary>
+        /// Construct a TestNestedNullableStruct from the values of its fields.
+        /// </summary>
+        public TestNestedNullableStruct (global::System.Collections.Generic.IList<global::KRPC.Client.Services.TestService.TestClass> listField, string stringField) : this ()
+        {
+            ListField = listField;
+            StringField = stringField;
+        }
+
+        public global::System.Collections.Generic.IList<global::KRPC.Client.Services.TestService.TestClass> ListField { get; private set; }
+
+        public string StringField { get; private set; }
+
+        /// <summary>
+        /// Returns true if this TestNestedNullableStruct is equal to the given object.
+        /// </summary>
+        public override bool Equals (object obj)
+        {
+            return obj is TestNestedNullableStruct && Equals ((TestNestedNullableStruct)obj);
+        }
+
+        /// <summary>
+        /// Returns true if this TestNestedNullableStruct is equal to the given one.
+        /// </summary>
+        public bool Equals (TestNestedNullableStruct other)
+        {
+            return global::KRPC.Client.ValueUtils.Equal (ListField, other.ListField) && global::KRPC.Client.ValueUtils.Equal (StringField, other.StringField);
+        }
+
+        /// <summary>
+        /// Returns a hash code for this TestNestedNullableStruct.
+        /// </summary>
+        public override int GetHashCode ()
+        {
+            int hash = 17;
+            hash = hash * 31 + global::KRPC.Client.ValueUtils.HashCode (ListField);
+            hash = hash * 31 + global::KRPC.Client.ValueUtils.HashCode (StringField);
+            return hash;
+        }
+
+        /// <summary>
+        /// Returns true if the two TestNestedNullableStruct values are equal.
+        /// </summary>
+        public static bool operator == (TestNestedNullableStruct lhs, TestNestedNullableStruct rhs)
+        {
+            return lhs.Equals (rhs);
+        }
+
+        /// <summary>
+        /// Returns true if the two TestNestedNullableStruct values are not equal.
+        /// </summary>
+        public static bool operator != (TestNestedNullableStruct lhs, TestNestedNullableStruct rhs)
+        {
+            return !lhs.Equals (rhs);
+        }
+
+        /// <summary>
+        /// Compares this TestNestedNullableStruct with the given one, by its fields in turn, which is
+        /// how a tuple of the same values compares. A field whose type has no ordering, such as
+        /// a collection, throws unless the two values are the same object, as it does in a
+        /// tuple, so two TestNestedNullableStructs that are equal can still throw here.
+        /// </summary>
+        public int CompareTo (TestNestedNullableStruct other)
+        {
+            int result;
+            result = global::System.Collections.Generic.Comparer<global::System.Collections.Generic.IList<global::KRPC.Client.Services.TestService.TestClass>>.Default.Compare (ListField, other.ListField);
+            if (result != 0)
+                return result;
+            result = global::System.Collections.Generic.Comparer<string>.Default.Compare (StringField, other.StringField);
+            if (result != 0)
+                return result;
+            return 0;
+        }
+
+        /// <summary>
+        /// Returns true if the first TestNestedNullableStruct orders before the second.
+        /// </summary>
+        public static bool operator < (TestNestedNullableStruct lhs, TestNestedNullableStruct rhs)
+        {
+            return lhs.CompareTo (rhs) < 0;
+        }
+
+        /// <summary>
+        /// Returns true if the first TestNestedNullableStruct orders after the second.
+        /// </summary>
+        public static bool operator > (TestNestedNullableStruct lhs, TestNestedNullableStruct rhs)
+        {
+            return lhs.CompareTo (rhs) > 0;
+        }
+
+        /// <summary>
+        /// Returns true if the first TestNestedNullableStruct does not order after the second.
+        /// </summary>
+        public static bool operator <= (TestNestedNullableStruct lhs, TestNestedNullableStruct rhs)
+        {
+            return lhs.CompareTo (rhs) <= 0;
+        }
+
+        /// <summary>
+        /// Returns true if the first TestNestedNullableStruct does not order before the second.
+        /// </summary>
+        public static bool operator >= (TestNestedNullableStruct lhs, TestNestedNullableStruct rhs)
         {
             return lhs.CompareTo (rhs) >= 0;
         }
@@ -1162,6 +1422,143 @@ namespace KRPC.Client.Services.TestService
         }
     }
 
+    /// <summary>
+    /// Nullable struct documentation string.
+    /// </summary>
+    [Serializable]
+    [global::KRPC.Client.Attributes.KRPCStruct]
+    public struct TestNullableStruct : IEquatable<TestNullableStruct>, IComparable<TestNullableStruct>
+    {
+        /// <summary>
+        /// Construct a TestNullableStruct from the values of its fields.
+        /// </summary>
+        public TestNullableStruct (int intField, int? nullableIntField, global::KRPC.Client.Services.TestService.TestEnum? nullableEnumField, string nullableStringField, global::KRPC.Client.Services.TestService.TestClass nullableObjectField) : this ()
+        {
+            IntField = intField;
+            NullableIntField = nullableIntField;
+            NullableEnumField = nullableEnumField;
+            NullableStringField = nullableStringField;
+            NullableObjectField = nullableObjectField;
+        }
+
+        public int IntField { get; private set; }
+
+        public int? NullableIntField { get; private set; }
+
+        public global::KRPC.Client.Services.TestService.TestEnum? NullableEnumField { get; private set; }
+
+        [global::KRPC.Client.Attributes.KRPCNullable]
+        public string NullableStringField { get; private set; }
+
+        [global::KRPC.Client.Attributes.KRPCNullable]
+        public global::KRPC.Client.Services.TestService.TestClass NullableObjectField { get; private set; }
+
+        /// <summary>
+        /// Returns true if this TestNullableStruct is equal to the given object.
+        /// </summary>
+        public override bool Equals (object obj)
+        {
+            return obj is TestNullableStruct && Equals ((TestNullableStruct)obj);
+        }
+
+        /// <summary>
+        /// Returns true if this TestNullableStruct is equal to the given one.
+        /// </summary>
+        public bool Equals (TestNullableStruct other)
+        {
+            return global::KRPC.Client.ValueUtils.Equal (IntField, other.IntField) && global::KRPC.Client.ValueUtils.Equal (NullableIntField, other.NullableIntField) && global::KRPC.Client.ValueUtils.Equal (NullableEnumField, other.NullableEnumField) && global::KRPC.Client.ValueUtils.Equal (NullableStringField, other.NullableStringField) && global::KRPC.Client.ValueUtils.Equal (NullableObjectField, other.NullableObjectField);
+        }
+
+        /// <summary>
+        /// Returns a hash code for this TestNullableStruct.
+        /// </summary>
+        public override int GetHashCode ()
+        {
+            int hash = 17;
+            hash = hash * 31 + global::KRPC.Client.ValueUtils.HashCode (IntField);
+            hash = hash * 31 + global::KRPC.Client.ValueUtils.HashCode (NullableIntField);
+            hash = hash * 31 + global::KRPC.Client.ValueUtils.HashCode (NullableEnumField);
+            hash = hash * 31 + global::KRPC.Client.ValueUtils.HashCode (NullableStringField);
+            hash = hash * 31 + global::KRPC.Client.ValueUtils.HashCode (NullableObjectField);
+            return hash;
+        }
+
+        /// <summary>
+        /// Returns true if the two TestNullableStruct values are equal.
+        /// </summary>
+        public static bool operator == (TestNullableStruct lhs, TestNullableStruct rhs)
+        {
+            return lhs.Equals (rhs);
+        }
+
+        /// <summary>
+        /// Returns true if the two TestNullableStruct values are not equal.
+        /// </summary>
+        public static bool operator != (TestNullableStruct lhs, TestNullableStruct rhs)
+        {
+            return !lhs.Equals (rhs);
+        }
+
+        /// <summary>
+        /// Compares this TestNullableStruct with the given one, by its fields in turn, which is
+        /// how a tuple of the same values compares. A field whose type has no ordering, such as
+        /// a collection, throws unless the two values are the same object, as it does in a
+        /// tuple, so two TestNullableStructs that are equal can still throw here.
+        /// </summary>
+        public int CompareTo (TestNullableStruct other)
+        {
+            int result;
+            result = global::System.Collections.Generic.Comparer<int>.Default.Compare (IntField, other.IntField);
+            if (result != 0)
+                return result;
+            result = global::System.Collections.Generic.Comparer<int?>.Default.Compare (NullableIntField, other.NullableIntField);
+            if (result != 0)
+                return result;
+            result = global::System.Collections.Generic.Comparer<global::KRPC.Client.Services.TestService.TestEnum?>.Default.Compare (NullableEnumField, other.NullableEnumField);
+            if (result != 0)
+                return result;
+            result = global::System.Collections.Generic.Comparer<string>.Default.Compare (NullableStringField, other.NullableStringField);
+            if (result != 0)
+                return result;
+            result = global::System.Collections.Generic.Comparer<global::KRPC.Client.Services.TestService.TestClass>.Default.Compare (NullableObjectField, other.NullableObjectField);
+            if (result != 0)
+                return result;
+            return 0;
+        }
+
+        /// <summary>
+        /// Returns true if the first TestNullableStruct orders before the second.
+        /// </summary>
+        public static bool operator < (TestNullableStruct lhs, TestNullableStruct rhs)
+        {
+            return lhs.CompareTo (rhs) < 0;
+        }
+
+        /// <summary>
+        /// Returns true if the first TestNullableStruct orders after the second.
+        /// </summary>
+        public static bool operator > (TestNullableStruct lhs, TestNullableStruct rhs)
+        {
+            return lhs.CompareTo (rhs) > 0;
+        }
+
+        /// <summary>
+        /// Returns true if the first TestNullableStruct does not order after the second.
+        /// </summary>
+        public static bool operator <= (TestNullableStruct lhs, TestNullableStruct rhs)
+        {
+            return lhs.CompareTo (rhs) <= 0;
+        }
+
+        /// <summary>
+        /// Returns true if the first TestNullableStruct does not order before the second.
+        /// </summary>
+        public static bool operator >= (TestNullableStruct lhs, TestNullableStruct rhs)
+        {
+            return lhs.CompareTo (rhs) >= 0;
+        }
+    }
+
     [Serializable]
     public class CustomException : global::KRPC.Client.RPCException
     {
@@ -1251,14 +1648,14 @@ namespace KRPC.Client.Services.TestService
         /// Deprecated method documentation string.
         /// </summary>
         [global::System.Obsolete ("Use TestClass.GetValue instead.")]
-        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "DeprecatedClass_DeprecatedMethod")]
+        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "DeprecatedClass_DeprecatedMethod", typeof(TypeSpecs))]
         public string DeprecatedMethod ()
         {
             var _args = new ByteString[] {
-                global::KRPC.Client.Encoder.Encode (this, typeof(TestService.DeprecatedClass))
+                global::KRPC.Client.Encoder.Encode (this, TypeSpecs.Spec31)
             };
             var _result = connection.Invoke ("TestService", "DeprecatedClass_DeprecatedMethod", _args);
-            return (string)global::KRPC.Client.Encoder.Decode (_result.Value, typeof(string), connection);
+            return (string)global::KRPC.Client.Encoder.Decode (_result.Value, TypeSpecs.Spec5, connection);
         }
     }
 
@@ -1274,133 +1671,133 @@ namespace KRPC.Client.Services.TestService
         {
         }
 
-        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "TestClass_EchoNullableObject")]
+        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "TestClass_EchoNullableObject", typeof(TypeSpecs))]
         public global::KRPC.Client.Services.TestService.TestClass EchoNullableObject (global::KRPC.Client.Services.TestService.TestClass value)
         {
             var _args = new ByteString[] {
-                global::KRPC.Client.Encoder.Encode (this, typeof(TestService.TestClass)),
-                global::KRPC.Client.Encoder.Encode (value, typeof(global::KRPC.Client.Services.TestService.TestClass))
+                global::KRPC.Client.Encoder.Encode (this, TypeSpecs.Spec7),
+                global::KRPC.Client.Encoder.Encode (value, TypeSpecs.Spec7)
             };
             var _result = connection.Invoke ("TestService", "TestClass_EchoNullableObject", _args);
             if (_result.IsNull)
                 return null;
-            return (global::KRPC.Client.Services.TestService.TestClass)global::KRPC.Client.Encoder.Decode (_result.Value, typeof(global::KRPC.Client.Services.TestService.TestClass), connection);
+            return (global::KRPC.Client.Services.TestService.TestClass)global::KRPC.Client.Encoder.Decode (_result.Value, TypeSpecs.Spec7, connection);
         }
 
-        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "TestClass_FloatToString")]
+        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "TestClass_FloatToString", typeof(TypeSpecs))]
         public string FloatToString (float x)
         {
             var _args = new ByteString[] {
-                global::KRPC.Client.Encoder.Encode (this, typeof(TestService.TestClass)),
-                global::KRPC.Client.Encoder.Encode (x, typeof(float))
+                global::KRPC.Client.Encoder.Encode (this, TypeSpecs.Spec7),
+                global::KRPC.Client.Encoder.Encode (x, TypeSpecs.Spec0)
             };
             var _result = connection.Invoke ("TestService", "TestClass_FloatToString", _args);
-            return (string)global::KRPC.Client.Encoder.Decode (_result.Value, typeof(string), connection);
+            return (string)global::KRPC.Client.Encoder.Decode (_result.Value, TypeSpecs.Spec5, connection);
         }
 
         /// <summary>
         /// Method documentation string.
         /// </summary>
-        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "TestClass_GetValue")]
+        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "TestClass_GetValue", typeof(TypeSpecs))]
         public string GetValue ()
         {
             var _args = new ByteString[] {
-                global::KRPC.Client.Encoder.Encode (this, typeof(TestService.TestClass))
+                global::KRPC.Client.Encoder.Encode (this, TypeSpecs.Spec7)
             };
             var _result = connection.Invoke ("TestService", "TestClass_GetValue", _args);
-            return (string)global::KRPC.Client.Encoder.Decode (_result.Value, typeof(string), connection);
+            return (string)global::KRPC.Client.Encoder.Decode (_result.Value, TypeSpecs.Spec5, connection);
         }
 
-        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "TestClass_ObjectToString")]
+        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "TestClass_ObjectToString", typeof(TypeSpecs))]
         public string ObjectToString (global::KRPC.Client.Services.TestService.TestClass other)
         {
             var _args = new ByteString[] {
-                global::KRPC.Client.Encoder.Encode (this, typeof(TestService.TestClass)),
-                global::KRPC.Client.Encoder.Encode (other, typeof(global::KRPC.Client.Services.TestService.TestClass))
+                global::KRPC.Client.Encoder.Encode (this, TypeSpecs.Spec7),
+                global::KRPC.Client.Encoder.Encode (other, TypeSpecs.Spec7)
             };
             var _result = connection.Invoke ("TestService", "TestClass_ObjectToString", _args);
-            return (string)global::KRPC.Client.Encoder.Decode (_result.Value, typeof(string), connection);
+            return (string)global::KRPC.Client.Encoder.Decode (_result.Value, TypeSpecs.Spec5, connection);
         }
 
-        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "TestClass_OptionalArguments")]
+        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "TestClass_OptionalArguments", typeof(TypeSpecs))]
         public string OptionalArguments (string x, string y = "foo", string z = "bar", global::KRPC.Client.Services.TestService.TestClass obj = null)
         {
             var _args = new ByteString[] {
-                global::KRPC.Client.Encoder.Encode (this, typeof(TestService.TestClass)),
-                global::KRPC.Client.Encoder.Encode (x, typeof(string)),
-                global::KRPC.Client.Encoder.Encode (y, typeof(string)),
-                global::KRPC.Client.Encoder.Encode (z, typeof(string)),
-                global::KRPC.Client.Encoder.Encode (obj, typeof(global::KRPC.Client.Services.TestService.TestClass))
+                global::KRPC.Client.Encoder.Encode (this, TypeSpecs.Spec7),
+                global::KRPC.Client.Encoder.Encode (x, TypeSpecs.Spec5),
+                global::KRPC.Client.Encoder.Encode (y, TypeSpecs.Spec5),
+                global::KRPC.Client.Encoder.Encode (z, TypeSpecs.Spec5),
+                global::KRPC.Client.Encoder.Encode (obj, TypeSpecs.Spec7)
             };
             var _result = connection.Invoke ("TestService", "TestClass_OptionalArguments", _args);
-            return (string)global::KRPC.Client.Encoder.Decode (_result.Value, typeof(string), connection);
+            return (string)global::KRPC.Client.Encoder.Decode (_result.Value, TypeSpecs.Spec5, connection);
         }
 
         /// <param name="connection">A connection object.</param>
-        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "TestClass_static_StaticMethod")]
+        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "TestClass_static_StaticMethod", typeof(TypeSpecs))]
         public static string StaticMethod (IConnection connection, string a = "", string b = "")
         {
             if (connection == null)
                 throw new ArgumentNullException (nameof (connection));
             var _args = new ByteString[] {
-                global::KRPC.Client.Encoder.Encode (a, typeof(string)),
-                global::KRPC.Client.Encoder.Encode (b, typeof(string))
+                global::KRPC.Client.Encoder.Encode (a, TypeSpecs.Spec5),
+                global::KRPC.Client.Encoder.Encode (b, TypeSpecs.Spec5)
             };
             var _result = connection.Invoke ("TestService", "TestClass_static_StaticMethod", _args);
-            return (string)global::KRPC.Client.Encoder.Decode (_result.Value, typeof(string), connection);
+            return (string)global::KRPC.Client.Encoder.Decode (_result.Value, TypeSpecs.Spec5, connection);
         }
 
         /// <param name="connection">A connection object.</param>
-        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "TestClass_static_StaticNullableObject")]
+        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "TestClass_static_StaticNullableObject", typeof(TypeSpecs))]
         public static global::KRPC.Client.Services.TestService.TestClass StaticNullableObject (IConnection connection, global::KRPC.Client.Services.TestService.TestClass value)
         {
             if (connection == null)
                 throw new ArgumentNullException (nameof (connection));
             var _args = new ByteString[] {
-                global::KRPC.Client.Encoder.Encode (value, typeof(global::KRPC.Client.Services.TestService.TestClass))
+                global::KRPC.Client.Encoder.Encode (value, TypeSpecs.Spec7)
             };
             var _result = connection.Invoke ("TestService", "TestClass_static_StaticNullableObject", _args);
             if (_result.IsNull)
                 return null;
-            return (global::KRPC.Client.Services.TestService.TestClass)global::KRPC.Client.Encoder.Decode (_result.Value, typeof(global::KRPC.Client.Services.TestService.TestClass), connection);
+            return (global::KRPC.Client.Services.TestService.TestClass)global::KRPC.Client.Encoder.Decode (_result.Value, TypeSpecs.Spec7, connection);
         }
 
         /// <summary>
         /// Property documentation string.
         /// </summary>
-        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "TestClass_get_IntProperty")]
+        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "TestClass_get_IntProperty", typeof(TypeSpecs))]
         public int IntProperty {
             get {
                 var _args = new ByteString[] {
-                    global::KRPC.Client.Encoder.Encode (this, typeof(TestService.TestClass))
+                    global::KRPC.Client.Encoder.Encode (this, TypeSpecs.Spec7)
                 };
                 var _result = connection.Invoke ("TestService", "TestClass_get_IntProperty", _args);
-                return (int)global::KRPC.Client.Encoder.Decode (_result.Value, typeof(int), connection);
+                return (int)global::KRPC.Client.Encoder.Decode (_result.Value, TypeSpecs.Spec2, connection);
             }
             set {
                 var _args = new ByteString[] {
-                    global::KRPC.Client.Encoder.Encode (this, typeof(TestService.TestClass)),
-                    global::KRPC.Client.Encoder.Encode (value, typeof(int))
+                    global::KRPC.Client.Encoder.Encode (this, TypeSpecs.Spec7),
+                    global::KRPC.Client.Encoder.Encode (value, TypeSpecs.Spec2)
                 };
                 connection.Invoke ("TestService", "TestClass_set_IntProperty", _args);
             }
         }
 
-        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "TestClass_get_ObjectProperty")]
+        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "TestClass_get_ObjectProperty", typeof(TypeSpecs))]
         public global::KRPC.Client.Services.TestService.TestClass ObjectProperty {
             get {
                 var _args = new ByteString[] {
-                    global::KRPC.Client.Encoder.Encode (this, typeof(TestService.TestClass))
+                    global::KRPC.Client.Encoder.Encode (this, TypeSpecs.Spec7)
                 };
                 var _result = connection.Invoke ("TestService", "TestClass_get_ObjectProperty", _args);
                 if (_result.IsNull)
                     return null;
-                return (global::KRPC.Client.Services.TestService.TestClass)global::KRPC.Client.Encoder.Decode (_result.Value, typeof(global::KRPC.Client.Services.TestService.TestClass), connection);
+                return (global::KRPC.Client.Services.TestService.TestClass)global::KRPC.Client.Encoder.Decode (_result.Value, TypeSpecs.Spec7, connection);
             }
             set {
                 var _args = new ByteString[] {
-                    global::KRPC.Client.Encoder.Encode (this, typeof(TestService.TestClass)),
-                    global::KRPC.Client.Encoder.Encode (value, typeof(global::KRPC.Client.Services.TestService.TestClass))
+                    global::KRPC.Client.Encoder.Encode (this, TypeSpecs.Spec7),
+                    global::KRPC.Client.Encoder.Encode (value, TypeSpecs.Spec7)
                 };
                 connection.Invoke ("TestService", "TestClass_set_ObjectProperty", _args);
             }
@@ -1409,21 +1806,21 @@ namespace KRPC.Client.Services.TestService
         public string StringPropertyPrivateGet {
             set {
                 var _args = new ByteString[] {
-                    global::KRPC.Client.Encoder.Encode (this, typeof(TestService.TestClass)),
-                    global::KRPC.Client.Encoder.Encode (value, typeof(string))
+                    global::KRPC.Client.Encoder.Encode (this, TypeSpecs.Spec7),
+                    global::KRPC.Client.Encoder.Encode (value, TypeSpecs.Spec5)
                 };
                 connection.Invoke ("TestService", "TestClass_set_StringPropertyPrivateGet", _args);
             }
         }
 
-        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "TestClass_get_StringPropertyPrivateSet")]
+        [global::KRPC.Client.Attributes.RPCAttribute ("TestService", "TestClass_get_StringPropertyPrivateSet", typeof(TypeSpecs))]
         public string StringPropertyPrivateSet {
             get {
                 var _args = new ByteString[] {
-                    global::KRPC.Client.Encoder.Encode (this, typeof(TestService.TestClass))
+                    global::KRPC.Client.Encoder.Encode (this, TypeSpecs.Spec7)
                 };
                 var _result = connection.Invoke ("TestService", "TestClass_get_StringPropertyPrivateSet", _args);
-                return (string)global::KRPC.Client.Encoder.Decode (_result.Value, typeof(string), connection);
+                return (string)global::KRPC.Client.Encoder.Decode (_result.Value, TypeSpecs.Spec5, connection);
             }
         }
     }

--- a/tools/krpctools/krpctools/test/clientgen-TestService-java.txt
+++ b/tools/krpctools/krpctools/test/clientgen-TestService-java.txt
@@ -219,6 +219,56 @@ public class TestService {
     }
 
     @SuppressWarnings({ "unchecked" })
+    @RPCInfo(service = "TestService", procedure = "EchoDictionaryOfNullableObjects", types = _Types.class)
+    public java.util.Map<String,krpc.client.services.TestService.TestClass> echoDictionaryOfNullableObjects(java.util.Map<String,krpc.client.services.TestService.TestClass> d) throws RPCException {
+        ByteString[] _args = new ByteString[] {
+            Encoder.encode(d, krpc.client.Types.createDictionary(krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.STRING), krpc.client.Types.nullable(krpc.client.Types.createClass("TestService", "TestClass"))))
+        };
+        krpc.schema.KRPC.ProcedureResult _data = this.connection.invoke("TestService", "EchoDictionaryOfNullableObjects", _args);
+        return (java.util.Map<String,krpc.client.services.TestService.TestClass>) Encoder.decode(_data.getValue(), krpc.client.Types.createDictionary(krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.STRING), krpc.client.Types.nullable(krpc.client.Types.createClass("TestService", "TestClass"))), this.connection);
+    }
+
+    @SuppressWarnings({ "unchecked" })
+    @RPCInfo(service = "TestService", procedure = "EchoListOfNullableInts", types = _Types.class)
+    public java.util.List<Integer> echoListOfNullableInts(java.util.List<Integer> l) throws RPCException {
+        ByteString[] _args = new ByteString[] {
+            Encoder.encode(l, krpc.client.Types.createList(krpc.client.Types.nullable(krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.SINT32))))
+        };
+        krpc.schema.KRPC.ProcedureResult _data = this.connection.invoke("TestService", "EchoListOfNullableInts", _args);
+        return (java.util.List<Integer>) Encoder.decode(_data.getValue(), krpc.client.Types.createList(krpc.client.Types.nullable(krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.SINT32))), this.connection);
+    }
+
+    @SuppressWarnings({ "unchecked" })
+    @RPCInfo(service = "TestService", procedure = "EchoListOfNullableObjects", types = _Types.class)
+    public java.util.List<krpc.client.services.TestService.TestClass> echoListOfNullableObjects(java.util.List<krpc.client.services.TestService.TestClass> l) throws RPCException {
+        ByteString[] _args = new ByteString[] {
+            Encoder.encode(l, krpc.client.Types.createList(krpc.client.Types.nullable(krpc.client.Types.createClass("TestService", "TestClass"))))
+        };
+        krpc.schema.KRPC.ProcedureResult _data = this.connection.invoke("TestService", "EchoListOfNullableObjects", _args);
+        return (java.util.List<krpc.client.services.TestService.TestClass>) Encoder.decode(_data.getValue(), krpc.client.Types.createList(krpc.client.Types.nullable(krpc.client.Types.createClass("TestService", "TestClass"))), this.connection);
+    }
+
+    @SuppressWarnings({ "unchecked" })
+    @RPCInfo(service = "TestService", procedure = "EchoNestedListOfNullableObjects", types = _Types.class)
+    public java.util.List<java.util.List<krpc.client.services.TestService.TestClass>> echoNestedListOfNullableObjects(java.util.List<java.util.List<krpc.client.services.TestService.TestClass>> l) throws RPCException {
+        ByteString[] _args = new ByteString[] {
+            Encoder.encode(l, krpc.client.Types.createList(krpc.client.Types.createList(krpc.client.Types.nullable(krpc.client.Types.createClass("TestService", "TestClass")))))
+        };
+        krpc.schema.KRPC.ProcedureResult _data = this.connection.invoke("TestService", "EchoNestedListOfNullableObjects", _args);
+        return (java.util.List<java.util.List<krpc.client.services.TestService.TestClass>>) Encoder.decode(_data.getValue(), krpc.client.Types.createList(krpc.client.Types.createList(krpc.client.Types.nullable(krpc.client.Types.createClass("TestService", "TestClass")))), this.connection);
+    }
+
+    @SuppressWarnings({ "unchecked" })
+    @RPCInfo(service = "TestService", procedure = "EchoNestedNullableStruct", types = _Types.class)
+    public krpc.client.services.TestService.TestNestedNullableStruct echoNestedNullableStruct(krpc.client.services.TestService.TestNestedNullableStruct value) throws RPCException {
+        ByteString[] _args = new ByteString[] {
+            Encoder.encode(value, krpc.client.Types.createStruct("TestService", "TestNestedNullableStruct"))
+        };
+        krpc.schema.KRPC.ProcedureResult _data = this.connection.invoke("TestService", "EchoNestedNullableStruct", _args);
+        return (krpc.client.services.TestService.TestNestedNullableStruct) Encoder.decode(_data.getValue(), krpc.client.Types.createStruct("TestService", "TestNestedNullableStruct"), this.connection);
+    }
+
+    @SuppressWarnings({ "unchecked" })
     @RPCInfo(service = "TestService", procedure = "EchoNullableInt", types = _Types.class)
     public Integer echoNullableInt(Integer value) throws RPCException {
         ByteString[] _args = new ByteString[] {
@@ -268,6 +318,16 @@ public class TestService {
           return null;
         }
         return (krpc.client.services.TestService.TestClass) Encoder.decode(_data.getValue(), krpc.client.Types.createClass("TestService", "TestClass"), this.connection);
+    }
+
+    @SuppressWarnings({ "unchecked" })
+    @RPCInfo(service = "TestService", procedure = "EchoTupleWithANullableObject", types = _Types.class)
+    public org.javatuples.Pair<Integer,krpc.client.services.TestService.TestClass> echoTupleWithANullableObject(org.javatuples.Pair<Integer,krpc.client.services.TestService.TestClass> t) throws RPCException {
+        ByteString[] _args = new ByteString[] {
+            Encoder.encode(t, krpc.client.Types.createTuple(krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.SINT32),krpc.client.Types.nullable(krpc.client.Types.createClass("TestService", "TestClass"))))
+        };
+        krpc.schema.KRPC.ProcedureResult _data = this.connection.invoke("TestService", "EchoTupleWithANullableObject", _args);
+        return (org.javatuples.Pair<Integer,krpc.client.services.TestService.TestClass>) Encoder.decode(_data.getValue(), krpc.client.Types.createTuple(krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.SINT32),krpc.client.Types.nullable(krpc.client.Types.createClass("TestService", "TestClass"))), this.connection);
     }
 
     @SuppressWarnings({ "unchecked" })
@@ -485,6 +545,16 @@ public class TestService {
         };
         krpc.schema.KRPC.ProcedureResult _data = this.connection.invoke("TestService", "NotNullableObject", _args);
         return (krpc.client.services.TestService.TestClass) Encoder.decode(_data.getValue(), krpc.client.Types.createClass("TestService", "TestClass"), this.connection);
+    }
+
+    @SuppressWarnings({ "unchecked" })
+    @RPCInfo(service = "TestService", procedure = "NullableStructEcho", types = _Types.class)
+    public krpc.client.services.TestService.TestNullableStruct nullableStructEcho(krpc.client.services.TestService.TestNullableStruct x) throws RPCException {
+        ByteString[] _args = new ByteString[] {
+            Encoder.encode(x, krpc.client.Types.createStruct("TestService", "TestNullableStruct"))
+        };
+        krpc.schema.KRPC.ProcedureResult _data = this.connection.invoke("TestService", "NullableStructEcho", _args);
+        return (krpc.client.services.TestService.TestNullableStruct) Encoder.decode(_data.getValue(), krpc.client.Types.createStruct("TestService", "TestNullableStruct"), this.connection);
     }
 
     @SuppressWarnings({ "unchecked" })
@@ -967,6 +1037,87 @@ public class TestService {
     }
 
     /**
+     * Nested nullable struct documentation string.
+     */
+    public static class TestNestedNullableStruct implements RemoteStruct, Comparable<TestNestedNullableStruct> {
+        private final java.util.List<krpc.client.services.TestService.TestClass> listField;
+        private final String stringField;
+
+        public TestNestedNullableStruct(java.util.List<krpc.client.services.TestService.TestClass> listField, String stringField) {
+            this.listField = listField;
+            this.stringField = stringField;
+        }
+
+        public java.util.List<krpc.client.services.TestService.TestClass> getListField() {
+            return listField;
+        }
+
+        public String getStringField() {
+            return stringField;
+        }
+
+        private static final java.util.List<krpc.schema.KRPC.Type> FIELD_TYPES =
+            java.util.Collections.unmodifiableList(java.util.Arrays.asList(
+                krpc.client.Types.createList(krpc.client.Types.nullable(krpc.client.Types.createClass("TestService", "TestClass"))),
+                krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.STRING)
+            ));
+
+        /** The types of the fields, in the order they are encoded in. */
+        public static java.util.List<krpc.schema.KRPC.Type> fieldTypes() {
+            return FIELD_TYPES;
+        }
+
+        /** Build a TestNestedNullableStruct from the values of its fields. */
+        @SuppressWarnings("unchecked")
+        public static TestNestedNullableStruct fromFieldValues(Object[] values) {
+            return new TestNestedNullableStruct(
+                (java.util.List<krpc.client.services.TestService.TestClass>) values[0],
+                (String) values[1]
+            );
+        }
+
+        @Override
+        public Object[] fieldValues() {
+            return new Object[] {
+                listField,
+                stringField
+            };
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (!(obj instanceof TestNestedNullableStruct)) {
+                return false;
+            }
+            TestNestedNullableStruct other = (TestNestedNullableStruct) obj;
+            return java.util.Objects.equals(this.listField, other.listField)                && java.util.Objects.equals(this.stringField, other.stringField);
+        }
+
+        @Override
+        public int hashCode() {
+            return java.util.Objects.hash(listField, stringField);
+        }
+
+        /**
+         * Compares this TestNestedNullableStruct with the given one, by its fields in turn, which is
+         * how a tuple of the same values compares.
+         */
+        @Override
+        public int compareTo(TestNestedNullableStruct other) {
+            int result;
+            result = RemoteStruct.compareFields(listField, other.listField);
+            if (result != 0) {
+                return result;
+            }
+            result = RemoteStruct.compareFields(stringField, other.stringField);
+            if (result != 0) {
+                return result;
+            }
+            return 0;
+        }
+    }
+
+    /**
      * Struct documentation string.
      */
     public static class TestStruct implements RemoteStruct, Comparable<TestStruct> {
@@ -1163,6 +1314,126 @@ public class TestService {
                 return result;
             }
             result = RemoteStruct.compareFields(stringField, other.stringField);
+            if (result != 0) {
+                return result;
+            }
+            return 0;
+        }
+    }
+
+    /**
+     * Nullable struct documentation string.
+     */
+    public static class TestNullableStruct implements RemoteStruct, Comparable<TestNullableStruct> {
+        private final int intField;
+        private final Integer nullableIntField;
+        private final krpc.client.services.TestService.TestEnum nullableEnumField;
+        private final String nullableStringField;
+        private final krpc.client.services.TestService.TestClass nullableObjectField;
+
+        public TestNullableStruct(int intField, Integer nullableIntField, krpc.client.services.TestService.TestEnum nullableEnumField, String nullableStringField, krpc.client.services.TestService.TestClass nullableObjectField) {
+            this.intField = intField;
+            this.nullableIntField = nullableIntField;
+            this.nullableEnumField = nullableEnumField;
+            this.nullableStringField = nullableStringField;
+            this.nullableObjectField = nullableObjectField;
+        }
+
+        public int getIntField() {
+            return intField;
+        }
+
+        public Integer getNullableIntField() {
+            return nullableIntField;
+        }
+
+        public krpc.client.services.TestService.TestEnum getNullableEnumField() {
+            return nullableEnumField;
+        }
+
+        public String getNullableStringField() {
+            return nullableStringField;
+        }
+
+        public krpc.client.services.TestService.TestClass getNullableObjectField() {
+            return nullableObjectField;
+        }
+
+        private static final java.util.List<krpc.schema.KRPC.Type> FIELD_TYPES =
+            java.util.Collections.unmodifiableList(java.util.Arrays.asList(
+                krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.SINT32),
+                krpc.client.Types.nullable(krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.SINT32)),
+                krpc.client.Types.nullable(krpc.client.Types.createEnumeration("TestService", "TestEnum")),
+                krpc.client.Types.nullable(krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.STRING)),
+                krpc.client.Types.nullable(krpc.client.Types.createClass("TestService", "TestClass"))
+            ));
+
+        /** The types of the fields, in the order they are encoded in. */
+        public static java.util.List<krpc.schema.KRPC.Type> fieldTypes() {
+            return FIELD_TYPES;
+        }
+
+        /** Build a TestNullableStruct from the values of its fields. */
+        @SuppressWarnings("unchecked")
+        public static TestNullableStruct fromFieldValues(Object[] values) {
+            return new TestNullableStruct(
+                (int) values[0],
+                (Integer) values[1],
+                (krpc.client.services.TestService.TestEnum) values[2],
+                (String) values[3],
+                (krpc.client.services.TestService.TestClass) values[4]
+            );
+        }
+
+        @Override
+        public Object[] fieldValues() {
+            return new Object[] {
+                intField,
+                nullableIntField,
+                nullableEnumField,
+                nullableStringField,
+                nullableObjectField
+            };
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (!(obj instanceof TestNullableStruct)) {
+                return false;
+            }
+            TestNullableStruct other = (TestNullableStruct) obj;
+            return java.util.Objects.equals(this.intField, other.intField)                && java.util.Objects.equals(this.nullableIntField, other.nullableIntField)                && java.util.Objects.equals(this.nullableEnumField, other.nullableEnumField)                && java.util.Objects.equals(this.nullableStringField, other.nullableStringField)                && java.util.Objects.equals(this.nullableObjectField, other.nullableObjectField);
+        }
+
+        @Override
+        public int hashCode() {
+            return java.util.Objects.hash(intField, nullableIntField, nullableEnumField, nullableStringField, nullableObjectField);
+        }
+
+        /**
+         * Compares this TestNullableStruct with the given one, by its fields in turn, which is
+         * how a tuple of the same values compares.
+         */
+        @Override
+        public int compareTo(TestNullableStruct other) {
+            int result;
+            result = RemoteStruct.compareFields(intField, other.intField);
+            if (result != 0) {
+                return result;
+            }
+            result = RemoteStruct.compareFields(nullableIntField, other.nullableIntField);
+            if (result != 0) {
+                return result;
+            }
+            result = RemoteStruct.compareFields(nullableEnumField, other.nullableEnumField);
+            if (result != 0) {
+                return result;
+            }
+            result = RemoteStruct.compareFields(nullableStringField, other.nullableStringField);
+            if (result != 0) {
+                return result;
+            }
+            result = RemoteStruct.compareFields(nullableObjectField, other.nullableObjectField);
             if (result != 0) {
                 return result;
             }
@@ -1425,6 +1696,16 @@ public class TestService {
             PARAMETER_TYPES.put("DoubleSpecialDefaults", new krpc.schema.KRPC.Type[] { krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.DOUBLE), krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.DOUBLE), krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.DOUBLE), krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.DOUBLE), krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.DOUBLE) });
             RETURN_TYPES.put("DoubleToString", krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.STRING));
             PARAMETER_TYPES.put("DoubleToString", new krpc.schema.KRPC.Type[] { krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.DOUBLE) });
+            RETURN_TYPES.put("EchoDictionaryOfNullableObjects", krpc.client.Types.createDictionary(krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.STRING), krpc.client.Types.nullable(krpc.client.Types.createClass("TestService", "TestClass"))));
+            PARAMETER_TYPES.put("EchoDictionaryOfNullableObjects", new krpc.schema.KRPC.Type[] { krpc.client.Types.createDictionary(krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.STRING), krpc.client.Types.nullable(krpc.client.Types.createClass("TestService", "TestClass"))) });
+            RETURN_TYPES.put("EchoListOfNullableInts", krpc.client.Types.createList(krpc.client.Types.nullable(krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.SINT32))));
+            PARAMETER_TYPES.put("EchoListOfNullableInts", new krpc.schema.KRPC.Type[] { krpc.client.Types.createList(krpc.client.Types.nullable(krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.SINT32))) });
+            RETURN_TYPES.put("EchoListOfNullableObjects", krpc.client.Types.createList(krpc.client.Types.nullable(krpc.client.Types.createClass("TestService", "TestClass"))));
+            PARAMETER_TYPES.put("EchoListOfNullableObjects", new krpc.schema.KRPC.Type[] { krpc.client.Types.createList(krpc.client.Types.nullable(krpc.client.Types.createClass("TestService", "TestClass"))) });
+            RETURN_TYPES.put("EchoNestedListOfNullableObjects", krpc.client.Types.createList(krpc.client.Types.createList(krpc.client.Types.nullable(krpc.client.Types.createClass("TestService", "TestClass")))));
+            PARAMETER_TYPES.put("EchoNestedListOfNullableObjects", new krpc.schema.KRPC.Type[] { krpc.client.Types.createList(krpc.client.Types.createList(krpc.client.Types.nullable(krpc.client.Types.createClass("TestService", "TestClass")))) });
+            RETURN_TYPES.put("EchoNestedNullableStruct", krpc.client.Types.createStruct("TestService", "TestNestedNullableStruct"));
+            PARAMETER_TYPES.put("EchoNestedNullableStruct", new krpc.schema.KRPC.Type[] { krpc.client.Types.createStruct("TestService", "TestNestedNullableStruct") });
             RETURN_TYPES.put("EchoNullableInt", krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.SINT32));
             PARAMETER_TYPES.put("EchoNullableInt", new krpc.schema.KRPC.Type[] { krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.SINT32) });
             RETURN_TYPES.put("EchoNullableList", krpc.client.Types.createList(krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.SINT32)));
@@ -1433,6 +1714,8 @@ public class TestService {
             PARAMETER_TYPES.put("EchoNullableString", new krpc.schema.KRPC.Type[] { krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.STRING) });
             RETURN_TYPES.put("EchoTestObject", krpc.client.Types.createClass("TestService", "TestClass"));
             PARAMETER_TYPES.put("EchoTestObject", new krpc.schema.KRPC.Type[] { krpc.client.Types.createClass("TestService", "TestClass") });
+            RETURN_TYPES.put("EchoTupleWithANullableObject", krpc.client.Types.createTuple(krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.SINT32),krpc.client.Types.nullable(krpc.client.Types.createClass("TestService", "TestClass"))));
+            PARAMETER_TYPES.put("EchoTupleWithANullableObject", new krpc.schema.KRPC.Type[] { krpc.client.Types.createTuple(krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.SINT32),krpc.client.Types.nullable(krpc.client.Types.createClass("TestService", "TestClass"))) });
             RETURN_TYPES.put("EmptyListDefault", krpc.client.Types.createList(krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.STRING)));
             PARAMETER_TYPES.put("EmptyListDefault", new krpc.schema.KRPC.Type[] { krpc.client.Types.createList(krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.STRING)) });
             RETURN_TYPES.put("EnumDefaultArg", krpc.client.Types.createEnumeration("TestService", "TestEnum"));
@@ -1473,6 +1756,8 @@ public class TestService {
             PARAMETER_TYPES.put("NestedStructEcho", new krpc.schema.KRPC.Type[] { krpc.client.Types.createStruct("TestService", "TestNestedStruct") });
             RETURN_TYPES.put("NotNullableObject", krpc.client.Types.createClass("TestService", "TestClass"));
             PARAMETER_TYPES.put("NotNullableObject", new krpc.schema.KRPC.Type[] { krpc.client.Types.createClass("TestService", "TestClass") });
+            RETURN_TYPES.put("NullableStructEcho", krpc.client.Types.createStruct("TestService", "TestNullableStruct"));
+            PARAMETER_TYPES.put("NullableStructEcho", new krpc.schema.KRPC.Type[] { krpc.client.Types.createStruct("TestService", "TestNullableStruct") });
             RETURN_TYPES.put("OnTimer", krpc.client.Types.createMessage(krpc.schema.KRPC.Type.TypeCode.EVENT));
             PARAMETER_TYPES.put("OnTimer", new krpc.schema.KRPC.Type[] { krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.UINT32), krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.UINT32) });
             RETURN_TYPES.put("OnTimerUsingLambda", krpc.client.Types.createMessage(krpc.schema.KRPC.Type.TypeCode.EVENT));
@@ -1485,6 +1770,9 @@ public class TestService {
             PARAMETER_TYPES.put("ResetInvalidOperationExceptionLater", new krpc.schema.KRPC.Type[] {  });
             RETURN_TYPES.put("ReturnNullWhenNotAllowed", krpc.client.Types.createClass("TestService", "TestClass"));
             PARAMETER_TYPES.put("ReturnNullWhenNotAllowed", new krpc.schema.KRPC.Type[] {  });
+        }
+
+        private static void initTypes1() {
             RETURN_TYPES.put("SetDefault", krpc.client.Types.createSet(krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.SINT32)));
             PARAMETER_TYPES.put("SetDefault", new krpc.schema.KRPC.Type[] { krpc.client.Types.createSet(krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.SINT32)) });
             RETURN_TYPES.put("StringToInt32", krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.SINT32));
@@ -1499,9 +1787,6 @@ public class TestService {
             PARAMETER_TYPES.put("ThrowArgumentException", new krpc.schema.KRPC.Type[] {  });
             RETURN_TYPES.put("ThrowArgumentNullException", krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.SINT32));
             PARAMETER_TYPES.put("ThrowArgumentNullException", new krpc.schema.KRPC.Type[] { krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.STRING) });
-        }
-
-        private static void initTypes1() {
             RETURN_TYPES.put("ThrowArgumentOutOfRangeException", krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.SINT32));
             PARAMETER_TYPES.put("ThrowArgumentOutOfRangeException", new krpc.schema.KRPC.Type[] { krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.SINT32) });
             RETURN_TYPES.put("ThrowCustomException", krpc.client.Types.createValue(krpc.schema.KRPC.Type.TypeCode.SINT32));

--- a/tools/krpctools/krpctools/test/clientgen-TestService-python.txt
+++ b/tools/krpctools/krpctools/test/clientgen-TestService-python.txt
@@ -58,6 +58,14 @@ class DeprecatedStruct(NamedTuple):
     """
 
 
+class TestNestedNullableStruct(NamedTuple):
+    """
+    Nested nullable struct documentation string.
+    """
+    list_field: List[Optional[TestClass]]
+    string_field: str
+
+
 class TestStruct(NamedTuple):
     """
     Struct documentation string.
@@ -78,6 +86,17 @@ class TestNestedStruct(NamedTuple):
     struct_field: TestStruct
     object_field: TestClass
     string_field: str
+
+
+class TestNullableStruct(NamedTuple):
+    """
+    Nullable struct documentation string.
+    """
+    int_field: int
+    nullable_int_field: Optional[int]
+    nullable_enum_field: Optional[TestEnum]
+    nullable_string_field: Optional[str]
+    nullable_object_field: Optional[TestClass]
 
 
 class CustomException(RuntimeError):
@@ -443,8 +462,10 @@ class TestService:
     }
     _structs = {
         "DeprecatedStruct": DeprecatedStruct,
+        "TestNestedNullableStruct": TestNestedNullableStruct,
         "TestStruct": TestStruct,
         "TestNestedStruct": TestNestedStruct,
+        "TestNullableStruct": TestNullableStruct,
     }
     _exceptions = {
         "CustomException": CustomException,
@@ -917,6 +938,111 @@ class TestService:
             self._client._types.string_type
         )
 
+    def echo_dictionary_of_nullable_objects(self, d: Dict[str, Optional[TestClass]]) -> Dict[str, Optional[TestClass]]:
+        return self._client._invoke(
+            "TestService",
+            "EchoDictionaryOfNullableObjects",
+            [d],
+            [self._client._types.dictionary_type(self._client._types.string_type, self._client._types.nullable(self._client._types.class_type("TestService", "TestClass")))],
+            self._client._types.dictionary_type(self._client._types.string_type, self._client._types.nullable(self._client._types.class_type("TestService", "TestClass")))
+        )
+
+    def _return_type_echo_dictionary_of_nullable_objects(self) -> TypeBase:
+        return self._client._types.dictionary_type(self._client._types.string_type, self._client._types.nullable(self._client._types.class_type("TestService", "TestClass")))
+
+    def _build_call_echo_dictionary_of_nullable_objects(self, d: Dict[str, Optional[TestClass]]) -> KRPC_pb2.ProcedureCall:
+        return self._client._build_call(
+            "TestService",
+            "EchoDictionaryOfNullableObjects",
+            [d],
+            [self._client._types.dictionary_type(self._client._types.string_type, self._client._types.nullable(self._client._types.class_type("TestService", "TestClass")))],
+            self._client._types.dictionary_type(self._client._types.string_type, self._client._types.nullable(self._client._types.class_type("TestService", "TestClass")))
+        )
+
+    def echo_list_of_nullable_ints(self, l: List[Optional[int]]) -> List[Optional[int]]:
+        return self._client._invoke(
+            "TestService",
+            "EchoListOfNullableInts",
+            [l],
+            [self._client._types.list_type(self._client._types.nullable(self._client._types.sint32_type))],
+            self._client._types.list_type(self._client._types.nullable(self._client._types.sint32_type))
+        )
+
+    def _return_type_echo_list_of_nullable_ints(self) -> TypeBase:
+        return self._client._types.list_type(self._client._types.nullable(self._client._types.sint32_type))
+
+    def _build_call_echo_list_of_nullable_ints(self, l: List[Optional[int]]) -> KRPC_pb2.ProcedureCall:
+        return self._client._build_call(
+            "TestService",
+            "EchoListOfNullableInts",
+            [l],
+            [self._client._types.list_type(self._client._types.nullable(self._client._types.sint32_type))],
+            self._client._types.list_type(self._client._types.nullable(self._client._types.sint32_type))
+        )
+
+    def echo_list_of_nullable_objects(self, l: List[Optional[TestClass]]) -> List[Optional[TestClass]]:
+        return self._client._invoke(
+            "TestService",
+            "EchoListOfNullableObjects",
+            [l],
+            [self._client._types.list_type(self._client._types.nullable(self._client._types.class_type("TestService", "TestClass")))],
+            self._client._types.list_type(self._client._types.nullable(self._client._types.class_type("TestService", "TestClass")))
+        )
+
+    def _return_type_echo_list_of_nullable_objects(self) -> TypeBase:
+        return self._client._types.list_type(self._client._types.nullable(self._client._types.class_type("TestService", "TestClass")))
+
+    def _build_call_echo_list_of_nullable_objects(self, l: List[Optional[TestClass]]) -> KRPC_pb2.ProcedureCall:
+        return self._client._build_call(
+            "TestService",
+            "EchoListOfNullableObjects",
+            [l],
+            [self._client._types.list_type(self._client._types.nullable(self._client._types.class_type("TestService", "TestClass")))],
+            self._client._types.list_type(self._client._types.nullable(self._client._types.class_type("TestService", "TestClass")))
+        )
+
+    def echo_nested_list_of_nullable_objects(self, l: List[List[Optional[TestClass]]]) -> List[List[Optional[TestClass]]]:
+        return self._client._invoke(
+            "TestService",
+            "EchoNestedListOfNullableObjects",
+            [l],
+            [self._client._types.list_type(self._client._types.list_type(self._client._types.nullable(self._client._types.class_type("TestService", "TestClass"))))],
+            self._client._types.list_type(self._client._types.list_type(self._client._types.nullable(self._client._types.class_type("TestService", "TestClass"))))
+        )
+
+    def _return_type_echo_nested_list_of_nullable_objects(self) -> TypeBase:
+        return self._client._types.list_type(self._client._types.list_type(self._client._types.nullable(self._client._types.class_type("TestService", "TestClass"))))
+
+    def _build_call_echo_nested_list_of_nullable_objects(self, l: List[List[Optional[TestClass]]]) -> KRPC_pb2.ProcedureCall:
+        return self._client._build_call(
+            "TestService",
+            "EchoNestedListOfNullableObjects",
+            [l],
+            [self._client._types.list_type(self._client._types.list_type(self._client._types.nullable(self._client._types.class_type("TestService", "TestClass"))))],
+            self._client._types.list_type(self._client._types.list_type(self._client._types.nullable(self._client._types.class_type("TestService", "TestClass"))))
+        )
+
+    def echo_nested_nullable_struct(self, value: TestNestedNullableStruct) -> TestNestedNullableStruct:
+        return self._client._invoke(
+            "TestService",
+            "EchoNestedNullableStruct",
+            [value],
+            [self._client._types.struct_type("TestService", "TestNestedNullableStruct")],
+            self._client._types.struct_type("TestService", "TestNestedNullableStruct")
+        )
+
+    def _return_type_echo_nested_nullable_struct(self) -> TypeBase:
+        return self._client._types.struct_type("TestService", "TestNestedNullableStruct")
+
+    def _build_call_echo_nested_nullable_struct(self, value: TestNestedNullableStruct) -> KRPC_pb2.ProcedureCall:
+        return self._client._build_call(
+            "TestService",
+            "EchoNestedNullableStruct",
+            [value],
+            [self._client._types.struct_type("TestService", "TestNestedNullableStruct")],
+            self._client._types.struct_type("TestService", "TestNestedNullableStruct")
+        )
+
     def echo_nullable_int(self, value: Optional[int]) -> Optional[int]:
         return self._client._invoke(
             "TestService",
@@ -999,6 +1125,27 @@ class TestService:
             [value],
             [self._client._types.class_type("TestService", "TestClass")],
             self._client._types.class_type("TestService", "TestClass")
+        )
+
+    def echo_tuple_with_a_nullable_object(self, t: Tuple[int,Optional[TestClass]]) -> Tuple[int,Optional[TestClass]]:
+        return self._client._invoke(
+            "TestService",
+            "EchoTupleWithANullableObject",
+            [t],
+            [self._client._types.tuple_type(self._client._types.sint32_type, self._client._types.nullable(self._client._types.class_type("TestService", "TestClass")))],
+            self._client._types.tuple_type(self._client._types.sint32_type, self._client._types.nullable(self._client._types.class_type("TestService", "TestClass")))
+        )
+
+    def _return_type_echo_tuple_with_a_nullable_object(self) -> TypeBase:
+        return self._client._types.tuple_type(self._client._types.sint32_type, self._client._types.nullable(self._client._types.class_type("TestService", "TestClass")))
+
+    def _build_call_echo_tuple_with_a_nullable_object(self, t: Tuple[int,Optional[TestClass]]) -> KRPC_pb2.ProcedureCall:
+        return self._client._build_call(
+            "TestService",
+            "EchoTupleWithANullableObject",
+            [t],
+            [self._client._types.tuple_type(self._client._types.sint32_type, self._client._types.nullable(self._client._types.class_type("TestService", "TestClass")))],
+            self._client._types.tuple_type(self._client._types.sint32_type, self._client._types.nullable(self._client._types.class_type("TestService", "TestClass")))
         )
 
     def empty_list_default(self, x: List[str] = []) -> List[str]:
@@ -1432,6 +1579,27 @@ class TestService:
             [value],
             [self._client._types.class_type("TestService", "TestClass")],
             self._client._types.class_type("TestService", "TestClass")
+        )
+
+    def nullable_struct_echo(self, x: TestNullableStruct) -> TestNullableStruct:
+        return self._client._invoke(
+            "TestService",
+            "NullableStructEcho",
+            [x],
+            [self._client._types.struct_type("TestService", "TestNullableStruct")],
+            self._client._types.struct_type("TestService", "TestNullableStruct")
+        )
+
+    def _return_type_nullable_struct_echo(self) -> TypeBase:
+        return self._client._types.struct_type("TestService", "TestNullableStruct")
+
+    def _build_call_nullable_struct_echo(self, x: TestNullableStruct) -> KRPC_pb2.ProcedureCall:
+        return self._client._build_call(
+            "TestService",
+            "NullableStructEcho",
+            [x],
+            [self._client._types.struct_type("TestService", "TestNullableStruct")],
+            self._client._types.struct_type("TestService", "TestNullableStruct")
         )
 
     def on_timer(self, milliseconds: int, repeats: int = 1) -> Event:

--- a/tools/krpctools/krpctools/test/docgen-TestService-cnano.rst
+++ b/tools/krpctools/krpctools/test/docgen-TestService-cnano.rst
@@ -202,6 +202,71 @@ Service documentation string.
 
 
 
+.. function:: krpc_error_t krpc_TestService_EchoDictionaryOfNullableObjects(krpc_connection_t connection, krpc_dictionary_string_nullable_object_t * result, const krpc_dictionary_string_nullable_object_t * d)
+
+
+
+   :Parameters:
+
+
+
+   
+
+
+
+
+.. function:: krpc_error_t krpc_TestService_EchoListOfNullableInts(krpc_connection_t connection, krpc_list_nullable_int32_t * result, const krpc_list_nullable_int32_t * l)
+
+
+
+   :Parameters:
+
+
+
+   
+
+
+
+
+.. function:: krpc_error_t krpc_TestService_EchoListOfNullableObjects(krpc_connection_t connection, krpc_list_nullable_object_t * result, const krpc_list_nullable_object_t * l)
+
+
+
+   :Parameters:
+
+
+
+   
+
+
+
+
+.. function:: krpc_error_t krpc_TestService_EchoNestedListOfNullableObjects(krpc_connection_t connection, krpc_list_list_nullable_object_t * result, const krpc_list_list_nullable_object_t * l)
+
+
+
+   :Parameters:
+
+
+
+   
+
+
+
+
+.. function:: krpc_error_t krpc_TestService_EchoNestedNullableStruct(krpc_connection_t connection, krpc_TestService_TestNestedNullableStruct_t * result, const krpc_TestService_TestNestedNullableStruct_t * value)
+
+
+
+   :Parameters:
+
+
+
+   
+
+
+
+
 .. function:: krpc_error_t krpc_TestService_EchoNullableInt(krpc_connection_t connection, int32_t * result, int32_t value)
 
 
@@ -242,6 +307,19 @@ Service documentation string.
 
 
 .. function:: krpc_error_t krpc_TestService_EchoTestObject(krpc_connection_t connection, krpc_TestService_TestClass_t * result, krpc_TestService_TestClass_t value)
+
+
+
+   :Parameters:
+
+
+
+   
+
+
+
+
+.. function:: krpc_error_t krpc_TestService_EchoTupleWithANullableObject(krpc_connection_t connection, krpc_tuple_int32_nullable_object_t * result, const krpc_tuple_int32_nullable_object_t * t)
 
 
 
@@ -521,6 +599,19 @@ Service documentation string.
 
 .. function:: krpc_error_t krpc_TestService_NullableObject(krpc_connection_t connection, krpc_TestService_TestClass_t * result)
 .. function:: void krpc_TestService_set_NullableObject(krpc_TestService_TestClass_t value)
+
+
+
+   
+
+
+
+
+.. function:: krpc_error_t krpc_TestService_NullableStructEcho(krpc_connection_t connection, krpc_TestService_TestNullableStruct_t * result, const krpc_TestService_TestNullableStruct_t * x)
+
+
+
+   :Parameters:
 
 
 
@@ -1014,6 +1105,46 @@ Service documentation string.
 
 
    .. member:: krpc_TestService_TestClass_t object_field
+
+
+
+   .. member:: char * string_field
+
+
+
+
+.. type:: krpc_TestService_TestNullableStruct_t
+
+   Nullable struct documentation string.
+
+
+   .. member:: int32_t int_field
+
+
+
+   .. member:: krpc_nullable_int32_t nullable_int_field
+
+
+
+   .. member:: krpc_nullable_enum_t nullable_enum_field
+
+
+
+   .. member:: krpc_nullable_string_t nullable_string_field
+
+
+
+   .. member:: krpc_nullable_object_t nullable_object_field
+
+
+
+
+.. type:: krpc_TestService_TestNestedNullableStruct_t
+
+   Nested nullable struct documentation string.
+
+
+   .. member:: krpc_list_nullable_object_t list_field
 
 
 

--- a/tools/krpctools/krpctools/test/docgen-TestService-cpp.rst
+++ b/tools/krpctools/krpctools/test/docgen-TestService-cpp.rst
@@ -166,7 +166,7 @@
 
    
 
-   .. function:: int32_t echo_nullable_int(int32_t value)
+   .. function:: std::map<std::string, std::optional<TestClass>> echo_dictionary_of_nullable_objects(std::map<std::string, std::optional<TestClass>> d)
 
 
 
@@ -176,7 +176,7 @@
 
    
 
-   .. function:: std::vector<int32_t> echo_nullable_list(std::vector<int32_t> l)
+   .. function:: std::vector<std::optional<int32_t>> echo_list_of_nullable_ints(std::vector<std::optional<int32_t>> l)
 
 
 
@@ -186,7 +186,7 @@
 
    
 
-   .. function:: std::string echo_nullable_string(std::string value)
+   .. function:: std::vector<std::optional<TestClass>> echo_list_of_nullable_objects(std::vector<std::optional<TestClass>> l)
 
 
 
@@ -196,7 +196,67 @@
 
    
 
-   .. function:: TestClass echo_test_object(TestClass value)
+   .. function:: std::vector<std::vector<std::optional<TestClass>>> echo_nested_list_of_nullable_objects(std::vector<std::vector<std::optional<TestClass>>> l)
+
+
+
+      :Parameters:
+
+
+
+   
+
+   .. function:: TestNestedNullableStruct echo_nested_nullable_struct(TestNestedNullableStruct value)
+
+
+
+      :Parameters:
+
+
+
+   
+
+   .. function:: std::optional<int32_t> echo_nullable_int(std::optional<int32_t> value)
+
+
+
+      :Parameters:
+
+
+
+   
+
+   .. function:: std::optional<std::vector<int32_t>> echo_nullable_list(std::optional<std::vector<int32_t>> l)
+
+
+
+      :Parameters:
+
+
+
+   
+
+   .. function:: std::optional<std::string> echo_nullable_string(std::optional<std::string> value)
+
+
+
+      :Parameters:
+
+
+
+   
+
+   .. function:: std::optional<TestClass> echo_test_object(std::optional<TestClass> value)
+
+
+
+      :Parameters:
+
+
+
+   
+
+   .. function:: std::tuple<int32_t, std::optional<TestClass>> echo_tuple_with_a_nullable_object(std::tuple<int32_t, std::optional<TestClass>> t)
 
 
 
@@ -411,15 +471,25 @@
 
    
 
-   .. function:: TestClass nullable_object()
-   .. function:: void set_nullable_object(TestClass value)
+   .. function:: std::optional<TestClass> nullable_object()
+   .. function:: void set_nullable_object(std::optional<TestClass> value)
 
 
 
    
 
-   .. function:: TestClass object_property()
-   .. function:: void set_object_property(TestClass value)
+   .. function:: TestNullableStruct nullable_struct_echo(TestNullableStruct x)
+
+
+
+      :Parameters:
+
+
+
+   
+
+   .. function:: std::optional<TestClass> object_property()
+   .. function:: void set_object_property(std::optional<TestClass> value)
 
 
 
@@ -446,7 +516,7 @@
 
    
 
-   .. function:: std::string optional_arguments(std::string x, std::string y = "foo", std::string z = "bar", TestClass obj)
+   .. function:: std::string optional_arguments(std::string x, std::string y = "foo", std::string z = "bar", std::optional<TestClass> obj)
 
 
 
@@ -539,7 +609,7 @@
 
    
 
-   .. function:: TestStruct struct_echo_nullable(TestStruct x)
+   .. function:: std::optional<TestStruct> struct_echo_nullable(std::optional<TestStruct> x)
 
 
 
@@ -640,7 +710,7 @@
 
    Class documentation string.
 
-   .. function:: TestClass echo_nullable_object(TestClass value)
+   .. function:: std::optional<TestClass> echo_nullable_object(std::optional<TestClass> value)
 
 
 
@@ -674,14 +744,14 @@
 
    
 
-   .. function:: TestClass object_property()
-   .. function:: void set_object_property(TestClass value)
+   .. function:: std::optional<TestClass> object_property()
+   .. function:: void set_object_property(std::optional<TestClass> value)
 
 
 
    
 
-   .. function:: std::string object_to_string(TestClass other)
+   .. function:: std::string object_to_string(std::optional<TestClass> other)
 
 
 
@@ -691,7 +761,7 @@
 
    
 
-   .. function:: std::string optional_arguments(std::string x, std::string y = "foo", std::string z = "bar", TestClass obj)
+   .. function:: std::string optional_arguments(std::string x, std::string y = "foo", std::string z = "bar", std::optional<TestClass> obj)
 
 
 
@@ -715,7 +785,7 @@
 
    
 
-   .. function:: static TestClass static_nullable_object(Client& connection, TestClass value)
+   .. function:: static std::optional<TestClass> static_nullable_object(Client& connection, std::optional<TestClass> value)
 
 
 
@@ -833,6 +903,48 @@
 
 
    .. member:: TestClass object_field
+
+
+
+   .. member:: std::string string_field
+
+
+
+
+.. namespace:: krpc::services::TestService
+.. struct:: TestNullableStruct
+
+   Nullable struct documentation string.
+
+
+   .. member:: int32_t int_field
+
+
+
+   .. member:: std::optional<int32_t> nullable_int_field
+
+
+
+   .. member:: std::optional<TestEnum> nullable_enum_field
+
+
+
+   .. member:: std::optional<std::string> nullable_string_field
+
+
+
+   .. member:: std::optional<TestClass> nullable_object_field
+
+
+
+
+.. namespace:: krpc::services::TestService
+.. struct:: TestNestedNullableStruct
+
+   Nested nullable struct documentation string.
+
+
+   .. member:: std::vector<std::optional<TestClass>> list_field
 
 
 

--- a/tools/krpctools/krpctools/test/docgen-TestService-csharp.rst
+++ b/tools/krpctools/krpctools/test/docgen-TestService-csharp.rst
@@ -160,6 +160,56 @@
 
       :Game Scenes: All
 
+   .. method:: System.Collections.Generic.IDictionary<string,TestClass> EchoDictionaryOfNullableObjects(System.Collections.Generic.IDictionary<string,TestClass> d)
+
+
+
+      :parameters:
+
+
+
+      :Game Scenes: All
+
+   .. method:: System.Collections.Generic.IList<int?> EchoListOfNullableInts(System.Collections.Generic.IList<int?> l)
+
+
+
+      :parameters:
+
+
+
+      :Game Scenes: All
+
+   .. method:: System.Collections.Generic.IList<TestClass> EchoListOfNullableObjects(System.Collections.Generic.IList<TestClass> l)
+
+
+
+      :parameters:
+
+
+
+      :Game Scenes: All
+
+   .. method:: System.Collections.Generic.IList<System.Collections.Generic.IList<TestClass>> EchoNestedListOfNullableObjects(System.Collections.Generic.IList<System.Collections.Generic.IList<TestClass>> l)
+
+
+
+      :parameters:
+
+
+
+      :Game Scenes: All
+
+   .. method:: TestNestedNullableStruct EchoNestedNullableStruct(TestNestedNullableStruct value)
+
+
+
+      :parameters:
+
+
+
+      :Game Scenes: All
+
    .. method:: int EchoNullableInt(int value)
 
 
@@ -191,6 +241,16 @@
       :Game Scenes: All
 
    .. method:: TestClass EchoTestObject(TestClass value)
+
+
+
+      :parameters:
+
+
+
+      :Game Scenes: All
+
+   .. method:: System.Tuple<int,TestClass> EchoTupleWithANullableObject(System.Tuple<int,TestClass> t)
 
 
 
@@ -406,6 +466,16 @@
       :Game Scenes: All
 
    .. property:: TestClass NullableObject { get; set; }
+
+
+
+      :Game Scenes: All
+
+   .. method:: TestNullableStruct NullableStructEcho(TestNullableStruct x)
+
+
+
+      :parameters:
 
 
 
@@ -818,6 +888,46 @@
 
 
    .. property:: TestClass ObjectField { get; set; }
+
+
+
+   .. property:: string StringField { get; set; }
+
+
+
+
+.. struct:: TestNullableStruct
+
+   Nullable struct documentation string.
+
+
+   .. property:: int IntField { get; set; }
+
+
+
+   .. property:: int? NullableIntField { get; set; }
+
+
+
+   .. property:: TestEnum? NullableEnumField { get; set; }
+
+
+
+   .. property:: string NullableStringField { get; set; }
+
+
+
+   .. property:: TestClass NullableObjectField { get; set; }
+
+
+
+
+.. struct:: TestNestedNullableStruct
+
+   Nested nullable struct documentation string.
+
+
+   .. property:: System.Collections.Generic.IList<TestClass> ListField { get; set; }
 
 
 

--- a/tools/krpctools/krpctools/test/docgen-TestService-java.rst
+++ b/tools/krpctools/krpctools/test/docgen-TestService-java.rst
@@ -123,6 +123,41 @@
       :param double value:
    
 
+   .. method:: java.util.Map<String,TestClass> echoDictionaryOfNullableObjects(java.util.Map<String,TestClass> d)
+
+
+
+      :param java.util.Map<String,TestClass> d:
+   
+
+   .. method:: java.util.List<Integer> echoListOfNullableInts(java.util.List<Integer> l)
+
+
+
+      :param java.util.List<Integer> l:
+   
+
+   .. method:: java.util.List<TestClass> echoListOfNullableObjects(java.util.List<TestClass> l)
+
+
+
+      :param java.util.List<TestClass> l:
+   
+
+   .. method:: java.util.List<java.util.List<TestClass>> echoNestedListOfNullableObjects(java.util.List<java.util.List<TestClass>> l)
+
+
+
+      :param java.util.List<java.util.List<TestClass>> l:
+   
+
+   .. method:: TestNestedNullableStruct echoNestedNullableStruct(TestNestedNullableStruct value)
+
+
+
+      :param TestNestedNullableStruct value:
+   
+
    .. method:: int echoNullableInt(int value)
 
 
@@ -149,6 +184,13 @@
 
 
       :param TestClass value:
+   
+
+   .. method:: org.javatuples.Pair<Integer,TestClass> echoTupleWithANullableObject(org.javatuples.Pair<Integer,TestClass> t)
+
+
+
+      :param org.javatuples.Pair<Integer,TestClass> t:
    
 
    .. method:: java.util.List<String> emptyListDefault(java.util.List<String> x)
@@ -304,6 +346,13 @@
 
 
 
+   
+
+   .. method:: TestNullableStruct nullableStructEcho(TestNullableStruct x)
+
+
+
+      :param TestNullableStruct x:
    
 
    .. method:: TestClass getObjectProperty()
@@ -656,6 +705,46 @@
 
 
    .. method:: TestClass getObjectField()
+
+
+
+   .. method:: String getStringField()
+
+
+
+
+.. type:: public class TestNullableStruct
+
+   Nullable struct documentation string.
+
+
+   .. method:: int getIntField()
+
+
+
+   .. method:: Integer getNullableIntField()
+
+
+
+   .. method:: TestEnum getNullableEnumField()
+
+
+
+   .. method:: String getNullableStringField()
+
+
+
+   .. method:: TestClass getNullableObjectField()
+
+
+
+
+.. type:: public class TestNestedNullableStruct
+
+   Nested nullable struct documentation string.
+
+
+   .. method:: java.util.List<TestClass> getListField()
 
 
 

--- a/tools/krpctools/krpctools/test/docgen-TestService-lua.rst
+++ b/tools/krpctools/krpctools/test/docgen-TestService-lua.rst
@@ -165,6 +165,56 @@ Service documentation string.
 
 
 
+.. staticmethod:: echo_dictionary_of_nullable_objects(d)
+
+
+
+   :param Map d:
+   :rtype: Map
+
+
+
+
+.. staticmethod:: echo_list_of_nullable_ints(l)
+
+
+
+   :param List l:
+   :rtype: List
+
+
+
+
+.. staticmethod:: echo_list_of_nullable_objects(l)
+
+
+
+   :param List l:
+   :rtype: List
+
+
+
+
+.. staticmethod:: echo_nested_list_of_nullable_objects(l)
+
+
+
+   :param List l:
+   :rtype: List
+
+
+
+
+.. staticmethod:: echo_nested_nullable_struct(value)
+
+
+
+   :param TestService.TestNestedNullableStruct value:
+   :rtype: :class:`TestService.TestNestedNullableStruct`
+
+
+
+
 .. staticmethod:: echo_nullable_int(value)
 
 
@@ -201,6 +251,16 @@ Service documentation string.
 
    :param TestService.TestClass value:
    :rtype: :class:`TestService.TestClass`
+
+
+
+
+.. staticmethod:: echo_tuple_with_a_nullable_object(t)
+
+
+
+   :param Tuple t:
+   :rtype: Tuple
 
 
 
@@ -418,6 +478,16 @@ Service documentation string.
 
    :Attribute: Can be read or written
    :rtype: :class:`TestService.TestClass`
+
+
+
+
+.. staticmethod:: nullable_struct_echo(x)
+
+
+
+   :param TestService.TestNullableStruct x:
+   :rtype: :class:`TestService.TestNullableStruct`
 
 
 
@@ -856,6 +926,60 @@ Service documentation string.
 
 
       :rtype: :class:`TestService.TestClass`
+
+   .. attribute:: string_field: string
+
+
+
+      :rtype: string
+
+
+.. class:: TestNullableStruct
+
+   Nullable struct documentation string.
+
+
+   .. attribute:: int_field: number
+
+
+
+      :rtype: number
+
+   .. attribute:: nullable_int_field: number
+
+
+
+      :rtype: number
+
+   .. attribute:: nullable_enum_field: TestService.TestEnum
+
+
+
+      :rtype: :class:`TestService.TestEnum`
+
+   .. attribute:: nullable_string_field: string
+
+
+
+      :rtype: string
+
+   .. attribute:: nullable_object_field: TestService.TestClass
+
+
+
+      :rtype: :class:`TestService.TestClass`
+
+
+.. class:: TestNestedNullableStruct
+
+   Nested nullable struct documentation string.
+
+
+   .. attribute:: list_field: List
+
+
+
+      :rtype: List
 
    .. attribute:: string_field: string
 

--- a/tools/krpctools/krpctools/test/docgen-TestService-python.rst
+++ b/tools/krpctools/krpctools/test/docgen-TestService-python.rst
@@ -179,12 +179,67 @@ Service documentation string.
 
 
 
+.. staticmethod:: echo_dictionary_of_nullable_objects(d)
+
+
+
+   :param dict d:
+   :rtype: dict(str, :class:`TestClass` or None)
+   
+
+
+
+
+.. staticmethod:: echo_list_of_nullable_ints(l)
+
+
+
+   :param list l:
+   :rtype: list(int or None)
+   
+
+
+
+
+.. staticmethod:: echo_list_of_nullable_objects(l)
+
+
+
+   :param list l:
+   :rtype: list(:class:`TestClass` or None)
+   
+
+
+
+
+.. staticmethod:: echo_nested_list_of_nullable_objects(l)
+
+
+
+   :param list l:
+   :rtype: list(list(:class:`TestClass` or None))
+   
+
+
+
+
+.. staticmethod:: echo_nested_nullable_struct(value)
+
+
+
+   :param TestNestedNullableStruct value:
+   :rtype: :class:`TestNestedNullableStruct`
+   
+
+
+
+
 .. staticmethod:: echo_nullable_int(value)
 
 
 
    :param int value:
-   :rtype: int
+   :rtype: int or None
    
 
 
@@ -195,7 +250,7 @@ Service documentation string.
 
 
    :param list l:
-   :rtype: list(int)
+   :rtype: list(int) or None
    
 
 
@@ -206,7 +261,7 @@ Service documentation string.
 
 
    :param str value:
-   :rtype: str
+   :rtype: str or None
    
 
 
@@ -217,7 +272,18 @@ Service documentation string.
 
 
    :param TestClass value:
-   :rtype: :class:`TestClass`
+   :rtype: :class:`TestClass` or None
+   
+
+
+
+
+.. staticmethod:: echo_tuple_with_a_nullable_object(t)
+
+
+
+   :param tuple t:
+   :rtype: tuple(int, :class:`TestClass` or None)
    
 
 
@@ -455,7 +521,18 @@ Service documentation string.
 
 
    :Attribute: Can be read or written
-   :rtype: :class:`TestClass`
+   :rtype: :class:`TestClass` or None
+   
+
+
+
+
+.. staticmethod:: nullable_struct_echo(x)
+
+
+
+   :param TestNullableStruct x:
+   :rtype: :class:`TestNullableStruct`
    
 
 
@@ -466,7 +543,7 @@ Service documentation string.
 
 
    :Attribute: Can be read or written
-   :rtype: :class:`TestClass`
+   :rtype: :class:`TestClass` or None
    
 
 
@@ -619,7 +696,7 @@ Service documentation string.
 
 
    :param TestStruct x:
-   :rtype: :class:`TestStruct`
+   :rtype: :class:`TestStruct` or None
    
 
 
@@ -740,7 +817,7 @@ Service documentation string.
 
 
       :param TestClass value:
-      :rtype: :class:`TestClass`
+      :rtype: :class:`TestClass` or None
    
 
    .. method:: float_to_string(x)
@@ -771,7 +848,7 @@ Service documentation string.
 
 
       :Attribute: Can be read or written
-      :rtype: :class:`TestClass`
+      :rtype: :class:`TestClass` or None
    
 
    .. method:: object_to_string(other)
@@ -807,7 +884,7 @@ Service documentation string.
 
 
       :param TestClass value:
-      :rtype: :class:`TestClass`
+      :rtype: :class:`TestClass` or None
    
 
    .. attribute:: string_property_private_get
@@ -932,6 +1009,60 @@ Service documentation string.
 
 
       :rtype: :class:`TestClass`
+
+   .. attribute:: string_field
+
+
+
+      :rtype: str
+
+
+.. class:: TestNullableStruct
+
+   Nullable struct documentation string.
+
+
+   .. attribute:: int_field
+
+
+
+      :rtype: int
+
+   .. attribute:: nullable_int_field
+
+
+
+      :rtype: int or None
+
+   .. attribute:: nullable_enum_field
+
+
+
+      :rtype: :class:`TestEnum` or None
+
+   .. attribute:: nullable_string_field
+
+
+
+      :rtype: str or None
+
+   .. attribute:: nullable_object_field
+
+
+
+      :rtype: :class:`TestClass` or None
+
+
+.. class:: TestNestedNullableStruct
+
+   Nested nullable struct documentation string.
+
+
+   .. attribute:: list_field
+
+
+
+      :rtype: list(:class:`TestClass` or None)
 
    .. attribute:: string_field
 

--- a/tools/krpctools/krpctools/test/test_clientgen_csharp.py
+++ b/tools/krpctools/krpctools/test/test_clientgen_csharp.py
@@ -3,9 +3,75 @@ from krpctools.test.clientgentest import ClientGenTestCase
 from krpctools.clientgen.csharp import CsharpGenerator
 
 
+def nullable_class(name):
+    return {"code": "CLASS", "service": "ServiceA", "name": name, "nullable": True}
+
+
+def service_with_a_parameter(typ):
+    return {
+        "ServiceA": {
+            "id": 1,
+            "documentation": "",
+            "procedures": {
+                "Frob": {
+                    "id": 1,
+                    "parameters": [{"name": "value", "type": typ}],
+                    "documentation": "",
+                }
+            },
+            "classes": {"Thing": {"documentation": ""}},
+            "enumerations": {},
+            "exceptions": {},
+            "structs": {
+                "Holder": {
+                    "documentation": "",
+                    "fields": [
+                        {
+                            "name": "Things",
+                            "type": {
+                                "code": "LIST",
+                                "types": [nullable_class("Thing")],
+                            },
+                            "documentation": "",
+                        }
+                    ],
+                }
+            },
+        }
+    }
+
+
 class TestClientGenCsharp(ClientGenTestCase, unittest.TestCase):
     language = "csharp"
     generator = CsharpGenerator
+
+    # A nullable reference-typed position is invisible in the C# type, so the generated stub
+    # names it with a spec. Every collection has to reach the positions inside it for that,
+    # whether or not a position of its own can hold null.
+
+    def test_nullable_position_inside_a_list(self):
+        content = self.generate(
+            "ServiceA",
+            service_with_a_parameter(
+                {"code": "LIST", "types": [nullable_class("Thing")]}
+            ),
+        )
+        self.assertIn("TypeSpec.Null (typeof(global::KRPC.Client", content)
+
+    def test_nullable_position_inside_a_set(self):
+        # A set element cannot itself be null, but a value it holds may hold one
+        content = self.generate(
+            "ServiceA",
+            service_with_a_parameter(
+                {
+                    "code": "SET",
+                    "types": [
+                        {"code": "STRUCT", "service": "ServiceA", "name": "Holder"}
+                    ],
+                }
+            ),
+        )
+        self.assertIn("TypeSpec.Null (typeof(global::KRPC.Client", content)
 
 
 if __name__ == "__main__":

--- a/tools/krpctools/krpctools/utils.py
+++ b/tools/krpctools/krpctools/utils.py
@@ -41,10 +41,10 @@ def as_type(types, type_info):
     return types.as_type(as_protobuf_type(type_info))
 
 
-def is_nullable(type_info):
-    """Whether the position described by the given type specification can hold null.
-    A procedure that returns nothing gives no specification"""
-    return type_info is not None and type_info.get("nullable", False)
+def is_nullable(typ):
+    """Whether the position the given type sits in can hold null. A procedure that returns
+    nothing has no type there"""
+    return typ is not None and typ.nullable
 
 
 def as_protobuf_type(type_info):

--- a/tools/krpctools/krpctools/utils.py
+++ b/tools/krpctools/krpctools/utils.py
@@ -58,6 +58,8 @@ def as_protobuf_type(type_info):
         protobuf_type.name = type_info["name"]
     if "types" in type_info:
         protobuf_type.types.extend([as_protobuf_type(t) for t in type_info["types"]])
+    if type_info.get("nullable", False):
+        protobuf_type.nullable = True
     return protobuf_type
 
 

--- a/tools/krpctools/krpctools/utils.py
+++ b/tools/krpctools/krpctools/utils.py
@@ -41,6 +41,12 @@ def as_type(types, type_info):
     return types.as_type(as_protobuf_type(type_info))
 
 
+def is_nullable(type_info):
+    """Whether the position described by the given type specification can hold null.
+    A procedure that returns nothing gives no specification"""
+    return type_info is not None and type_info.get("nullable", False)
+
+
 def as_protobuf_type(type_info):
     """Convert a type parsed from a JSON service definitions file
     into a protocol buffer type"""


### PR DESCRIPTION
**Problem.** Nullability was a property of the call boundary. `Parameter.nullable` and `Procedure.return_is_nullable` declared it, and `Argument.is_null` and `ProcedureResult.is_null` carried the null beside the encoded bytes. A nested value has no such channel, so a structure field, a list element, a tuple item and a dictionary value could not be nullable. That blocks the structure adoptions of `SpaceCenter.CommNode` and `ActionGroupAction`.

**Breaking: nullability moves onto `Type`.** A `bool nullable` on the `Type` message replaces the two flags, which are removed and their field numbers freed. A type describes every position a value sits in, so the same field declares a parameter, a return value, a structure field and a position nested inside a collection.

**Declaring one.** A structure field is nullable through the `Nullable` parameter of its `KRPCProperty` attribute, or through a `Nullable<T>` field type. A position inside a value is nullable through a path of named positions on `KRPCNullable`, such as `[KRPCNullable (Position.Element)]`. A dictionary key and a set element have no position a path can name.

**Server.** The scanner builds a `TypeSpec` for every parameter, return value and structure field, carrying the type together with the nullability of every position inside it. The codec encodes and decodes from that spec alone, writing a presence bool ahead of a value at a nullable position. A slot keeps its null out of band, so encoding a value there ignores nullability. The object store no longer maps a null to the id 0.

**Clients.** Each client holds a nullable value in the form its language already uses: `std::optional` in C++, the boxed type in Java, `T?` in C#, `None` in Python, `Types.none` in Lua. cnano stores by value, so a nullable position takes a generated type holding the value beside a `bool` presence flag. clientgen and docgen read nullability off the type the service definition gives.

**Testing.** The test service gained procedures and a structure taking a null in a field, a list element, a tuple item and a dictionary value, which every client's tests call.

Related to #906
Related to #843
