### PR TITLE
Fix control inputs on a vessel with a RemoteTech flight computer

### DIFF
--- a/service/RemoteTech/test/test_control.py
+++ b/service/RemoteTech/test/test_control.py
@@ -3,13 +3,8 @@ import unittest
 import krpctest
 
 
-class TestControlThrottleRemoteTechConnected(krpctest.TestCase):
-    """Throttle is applied to a vessel that is controllable via RemoteTech.
-
-    Regression test for the throttle gate in PilotAddon.HandleThrottle: throttle
-    must follow RemoteTech's controllability rule rather than either being
-    blocked when the vessel is controllable, or leaking through when it is not.
-    """
+class TestControlRemoteTechConnected(krpctest.TestCase):
+    """Control inputs are applied to a vessel that is controllable via RemoteTech."""
 
     mods = ["RemoteTech"]
 
@@ -25,8 +20,6 @@ class TestControlThrottleRemoteTechConnected(krpctest.TestCase):
         cls.engine.active = True
 
     def test_throttle_applied(self):
-        # On the launch pad the uncrewed probe's antenna reaches the ground
-        # station, so it is controllable and throttle should be applied.
         comms = self.rt.comms(self.vessel)
         self.assertFalse(comms.has_local_control)
         self.assertTrue(comms.has_connection)
@@ -37,13 +30,24 @@ class TestControlThrottleRemoteTechConnected(krpctest.TestCase):
         self.wait(1)
         self.assertAlmostEqual(0, self.engine.throttle, places=2)
 
+    def test_pitch_applied_once(self):
+        """RemoteTech runs kRPC's fly-by-wire callback as a sanctioned pilot, so the
+        callback must not also be on the vessel's own callback list."""
+        self.assertTrue(self.rt.comms(self.vessel).has_connection)
+        self.control.sas = False
+        self.control.pitch = 0.5
+        self.wait(1)
+        self.assertAlmostEqual(0.5, self.control.pitch, places=2)
+        self.control.pitch = 0
 
-class TestControlThrottleRemoteTechNoConnection(krpctest.TestCase):
-    """Throttle is dropped for a vessel that is not controllable via RemoteTech.
+
+class TestControlRemoteTechNoConnection(krpctest.TestCase):
+    """Throttle is applied to a vessel that RemoteTech cannot reach.
 
     The uncrewed probe is placed far from Kerbin so its antenna cannot reach any
-    ground station: with no local control and no connection it cannot be
-    controlled, and throttle set over kRPC must not be applied.
+    ground station. kRPC flies the vessel as a RemoteTech sanctioned pilot, which
+    the flight computer's signal delay and connection rules do not apply to, so
+    the throttle follows the other control axes and is applied.
     """
 
     mods = ["RemoteTech"]
@@ -60,12 +64,15 @@ class TestControlThrottleRemoteTechNoConnection(krpctest.TestCase):
         cls.engine = next(iter(cls.vessel.parts.engines))
         cls.engine.active = True
 
-    def test_throttle_blocked(self):
+    def test_throttle_applied(self):
         comms = self.rt.comms(self.vessel)
         self.assertFalse(comms.has_local_control)
         self.assertFalse(comms.has_connection)
         self.control.throttle = 1
         self.wait(1.5)
+        self.assertAlmostEqual(1, self.engine.throttle, places=2)
+        self.control.throttle = 0
+        self.wait(1)
         self.assertAlmostEqual(0, self.engine.throttle, places=2)
 
 

--- a/service/SpaceCenter/CHANGELOG.md
+++ b/service/SpaceCenter/CHANGELOG.md
@@ -160,6 +160,10 @@
   - Setting `Control.StageLock` leaves the in-game Alt+L shortcut in step with it (#1022)
   - Add `Control.PrecisionMode`, the precision control mode that the Caps Lock key
     toggles (#1082)
+  - Fix control inputs being applied twice each tick to a vessel with a RemoteTech flight
+    computer (#1093)
+  - Apply `Control.Throttle` on a RemoteTech vessel regardless of signal delay and
+    connection, matching the other control axes (#1093)
 
 - Parts
   - **Breaking:** `RCS.TranslationOverride` thrusts along the right, up and forward axes it

--- a/service/SpaceCenter/src/PilotAddon.cs
+++ b/service/SpaceCenter/src/PilotAddon.cs
@@ -69,6 +69,13 @@ namespace KRPC.SpaceCenter
 
             public bool ThrottleUpdated { get; set; }
 
+            /// <summary>
+            /// The throttle kRPC latched onto the game, or null when it holds no throttle.
+            /// Held so that it can be re-applied to a vessel whose RemoteTech flight computer
+            /// rewrites the throttle every tick.
+            /// </summary>
+            public float? LatchedThrottle { get; set; }
+
             public float Pitch {
                 get { return state.pitch; }
                 set { state.pitch = value.Clamp (-1f, 1f); }
@@ -266,6 +273,15 @@ namespace KRPC.SpaceCenter
         /// Set of FlyByWire callbacks that have been registered with RemoteTech.
         /// </summary>
         static HashSet<Vessel> remoteTechSanctionedDelegates = new HashSet<Vessel> ();
+
+        // Physics ticks between registering the sanctioned pilots again. RemoteTech drops
+        // them when a flight computer changes vessel, which docking and undocking do, and
+        // every call into its API searches each satellite in the game. Half a second picks a
+        // dropped pilot back up without paying that search every tick
+        const int RegisterSanctionedPilotsTicks = 25;
+        static int registerSanctionedPilotsCountdown;
+        static bool registerSanctionedPilots;
+
         /// <summary>
         /// The attitude controller for each vessel. Owned here rather than by the AutoPilot
         /// service objects, which are transient API surface objects, so controller state (the
@@ -348,6 +364,8 @@ namespace KRPC.SpaceCenter
             manualInputClients.Clear ();
             controlDelegates.Clear ();
             remoteTechSanctionedDelegates.Clear ();
+            registerSanctionedPilotsCountdown = 0;
+            registerSanctionedPilots = false;
             attitudeControllers.Clear ();
             controllers.Clear ();
         }
@@ -446,6 +464,9 @@ namespace KRPC.SpaceCenter
         public void FixedUpdate ()
         {
             CheckClients ();
+            registerSanctionedPilots = --registerSanctionedPilotsCountdown <= 0;
+            if (registerSanctionedPilots)
+                registerSanctionedPilotsCountdown = RegisterSanctionedPilotsTicks;
             foreach (var vessel in FlightGlobals.Vessels) {
                 // If the vessel is controllable, pilot it
                 if (vessel.rootPart != null)
@@ -455,14 +476,33 @@ namespace KRPC.SpaceCenter
 
         static void Fly (Vessel vessel)
         {
-            if (!controlDelegates.ContainsKey (vessel)) {
-                Action<FlightCtrlState> action = s => OnFlyByWire (vessel, s);
+            Action<FlightCtrlState> action;
+            if (!controlDelegates.TryGetValue (vessel, out action)) {
+                action = s => OnFlyByWire (vessel, s);
                 controlDelegates [vessel] = action;
                 vessel.OnFlyByWire += new FlightInputCallback (action);
             }
-            if (RemoteTech.IsAvailable && !remoteTechSanctionedDelegates.Contains (vessel) && RemoteTech.HasFlightComputer (vessel.id)) {
-                RemoteTech.AddSanctionedPilot (vessel.id, controlDelegates [vessel]);
+            if (!RemoteTech.IsAvailable)
+                return;
+            // RemoteTech runs a sanctioned pilot from its own fly-by-wire hook, after the
+            // flight computer's commands. The vessel's callback would merge the inputs a
+            // second time in the same tick. Take the sanctioned pilot instead, and put the
+            // callback back when the flight computer goes away
+            if (remoteTechSanctionedDelegates.Contains (vessel)) {
+                // Reconcile a vessel already flown as a sanctioned pilot now and then
+                if (!registerSanctionedPilots)
+                    return;
+                if (RemoteTech.HasFlightComputer (vessel.id)) {
+                    RemoteTech.AddSanctionedPilot (vessel.id, action);
+                } else {
+                    remoteTechSanctionedDelegates.Remove (vessel);
+                    RemoteTech.RemoveSanctionedPilot (vessel.id, action);
+                    vessel.OnFlyByWire += new FlightInputCallback (action);
+                }
+            } else if (RemoteTech.HasFlightComputer (vessel.id)) {
                 remoteTechSanctionedDelegates.Add (vessel);
+                RemoteTech.AddSanctionedPilot (vessel.id, action);
+                vessel.OnFlyByWire -= new FlightInputCallback (action);
             }
         }
 
@@ -475,7 +515,7 @@ namespace KRPC.SpaceCenter
             // Manual inputs
             if (!manualInputs.ContainsKey (vessel))
                 manualInputs [vessel] = new ControlInputs (vessel);
-            HandleThrottle (vessel, manualInputs [vessel]);
+            HandleThrottle (vessel, state, manualInputs [vessel]);
             inputs.Add (manualInputs [vessel]);
 
             // Auto-pilot inputs. The control loop runs at the point in the server's update
@@ -515,19 +555,6 @@ namespace KRPC.SpaceCenter
         }
 
         /// <summary>
-        /// Whether kRPC is permitted to send control inputs to the vessel.
-        /// When RemoteTech is installed this requires the vessel to be controllable via
-        /// RemoteTech: either local (crewed) control, or a connection to a command station
-        /// (a ground station or a crewed command station).
-        /// </summary>
-        static bool HasControlConnection (Vessel vessel)
-        {
-            if (!RemoteTech.IsAvailable)
-                return true;
-            return RemoteTech.HasLocalControl (vessel.id) || RemoteTech.HasAnyConnection (vessel.id);
-        }
-
-        /// <summary>
         /// Apply the manually set throttle to the vessel.
         ///
         /// Throttle is handled differently to the other control axes. Rather than being
@@ -536,24 +563,32 @@ namespace KRPC.SpaceCenter
         /// frames and stays in sync with the throttle gauge. The input is consumed once
         /// handled so that it is not also re-applied via the per-frame FlightCtrlState in
         /// ControlInputs.Add.
+        ///
+        /// A RemoteTech flight computer rebuilds the control state from its own queue before
+        /// this runs. That delays the latched throttle, and zeroes it when the connection
+        /// drops. kRPC flies the vessel as a sanctioned pilot, which RemoteTech runs after
+        /// both, so re-apply the latched throttle to this frame's state. The latch is
+        /// released once the game's throttle moves on its own, which hands the throttle back
+        /// to the player and to the flight computer.
         /// </summary>
-        static void HandleThrottle (Vessel vessel, ControlInputs inputs)
+        static void HandleThrottle (Vessel vessel, FlightCtrlState state, ControlInputs inputs)
         {
-            if (!inputs.ThrottleUpdated)
-                return;
             if (FlightGlobals.ActiveVessel != vessel)
                 return;
-            // If RemoteTech is controlling the vessel and there is no control connection,
-            // drop the input. Note: the input has to be consumed, or the per-frame
-            // FlightCtrlState in ControlInputs.Add re-applies it
-            if (!HasControlConnection (vessel)) {
+            if (inputs.ThrottleUpdated) {
+                FlightInputHandler.state.mainThrottle = inputs.Throttle;
+                inputs.LatchedThrottle = FlightInputHandler.state.mainThrottle;
                 inputs.Throttle = 0f;
                 inputs.ThrottleUpdated = false;
-                return;
             }
-            FlightInputHandler.state.mainThrottle = inputs.Throttle;
-            inputs.Throttle = 0f;
-            inputs.ThrottleUpdated = false;
+            if (!inputs.LatchedThrottle.HasValue || !remoteTechSanctionedDelegates.Contains (vessel))
+                return;
+            // Anything else that moves the throttle, a keypress or the throttle cutoff, writes
+            // the same field. Take that as the player taking the throttle back
+            if (inputs.LatchedThrottle.Value != FlightInputHandler.state.mainThrottle)
+                inputs.LatchedThrottle = null;
+            else
+                state.mainThrottle = inputs.LatchedThrottle.Value;
         }
     }
 }


### PR DESCRIPTION
**Root cause.** RemoteTech hooks the vessel's fly-by-wire chain either side of its flight computer, and runs sanctioned pilots from the trailing hook. kRPC was registered in both places, so an additive input was merged twice per tick. The throttle took a third route, latched onto `FlightInputHandler` upstream of the flight computer, which rebuilds the control state from its delay queue every tick.

**Fix.** kRPC flies a vessel with a flight computer only as a sanctioned pilot, and re-applies its latched throttle to the frame's control state. `Control.Throttle` now arrives without the signal delay and without a connection, matching the other control axes. The latch is released once the game's throttle moves on its own, so the player and the flight computer can take it back.

**Testing.** Verified in game with RemoteTech installed: throttle applied with and without a connection, and pitch applied once per tick. Relying on `FlightInputHandler` alone, with no sanctioned pilot, fails the no-connection case.

Fixes #1092
