### PR TITLE
Generator and client fixes

### DIFF
--- a/client/cpp/CHANGELOG.md
+++ b/client/cpp/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## [v0.7.0] - unreleased
+- Fix a stream of a value whose type a service defines, such as an enumeration or a structure,
+  failing to compile (#1094)
 - Support a nullable structure field, list element, tuple item and dictionary value (#1091)
 - Support structure types, a compound value with named fields a service defines, generated as
   a `struct` with a constructor, equality, ordering and a `std::hash` over its fields (#1066)

--- a/client/cpp/include/krpc/stream.hpp
+++ b/client/cpp/include/krpc/stream.hpp
@@ -104,7 +104,10 @@ inline T Stream<T>::operator()() {
   // A null value is signaled out-of-band by is_null, and leaves the value default
   // constructed, which for a nullable stream is an empty optional.
   T value{};
-  if (!impl->is_null()) decoder::decode(value, data, impl->get_client());
+  // Unqualified, so that argument dependent lookup finds the overload for a type a
+  // service defines at the point this template is used
+  using decoder::decode;
+  if (!impl->is_null()) decode(value, data, impl->get_client());
   return value;
 }
 
@@ -151,7 +154,8 @@ inline int Stream<T>::add_callback(const Callback& callback) {
   check_exists();
   auto callback_wrapper = [this, callback](const std::string& data) {
     T value{};
-    if (!this->impl->is_null()) decoder::decode(value, data, this->impl->get_client());
+    using decoder::decode;
+    if (!this->impl->is_null()) decode(value, data, this->impl->get_client());
     callback(value);
   };
   return impl->add_callback(callback_wrapper);

--- a/client/cpp/test/test_stream.cpp
+++ b/client/cpp/test/test_stream.cpp
@@ -42,6 +42,23 @@ TEST_F(test_stream, test_property) {
   }
 }
 
+TEST_F(test_stream, test_enumeration) {
+  auto x = test_service.enum_return_stream();
+  for (int i = 0; i < 5; i++) {
+    ASSERT_EQ(krpc::services::TestService::TestEnum::value_b, x());
+    wait();
+  }
+}
+
+TEST_F(test_stream, test_struct) {
+  auto x = test_service.struct_echo_stream(krpc::services::TestService::TestStruct(
+      1, "jeb", krpc::services::TestService::TestEnum::value_c, {1, 2}));
+  for (int i = 0; i < 5; i++) {
+    ASSERT_EQ("jeb", x().string_field);
+    wait();
+  }
+}
+
 TEST_F(test_stream, test_nullable) {
   auto x = test_service.echo_nullable_int_stream(std::nullopt);
   auto y = test_service.echo_nullable_string_stream(std::nullopt);

--- a/client/python/CHANGELOG.md
+++ b/client/python/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## [v0.7.0] - unreleased
+- A dynamically created service escapes an enumeration member whose name is a python keyword,
+  such as `Class` to `class_`, matching the pre-generated stubs (#1094)
 - Support a nullable structure field, list element, tuple item and dictionary value, which is
   `None` when absent (#1091)
 - A service with pre-generated stubs also gains the class members that only the server

--- a/client/python/krpc/service.py
+++ b/client/python/krpc/service.py
@@ -288,7 +288,7 @@ def service_definitions(service: KRPC.Service) -> Iterator[Definition]:
         doc = _documentation(enumeration, name)
         values = dict(
             (
-                str(snake_case(value.name)),
+                _member_name(value.name),
                 {"value": value.value, "doc": _documentation(value, name)},
             )
             for value in enumeration.values

--- a/tools/krpctools/CHANGELOG.md
+++ b/tools/krpctools/CHANGELOG.md
@@ -1,4 +1,14 @@
 ## [v0.7.0] - unreleased
+- Fix the python stubs for a service that names a type the KRPC service defines failing to
+  import (#1094)
+- Fix a generated python exception type not naming the service and class it was built from
+  (#1094)
+- Fix a python documentation reference to a member whose name is a keyword naming the
+  unescaped form (#1094)
+- Fix C++ documentation escaping a keyword member name twice in a declaration and not at all
+  in a cross reference (#1094)
+- Fix a generated Java enumeration member carrying an escaping suffix, such as `DOUBLE__` in
+  place of `DOUBLE` (#1094)
 - Generate and document the nullable structure fields and collection elements a service
   defines, for every client (#1091)
 - Generate and document the structure types a service defines, for every client (#1066)

--- a/tools/krpctools/krpctools/clientgen/python.py
+++ b/tools/krpctools/krpctools/clientgen/python.py
@@ -21,7 +21,10 @@ from ..utils import as_type
 
 class StubLanguage(PythonLanguage):
     """How a generated stub module names the types it uses: another service's through the module
-    its stubs are imported from, and its own service's directly."""
+    its stubs are imported from, and its own service's directly.
+
+    The module another service's stubs are imported from is aliased, so that a service whose name
+    is also that of a module the stubs use, such as KRPC, does not hide it."""
 
     def __init__(self, service):
         super().__init__()
@@ -31,7 +34,7 @@ class StubLanguage(PythonLanguage):
         if isinstance(typ, (ClassType, EnumerationType, StructType)):
             name = typ.protobuf_type.name
             if typ.protobuf_type.service != self.module:
-                name = typ.protobuf_type.service.lower() + "." + name
+                name = "_service_" + typ.protobuf_type.service.lower() + "." + name
             return name
         return super().parse_type(typ)
 

--- a/tools/krpctools/krpctools/clientgen/python.tmpl
+++ b/tools/krpctools/krpctools/clientgen/python.tmpl
@@ -49,7 +49,8 @@ class {{struct_name}}(NamedTuple):
 class {{exception_name}}(RuntimeError):
 {% if exception.documentation %}{{ exception.documentation | indent(width=4) }}
 {% endif %}
-    pass
+    _service_name = '{{ service_name }}'
+    _class_name = '{{ exception_name }}'
 
 
 {% endfor %}

--- a/tools/krpctools/krpctools/clientgen/python.tmpl
+++ b/tools/krpctools/krpctools/clientgen/python.tmpl
@@ -10,7 +10,7 @@ from krpc.event import Event
 if TYPE_CHECKING:
     from krpc.services import Client
 {% for service in dependencies %}
-from krpc.services import {{service|lower()}}
+from krpc.services import {{service|lower()}} as _service_{{service|lower()}}
 {% endfor %}
 
 {% macro arg_list(parameters) %}

--- a/tools/krpctools/krpctools/docgen/cpp.py
+++ b/tools/krpctools/krpctools/docgen/cpp.py
@@ -39,14 +39,13 @@ class CppDomain(Domain):
         return ".. namespace:: krpc::services::%s" % name
 
     def method_name(self, name):
-        if snake_case(name) in self.language.keywords:
-            return "%s_" % name
-        return name
+        """The C++ name of a member. A name that is a keyword is suffixed with an
+        underscore, as the client generator does, and the suffix is added after the
+        name is converted so that the two agree."""
+        return self.language.parse_name(name)
 
     def enumeration_name(self, name):
-        if snake_case(name) in self.language.keywords:
-            return "%s_" % name
-        return name
+        return self.language.parse_name(name)
 
     def type_description(self, typ):
         if typ is None:
@@ -90,7 +89,7 @@ class CppDomain(Domain):
                 StructField,
             )
         ):
-            name[-1] = snake_case(name[-1])
+            name[-1] = self.method_name(name[-1])
         if isinstance(obj, (Property, ClassProperty)) and obj.getter is None:
             name[-1] = "set_" + name[-1]
         return self.shorten_ref(".".join(name)).replace(".", "::")

--- a/tools/krpctools/krpctools/docgen/cpp.tmpl
+++ b/tools/krpctools/krpctools/docgen/cpp.tmpl
@@ -48,7 +48,7 @@
 {% endmacro %}
 
 {% macro procedure(x) %}{{ mark_documented(x) }}
-.. function:: {{ domain.return_type(x.return_type) }} {{ domain.method_name(x.name) | snakecase }}({{ parameters(x.parameters) }})
+.. function:: {{ domain.return_type(x.return_type) }} {{ domain.method_name(x.name) }}({{ parameters(x.parameters) }})
 
 {% if x.deprecated %}{{ deprecated(x) | indent }}
 
@@ -69,7 +69,7 @@
 
 {% macro property(x) %}{{ mark_documented(x) }}
 {% if x.getter != None %}
-.. function:: {{ domain.return_type(x.type) }} {{ domain.method_name(x.name) | snakecase }}()
+.. function:: {{ domain.return_type(x.type) }} {{ domain.method_name(x.name) }}()
 {% endif %}
 {% if x.setter != None %}
 .. function:: void set_{{ x.name | snakecase }}({{ domain.parameter_type(x.type) }} value)
@@ -92,7 +92,7 @@
 {% endmacro %}
 
 {% macro class_method(x) %}{{ mark_documented(x) }}
-.. function:: {{ domain.return_type(x.return_type) }} {{ domain.method_name(x.name) | snakecase }}({{ parameters(x.parameters[1:]) }})
+.. function:: {{ domain.return_type(x.return_type) }} {{ domain.method_name(x.name) }}({{ parameters(x.parameters[1:]) }})
 
 {% if x.deprecated %}{{ deprecated(x) | indent }}
 
@@ -112,7 +112,7 @@
 {% endmacro %}
 
 {% macro class_static_method(x) %}{{ mark_documented(x) }}
-.. function:: static {{ domain.return_type(x.return_type) }} {{ domain.method_name(x.name) | snakecase }}(Client& connection{% if x.parameters | length > 0 %}, {% endif %}{{ parameters(x.parameters) }})
+.. function:: static {{ domain.return_type(x.return_type) }} {{ domain.method_name(x.name) }}(Client& connection{% if x.parameters | length > 0 %}, {% endif %}{{ parameters(x.parameters) }})
 
 {% if x.deprecated %}{{ deprecated(x) | indent }}
 
@@ -146,7 +146,7 @@
 
 {% if hasdoc(x.documentation, './remarks') %}{{ remarks(x.documentation) | indent }}{% endif %}
 {% for value in x.values.values() %}{{ mark_documented(value) }}
-   .. enumerator:: {{ domain.enumeration_name(value.name) | snakecase }}
+   .. enumerator:: {{ domain.enumeration_name(value.name) }}
 
 {% if value.deprecated %}{{ deprecated(value) | indent(width=6) }}
 

--- a/tools/krpctools/krpctools/docgen/python.py
+++ b/tools/krpctools/krpctools/docgen/python.py
@@ -74,6 +74,9 @@ class PythonDomain(Domain):
 
     def ref(self, obj):
         name = obj.fullname
+        # A procedure, property or method is documented under the name the client
+        # generates for it, which escapes a python keyword; an enumeration value
+        # or a structure field is documented under its plain snake case name
         if any(
             isinstance(obj, cls)
             for cls in (
@@ -82,10 +85,12 @@ class PythonDomain(Domain):
                 ClassMethod,
                 ClassStaticMethod,
                 ClassProperty,
-                EnumerationValue,
-                StructField,
             )
         ):
+            name = name.split(".")
+            name[-1] = self.method_name(name[-1])
+            name = ".".join(name)
+        elif any(isinstance(obj, cls) for cls in (EnumerationValue, StructField)):
             name = name.split(".")
             name[-1] = snake_case(name[-1])
             name = ".".join(name)

--- a/tools/krpctools/krpctools/lang/java.py
+++ b/tools/krpctools/krpctools/lang/java.py
@@ -120,7 +120,10 @@ class JavaLanguage(Language):
 
     @staticmethod
     def parse_const_name(name):
-        return snake_case(name).upper()
+        # Drop the keyword-escaping trailing underscore parse_name adds. A const
+        # name is upper case and a Java keyword lower case, so the two never
+        # collide, and a kRPC identifier carries no underscore of its own
+        return snake_case(name.rstrip("_")).upper()
 
     def parse_type(self, typ):
         return self._parse_type(typ)

--- a/tools/krpctools/krpctools/test/clientgen-Ordering-python.txt
+++ b/tools/krpctools/krpctools/test/clientgen-Ordering-python.txt
@@ -9,7 +9,7 @@ from krpc.types import TypeBase, ClassBase, WrappedClass, DocEnum, StaticMethod
 from krpc.event import Event
 if TYPE_CHECKING:
     from krpc.services import Client
-from krpc.services import serviceb
+from krpc.services import serviceb as _service_serviceb
 
 
 class ServiceA:
@@ -55,7 +55,7 @@ class ServiceA:
     _exceptions = {
     }
 
-    def frob(self, mode: serviceb.Mode = serviceb.Mode.fast) -> None:
+    def frob(self, mode: _service_serviceb.Mode = _service_serviceb.Mode.fast) -> None:
         """
         Defaults to a member of another service's enumeration.
         """
@@ -70,7 +70,7 @@ class ServiceA:
     def _return_type_frob(self) -> TypeBase:
         return None
 
-    def _build_call_frob(self, mode: serviceb.Mode = serviceb.Mode.fast) -> KRPC_pb2.ProcedureCall:
+    def _build_call_frob(self, mode: _service_serviceb.Mode = _service_serviceb.Mode.fast) -> KRPC_pb2.ProcedureCall:
         return self._client._build_call(
             "ServiceA",
             "Frob",
@@ -79,7 +79,7 @@ class ServiceA:
             None
         )
 
-    def frob_all(self, modes: List[serviceb.Mode] = [serviceb.Mode.fast]) -> None:
+    def frob_all(self, modes: List[_service_serviceb.Mode] = [_service_serviceb.Mode.fast]) -> None:
         """
         Defaults to a collection containing a member of another service's enumeration.
         """
@@ -94,7 +94,7 @@ class ServiceA:
     def _return_type_frob_all(self) -> TypeBase:
         return None
 
-    def _build_call_frob_all(self, modes: List[serviceb.Mode] = [serviceb.Mode.fast]) -> KRPC_pb2.ProcedureCall:
+    def _build_call_frob_all(self, modes: List[_service_serviceb.Mode] = [_service_serviceb.Mode.fast]) -> KRPC_pb2.ProcedureCall:
         return self._client._build_call(
             "ServiceA",
             "FrobAll",

--- a/tools/krpctools/krpctools/test/clientgen-TestService-python.txt
+++ b/tools/krpctools/krpctools/test/clientgen-TestService-python.txt
@@ -100,7 +100,8 @@ class TestNullableStruct(NamedTuple):
 
 
 class CustomException(RuntimeError):
-    pass
+    _service_name = 'TestService'
+    _class_name = 'CustomException'
 
 
 class DeprecatedException(RuntimeError):
@@ -109,7 +110,8 @@ class DeprecatedException(RuntimeError):
 
     Deprecated exception documentation string.
     """
-    pass
+    _service_name = 'TestService'
+    _class_name = 'DeprecatedException'
 
 
 class DeprecatedClass(ClassBase):


### PR DESCRIPTION
Independent fixes to the client generators, the documentation generator and the C++ and python clients. One commit each.

- The python stubs for a service that names a KRPC type failed to import, because the imported module hid the `krpc` package the stubs read their limits and schema from.
- A generated python exception type did not carry the service and class name that a dynamically created one has.
- A python documentation cross reference named a member whose name is a keyword in its unescaped form.
- C++ documentation escaped a keyword member name twice in a declaration and not at all in a cross reference.
- A generated Java enumeration member carried an escaping suffix, `DOUBLE__` in place of `DOUBLE`.
- A C++ stream of a value whose type a service defines failed to compile, because the decoder was looked up ahead of the service header that generates it.
- A dynamically created python service did not escape an enumeration member whose name is a python keyword.

**Testing.** New C++ stream tests cover an enumeration and a structure. The python stub goldens cover the module alias and the exception names.
